### PR TITLE
Check for a blank host while opening a connection

### DIFF
--- a/urllib3/connectionpool.py
+++ b/urllib3/connectionpool.py
@@ -55,6 +55,7 @@ from .exceptions import (
 
 from .packages.ssl_match_hostname import match_hostname, CertificateError
 from .packages import six
+from .util import parse_url
 
 
 xrange = six.moves.xrange
@@ -572,8 +573,12 @@ def connection_from_url(url, **kw):
         >>> conn = connection_from_url('http://google.com/')
         >>> r = conn.request('GET', '/')
     """
-    scheme, host, port = get_host(url)
-    if scheme == 'https':
-        return HTTPSConnectionPool(host, port=port, **kw)
+
+    u = parse_url(url)
+    if u.host is None:
+        raise ValueError('No host given')
+
+    if u.scheme == 'https':
+        return HTTPSConnectionPool(u.host, port=u.port, **kw)
     else:
-        return HTTPConnectionPool(host, port=port, **kw)
+        return HTTPConnectionPool(u.host, port=u.port, **kw)

--- a/urllib3/poolmanager.py
+++ b/urllib3/poolmanager.py
@@ -111,6 +111,9 @@ class PoolManager(RequestMethods):
         constructor.
         """
         u = parse_url(url)
+        if u.host is None:
+            raise ValueError('No host given')
+
         return self.connection_from_host(u.host, port=u.port, scheme=u.scheme)
 
     def urlopen(self, method, url, redirect=True, **kw):
@@ -123,6 +126,9 @@ class PoolManager(RequestMethods):
         :class:`urllib3.connectionpool.ConnectionPool` can be chosen for it.
         """
         u = parse_url(url)
+        if u.host is None:
+            raise ValueError('No host given')
+
         conn = self.connection_from_host(u.host, port=u.port, scheme=u.scheme)
 
         kw['assert_same_host'] = False


### PR DESCRIPTION
Because we can't open a http(s) connection to host, which equals to None.

I'm not sure, if this check should be done in the `urllib3.parse_url`, because it can be used to parse URLs like a `file:///tmp/some_file.txt`.

Also, see issue #143 for a first part of the discussion.
