### PR TITLE
Close connection when no data is read.

### DIFF
--- a/urllib3/response.py
+++ b/urllib3/response.py
@@ -145,7 +145,17 @@ class HTTPResponse(object):
                 # cStringIO doesn't like amt=None
                 data = self._fp.read()
             else:
-                return self._fp.read(amt)
+                data = self._fp.read(amt)
+                # Close the connection when no data is returned
+                #
+                # This is redundant to what httplib/http.client _should_
+                # already do.  However, versions of python released before
+                # December 15, 2012 (http://bugs.python.org/issue16298) do not
+                # properly close the connection in all cases. There is no harm
+                # in redundantly calling close.
+                if amt != 0 and not data:
+                    self._fp.close()
+                return data
 
             try:
                 if decode_content and decoder:


### PR DESCRIPTION
As per the long discussion in PR #132 that originated with kennethreitz/requests#1041 the solution is to make sure to read the EOF marker in order for httplib to automatically shutdown the connection. This actually occurs already with httplib in all but one condition (how requests uses it).

While there is an [upstream fix](http://hg.python.org/cpython/rev/5d6c2c7bc5d4), not everyone will upgrade to the newest releases of python 2.7 and 3.2+. This pull request fixes the behavior on urllib3 in a way that won't break if someone is running a version of python with the upstream fix (subsequent `close` calls have no effect).

I have verified that this fixes kennethreitz/requests#1041 when I applied this code to the version of urllib3 included with requests.
