### PR TITLE
Close socket used for port allocation.

### DIFF
--- a/dummyserver/testcase.py
+++ b/dummyserver/testcase.py
@@ -13,7 +13,9 @@ from dummyserver.server import (
 def get_free_port():
     s = socket.socket()
     s.bind(('127.0.0.1', 0))
-    return s.getsockname()[1]
+    port = s.getsockname()[1]
+    s.close()
+    return port
 
 
 class SocketDummyServerTestCase(unittest.TestCase):


### PR DESCRIPTION
I have seen some strange issues with such half-opened sockets, e.g. on Windows where you can't use SO_REUSEADDR.
