### PR TITLE
Switch uses of `with self.assertRaises(...)` to standard calls.

### DIFF
--- a/test/test_collections.py
+++ b/test/test_collections.py
@@ -119,9 +119,7 @@ class TestLRUContainer(unittest.TestCase):
     def test_iter(self):
         d = Container()
 
-        with self.assertRaises(NotImplementedError):
-            for i in d:
-                self.fail("Iteration shouldn't be implemented.")
+        self.assertRaises(NotImplementedError, d.__iter__)
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_connectionpool.py
+++ b/test/test_connectionpool.py
@@ -106,7 +106,7 @@ class TestConnectionPool(unittest.TestCase):
                 HTTPConnectionPool(host='localhost'), "Test.", err)),
             "HTTPConnectionPool(host='localhost', port=None): "
             "Max retries exceeded with url: Test. "
-            "(Caused by {}: Test)".format(str(err.__class__)))
+            "(Caused by {0}: Test)".format(str(err.__class__)))
 
     def test_pool_size(self):
         POOL_SIZE = 1
@@ -117,8 +117,7 @@ class TestConnectionPool(unittest.TestCase):
 
         def _test(exception, expect):
             pool._make_request = lambda *args, **kwargs: _raise(exception)
-            with self.assertRaises(expect):
-                pool.request('GET', '/')
+            self.assertRaises(expect, pool.request, 'GET', '/')
 
             self.assertEqual(pool.pool.qsize(), POOL_SIZE)
 
@@ -133,15 +132,15 @@ class TestConnectionPool(unittest.TestCase):
         # MaxRetryError, not EmptyPoolError
         # See: https://github.com/shazow/urllib3/issues/76
         pool._make_request = lambda *args, **kwargs: _raise(HTTPException)
-        with self.assertRaises(MaxRetryError):
-            pool.request('GET', '/', retries=1, pool_timeout=0.01)
+        self.assertRaises(MaxRetryError, pool.request,
+                          'GET', '/', retries=1, pool_timeout=0.01)
         self.assertEqual(pool.pool.qsize(), POOL_SIZE)
 
     def test_assert_same_host(self):
         c = connection_from_url('http://google.com:80')
 
-        with self.assertRaises(HostChangedError):
-            c.request('GET', 'http://yahoo.com:80', assert_same_host=True)
+        self.assertRaises(HostChangedError, c.request,
+                          'GET', 'http://yahoo.com:80', assert_same_host=True)
 
     def test_pool_close(self):
         pool = connection_from_url('http://google.com:80')
@@ -158,16 +157,13 @@ class TestConnectionPool(unittest.TestCase):
         pool.close()
         self.assertEqual(pool.pool, None)
 
-        with self.assertRaises(ClosedPoolError):
-            pool._get_conn()
+        self.assertRaises(ClosedPoolError, pool._get_conn)
 
         pool._put_conn(conn3)
 
-        with self.assertRaises(ClosedPoolError):
-            pool._get_conn()
+        self.assertRaises(ClosedPoolError, pool._get_conn)
 
-        with self.assertRaises(Empty):
-            old_pool_queue.get(block=False)
+        self.assertRaises(Empty, old_pool_queue.get, block=False)
 
 
 

--- a/test/test_poolmanager.py
+++ b/test/test_poolmanager.py
@@ -54,13 +54,11 @@ class TestPoolManager(unittest.TestCase):
         p.clear()
         self.assertEqual(len(p.pools), 0)
 
-        with self.assertRaises(ClosedPoolError):
-            conn_pool._get_conn()
+        self.assertRaises(ClosedPoolError, conn_pool._get_conn)
 
         conn_pool._put_conn(conn)
 
-        with self.assertRaises(ClosedPoolError):
-            conn_pool._get_conn()
+        self.assertRaises(ClosedPoolError, conn_pool._get_conn)
 
         self.assertEqual(len(p.pools), 0)
 

--- a/test/with_dummyserver/test_connectionpool.py
+++ b/test/with_dummyserver/test_connectionpool.py
@@ -105,23 +105,22 @@ class TestConnectionPool(HTTPDummyServerTestCase):
         pool = HTTPConnectionPool(self.host, self.port, timeout=timeout)
 
         conn = pool._get_conn()
-        with self.assertRaises(SocketTimeout):
-            pool._make_request(conn, 'GET', url)
+        self.assertRaises(SocketTimeout, pool._make_request,
+                          conn, 'GET', url)
         pool._put_conn(conn)
 
-        with self.assertRaises(TimeoutError):
-            pool.request('GET', url)
+        self.assertRaises(TimeoutError, pool.request, 'GET', url)
 
         # Request-specific timeout
         pool = HTTPConnectionPool(self.host, self.port, timeout=0.5)
 
         conn = pool._get_conn()
-        with self.assertRaises(SocketTimeout):
-            pool._make_request(conn, 'GET', url, timeout=timeout)
+        self.assertRaises(SocketTimeout, pool._make_request,
+                          conn, 'GET', url, timeout=timeout)
         pool._put_conn(conn)
 
-        with self.assertRaises(TimeoutError):
-            pool.request('GET', url, timeout=timeout)
+        self.assertRaises(TimeoutError, pool.request,
+                          'GET', url, timeout=timeout)
 
     def test_redirect(self):
         r = self.pool.request('GET', '/redirect', fields={'target': '/'}, redirect=False)
@@ -245,13 +244,13 @@ class TestConnectionPool(HTTPDummyServerTestCase):
         self.assertEqual(r.data, b'hello, world!')
 
     def test_bad_decode(self):
-        with self.assertRaises(DecodeError):
-            self.pool.request('GET', '/encodingrequest',
-                              headers={'accept-encoding': 'garbage-deflate'})
+        self.assertRaises(DecodeError, self.pool.request,
+                          'GET', '/encodingrequest',
+                          headers={'accept-encoding': 'garbage-deflate'})
 
-        with self.assertRaises(DecodeError):
-            self.pool.request('GET', '/encodingrequest',
-                              headers={'accept-encoding': 'garbage-gzip'})
+        self.assertRaises(DecodeError, self.pool.request,
+                          'GET', '/encodingrequest',
+                          headers={'accept-encoding': 'garbage-gzip'})
 
     def test_connection_count(self):
         pool = HTTPConnectionPool(self.host, self.port, maxsize=1)

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -72,8 +72,7 @@ class TestSocketClosing(SocketDummyServerTestCase):
         # Does the pool retry if there is no listener on the port?
         # Note: Socket server is not started until after the test.
         pool = HTTPConnectionPool(self.host, self.port)
-        with self.assertRaises(MaxRetryError):
-            pool.request('GET', '/')
+        self.assertRaises(MaxRetryError, pool.request, 'GET', '/')
         self._start_server(lambda x: None)
 
     def test_connection_timeout(self):
@@ -86,8 +85,7 @@ class TestSocketClosing(SocketDummyServerTestCase):
         self._start_server(socket_handler)
         pool = HTTPConnectionPool(self.host, self.port, timeout=0.001)
 
-        with self.assertRaises(TimeoutError):
-            pool.request('GET', '/', retries=0)
+        self.assertRaises(TimeoutError, pool.request, 'GET', '/', retries=0)
 
         timed_out.set()
 


### PR DESCRIPTION
In Python 2.6, `self.assertRaises()` is not a ContextManager, and can't be
used with the `with` statement.
