### PR TITLE
issue with PoolManager.request() method

### DIFF
--- a/test/test_connectionpool.py
+++ b/test/test_connectionpool.py
@@ -12,16 +12,16 @@ from urllib3.exceptions import EmptyPoolError
 class TestConnectionPool(unittest.TestCase):
     def test_get_host(self):
         url_host_map = {
-            'http://google.com/mail': ('http', 'google.com', None),
-            'http://google.com/mail/': ('http', 'google.com', None),
-            'google.com/mail': ('http', 'google.com', None),
-            'http://google.com/': ('http', 'google.com', None),
-            'http://google.com': ('http', 'google.com', None),
-            'http://www.google.com': ('http', 'www.google.com', None),
-            'http://mail.google.com': ('http', 'mail.google.com', None),
+            'http://google.com/mail': ('http', 'google.com', 80),
+            'http://google.com/mail/': ('http', 'google.com', 80),
+            'google.com/mail': ('http', 'google.com', 80),
+            'http://google.com/': ('http', 'google.com', 80),
+            'http://google.com': ('http', 'google.com', 80),
+            'http://www.google.com': ('http', 'www.google.com', 80),
+            'http://mail.google.com': ('http', 'mail.google.com', 80),
             'http://google.com:8000/mail/': ('http', 'google.com', 8000),
             'http://google.com:8000': ('http', 'google.com', 8000),
-            'https://google.com': ('https', 'google.com', None),
+            'https://google.com': ('https', 'google.com', 443),
             'https://google.com:8000': ('https', 'google.com', 8000),
             'http://user:password@127.0.0.1:1234': ('http', '127.0.0.1', 1234),
         }

--- a/test/test_poolmanager.py
+++ b/test/test_poolmanager.py
@@ -20,6 +20,22 @@ class TestPoolManager(unittest.TestCase):
 
         self.assertEqual(conn1, conn2)
 
+    def test_post_request(self):
+
+       pool_manager = PoolManager()
+
+       url = "http://www.snee.com/xml/crud/posttest.cgi"
+
+       params = { "fname": "test firstname", "lname": "test lastname" }
+
+       response = pool_manager.request(method="POST", url=url,
+                                          fields=params)
+
+       self.assertEqual(response.status, 200)
+
+       self.assertTrue(response.data.find('''<p>First name: "test firstname"</p><p>Last
+                           name: "test lastname"</p>'''))
+
     def test_many_urls(self):
         urls = [
             "http://localhost:8081/foo",


### PR DESCRIPTION
hey, 

there's two issues i noticed today:  when i do a POST like this (using the example from your github wiki):

```
import urllib3 # (Version 1.0)

http = urllib3.PoolManager()

params = ...

r = http.request('POST', 'http://localhost:1111/my/post/uri' , params)

print r.status, r.data
```

The POST directive in the request headers does not remove the host url, e.g. it will do:

```
POST http://localhost:1111/my/post/uri
```

instead of 

```
POST /my/post/uri
```

Additionally, I noticed if i do an PoolManager.request('GET', 'http://blahblah.com', 80) after creating it tries to go into a loop retrying when I don't specify the port # in the URL. that's because it sets self.port = 80 in is_host_same() even when get_host returns "None".  

Let me know if I am using the API wrong, or you have problems reproducing this, or there any other issues.
