### PR TITLE
Be able to retrieve Peer SSL certificate from an HTTPResponse

### DIFF
--- a/urllib3/response.py
+++ b/urllib3/response.py
@@ -93,6 +93,10 @@ class HTTPResponse(io.IOBase):
         self._pool = pool
         self._connection = connection
 
+        if getattr(connection, 'sock', False) and\
+            getattr(connection.sock, 'getpeercert', False):
+            self.peer_cert = connection.sock.getpeercert(binary_form=True)
+
         if hasattr(body, 'read'):
             self._fp = body
 


### PR DESCRIPTION
I'm using python requests lib to create a request to an https/ssl server. Internally, it uses urllib3. In my specific use case, I need not to verify the server's certificate CA, but to store the ssl certificate itself to be able to check later in other connections that it's still using the same one.

This is not possible to do easily with urllib3 because the HTTPResponse class from response.py does not expose this information, specially after release_conn() has been called (before, one could still get that using response._connection.sock.getpeercert(binary_form=True)), but I can't do that as an user of requests library.

I propose to add the patched lines in the constructor of HTTPResponse so that the certificate will be always retrievable in an ssl req using "request.peer_cert".
