### PR TITLE
when data is long convert to string before posting

### DIFF
--- a/urllib3/filepost.py
+++ b/urllib3/filepost.py
@@ -83,7 +83,7 @@ def encode_multipart_formdata(fields, boundary=None):
         writer(body).write(field.render_headers())
         data = field.data
 
-        if isinstance(data, int) or isinstance(data, long):
+        if isinstance(data, six.integer_types):
             data = str(data)  # Backwards compatibility
 
         if isinstance(data, six.text_type):


### PR DESCRIPTION
For some reason when the data is a long there is an issue in `filepost.py`

It creates the error

`TypeError: 'long' does not have the buffer interface`
