### PR TITLE
Fix Sphinx complaint. Methods named 'request' are very common and cause ...

### DIFF
--- a/urllib3/connectionpool.py
+++ b/urllib3/connectionpool.py
@@ -294,7 +294,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         .. note::
 
            More commonly, it's appropriate to use a convenience method provided
-           by :class:`.RequestMethods`, such as :meth:`.request`.
+           by :class:`.RequestMethods`, such as :meth:`request`.
 
         .. note::
 


### PR DESCRIPTION
...cross-reference warnings.

If you want it this commit with fix those warnings.
