### PR TITLE
Please merge trivial change to allow some overrides

### DIFF
--- a/urllib3/poolmanager.py
+++ b/urllib3/poolmanager.py
@@ -85,12 +85,20 @@ class PoolManager(RequestMethods):
             return pool
 
         # Make a fresh ConnectionPool of the desired type
-        pool_cls = pool_classes_by_scheme[scheme]
-        pool = pool_cls(host, port, **self.connection_pool_kw)
-
+        pool = self._new_pool(scheme, host, port)
         self.pools[pool_key] = pool
-
         return pool
+
+    def _new_pool(self, scheme, host, port):
+        """
+        Create a new :class:`ConnectionPool` based on host, port and scheme.
+
+        This method is used to actually create the connection pools handed out
+        by :meth:`connection_from_url` and companion methods. It is intended
+        to be overridden for customization.
+        """
+        pool_cls = pool_classes_by_scheme[scheme]
+        return pool_cls(host, port, **self.connection_pool_kw)
 
     def connection_from_url(self, url):
         """


### PR DESCRIPTION
This commit allows code as this example:

https://gist.github.com/3559286

It is also a step in to support stuff like smart card based authentication as it allows replacing the connection factories for a single PoolManager. I used something like this to inject a SSL.Connection instance with a SSLContext that refers to a private key on a PKCS #11 token.
