### PR TITLE
Fixed test_fields on Windows and some PEP8 love.

### DIFF
--- a/test/test_fields.py
+++ b/test/test_fields.py
@@ -1,34 +1,39 @@
 import unittest
 
 from urllib3.fields import guess_content_type, RequestField
-from urllib3.packages.six import b, u
+from urllib3.packages.six import u
 
 
 class TestRequestField(unittest.TestCase):
 
     def test_guess_content_type(self):
-      self.assertEqual(guess_content_type('image.jpg'), 'image/jpeg')
-      self.assertEqual(guess_content_type('notsure'), 'application/octet-stream')
-      self.assertEqual(guess_content_type(None), 'application/octet-stream')
+        self.assertTrue(guess_content_type('image.jpg') in
+                        ['image/jpeg', 'image/pjpeg'])
+        self.assertEqual(guess_content_type('notsure'),
+                         'application/octet-stream')
+        self.assertEqual(guess_content_type(None), 'application/octet-stream')
 
     def test_create(self):
-      simple_field = RequestField('somename', 'data')
-      self.assertEqual(simple_field.render_headers(), '\r\n')
-      filename_field = RequestField('somename', 'data', filename='somefile.txt')
-      self.assertEqual(filename_field.render_headers(), '\r\n')
-      headers_field = RequestField('somename', 'data', headers={'Content-Length': 4})
-      self.assertEqual(headers_field.render_headers(),
-          'Content-Length: 4\r\n'
-          '\r\n')
+        simple_field = RequestField('somename', 'data')
+        self.assertEqual(simple_field.render_headers(), '\r\n')
+        filename_field = RequestField('somename', 'data',
+                                      filename='somefile.txt')
+        self.assertEqual(filename_field.render_headers(), '\r\n')
+        headers_field = RequestField('somename', 'data',
+                                     headers={'Content-Length': 4})
+        self.assertEqual(
+            headers_field.render_headers(), 'Content-Length: 4\r\n\r\n')
 
     def test_make_multipart(self):
-      field = RequestField('somename', 'data')
-      field.make_multipart(content_type='image/jpg', content_location='/test')
-      self.assertEqual(field.render_headers(),
-          'Content-Disposition: form-data; name="somename"\r\n'
-          'Content-Type: image/jpg\r\n'
-          'Content-Location: /test\r\n'
-          '\r\n')
+        field = RequestField('somename', 'data')
+        field.make_multipart(content_type='image/jpg',
+                             content_location='/test')
+        self.assertEqual(
+            field.render_headers(),
+            'Content-Disposition: form-data; name="somename"\r\n'
+            'Content-Type: image/jpg\r\n'
+            'Content-Location: /test\r\n'
+            '\r\n')
 
     def test_render_parts(self):
         field = RequestField('somename', 'data')


### PR DESCRIPTION
Fix is in line 10/11:

```
self.assertTrue(guess_content_type('image.jpg') in
                      ['image/jpeg', 'image/pjpeg'])
```

The rest is indentation and max line length corrections.
