### PR TITLE
Set default timeout on the server socket

### DIFF
--- a/dummyserver/testcase.py
+++ b/dummyserver/testcase.py
@@ -10,11 +10,6 @@ from dummyserver.server import (
 )
 
 has_ipv6 = hasattr(socket, 'has_ipv6')
-# In situations where the main thread throws an exception, the server thread
-# can hang on an accept() call. This ensures everything times out within
-# 3 seconds. This should be long enough for any socket operations in the test
-# suite to complete
-socket.setdefaulttimeout(3)
 
 class SocketDummyServerTestCase(unittest.TestCase):
     """


### PR DESCRIPTION
This probably isn't the best way to solve this, but in some cases (for me, test_timeout_errors_cause_retries) if the main thread fails with an exception, the server thread will never get an accept() and it will hang indefinitely. Control won't be returned to the caller and you can't kill it with a KeyboardInterrupt.

This sets a default timeout on the socket so control is eventually returned and the tests complete.
