### PR TITLE
multiple values for a single key

### DIFF
--- a/test/with_dummyserver/test_connectionpool.py
+++ b/test/with_dummyserver/test_connectionpool.py
@@ -60,6 +60,19 @@ class TestConnectionPool(HTTPDummyServerTestCase):
         r = self.pool.request('POST', '/upload', fields=fields)
         self.assertEqual(r.status, 200, r.data)
 
+    def test_upload_with_multipul_values(self):
+        data = "I'm in ur multipart form-data, hazing a cheezburgr"
+        fields = {
+            'params': ['aaa', 'bbb'],
+            'upload_param': 'filefield',
+            'upload_filename': 'lolcat.txt',
+            'upload_size': len(data),
+            'filefield': ('lolcat.txt', data),
+        }
+
+        r = self.pool.request('POST', '/upload', fields=fields)
+        self.assertEqual(r.status, 200, r.data)
+
     def test_unicode_upload(self):
         fieldname = u('myfile')
         filename = u('\xe2\x99\xa5.txt')


### PR DESCRIPTION
... if the request is with files.

fixed: issue #48: Urllib3 doesn't allow multiple values for a single key if the request is with files. by adding list support for encode_multipart_formdata
by adding list support for encode_multipart_formdata
