### PR TITLE
Fix for the multiple cookies problem (Issue #3 and #53)

### DIFF
--- a/urllib3/response.py
+++ b/urllib3/response.py
@@ -171,11 +171,20 @@ class HTTPResponse(object):
         with ``original_response=r``.
         """
 
+        # comma-seperate header values with identical header names
+        headers = {}
+        for k, v in r.getheaders():
+            # In Python 3, the header keys are returned capitalised
+            k = k.lower()
+            if k in headers:
+                headers[k] = headers[k] + ", " + v
+            else:
+                headers[k] = v
+
         # HTTPResponse objects in Python 3 don't have a .strict attribute
         strict = getattr(r, 'strict', 0)
         return ResponseCls(body=r,
-                           # In Python 3, the header keys are returned capitalised
-                           headers=dict((k.lower(), v) for k,v in r.getheaders()),
+                           headers=headers,
                            status=r.status,
                            version=r.version,
                            reason=r.reason,


### PR DESCRIPTION
In response to [issue 3](https://github.com/shazow/urllib3/issues/3) and [issue 53](https://github.com/shazow/urllib3/issues/53), headers with the same name are comma-separated under a single entry in the headers dict.
