### PR TITLE
RFC: Fix WantReadError when using pyOpenSSL and Timeouts

### DIFF
--- a/urllib3/contrib/pyopenssl.py
+++ b/urllib3/contrib/pyopenssl.py
@@ -289,8 +289,9 @@ class WrappedSocket(object):
 
     def getpeercert(self, binary_form=False):
         x509 = self.connection.get_peer_certificate()
+
         if not x509:
-            raise ssl.SSLError('')
+            return x509
 
         if binary_form:
             return OpenSSL.crypto.dump_certificate(


### PR DESCRIPTION
Fixes the issues mentioned in kennethreitz/requests#749

Prevent WantReadError by using a fileobject which correctly handles those.
socket._fileobject which was previously used only handled builtin `EINTR` which
are is the corresponding error from the stdlib to WantReadError.
The new implementation inherits from socket._fileobject overwriting read() and
readline(). The overwritten methods are taken straight from CPython 2.7.5 and
modified as follows in the relevant places:

```
-except error, e:
-    if e.args[0] == EINTR:
-        continue
-    raise
+except OpenSSL.SSL.WantReadError:
+    continue
```

urllib3 itself only needs `readline()` overwritten, but requests also needs
`read()`.
The handshake could have been handled automatically by writes and reads, but
when requesting the certificate directly after connection setup an error is
thrown.
