### PR TITLE
connectionpool: pass strict to the HTTP and HTTPSConnections.

### DIFF
--- a/urllib3/connectionpool.py
+++ b/urllib3/connectionpool.py
@@ -190,7 +190,9 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         self.num_connections += 1
         log.info("Starting new HTTP connection (%d): %s" %
                  (self.num_connections, self.host))
-        return HTTPConnection(host=self.host, port=self.port)
+        return HTTPConnection(host=self.host,
+                              port=self.port,
+                              strict=self.strict)
 
     def _get_conn(self, timeout=None):
         """
@@ -531,9 +533,13 @@ class HTTPSConnectionPool(HTTPConnectionPool):
                 raise SSLError("Can't connect to HTTPS URL because the SSL "
                                "module is not available.")
 
-            return HTTPSConnection(host=self.host, port=self.port)
+            return HTTPSConnection(host=self.host,
+                                   port=self.port,
+                                   strict=self.strict)
 
-        connection = VerifiedHTTPSConnection(host=self.host, port=self.port)
+        connection = VerifiedHTTPSConnection(host=self.host,
+                                             port=self.port,
+                                             strict=self.strict)
         connection.set_cert(key_file=self.key_file, cert_file=self.cert_file,
                             cert_reqs=self.cert_reqs, ca_certs=self.ca_certs)
         return connection


### PR DESCRIPTION
While writing a small app with Requests, I discovered that an app I want to integrate with is pretty brain-dead with  SSL, and will return garbage at you if you accidentally use HTTP vs. HTTPS.  Unfortunately, Requests was happy to say it was successful.  Come to find out that turning on strict is the answer (as I don't care about operating with an HTTP 0.9 server), but urllib3 doesn't actually pass the strict parameter to the underlying connection.  This PR solves that problem.

FYI: I tried running tests, but they fail (without my patch).  It looks like several servers are being started, and one of them is unhappy because another one is listening on the same port.  Then it dies, and the tests don't proceed any further.
