### PR TITLE
Remove incorrect comments

### DIFF
--- a/urllib3/connectionpool.py
+++ b/urllib3/connectionpool.py
@@ -309,9 +309,9 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
 
         # Receive the response from the server
         try:
-            try: # Python 2.7+, use buffering of HTTP responses
+            try:
                 httplib_response = conn.getresponse(buffering=True)
-            except TypeError: # Python 2.6 and older
+            except TypeError:
                 httplib_response = conn.getresponse()
         except SocketTimeout:
             raise ReadTimeoutError(


### PR DESCRIPTION
httplib.HTTPConnection.getresponse() doesn't accept any keyword arguments in Python 3.x

See:
1) http://docs.python.org/3.3/library/http.client.html?highlight=httpconnection#http.client.HTTPConnection.getresponse
2) http://hg.python.org/cpython/file/3.3/Lib/http/client.py#l1101

And as per https://github.com/shazow/urllib3/issues/301, the comments are incorrect at https://github.com/shazow/urllib3/blob/master/urllib3/connectionpool.py#L313:

```
   try: # Python 2.7+, use buffering of HTTP responses
            httplib_response = conn.getresponse(buffering=True)
        except TypeError: # Python 2.6 and older
            httplib_response = conn.getresponse()
```
