### PR TITLE
Refactor to support eager release of pooled connections

### DIFF
--- a/test/test_collections.py
+++ b/test/test_collections.py
@@ -36,19 +36,7 @@ class TestLRUContainer(unittest.TestCase):
         d[5] = '5'
 
         # Check state
-        self.assertEqual(list(d.keys()), [0, 2, 3, 4, 5])
-
-    def test_pruning(self):
-        d = Container(5)
-
-        for i in xrange(5):
-            d[i] = str(i)
-
-        # Contend 2 entries for the most-used slot to balloon the heap
-        for i in xrange(100):
-            d.get(i % 2)
-
-        self.assertTrue(len(d.access_log) <= d.CLEANUP_FACTOR * d._maxsize)
+        self.assertEqual(list(d.keys()), [2, 3, 4, 0, 5])
 
     def test_same_key(self):
         d = Container(5)
@@ -57,10 +45,7 @@ class TestLRUContainer(unittest.TestCase):
             d['foo'] = i
 
         self.assertEqual(list(d.keys()), ['foo'])
-
-        d._prune_invalidated_entries()
-
-        self.assertEqual(len(d.access_log), 1)
+        self.assertEqual(len(d), 1)
 
     def test_access_ordering(self):
         d = Container(5)
@@ -68,13 +53,14 @@ class TestLRUContainer(unittest.TestCase):
         for i in xrange(10):
             d[i] = True
 
-        self.assertEqual(d._get_ordered_access_keys(), [9,8,7,6,5])
+        # keys should be ordered by access time
+        self.assertEqual(list(d.keys()), [5, 6, 7, 8, 9])
 
         new_order = [7,8,6,9,5]
-        for k in reversed(new_order):
+        for k in new_order:
             d[k]
 
-        self.assertEqual(d._get_ordered_access_keys(), new_order)
+        self.assertEqual(list(d.keys()), new_order)
 
     def test_delete(self):
         d = Container(5)
@@ -107,6 +93,26 @@ class TestLRUContainer(unittest.TestCase):
 
         self.assertRaises(KeyError, lambda: d[5])
 
+    def test_disposal(self):
+        evicted_items = []
+        def dispose_func(arg):
+            # save the evicted datum for inspection
+            evicted_items.append(arg)
+
+        d = Container(5, dispose_func=dispose_func)
+        for i in xrange(5):
+            d[i] = i
+        self.assertEqual(list(d.keys()), list(xrange(5)))
+        # nothing should have been disposed
+        self.assertEqual(evicted_items, [])
+
+        d[5] = 5
+        self.assertEqual(list(d.keys()), list(xrange(1, 6)))
+        # dispose_func should have been called on the LRU item, 0
+        self.assertEqual(evicted_items, [0])
+
+        d.clear()
+        self.assertEqual(evicted_items, list(xrange(0, 6)))
 
 if __name__ == '__main__':
     unittest.main()

--- a/urllib3/_collections.py
+++ b/urllib3/_collections.py
@@ -3,129 +3,92 @@
 #
 # This module is part of urllib3 and is released under
 # the MIT License: http://www.opensource.org/licenses/mit-license.php
+from __future__ import with_statement
 
-from collections import deque
+import threading
+from collections import MutableMapping
 
-from threading import RLock
+try:
+    # available on 2.7 and up
+    from collections import OrderedDict
+    # hush pyflakes
+    OrderedDict
+except ImportError:
+    from .packages.ordered_dict import OrderedDict
 
 __all__ = ['RecentlyUsedContainer']
 
-
-class AccessEntry(object):
-    __slots__ = ('key', 'is_valid')
-
-    def __init__(self, key, is_valid=True):
-        self.key = key
-        self.is_valid = is_valid
-
-
-class RecentlyUsedContainer(dict):
+class RecentlyUsedContainer(MutableMapping):
     """
     Provides a dict-like that maintains up to ``maxsize`` keys while throwing
     away the least-recently-used keys beyond ``maxsize``.
     """
 
-    # If len(self.access_log) exceeds self._maxsize * CLEANUP_FACTOR, then we
-    # will attempt to cleanup the invalidated entries in the access_log
-    # datastructure during the next 'get' operation.
-    CLEANUP_FACTOR = 10
+    # this is an object no one else knows about, sort of a hyper-None
+    # cf. the implementation of OrderedDict
+    __marker = object()
 
-    def __init__(self, maxsize=10):
+    def __init__(self, maxsize=10, dispose_func=None):
+        """Constructor.
+
+        Args:
+            maxsize - int, maximum number of elements to retain
+            dispose_func - callback taking a single argument, called to destroy
+                elements that are being evicted or released
+        """
         self._maxsize = maxsize
+        self.dispose_func = dispose_func
 
-        self._container = {}
+        # OrderedDict is not inherently threadsafe, so protect it with a lock
+        self._mapping = OrderedDict()
+        self._lock = threading.Lock()
 
-        # We use a deque to to store our keys ordered by the last access.
-        self.access_log = deque()
-        self.access_log_lock = RLock()
+    def clear(self):
+        with self._lock:
+            # copy pointers to all values, then wipe the mapping
+            # under Python 2, this copies the list of values twice :-|
+            values = list(self._mapping.values())
+            self._mapping.clear()
 
-        # We look up the access log entry by the key to invalidate it so we can
-        # insert a new authorative entry at the head without having to dig and
-        # find the old entry for removal immediately.
-        self.access_lookup = {}
-
-        # Trigger a heap cleanup when we get past this size
-        self.access_log_limit = maxsize * self.CLEANUP_FACTOR
-
-    def _invalidate_entry(self, key):
-        "If exists: Invalidate old entry and return it."
-        old_entry = self.access_lookup.get(key)
-        if old_entry:
-            old_entry.is_valid = False
-
-        return old_entry
-
-    def _push_entry(self, key):
-        "Push entry onto our access log, invalidate the old entry if exists."
-        self._invalidate_entry(key)
-
-        new_entry = AccessEntry(key)
-        self.access_lookup[key] = new_entry
-
-        self.access_log_lock.acquire()
-        self.access_log.appendleft(new_entry)
-        self.access_log_lock.release()
-
-    def _prune_entries(self, num):
-        "Pop entries from our access log until we popped ``num`` valid ones."
-        while num > 0:
-            self.access_log_lock.acquire()
-            p = self.access_log.pop()
-            self.access_log_lock.release()
-
-            if not p.is_valid:
-                continue # Invalidated entry, skip
-
-            dict.pop(self, p.key, None)
-            self.access_lookup.pop(p.key, None)
-            num -= 1
-
-    def _prune_invalidated_entries(self):
-        "Rebuild our access_log without the invalidated entries."
-        self.access_log_lock.acquire()
-        self.access_log = deque(e for e in self.access_log if e.is_valid)
-        self.access_log_lock.release()
-
-    def _get_ordered_access_keys(self):
-        "Return ordered access keys for inspection. Used for testing."
-        self.access_log_lock.acquire()
-        r = [e.key for e in self.access_log if e.is_valid]
-        self.access_log_lock.release()
-
-        return r
+        if self.dispose_func:
+            for value in values:
+                self.dispose_func(value)
 
     def __getitem__(self, key):
-        item = dict.get(self, key)
-
-        if not item:
-            raise KeyError(key)
-
-        # Insert new entry with new high priority, also implicitly invalidates
-        # the old entry.
-        self._push_entry(key)
-
-        if len(self.access_log) > self.access_log_limit:
-            # Heap is getting too big, try to clean up any tailing invalidated
-            # entries.
-            self._prune_invalidated_entries()
-
-        return item
+        with self._lock:
+            # remove and re-add the item, moving it to the end of the eviction line
+            # throw the KeyError back to calling code if it's not present:
+            item = self._mapping.pop(key)
+            self._mapping[key] = item
+            return item
 
     def __setitem__(self, key, item):
-        # Add item to our container and access log
-        dict.__setitem__(self, key, item)
-        self._push_entry(key)
+        evicted_entry = self.__marker
+        with self._lock:
+            # possibly evict the existing value of 'key'
+            evicted_entry = self._mapping.get(key, self.__marker)
+            self._mapping[key] = item
+            # if we didn't evict an existing value, we might have to evict the LRU value
+            if len(self._mapping) > self._maxsize:
+                # pop from the beginning of the dict
+                _key, evicted_entry = self._mapping.popitem(last=False)
 
-        # Discard invalid and excess entries
-        self._prune_entries(len(self) - self._maxsize)
+        if self.dispose_func and evicted_entry is not self.__marker:
+            self.dispose_func(evicted_entry)
 
     def __delitem__(self, key):
-        self._invalidate_entry(key)
-        self.access_lookup.pop(key, None)
-        dict.__delitem__(self, key)
+        with self._lock:
+            entry = self._mapping.pop(key)
+        if self.dispose_func:
+            self.dispose_func(entry)
 
-    def get(self, key, default=None):
-        try:
-            return self[key]
-        except KeyError:
-            return default
+    def __len__(self):
+        with self._lock:
+            return len(self._mapping)
+
+    def __iter__(self):
+        raise NotImplementedError('Iteration over this class is unlikely to be threadsafe.')
+
+    def keys(self):
+        with self._lock:
+            return self._mapping.keys()

--- a/urllib3/packages/ordered_dict.py
+++ b/urllib3/packages/ordered_dict.py
@@ -1,0 +1,260 @@
+# Backport of OrderedDict() class that runs on Python 2.4, 2.5, 2.6, 2.7 and pypy.
+# Passes Python2.7's test suite and incorporates all the latest updates.
+# Copyright 2009 Raymond Hettinger, released under the MIT License.
+# http://code.activestate.com/recipes/576693/
+
+try:
+    from thread import get_ident as _get_ident
+except ImportError:
+    from dummy_thread import get_ident as _get_ident
+
+try:
+    from _abcoll import KeysView, ValuesView, ItemsView
+except ImportError:
+    pass
+
+
+class OrderedDict(dict):
+    'Dictionary that remembers insertion order'
+    # An inherited dict maps keys to values.
+    # The inherited dict provides __getitem__, __len__, __contains__, and get.
+    # The remaining methods are order-aware.
+    # Big-O running times for all methods are the same as for regular dictionaries.
+
+    # The internal self.__map dictionary maps keys to links in a doubly linked list.
+    # The circular doubly linked list starts and ends with a sentinel element.
+    # The sentinel element never gets deleted (this simplifies the algorithm).
+    # Each link is stored as a list of length three:  [PREV, NEXT, KEY].
+
+    def __init__(self, *args, **kwds):
+        '''Initialize an ordered dictionary.  Signature is the same as for
+        regular dictionaries, but keyword arguments are not recommended
+        because their insertion order is arbitrary.
+
+        '''
+        if len(args) > 1:
+            raise TypeError('expected at most 1 arguments, got %d' % len(args))
+        try:
+            self.__root
+        except AttributeError:
+            self.__root = root = []                     # sentinel node
+            root[:] = [root, root, None]
+            self.__map = {}
+        self.__update(*args, **kwds)
+
+    def __setitem__(self, key, value, dict_setitem=dict.__setitem__):
+        'od.__setitem__(i, y) <==> od[i]=y'
+        # Setting a new item creates a new link which goes at the end of the linked
+        # list, and the inherited dictionary is updated with the new key/value pair.
+        if key not in self:
+            root = self.__root
+            last = root[0]
+            last[1] = root[0] = self.__map[key] = [last, root, key]
+        dict_setitem(self, key, value)
+
+    def __delitem__(self, key, dict_delitem=dict.__delitem__):
+        'od.__delitem__(y) <==> del od[y]'
+        # Deleting an existing item uses self.__map to find the link which is
+        # then removed by updating the links in the predecessor and successor nodes.
+        dict_delitem(self, key)
+        link_prev, link_next, key = self.__map.pop(key)
+        link_prev[1] = link_next
+        link_next[0] = link_prev
+
+    def __iter__(self):
+        'od.__iter__() <==> iter(od)'
+        root = self.__root
+        curr = root[1]
+        while curr is not root:
+            yield curr[2]
+            curr = curr[1]
+
+    def __reversed__(self):
+        'od.__reversed__() <==> reversed(od)'
+        root = self.__root
+        curr = root[0]
+        while curr is not root:
+            yield curr[2]
+            curr = curr[0]
+
+    def clear(self):
+        'od.clear() -> None.  Remove all items from od.'
+        try:
+            for node in self.__map.itervalues():
+                del node[:]
+            root = self.__root
+            root[:] = [root, root, None]
+            self.__map.clear()
+        except AttributeError:
+            pass
+        dict.clear(self)
+
+    def popitem(self, last=True):
+        '''od.popitem() -> (k, v), return and remove a (key, value) pair.
+        Pairs are returned in LIFO order if last is true or FIFO order if false.
+
+        '''
+        if not self:
+            raise KeyError('dictionary is empty')
+        root = self.__root
+        if last:
+            link = root[0]
+            link_prev = link[0]
+            link_prev[1] = root
+            root[0] = link_prev
+        else:
+            link = root[1]
+            link_next = link[1]
+            root[1] = link_next
+            link_next[0] = root
+        key = link[2]
+        del self.__map[key]
+        value = dict.pop(self, key)
+        return key, value
+
+    # -- the following methods do not depend on the internal structure --
+
+    def keys(self):
+        'od.keys() -> list of keys in od'
+        return list(self)
+
+    def values(self):
+        'od.values() -> list of values in od'
+        return [self[key] for key in self]
+
+    def items(self):
+        'od.items() -> list of (key, value) pairs in od'
+        return [(key, self[key]) for key in self]
+
+    def iterkeys(self):
+        'od.iterkeys() -> an iterator over the keys in od'
+        return iter(self)
+
+    def itervalues(self):
+        'od.itervalues -> an iterator over the values in od'
+        for k in self:
+            yield self[k]
+
+    def iteritems(self):
+        'od.iteritems -> an iterator over the (key, value) items in od'
+        for k in self:
+            yield (k, self[k])
+
+    def update(*args, **kwds):
+        '''od.update(E, **F) -> None.  Update od from dict/iterable E and F.
+
+        If E is a dict instance, does:           for k in E: od[k] = E[k]
+        If E has a .keys() method, does:         for k in E.keys(): od[k] = E[k]
+        Or if E is an iterable of items, does:   for k, v in E: od[k] = v
+        In either case, this is followed by:     for k, v in F.items(): od[k] = v
+
+        '''
+        if len(args) > 2:
+            raise TypeError('update() takes at most 2 positional '
+                            'arguments (%d given)' % (len(args),))
+        elif not args:
+            raise TypeError('update() takes at least 1 argument (0 given)')
+        self = args[0]
+        # Make progressively weaker assumptions about "other"
+        other = ()
+        if len(args) == 2:
+            other = args[1]
+        if isinstance(other, dict):
+            for key in other:
+                self[key] = other[key]
+        elif hasattr(other, 'keys'):
+            for key in other.keys():
+                self[key] = other[key]
+        else:
+            for key, value in other:
+                self[key] = value
+        for key, value in kwds.items():
+            self[key] = value
+
+    __update = update  # let subclasses override update without breaking __init__
+
+    __marker = object()
+
+    def pop(self, key, default=__marker):
+        '''od.pop(k[,d]) -> v, remove specified key and return the corresponding value.
+        If key is not found, d is returned if given, otherwise KeyError is raised.
+
+        '''
+        if key in self:
+            result = self[key]
+            del self[key]
+            return result
+        if default is self.__marker:
+            raise KeyError(key)
+        return default
+
+    def setdefault(self, key, default=None):
+        'od.setdefault(k[,d]) -> od.get(k,d), also set od[k]=d if k not in od'
+        if key in self:
+            return self[key]
+        self[key] = default
+        return default
+
+    def __repr__(self, _repr_running={}):
+        'od.__repr__() <==> repr(od)'
+        call_key = id(self), _get_ident()
+        if call_key in _repr_running:
+            return '...'
+        _repr_running[call_key] = 1
+        try:
+            if not self:
+                return '%s()' % (self.__class__.__name__,)
+            return '%s(%r)' % (self.__class__.__name__, self.items())
+        finally:
+            del _repr_running[call_key]
+
+    def __reduce__(self):
+        'Return state information for pickling'
+        items = [[k, self[k]] for k in self]
+        inst_dict = vars(self).copy()
+        for k in vars(OrderedDict()):
+            inst_dict.pop(k, None)
+        if inst_dict:
+            return (self.__class__, (items,), inst_dict)
+        return self.__class__, (items,)
+
+    def copy(self):
+        'od.copy() -> a shallow copy of od'
+        return self.__class__(self)
+
+    @classmethod
+    def fromkeys(cls, iterable, value=None):
+        '''OD.fromkeys(S[, v]) -> New ordered dictionary with keys from S
+        and values equal to v (which defaults to None).
+
+        '''
+        d = cls()
+        for key in iterable:
+            d[key] = value
+        return d
+
+    def __eq__(self, other):
+        '''od.__eq__(y) <==> od==y.  Comparison to another OD is order-sensitive
+        while comparison to a regular mapping is order-insensitive.
+
+        '''
+        if isinstance(other, OrderedDict):
+            return len(self)==len(other) and self.items() == other.items()
+        return dict.__eq__(self, other)
+
+    def __ne__(self, other):
+        return not self == other
+
+    # -- the following methods are only used in Python 2.7 --
+
+    def viewkeys(self):
+        "od.viewkeys() -> a set-like object providing a view on od's keys"
+        return KeysView(self)
+
+    def viewvalues(self):
+        "od.viewvalues() -> an object providing a view on od's values"
+        return ValuesView(self)
+
+    def viewitems(self):
+        "od.viewitems() -> a set-like object providing a view on od's items"
+        return ItemsView(self)

--- a/urllib3/poolmanager.py
+++ b/urllib3/poolmanager.py
@@ -52,7 +52,15 @@ class PoolManager(RequestMethods):
 
     def __init__(self, num_pools=10, **connection_pool_kw):
         self.connection_pool_kw = connection_pool_kw
-        self.pools = RecentlyUsedContainer(num_pools)
+        self.pools = RecentlyUsedContainer(num_pools, dispose_func=lambda p: p.close())
+
+    def close(self):
+        """Empty our store of pools and direct them all to close.
+
+        This won't break in-flight connections, because the message is forwarded to
+        HTTPConnectionPool.close(), which is thread-safe.
+        """
+        self.pools.clear()
 
     def connection_from_host(self, host, port=80, scheme='http'):
         """


### PR DESCRIPTION
This is a rewrite of the eager release patch from kennethreitz/requests#616 against the current urllib3 master.

The "XXX: this isn't eager enough" issue has been corrected. However, I didn't move the disposal feature to a subclass of `RecentlyUsedContainer`, instead I ended up rewriting the original class against `OrderedDict` and adding the 2.6 backport of it to packages :-\

I got the unit tests here passing, then installed this branch in the current Requests development master and ran the tests there, but this probably needs more testing. I'm not entirely sure about the best way to do that, though.

Tell me what you think of the design? Thanks for your help.
