### PR TITLE
When 3316f5b reverted the removal of special headers for proxies, the un...

### DIFF
--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -205,6 +205,7 @@ class TestProxyManager(SocketDummyServerTestCase):
                              b'GET http://google.com/ HTTP/1.1',
                              b'Host: google.com',
                              b'Accept-Encoding: identity',
+                             b'Accept: */*',
                              b'',
                              b'',
                          ]))


### PR DESCRIPTION
...ittest change should have been reverted as well.

This fixes a unittest failure introduced by pull #271 
