### PR TITLE
Add missing WrappedSocket.fileno method in PyOpenSSL (issue #188)

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -72,5 +72,8 @@ In chronological order:
   * Return native strings in header values.
   * Generate 'Host' header when using proxies.
 
+* Jason Robinson <jaywink@basshero.org>
+  * Add missing WrappedSocket.fileno method in PyOpenSSL
+
 * [Your name or handle] <[email or website]>
   * [Brief summary of your changes]

--- a/urllib3/contrib/pyopenssl.py
+++ b/urllib3/contrib/pyopenssl.py
@@ -106,6 +106,9 @@ class WrappedSocket(object):
         self.connection = connection
         self.socket = socket
 
+    def fileno(self):
+        return self.socket.fileno()
+
     def makefile(self, mode, bufsize=-1):
         return _fileobject(self.connection, mode, bufsize)
 


### PR DESCRIPTION
This fixes (at least for myself) issue #188 where a missing fileno() method in the WrappedSocket object is required later in urllib3.util method is_connection_dropped() (or more precisely by the poll object select.poll.register() method called there).

I could try to provide a test though I'm not sure where to start, here for preliminary review if you think this fix is appropriate.

From Python documentation (http://docs.python.org/2/library/select) for poll.register method:

> ...
>  fd can be either an integer, or an object with a fileno() method that returns an integer.
> ...
