### PR TITLE
avoid calling 'close' on a None object

### DIFF
--- a/urllib3/connectionpool.py
+++ b/urllib3/connectionpool.py
@@ -292,7 +292,8 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
                         % self.host)
 
         # Connection never got put back into the pool, close it.
-        conn.close()
+        if conn:
+            conn.close()
 
     def _make_request(self, conn, method, url, timeout=_Default,
                       **httplib_request_kw):


### PR DESCRIPTION
#### Ran into this in the field when used by the pyes client:

Unfortunately I am unable to give exact details on how to replicate this behavior at this time.
It appears that when the ES server is under heavy load that there are times when the `conn` variable is not initialized with a HTTPConnection and then the code attempts to 'close' it when it is put back in the pool.
This changeset merely validates that the `conn` variable passed in to `def _put_conn` is `truthy` before calling it's `close` method.

```
[Wed Aug 28 15:51:32 2013] [error] [client 103.8.52.41] File "/usr/lib/python2.6/site-packages/pyes/es.py", line 1171, in force_bulk 
[Wed Aug 28 15:51:32 2013] [error] [client 103.8.52.41] return self.flush_bulk(True) 
[Wed Aug 28 15:51:32 2013] [error] [client 103.8.52.41] File "/usr/lib/python2.6/site-packages/pyes/es.py", line 1163, in flush_bulk 
[Wed Aug 28 15:51:32 2013] [error] [client 103.8.52.41] return self.bulker.flush_bulk(forced) 
[Wed Aug 28 15:51:32 2013] [error] [client 103.8.52.41] File "/usr/lib/python2.6/site-packages/pyes/es.py", line 305, in flush_bulk 
[Wed Aug 28 15:51:32 2013] [error] [client 103.8.52.41] "\\n".join(batch) + "\\n") 
[Wed Aug 28 15:51:32 2013] [error] [client 103.8.52.41] File "/usr/lib/python2.6/site-packages/pyes/es.py", line 583, in _send_request 
[Wed Aug 28 15:51:32 2013] [error] [client 103.8.52.41] response = self.connection.execute(request) 
[Wed Aug 28 15:51:32 2013] [error] [client 103.8.52.41] File "/usr/lib/python2.6/site-packages/pyes/connection_http.py", line 94, in execute 
[Wed Aug 28 15:51:32 2013] [error] [client 103.8.52.41] response = conn.urlopen(**kwargs) 
[Wed Aug 28 15:51:32 2013] [error] [client 103.8.52.41] File "/usr/lib/python2.6/site-packages/urllib3/connectionpool.py", line 463, in urlopen 
[Wed Aug 28 15:51:32 2013] [error] [client 103.8.52.41] self._put_conn(conn) 
[Wed Aug 28 15:51:32 2013] [error] [client 103.8.52.41] File "/usr/lib/python2.6/site-packages/urllib3/connectionpool.py", line 253, in _put_conn 
[Wed Aug 28 15:51:32 2013] [error] [client 103.8.52.41] conn.close() 
[Wed Aug 28 15:51:32 2013] [error] [client 103.8.52.41] AttributeError: 'NoneType' object has no attribute 'close' 
```
