### PR TITLE
Fix connection pooling behavior when maxsize > 1

### DIFF
--- a/test/with_dummyserver/test_connectionpool.py
+++ b/test/with_dummyserver/test_connectionpool.py
@@ -218,6 +218,16 @@ class TestConnectionPool(HTTPDummyServerTestCase):
         self.assertEqual(http_pool.num_connections, 1)
         self.assertEqual(http_pool.num_requests, 3)
 
+    def test_connection_count_bigpool(self):
+        http_pool = HTTPConnectionPool(self.host, self.port, maxsize=16)
+
+        http_pool.request('GET', '/')
+        http_pool.request('GET', '/')
+        http_pool.request('GET', '/')
+
+        self.assertEqual(http_pool.num_connections, 1)
+        self.assertEqual(http_pool.num_requests, 3)
+
     def test_partial_response(self):
         http_pool = HTTPConnectionPool(self.host, self.port, maxsize=1)
 

--- a/urllib3/connectionpool.py
+++ b/urllib3/connectionpool.py
@@ -9,7 +9,7 @@ import socket
 
 
 from httplib import HTTPConnection, HTTPSConnection, HTTPException
-from Queue import Queue, Empty, Full
+from Queue import LifoQueue, Empty, Full
 from select import select
 from socket import error as SocketError, timeout as SocketTimeout
 
@@ -129,7 +129,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         self.port = port
         self.strict = strict
         self.timeout = timeout
-        self.pool = Queue(maxsize)
+        self.pool = LifoQueue(maxsize)
         self.block = block
         self.headers = headers or {}
 


### PR DESCRIPTION
The connection pool's underlying Queue.Queue (a FIFO queue) is prefilled
with None objects; therefore, until you make maxsize HTTP requests, no
connections will be reused. I've attached a test which demonstrates this
(and now passes after switching to Queue.LifoQueue.)

The requests library defaults to a pool size of 10, which exposes this
bug.

Thanks for considering my patch! I didn't add myself to CONTRIBUTORS as this is a pretty minor fix. :)
