### PR TITLE
fix skipping tests on OSX

### DIFF
--- a/test/__init__.py
+++ b/test/__init__.py
@@ -21,7 +21,8 @@ def requires_network(test):
     """Helps you skip tests that require the network"""
 
     def _is_unreachable_err(err):
-        return hasattr(err, 'errno') and err.errno == errno.ENETUNREACH
+        return getattr(err, 'errno', None) in (errno.ENETUNREACH,
+                                               errno.EHOSTUNREACH) # For OSX
 
     @functools.wraps(test)
     def wrapper(*args, **kwargs):


### PR DESCRIPTION
On OSX 10.7 Python 2.7 not being connected to the network raises `errno.EHOSTUNREACH` instead of `errno.ENETUNREACH` which meant that skipping the network tests failed.
