### PR TITLE
Skip network tests if machine isn't on a network

### DIFF
--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,0 +1,34 @@
+import errno
+import functools
+import socket
+
+from nose.plugins.skip import SkipTest
+
+from urllib3.exceptions import MaxRetryError
+
+
+def requires_network(test):
+    """Helps you skip tests that require the network"""
+
+    def _is_unreachable_err(err):
+        return hasattr(err, 'errno') and err.errno == errno.ENETUNREACH
+
+    @functools.wraps(test)
+    def wrapper(*args, **kwargs):
+        msg = "Can't run {name} because the network is unreachable".format(
+            name=test.__name__)
+        try:
+            return test(*args, **kwargs)
+        except socket.error as e:
+            # This test needs an initial network connection to attempt the
+            # connection to the TARPIT_HOST. This fails if you are in a place
+            # without an Internet connection, so we skip the test in that case.
+            if _is_unreachable_err(e):
+                raise SkipTest(msg)
+            raise
+        except MaxRetryError as e:
+            if (isinstance(e.reason, socket.error) and
+                _is_unreachable_err(e.reason)):
+                raise SkipTest(msg)
+            raise
+    return wrapper

--- a/test/with_dummyserver/test_connectionpool.py
+++ b/test/with_dummyserver/test_connectionpool.py
@@ -1,3 +1,5 @@
+import errno
+import functools
 import logging
 import socket
 import sys
@@ -10,6 +12,7 @@ try:
 except:
     from urllib import urlencode
 
+from test import requires_network
 from urllib3 import (
     encode_multipart_formdata,
     HTTPConnectionPool,
@@ -27,7 +30,6 @@ from urllib3 import util
 from dummyserver.testcase import HTTPDummyServerTestCase
 
 from nose.tools import timed
-from nose.plugins.skip import SkipTest
 
 log = logging.getLogger('urllib3.connectionpool')
 log.setLevel(logging.NOTSET)
@@ -165,6 +167,7 @@ class TestConnectionPool(HTTPDummyServerTestCase):
         # request timeout if it's a high value
         pool.request('GET', url, timeout=5)
 
+    @requires_network
     @timed(0.1)
     def test_connect_timeout(self):
         url = '/sleep'
@@ -200,6 +203,7 @@ class TestConnectionPool(HTTPDummyServerTestCase):
         except ReadTimeoutError:
             self.fail("This request shouldn't trigger a read timeout.")
 
+    @requires_network
     @timed(2.0)
     def test_total_timeout(self):
         url = '/sleep?seconds=0.005'

--- a/test/with_dummyserver/test_https.py
+++ b/test/with_dummyserver/test_https.py
@@ -1,7 +1,3 @@
-try: # Python 3
-    from http.client import HTTPSConnection
-except ImportError:
-    from httplib import HTTPSConnection
 import logging
 import ssl
 import sys
@@ -12,9 +8,9 @@ import mock
 from dummyserver.testcase import HTTPSDummyServerTestCase
 from dummyserver.server import DEFAULT_CA, DEFAULT_CA_BAD, DEFAULT_CERTS
 
+from test import requires_network
 from urllib3 import HTTPSConnectionPool
 from urllib3.connection import (
-    HTTPSConnection,
     VerifiedHTTPSConnection,
     UnverifiedHTTPSConnection,
 )
@@ -188,6 +184,7 @@ class TestHTTPS(HTTPSDummyServerTestCase):
 
         self.assertRaises(SSLError, https_pool.request, 'GET', '/')
 
+    @requires_network
     def test_https_timeout(self):
         timeout = Timeout(connect=0.001)
         https_pool = HTTPSConnectionPool(TARPIT_HOST, self.port,
@@ -243,6 +240,7 @@ class TestHTTPS(HTTPSDummyServerTestCase):
         self._pool._make_request(conn, 'GET', '/')
 
 
+    @requires_network
     def test_enhanced_timeout(self):
         def new_pool(timeout, cert_reqs='CERT_REQUIRED'):
             https_pool = HTTPSConnectionPool(TARPIT_HOST, self.port,


### PR DESCRIPTION
So, I tried running the tests this morning on the train and found out that some of the unit tests fail if your machine is not connected to the Internet. To reproduce, unplug wifi etc. and run the tests and they should fail - at least, on my Mac they do.

This PR adds a new `requires_network` decorator which should be used if the test
requires a connection to a network resource like TARPIT_HOST. Otherwise, the
unit tests fail when running on an isolated machine.
