### PR TITLE
Safely access to 'pool_classes_by_scheme' avoiding possible KeyErrors.

### DIFF
--- a/urllib3/poolmanager.py
+++ b/urllib3/poolmanager.py
@@ -85,7 +85,7 @@ class PoolManager(RequestMethods):
             return pool
 
         # Make a fresh ConnectionPool of the desired type
-        pool_cls = pool_classes_by_scheme[scheme]
+        pool_cls = pool_classes_by_scheme.get(scheme, 'http')
         pool = pool_cls(host, port, **self.connection_pool_kw)
 
         self.pools[pool_key] = pool


### PR DESCRIPTION
Access safely to "pool_classes_by_scheme" because "scheme" can be None, and we must provide a default action to be taken or a KeyError will ocurr.

Copied the same structure like the line 77 on the same file, that takes the HTTP protocol as default.
