### PR TITLE
Setting assert_hostname to False will disable SSL hostname verification

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -64,5 +64,8 @@ In chronological order:
   * Correct six.moves conflict
   * Fixed pickle support of some exceptions
 
+* Boris Figovsky <boris.figovsky@ravellosystems.com>
+  * Allowed to skip SSL hostname verification
+
 * [Your name or handle] <[email or website]>
   * [Brief summary of your changes]

--- a/test/with_dummyserver/test_https.py
+++ b/test/with_dummyserver/test_https.py
@@ -115,6 +115,14 @@ class TestHTTPS(HTTPSDummyServerTestCase):
 
         self.assertRaises(SSLError, https_pool.request, 'GET', '/')
 
+    def test_assert_hostname_false(self):
+        https_pool = HTTPSConnectionPool('127.0.0.1', self.port,
+                                         cert_reqs='CERT_REQUIRED')
+
+        https_pool.ca_certs = DEFAULT_CA
+        https_pool.assert_hostname = False
+        https_pool.request('GET', '/')
+
     def test_assert_specific_hostname(self):
         https_pool = HTTPSConnectionPool('127.0.0.1', self.port,
                                          cert_reqs='CERT_REQUIRED')

--- a/urllib3/connectionpool.py
+++ b/urllib3/connectionpool.py
@@ -110,7 +110,7 @@ class VerifiedHTTPSConnection(HTTPSConnection):
             if self.assert_fingerprint:
                 assert_fingerprint(self.sock.getpeercert(binary_form=True),
                                    self.assert_fingerprint)
-            else:
+            elif self.assert_hostname is not False:
                 match_hostname(self.sock.getpeercert(),
                                self.assert_hostname or self.host)
 
@@ -513,6 +513,7 @@ class HTTPSConnectionPool(HTTPConnectionPool):
 
     :class:`.VerifiedHTTPSConnection` uses one of ``assert_fingerprint``,
     ``assert_hostname`` and ``host`` in this order to verify connections.
+    If ``assert_hostname`` is False, no verification is done.
 
     The ``key_file``, ``cert_file``, ``cert_reqs``, ``ca_certs`` and
     ``ssl_version`` are only used if :mod:`ssl` is available and are fed into


### PR DESCRIPTION
This commit enables the use of `assert_hostname=False` to disable SSL hostname verification.
