### PR TITLE
request_encode_body will empty the potential headers defined when HTTPConnectionPool init

### DIFF
--- a/urllib3/request.py
+++ b/urllib3/request.py
@@ -121,7 +121,10 @@ class RequestMethods(object):
             body, content_type = (urlencode(fields or {}),
                                     'application/x-www-form-urlencoded')
 
-        headers = headers or {}
+        if hasattr(self, 'headers'):
+            headers = headers or self.headers or {}
+        else:
+            headers = headers or {}
         headers.update({'Content-Type': content_type})
 
         return self.urlopen(method, url, body=body, headers=headers,


### PR DESCRIPTION
When creating a `HTTPConnectionPool` object, you can pass `headers` which should be included in all requests. However the `request_encode_body` method from parent class will empty these default headers and add a `Content-Type` value, unless you pass `headers` explicitly when calling this method.

I think it's a bug and there is a rough fix.
