### PR TITLE
Reference PR for wrapping HTTP(S)Connection and disabling Nagle by default

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,8 @@ dev (master)
 * New `urllib3.connection` module which contains all the HTTPConnection
   objects.
 
+* Disable Nagle's Algorithm on the socket for non-proxies. (Issue #254)
+
 * ...
 
 

--- a/urllib3/connection.py
+++ b/urllib3/connection.py
@@ -8,9 +8,9 @@ import socket
 from socket import timeout as SocketTimeout
 
 try: # Python 3
-    from http.client import HTTPConnection, HTTPException
+    from http.client import HTTPConnection as _HTTPConnection, HTTPException
 except ImportError:
-    from httplib import HTTPConnection, HTTPException
+    from httplib import HTTPConnection as _HTTPConnection, HTTPException
 
 class DummyConnection(object):
     "Used to detect a failed ConnectionCls import."
@@ -24,9 +24,9 @@ try: # Compiled with SSL?
         pass
 
     try: # Python 3
-        from http.client import HTTPSConnection
+        from http.client import HTTPSConnection as _HTTPSConnection
     except ImportError:
-        from httplib import HTTPSConnection
+        from httplib import HTTPSConnection as _HTTPSConnection
 
     import ssl
     BaseSSLError = ssl.SSLError
@@ -44,6 +44,53 @@ from .util import (
     resolve_ssl_version,
     ssl_wrap_socket,
 )
+
+
+port_by_scheme = {
+    'http': 80,
+    'https': 443,
+}
+
+
+class HTTPConnection(object, _HTTPConnection):
+    default_port = port_by_scheme['http']
+
+    def _new_conn(self):
+        conn = socket.create_connection(
+            (self.host,self.port),
+            self.timeout,
+            self.source_address, # XXX: Support Py26 without source_address
+        )
+        conn.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+        return conn
+
+    def _prepare_conn(self, conn):
+        self.sock = conn
+        if self._tunnel_host:
+            # TODO: Fix tunnel so it doesn't depend on self.sock state.
+            self._tunnel()
+
+    def connect(self):
+        sock = self._new_conn()
+        self._prepare_conn(sock)
+
+
+class HTTPSConnection(HTTPConnection):
+    default_port = port_by_scheme['https']
+
+    def __init__(self, host, port=None, key_file=None, cert_file=None,
+                 strict=None, timeout=socket._GLOBAL_DEFAULT_TIMEOUT,
+                 source_address=None):
+        super(HTTPSConnection, self).__init__(
+            self, host, port, strict, timeout, source_address)
+        self.key_file = key_file
+        self.cert_file = cert_file
+
+    def connect(self):
+        sock = self._new_conn()
+        self._prepare_conn(sock)
+        self.sock = ssl.wrap_socket(sock, self.key_file, self.cert_file)
+
 
 class VerifiedHTTPSConnection(HTTPSConnection):
     """
@@ -76,6 +123,8 @@ class VerifiedHTTPSConnection(HTTPSConnection):
                 raise ConnectTimeoutError(
                     self, "Connection to %s timed out. (connect timeout=%s)" %
                     (self.host, self.timeout))
+
+        sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
 
         resolved_cert_reqs = resolve_cert_reqs(self.cert_reqs)
         resolved_ssl_version = resolve_ssl_version(self.ssl_version)

--- a/urllib3/connectionpool.py
+++ b/urllib3/connectionpool.py
@@ -30,6 +30,7 @@ from .exceptions import (
 from .packages.ssl_match_hostname import CertificateError
 from .packages import six
 from .connection import (
+    port_by_scheme,
     DummyConnection,
     HTTPConnection, HTTPSConnection, VerifiedHTTPSConnection,
     HTTPException, BaseSSLError,
@@ -49,12 +50,6 @@ xrange = six.moves.xrange
 log = logging.getLogger(__name__)
 
 _Default = object()
-
-port_by_scheme = {
-    'http': 80,
-    'https': 443,
-}
-
 
 ## Pool objects
 


### PR DESCRIPTION
This is a broken branch for now, but wanted to share my (little) progress...

Related to #253 and the discussion in #254. 

Outstanding issues:
- [ ] Can't inherit from httplib classes and use super(...) because they're old-style classes.
- [ ] I'd like to reduce repeating logic by reusing it in `_new_conn` and `_prepare_conn`. This is half-done.
- [ ] Consider whether we want to vendor in more of httplib/http.client logic into urllib3. Or maybe roll our own? Doesn't seem like that much... #famouslastwords (cc @lukasa)
  - If we do roll our own, we can put it inside `urllib3.yolo`. #halfjoking
- [ ] Allow some kind of backwards compat access to `source_address` (Py26 sockets don't have it).
- ...

Anyone interested in picking this up?
