### PR TITLE
Account retries on ProxyError

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,9 @@ dev (master)
 * Improved default SSL/TLS settings to avoid vulnerabilities.
   (Issue #309)
 
+* Fix retires when using proxy: do not fail immediately on proxy errors,
+  but continue until we exceed retry limit. (Issue #310)
+
 * ... [Short description of non-trivial change.] (Issue #)
 
 

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -101,5 +101,8 @@ In chronological order:
   * Disabled TLS compression in pyopenssl contrib module
   * Configurable cipher suites in pyopenssl contrib module
 
+* Roman Bogorodskiy <roman.bogorodskiy@ericsson.com>
+  * Account retries on proxy errors
+
 * [Your name or handle] <[email or website]>
   * [Brief summary of your changes]

--- a/urllib3/connectionpool.py
+++ b/urllib3/connectionpool.py
@@ -517,17 +517,17 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
                 raise
 
         except (HTTPException, SocketError) as e:
-            if isinstance(e, SocketError) and self.proxy is not None:
-                raise ProxyError('Cannot connect to proxy. '
-                                 'Socket error: %s.' % e)
-
             # Connection broken, discard. It will be replaced next _get_conn().
             conn = None
             # This is necessary so we can access e below
             err = e
 
             if retries == 0:
-                raise MaxRetryError(self, url, e)
+                if isinstance(e, SocketError) and self.proxy is not None:
+                    raise ProxyError('Cannot connect to proxy. '
+                                     'Socket error: %s.' % e)
+                else:
+                    raise MaxRetryError(self, url, e)
 
         finally:
             if release_conn:


### PR DESCRIPTION
Current implementation fails if it encounters a proxy error no
matter how many retries left.

Change the behaviour to try connecting until retry limit has reached
and then throw an appropriate exception: ProxyError or MaxRetryError.
