### PR TITLE
Fixed check for IPv6 support.

### DIFF
--- a/dummyserver/testcase.py
+++ b/dummyserver/testcase.py
@@ -9,7 +9,6 @@ from dummyserver.server import (
     ProxyServerThread,
 )
 
-has_ipv6 = hasattr(socket, 'has_ipv6')
 
 class SocketDummyServerTestCase(unittest.TestCase):
     """
@@ -114,7 +113,7 @@ class IPv6HTTPDummyServerTestCase(HTTPDummyServerTestCase):
 
     @classmethod
     def setUpClass(cls):
-        if not has_ipv6:
+        if not socket.has_ipv6:
             raise SkipTest('IPv6 not available')
         else:
             super(IPv6HTTPDummyServerTestCase, cls).setUpClass()


### PR DESCRIPTION
The `hasattr` check doesn't make any sense according to the docs: http://docs.python.org/2/library/socket.html#socket.has_ipv6

Was added by @t-8ch in b794413042e8b2ab8ca362b2c8ebd6b8aa5bb9e9
