### PR TITLE
Speed up tests on Windows

### DIFF
--- a/dummyserver/server.py
+++ b/dummyserver/server.py
@@ -8,6 +8,8 @@ from __future__ import print_function
 import errno
 import logging
 import os
+import random
+import string
 import sys
 import threading
 import socket
@@ -162,3 +164,18 @@ def run_loop_in_thread(io_loop):
     t = threading.Thread(target=io_loop.start)
     t.start()
     return t
+
+
+def get_unreachable_address():
+    while True:
+        host = ''.join(random.choice(string.ascii_lowercase)
+                       for _ in range(60))
+        sockaddr = (host, 54321)
+
+        # check if we are really "lucky" and hit an actual server
+        try:
+            s = socket.create_connection(sockaddr)
+        except socket.error:
+            return sockaddr
+        else:
+            s.close()

--- a/test/with_dummyserver/test_proxy_poolmanager.py
+++ b/test/with_dummyserver/test_proxy_poolmanager.py
@@ -3,7 +3,8 @@ import json
 import socket
 
 from dummyserver.testcase import HTTPDummyProxyTestCase
-from dummyserver.server import DEFAULT_CA, DEFAULT_CA_BAD
+from dummyserver.server import (
+    DEFAULT_CA, DEFAULT_CA_BAD, get_unreachable_address)
 
 from urllib3.poolmanager import proxy_from_url, ProxyManager
 from urllib3.exceptions import MaxRetryError, SSLError, ProxyError
@@ -42,13 +43,8 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
                           "to zero, instead was %s" % tcp_nodelay_setting))
 
     def test_proxy_conn_fail(self):
-        # Get a free port on localhost, so a connection will be refused
-        s = socket.socket()
-        s.bind(('127.0.0.1', 0))
-        free_port = s.getsockname()[1]
-        s.close()
-
-        http = proxy_from_url('http://127.0.0.1:%s/' % free_port)
+        host, port = get_unreachable_address()
+        http = proxy_from_url('http://%s:%s/' % (host, port))
         self.assertRaises(ProxyError, http.request, 'GET',
                           '%s/' % self.https_url)
         self.assertRaises(ProxyError, http.request, 'GET',

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -10,7 +10,8 @@ from urllib3.exceptions import (
 from urllib3 import util
 
 from dummyserver.testcase import SocketDummyServerTestCase
-from dummyserver.server import DEFAULT_CERTS, DEFAULT_CA
+from dummyserver.server import (
+    DEFAULT_CERTS, DEFAULT_CA, get_unreachable_address)
 
 from nose.plugins.skip import SkipTest
 from threading import Event
@@ -110,13 +111,8 @@ class TestSocketClosing(SocketDummyServerTestCase):
 
     def test_connection_refused(self):
         # Does the pool retry if there is no listener on the port?
-        # Get a free port on localhost, so a connection will be refused
-        s = socket.socket()
-        s.bind(('127.0.0.1', 0))
-        free_port = s.getsockname()[1]
-        s.close()
-
-        pool = HTTPConnectionPool(self.host, free_port)
+        host, port = get_unreachable_address()
+        pool = HTTPConnectionPool(host, port)
         self.assertRaises(MaxRetryError, pool.request, 'GET', '/', retries=0)
 
     def test_connection_timeout(self):


### PR DESCRIPTION
This reduces test duration from 120s to about 4s (!!). See #256
