### PR TITLE
Handle non-ascii headers in multipart/form-data

### DIFF
--- a/test/test_response.py
+++ b/test/test_response.py
@@ -31,12 +31,6 @@ class TestResponse(unittest.TestCase):
         r = HTTPResponse(None)
         self.assertEqual(r.data, None)
 
-    def test_release_conn(self):
-        r = HTTPResponse(None)
-        r._fp = BytesIO()
-        r.release_conn()
-        self.assertTrue(r._fp.closed)
-
     def test_preload(self):
         fp = BytesIO(b'foo')
 

--- a/urllib3/response.py
+++ b/urllib3/response.py
@@ -94,9 +94,6 @@ class HTTPResponse(object):
         return False
 
     def release_conn(self):
-        if self._fp:
-            self._fp.close()
-
         if not self._pool or not self._connection:
             return
 


### PR DESCRIPTION
These commits fix shazow/urllib3#119 as well as a broken indentation of another test case.
