### PR TITLE
Fix a race condition between pools.get and pools.set

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -75,5 +75,8 @@ In chronological order:
 * Jason Robinson <jaywink@basshero.org>
   * Add missing WrappedSocket.fileno method in PyOpenSSL
 
+* Audrius Butkevicius <audrius.butkevicius@elastichosts.com>
+  * Fixed a race condition
+
 * [Your name or handle] <[email or website]>
   * [Brief summary of your changes]

--- a/urllib3/poolmanager.py
+++ b/urllib3/poolmanager.py
@@ -104,15 +104,16 @@ class PoolManager(RequestMethods):
 
         pool_key = (scheme, host, port)
 
-        # If the scheme, host, or port doesn't match existing open connections,
-        # open a new ConnectionPool.
-        pool = self.pools.get(pool_key)
-        if pool:
-            return pool
+        with self.pools.lock:
+          # If the scheme, host, or port doesn't match existing open connections,
+          # open a new ConnectionPool.
+          pool = self.pools.get(pool_key)
+          if pool:
+              return pool
 
-        # Make a fresh ConnectionPool of the desired type
-        pool = self._new_pool(scheme, host, port)
-        self.pools[pool_key] = pool
+          # Make a fresh ConnectionPool of the desired type
+          pool = self._new_pool(scheme, host, port)
+          self.pools[pool_key] = pool
         return pool
 
     def connection_from_url(self, url):


### PR DESCRIPTION
We have parallel threads opening multiple connections to the same destination which lead to discovery of this.

Sequence of events:
T1: pools.get results a None
T2: pools.get results a None
T1: creates a new pool with key (x,y,z)
T2: creates a new pool with key (x,y,z)
T1: adds the pool to pools container under key (x,y,z)
T2: adds the pool to pools container under key (x,y,z) replacing the pool set by T1, and as a result applying dispose_func (closing the pool)
T1: returns the now closed pool for use
T1: calls pool.urlopen and throws an exception
