### PR TITLE
Log to DEBUG instead of INFO when a new connection is started

### DIFF
--- a/urllib3/connectionpool.py
+++ b/urllib3/connectionpool.py
@@ -186,7 +186,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         Return a fresh :class:`httplib.HTTPConnection`.
         """
         self.num_connections += 1
-        log.info("Starting new HTTP connection (%d): %s" %
+        log.debug("Starting new HTTP connection (%d): %s" %
                  (self.num_connections, self.host))
         return HTTPConnection(host=self.host, port=self.port)
 
@@ -482,7 +482,7 @@ class HTTPSConnectionPool(HTTPConnectionPool):
         Return a fresh :class:`httplib.HTTPSConnection`.
         """
         self.num_connections += 1
-        log.info("Starting new HTTPS connection (%d): %s"
+        log.debug("Starting new HTTPS connection (%d): %s"
                  % (self.num_connections, self.host))
 
         if not ssl: # Platform-specific: Python compiled without +ssl


### PR DESCRIPTION
Logging to INFO creates a lot of noise in the log files when making consecutive requests, e.g., batch requests to the Facebook API. For example:

2012-05-13T17:14:00.411 requests.packages.urllib3.connectionpool: INFO: Starting new HTTPS connection (1): graph.facebook.com
2012-05-13T17:14:01.099 requests.packages.urllib3.connectionpool: INFO: Starting new HTTPS connection (1): graph.facebook.com
2012-05-13T17:14:02.374 requests.packages.urllib3.connectionpool: INFO: Starting new HTTPS connection (1): graph.facebook.com
2012-05-13T17:14:03.238 requests.packages.urllib3.connectionpool: INFO: Starting new HTTPS connection (1): graph.facebook.com
2012-05-13T17:14:04.338 requests.packages.urllib3.connectionpool: INFO: Starting new HTTPS connection (1): graph.facebook.com
2012-05-13T17:14:05.474 requests.packages.urllib3.connectionpool: INFO: Starting new HTTPS connection (1): graph.facebook.com
2012-05-13T17:14:06.240 requests.packages.urllib3.connectionpool: INFO: Starting new HTTPS connection (1): graph.facebook.com
2012-05-13T17:14:07.131 requests.packages.urllib3.connectionpool: INFO: Starting new HTTPS connection (1): graph.facebook.com
2012-05-13T17:14:07.800 requests.packages.urllib3.connectionpool: INFO: Starting new HTTPS connection (1): graph.facebook.com
2012-05-13T17:14:08.685 requests.packages.urllib3.connectionpool: INFO: Starting new HTTPS connection (1): graph.facebook.com
2012-05-13T17:14:09.830 requests.packages.urllib3.connectionpool: INFO: Starting new HTTPS connection (1): graph.facebook.com
2012-05-13T17:14:10.612 requests.packages.urllib3.connectionpool: INFO: Starting new HTTPS connection (1): graph.facebook.com
2012-05-13T17:14:11.476 requests.packages.urllib3.connectionpool: INFO: Starting new HTTPS connection (1): graph.facebook.com
2012-05-13T17:14:12.355 requests.packages.urllib3.connectionpool: INFO: Starting new HTTPS connection (1): graph.facebook.com
2012-05-13T17:14:13.302 requests.packages.urllib3.connectionpool: INFO: Starting new HTTPS connection (1): graph.facebook.com
2012-05-13T17:14:14.644 requests.packages.urllib3.connectionpool: INFO: Starting new HTTPS connection (1): graph.facebook.com
2012-05-13T17:14:15.463 requests.packages.urllib3.connectionpool: INFO: Starting new HTTPS connection (1): graph.facebook.com
2012-05-13T17:14:16.164 requests.packages.urllib3.connectionpool: INFO: Starting new HTTPS connection (1): graph.facebook.com
2012-05-13T17:14:54.365 requests.packages.urllib3.connectionpool: INFO: Starting new HTTPS connection (1): graph.facebook.com
2012-05-13T17:14:56.520 requests.packages.urllib3.connectionpool: INFO: Starting new HTTPS connection (1): graph.facebook.com
2012-05-13T17:15:02.474 requests.packages.urllib3.connectionpool: INFO: Starting new HTTPS connection (1): graph.facebook.com
2012-05-13T17:15:04.426 requests.packages.urllib3.connectionpool: INFO: Starting new HTTPS connection (1): graph.facebook.com
