### PR TITLE
Pass DontVerify singleton to assert_hostname to bypass SSL hostname verification

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -64,5 +64,8 @@ In chronological order:
   * Correct six.moves conflict
   * Fixed pickle support of some exceptions
 
+* Boris Figovsky <boris.figovsky@ravellosystems.com>
+  * Allowed to skip SSL hostname verification
+
 * [Your name or handle] <[email or website]>
   * [Brief summary of your changes]

--- a/test/with_dummyserver/test_https.py
+++ b/test/with_dummyserver/test_https.py
@@ -7,7 +7,7 @@ from dummyserver.testcase import HTTPSDummyServerTestCase
 from dummyserver.server import DEFAULT_CA, DEFAULT_CA_BAD, DEFAULT_CERTS
 
 from urllib3 import HTTPSConnectionPool
-from urllib3.connectionpool import VerifiedHTTPSConnection
+from urllib3.connectionpool import VerifiedHTTPSConnection, DontVerify
 from urllib3.exceptions import SSLError
 
 
@@ -114,6 +114,14 @@ class TestHTTPS(HTTPSDummyServerTestCase):
         https_pool.ca_certs = '/no_valid_path_to_ca_certs'
 
         self.assertRaises(SSLError, https_pool.request, 'GET', '/')
+
+    def test_dont_verify_hostname(self):
+        https_pool = HTTPSConnectionPool('127.0.0.1', self.port,
+                                         cert_reqs='CERT_REQUIRED')
+
+        https_pool.ca_certs = DEFAULT_CA
+        https_pool.assert_hostname = DontVerify
+        https_pool.request('GET', '/')
 
     def test_assert_specific_hostname(self):
         https_pool = HTTPSConnectionPool('127.0.0.1', self.port,

--- a/urllib3/connectionpool.py
+++ b/urllib3/connectionpool.py
@@ -68,6 +68,9 @@ port_by_scheme = {
     'https': HTTPS_PORT,
 }
 
+class DontVerify(object):
+    pass
+DontVerify = DontVerify()
 
 ## Connection objects (extension of httplib)
 
@@ -110,7 +113,7 @@ class VerifiedHTTPSConnection(HTTPSConnection):
             if self.assert_fingerprint:
                 assert_fingerprint(self.sock.getpeercert(binary_form=True),
                                    self.assert_fingerprint)
-            else:
+            elif self.assert_hostname is not DontVerify:
                 match_hostname(self.sock.getpeercert(),
                                self.assert_hostname or self.host)
 


### PR DESCRIPTION
This commit adds a `DontVerify` singleton to pass via `assert_hostname` to disable SSL hostname verification.

This is the result of the discussion at #191 .
