### PR TITLE
Add proxy_basic_auth option to util.make_headers()

### DIFF
--- a/test/test_util.py
+++ b/test/test_util.py
@@ -171,6 +171,9 @@ class TestUtil(unittest.TestCase):
             make_headers(basic_auth='foo:bar'),
             {'authorization': 'Basic Zm9vOmJhcg=='})
 
+        self.assertEqual(
+            make_headers(proxy_basic_auth='foo:bar'),
+            {'proxy-authorization': 'Basic Zm9vOmJhcg=='})
 
     def test_split_first(self):
         test_cases = {

--- a/urllib3/util.py
+++ b/urllib3/util.py
@@ -426,7 +426,7 @@ def get_host(url):
 
 
 def make_headers(keep_alive=None, accept_encoding=None, user_agent=None,
-                 basic_auth=None):
+                 basic_auth=None, proxy_basic_auth=None):
     """
     Shortcuts for generating request headers.
 
@@ -445,6 +445,10 @@ def make_headers(keep_alive=None, accept_encoding=None, user_agent=None,
 
     :param basic_auth:
         Colon-separated username:password string for 'authorization: basic ...'
+        auth header.
+
+    :param proxy_basic_auth:
+        Colon-separated username:password string for 'proxy-authorization: basic ...'
         auth header.
 
     Example: ::
@@ -473,6 +477,10 @@ def make_headers(keep_alive=None, accept_encoding=None, user_agent=None,
     if basic_auth:
         headers['authorization'] = 'Basic ' + \
             b64encode(six.b(basic_auth)).decode('utf-8')
+
+    if proxy_basic_auth:
+        headers['proxy-authorization'] = 'Basic ' + \
+            b64encode(six.b(proxy_basic_auth)).decode('utf-8')
 
     return headers
 


### PR DESCRIPTION
With this option, `util.make_headers()` will return a dictionary
containing the key `Proxy-Authorization` needed to authenticate against
proxy servers.
