### PR TITLE
Use a default port when comparing hosts to a connection pool

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,10 @@ dev (master)
 
 * Support for platforms without threading. (Issue #289)
 
+* Expand default-port comparison in ``HTTPConnectionPool.is_same_host``
+  to allow a pool with no specified port to be considered equal to to an
+  HTTP/HTTPS url with port 80/443 explicitly provided
+
 * ...
 
 

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -93,5 +93,8 @@ In chronological order:
 * Peter Waller <p@pwaller.net>
   * HTTPResponse.tell() for determining amount received over the wire
 
+* Nipunn Koorapati <nipunn1313@gmail.com>
+  * Ignore default ports when comparing hosts for equality
+
 * [Your name or handle] <[email or website]>
   * [Brief summary of your changes]

--- a/test/test_connectionpool.py
+++ b/test/test_connectionpool.py
@@ -39,6 +39,11 @@ class TestConnectionPool(unittest.TestCase):
             ('http://google.com/', 'http://google.com'),
             ('http://google.com/', 'http://google.com/abra/cadabra'),
             ('http://google.com:42/', 'http://google.com:42/abracadabra'),
+            # Test comparison using default ports
+            ('http://google.com:80/', 'http://google.com/abracadabra'),
+            ('http://google.com/', 'http://google.com:80/abracadabra'),
+            ('https://google.com:443/', 'https://google.com/abracadabra'),
+            ('https://google.com/', 'https://google.com:443/abracadabra'),
         ]
 
         for a, b in same_host:
@@ -51,11 +56,22 @@ class TestConnectionPool(unittest.TestCase):
             ('http://yahoo.com/', 'http://google.com/'),
             ('http://google.com:42', 'https://google.com/abracadabra'),
             ('http://google.com', 'https://google.net/'),
+            # Test comparison with default ports
+            ('http://google.com:42', 'http://google.com'),
+            ('https://google.com:42', 'https://google.com'),
+            ('http://google.com:443', 'http://google.com'),
+            ('https://google.com:80', 'https://google.com'),
+            ('http://google.com:443', 'https://google.com'),
+            ('https://google.com:80', 'http://google.com'),
+            ('https://google.com:443', 'http://google.com'),
+            ('http://google.com:80', 'https://google.com'),
         ]
 
         for a, b in not_same_host:
             c = connection_from_url(a)
             self.assertFalse(c.is_same_host(b), "%s =? %s" % (a, b))
+            c = connection_from_url(b)
+            self.assertFalse(c.is_same_host(a), "%s =? %s" % (b, a))
 
 
     def test_max_connections(self):

--- a/urllib3/connectionpool.py
+++ b/urllib3/connectionpool.py
@@ -371,9 +371,11 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         # TODO: Add optional support for socket.gethostbyname checking.
         scheme, host, port = get_host(url)
 
+        # Use explicit default port for comparison when none is given
         if self.port and not port:
-            # Use explicit default port for comparison when none is given.
             port = port_by_scheme.get(scheme)
+        elif not self.port and port == port_by_scheme.get(scheme):
+            port = None
 
         return (scheme, host, port) == (self.scheme, self.host, self.port)
 


### PR DESCRIPTION
Added tests to verify and show expected behavior
