### PR TITLE
Disable Nagle's algorithm for non-proxies

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,7 +31,12 @@ dev (master)
 * Fixed ``urllib3.poolmanager.ProxyManager`` not retrying on connect errors.
   (Issue #310)
 
+* Disable Nagle's Algorithm on the socket for non-proxies. A subset of requests
+  will send the entire HTTP request ~200 milliseconds faster; however, some of
+  the resulting TCP packets will be smaller. (Issue #254)
+
 * ... [Short description of non-trivial change.] (Issue #)
+
 
 
 1.7.1 (2013-09-25)

--- a/test/with_dummyserver/test_https.py
+++ b/test/with_dummyserver/test_https.py
@@ -13,7 +13,11 @@ from dummyserver.testcase import HTTPSDummyServerTestCase
 from dummyserver.server import DEFAULT_CA, DEFAULT_CA_BAD, DEFAULT_CERTS
 
 from urllib3 import HTTPSConnectionPool
-from urllib3.connectionpool import VerifiedHTTPSConnection
+from urllib3.connection import (
+    HTTPSConnection,
+    VerifiedHTTPSConnection,
+    UnverifiedHTTPSConnection,
+)
 from urllib3.exceptions import SSLError, ConnectTimeoutError, ReadTimeoutError
 from urllib3.util import Timeout
 
@@ -78,6 +82,16 @@ class TestHTTPS(HTTPSDummyServerTestCase):
 
             self.assertRaises(SSLError, self._pool._new_conn)
             self.assertRaises(SSLError, self._pool.request, 'GET', '/')
+
+        finally:
+            self._pool.ConnectionCls = OriginalConnectionCls
+
+    def test_unverified_ssl(self):
+        """ Test that bare HTTPSConnection can connect, make requests """
+        try:
+            OriginalConnectionCls = self._pool.ConnectionCls
+            self._pool.ConnectionCls = UnverifiedHTTPSConnection
+            self._pool.request('GET', '/')
 
         finally:
             self._pool.ConnectionCls = OriginalConnectionCls

--- a/urllib3/connection.py
+++ b/urllib3/connection.py
@@ -8,9 +8,9 @@ import socket
 from socket import timeout as SocketTimeout
 
 try: # Python 3
-    from http.client import HTTPConnection, HTTPException
+    from http.client import HTTPConnection as _HTTPConnection, HTTPException
 except ImportError:
-    from httplib import HTTPConnection, HTTPException
+    from httplib import HTTPConnection as _HTTPConnection, HTTPException
 
 class DummyConnection(object):
     "Used to detect a failed ConnectionCls import."
@@ -24,9 +24,9 @@ try: # Compiled with SSL?
         pass
 
     try: # Python 3
-        from http.client import HTTPSConnection
+        from http.client import HTTPSConnection as _HTTPSConnection
     except ImportError:
-        from httplib import HTTPSConnection
+        from httplib import HTTPSConnection as _HTTPSConnection
 
     import ssl
     BaseSSLError = ssl.SSLError
@@ -44,6 +44,66 @@ from .util import (
     resolve_ssl_version,
     ssl_wrap_socket,
 )
+
+
+port_by_scheme = {
+    'http': 80,
+    'https': 443,
+}
+
+
+class HTTPConnection(_HTTPConnection, object):
+    default_port = port_by_scheme['http']
+
+    # By default, disable Nagle's Algorithm.
+    tcp_nodelay = 1
+
+    def _new_conn(self):
+        """ Establish a socket connection and set nodelay settings on it """
+        try:
+            sock = socket.create_connection(
+                (self.host, self.port),
+                self.timeout,
+                self.source_address,
+            )
+        except AttributeError: # Python 2.6
+            sock = socket.create_connection(
+                (self.host, self.port),
+                self.timeout,
+            )
+        sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY,
+                        self.tcp_nodelay)
+        return sock
+
+    def _prepare_conn(self, sock):
+        self.sock = sock
+        if self._tunnel_host:
+            # TODO: Fix tunnel so it doesn't depend on self.sock state.
+            self._tunnel()
+
+    def connect(self):
+        sock = self._new_conn()
+        self._prepare_conn(sock)
+
+
+class HTTPSConnection(HTTPConnection):
+    default_port = port_by_scheme['https']
+
+    def __init__(self, host, port=None, key_file=None, cert_file=None,
+                 strict=None, timeout=socket._GLOBAL_DEFAULT_TIMEOUT,
+                 source_address=None):
+        try:
+            HTTPConnection.__init__(self, host, port, strict, timeout, source_address)
+        except TypeError: # Python 2.6
+            HTTPConnection.__init__(self, host, port, strict, timeout)
+        self.key_file = key_file
+        self.cert_file = cert_file
+
+    def connect(self):
+        sock = self._new_conn()
+        self._prepare_conn(sock)
+        self.sock = ssl.wrap_socket(sock, self.key_file, self.cert_file)
+
 
 class VerifiedHTTPSConnection(HTTPSConnection):
     """
@@ -73,9 +133,12 @@ class VerifiedHTTPSConnection(HTTPSConnection):
                 timeout=self.timeout,
             )
         except SocketTimeout:
-                raise ConnectTimeoutError(
-                    self, "Connection to %s timed out. (connect timeout=%s)" %
-                    (self.host, self.timeout))
+            raise ConnectTimeoutError(
+                self, "Connection to %s timed out. (connect timeout=%s)" %
+                (self.host, self.timeout))
+
+        sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY,
+                        self.tcp_nodelay)
 
         resolved_cert_reqs = resolve_cert_reqs(self.cert_reqs)
         resolved_ssl_version = resolve_ssl_version(self.ssl_version)
@@ -107,4 +170,6 @@ class VerifiedHTTPSConnection(HTTPSConnection):
 
 
 if ssl:
+    # Make a copy for testing.
+    UnverifiedHTTPSConnection = HTTPSConnection
     HTTPSConnection = VerifiedHTTPSConnection

--- a/urllib3/poolmanager.py
+++ b/urllib3/poolmanager.py
@@ -1,5 +1,5 @@
 # urllib3/poolmanager.py
-# Copyright 2008-2013 Andrey Petrov and contributors (see CONTRIBUTORS.txt)
+# Copyright 2008-2014 Andrey Petrov and contributors (see CONTRIBUTORS.txt)
 #
 # This module is part of urllib3 and is released under
 # the MIT License: http://www.opensource.org/licenses/mit-license.php


### PR DESCRIPTION
Nagle's algorithm can be useful in some scenarios to limit packet overhead and
bandwidth over the wire. This change allows consumers to disable Nagle's
algorithm by subclassing HTTPConnection in urllib3/connection.py.
