### PR TITLE
don't raise ProxyError in VerifiedHTTPSConnection

### DIFF
--- a/urllib3/connectionpool.py
+++ b/urllib3/connectionpool.py
@@ -98,11 +98,8 @@ class VerifiedHTTPSConnection(HTTPSConnection):
 
     def connect(self):
         # Add certificate verification
-        try:
-            sock = socket.create_connection((self.host, self.port),
-                                            self.timeout)
-        except SocketError as e:
-            raise ProxyError('Cannot connect to proxy. Socket error: %s.' % e)
+        sock = socket.create_connection((self.host, self.port),
+                                        self.timeout)
 
         resolved_cert_reqs = resolve_cert_reqs(self.cert_reqs)
         resolved_ssl_version = resolve_ssl_version(self.ssl_version)


### PR DESCRIPTION
Reverts a part of 51d485a (introduced in #221)

Before this path SocketErrors were always wrapped in ProxyErrors.
This should only happen if the connection is to a proxy.
Just remove the check as it will happen anyway in HTTPConnectionPool.url_open
