### PR TITLE
fix the benchmark file to run

### DIFF
--- a/test/benchmark.py
+++ b/test/benchmark.py
@@ -46,10 +46,10 @@ def urllib_get(url_list):
 
 def pool_get(url_list):
     assert url_list
-    pool = urllib3.connection_from_url(url_list[0])
+    pool = urllib3.PoolManager()
     for url in url_list:
         now = time.time()
-        r = pool.get_url(url)
+        r = pool.request('GET', url, assert_same_host=False)
         elapsed = time.time() - now
         print("Got in %0.3fs: %s" % (elapsed, url))
 


### PR DESCRIPTION
`get_url` doesn't seem to exist anymore and these http links get redirected to https which doesn't seem to work with an`HTTPConnectionPool` which is the bug I reported in #336 so I switched to using a `PoolManager`. Also, the redirect switches the host so I had to add in the `assert_same_host=False`. Or I guess we could switch the benchmark urls instead :)
