### PR TITLE
Speed up tests on Windows

### DIFF
--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -102,7 +102,7 @@ class TestSocketClosing(SocketDummyServerTestCase):
         # Does the pool retry if there is no listener on the port?
         # Note: Socket server is not started until after the test.
         pool = HTTPConnectionPool(self.host, self.port)
-        self.assertRaises(MaxRetryError, pool.request, 'GET', '/')
+        self.assertRaises(MaxRetryError, pool.request, 'GET', '/', retries=0)
         self._start_server(lambda x: None)
 
     def test_connection_timeout(self):


### PR DESCRIPTION
This reduces the test duration from ~13 seconds to ~7 seconds on Windows (Python 2.7).
