### PR TITLE
Correctly set Host header when using a proxy

### DIFF
--- a/test/test_proxymanager.py
+++ b/test/test_proxymanager.py
@@ -23,5 +23,14 @@ class TestProxyManager(unittest.TestCase):
 
         self.assertEqual(headers, provided_headers)
 
+        # Verify proxy with nonstandard port
+        provided_headers = {'Accept': 'application/json'}
+        expected_headers = provided_headers.copy()
+        expected_headers.update({'Host': 'pypi.python.org:8080'})
+        url_with_port = 'http://pypi.python.org:8080/test'
+        headers = p._set_proxy_headers(url_with_port, provided_headers)
+
+        self.assertEqual(headers, expected_headers)
+
 if __name__ == '__main__':
     unittest.main()

--- a/urllib3/poolmanager.py
+++ b/urllib3/poolmanager.py
@@ -181,9 +181,9 @@ class ProxyManager(RequestMethods):
         """
         headers_ = {'Accept': '*/*'}
 
-        host = parse_url(url).host
-        if host:
-            headers_['Host'] = host
+        netloc = parse_url(url).netloc
+        if netloc:
+            headers_['Host'] = netloc
 
         if headers:
             headers_.update(headers)


### PR DESCRIPTION
Fixed a bug in _set_proxy_headers that ignores the port when setting the
'Host' HTTP header while a proxy is used.
