### PR TITLE
Ensure connections are properly closed on objects destruction

### DIFF
--- a/urllib3/_collections.py
+++ b/urllib3/_collections.py
@@ -51,6 +51,9 @@ class RecentlyUsedContainer(MutableMapping):
         self._container = self.ContainerCls()
         self.lock = RLock()
 
+    def __del__(self):
+        self.clear()
+
     def __getitem__(self, key):
         # Re-insert the item, moving it to the end of the eviction line.
         with self.lock:

--- a/urllib3/connectionpool.py
+++ b/urllib3/connectionpool.py
@@ -167,6 +167,9 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         self.num_connections = 0
         self.num_requests = 0
 
+    def __del__(self):
+        self.close()
+
     def _new_conn(self):
         """
         Return a fresh :class:`httplib.HTTPConnection`.

--- a/urllib3/poolmanager.py
+++ b/urllib3/poolmanager.py
@@ -68,6 +68,9 @@ class PoolManager(RequestMethods):
         self.pools = RecentlyUsedContainer(num_pools,
                                            dispose_func=lambda p: p.close())
 
+    def __del__(self):
+        self.clear()
+
     def _new_pool(self, scheme, host, port):
         """
         Create a new :class:`ConnectionPool` based on host, port and scheme.


### PR DESCRIPTION
This fixes the issue raised by @tardyp on https://github.com/kennethreitz/requests/issues/239.

We have not been able to reproduce the scenario on a simple testcase. However, in our environment involving Buildbot, Twisted, and txrequests, the number of connections in a CLOSE_WAIT state grows until we reach the maximum open files limit per process!

While it's still obscure to me what would prevent an HTTPConnection object from being destroyed once it's no longer used, this fix appears to work in our environment, at least we no longer see this CLOSE_WAIT connections leak...
