### PR TITLE
Use real error class as fallback for BaseSSLError

### DIFF
--- a/urllib3/connectionpool.py
+++ b/urllib3/connectionpool.py
@@ -26,7 +26,10 @@ except ImportError:
 
 try: # Compiled with SSL?
     HTTPSConnection = object
-    BaseSSLError = None
+
+    class BaseSSLError(BaseException):
+        pass
+
     ssl = None
 
     try: # Python 3


### PR DESCRIPTION
If BaseSSLError is None, it is not a valid exception class and when evaluating
the try-except-block where all BaseSSLErrors are meant to be catched the python
interpreter blows up because of this.
