### PR TITLE
Support source_address

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -5,7 +5,6 @@ omit = urllib3/packages/*
 exclude_lines =
     .* # Platform-specific.*
     except ImportError:
-    .*:.* # Py\d.*
     .*:.* # Python \d.*
     pass
     .* # Abstract

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -13,14 +13,13 @@ from urllib3.packages import six
 # Reset. SO suggests this hostname
 TARPIT_HOST = '10.255.255.1'
 
-VALID_SOURCE_ADDRESSES = ['::1', ('::1', 0), '127.0.0.1', ('127.0.0.1', 0)]
+VALID_SOURCE_ADDRESSES = [('::1', 0), ('127.0.0.1', 0)]
 # RFC 5737: 192.0.2.0/24 is for testing only.
 # RFC 3849: 2001:db8::/32 is for documentation only.
-INVALID_SOURCE_ADDRESSES = [
-    '192.0.2.255', ('192.0.2.255', 0), '2001:db8::1', ('2001:db8::1', 0)]
+INVALID_SOURCE_ADDRESSES = [('192.0.2.255', 0), ('2001:db8::1', 0)]
 
 
-def onlyPy26OrEarlier(test):
+def onlyPy26OrOlder(test):
     """Skips this test unless you are on Python2.6.x or earlier."""
 
     @functools.wraps(test)
@@ -31,7 +30,7 @@ def onlyPy26OrEarlier(test):
         return test(*args, **kwargs)
     return wrapper
 
-def onlyPy27OrLater(test):
+def onlyPy27OrNewer(test):
     """Skips this test unless you are on Python2.7.x or later."""
 
     @functools.wraps(test)

--- a/test/with_dummyserver/test_connectionpool.py
+++ b/test/with_dummyserver/test_connectionpool.py
@@ -11,7 +11,7 @@ except:
     from urllib import urlencode
 
 from test import (
-    onlyPy3, onlyPy27OrLater, onlyPy26OrEarlier, requires_network, TARPIT_HOST,
+    onlyPy3, onlyPy27OrNewer, onlyPy26OrOlder, requires_network, TARPIT_HOST,
     VALID_SOURCE_ADDRESSES, INVALID_SOURCE_ADDRESSES)
 from urllib3 import (
     encode_multipart_formdata,
@@ -534,25 +534,24 @@ class TestConnectionPool(HTTPDummyServerTestCase):
         pool = HTTPConnectionPool('thishostdoesnotexist.invalid', self.port, timeout=0.001)
         self.assertRaises(MaxRetryError, pool.request, 'GET', '/test', retries=2)
 
-    @onlyPy26OrEarlier
+    @onlyPy26OrOlder
     def test_source_address_ignored(self):
-        # source_address is ignored in Python 2.6 and earlier.
+        # source_address is ignored in Python 2.6 and older.
         for addr in INVALID_SOURCE_ADDRESSES:
             pool = HTTPConnectionPool(
                 self.host, self.port, source_address=addr)
             r = pool.request('GET', '/source_address')
             assert r.status == 200
 
-    @onlyPy27OrLater
+    @onlyPy27OrNewer
     def test_source_address(self):
         for addr in VALID_SOURCE_ADDRESSES:
             pool = HTTPConnectionPool(
                 self.host, self.port, source_address=addr)
             r = pool.request('GET', '/source_address')
-            addr_bytes = b(addr if isinstance(addr, string_types) else addr[0])
-            assert r.data == addr_bytes
+            assert r.data == b(addr[0])
 
-    @onlyPy27OrLater
+    @onlyPy27OrNewer
     def test_source_address_error(self):
         for addr in INVALID_SOURCE_ADDRESSES:
             pool = HTTPConnectionPool(

--- a/test/with_dummyserver/test_https.py
+++ b/test/with_dummyserver/test_https.py
@@ -10,7 +10,7 @@ from dummyserver.testcase import HTTPSDummyServerTestCase
 from dummyserver.server import DEFAULT_CA, DEFAULT_CA_BAD, DEFAULT_CERTS
 
 from test import (
-    onlyPy3, onlyPy27OrLater, onlyPy26OrEarlier, requires_network, TARPIT_HOST,
+    onlyPy3, onlyPy27OrNewer, onlyPy26OrOlder, requires_network, TARPIT_HOST,
     VALID_SOURCE_ADDRESSES, INVALID_SOURCE_ADDRESSES)
 from urllib3 import HTTPSConnectionPool
 from urllib3.packages.six import b, string_types
@@ -302,7 +302,7 @@ class TestHTTPS(HTTPSDummyServerTestCase):
                                         '7A:F2:8A:D7:1E:07:33:67:DE'
         https_pool._make_request(conn, 'GET', '/')
 
-    @onlyPy26OrEarlier
+    @onlyPy26OrOlder
     def test_source_address_ignored(self):
         # source_address is ignored in Python 2.6 and earlier.
         for addr in INVALID_SOURCE_ADDRESSES:
@@ -313,7 +313,7 @@ class TestHTTPS(HTTPSDummyServerTestCase):
             r = https_pool.request('GET', '/source_address')
             assert r.status == 200
 
-    @onlyPy27OrLater
+    @onlyPy27OrNewer
     def test_source_address(self):
         for addr in VALID_SOURCE_ADDRESSES:
             https_pool = HTTPSConnectionPool(
@@ -321,10 +321,9 @@ class TestHTTPS(HTTPSDummyServerTestCase):
                 source_address=addr)
             https_pool.ca_certs = DEFAULT_CA
             r = https_pool.request('GET', '/source_address')
-            addr_bytes = b(addr if isinstance(addr, string_types) else addr[0])
-            assert r.data == addr_bytes
+            assert r.data == b(addr[0])
     
-    @onlyPy27OrLater
+    @onlyPy27OrNewer
     def test_source_address_error(self):
         for addr in INVALID_SOURCE_ADDRESSES:
             https_pool = HTTPSConnectionPool(

--- a/urllib3/connection.py
+++ b/urllib3/connection.py
@@ -66,14 +66,12 @@ class HTTPConnection(_HTTPConnection, object):
     tcp_nodelay = 1
 
     def __init__(self, *args, **kw):
-        if six.PY3:  # Python 3.
+        if six.PY3:  # Python 3
             kw.pop('strict', None)
-        if sys.version_info < (2, 7):  # Python 2.6 and earlier.
+        if sys.version_info < (2, 7):  # Python 2.6 and older
             kw.pop('source_address', None)
 
-        if isinstance(kw.get('source_address'), six.string_types):  # Py2.7+.
-            kw['source_address'] = (kw['source_address'], 0)
-        self.source_address = kw.get('source_address')  # For Py2.6 and earlier.
+        self.source_address = kw.get('source_address')  # For Py2.6 and older.
 
         # _HTTPConnection.__init__() sets self.source_address in Python 2.7+.
         _HTTPConnection.__init__(self, *args, **kw)  
@@ -143,12 +141,10 @@ class VerifiedHTTPSConnection(HTTPSConnection):
     def connect(self):
         # Add certificate verification
 
-        kw = dict(self.conn_kw)
-        if isinstance(kw.get('source_address'), six.string_types):  # Py2.7+.
-            kw['source_address'] = (kw['source_address'], 0)
         try:
             sock = socket.create_connection(
-                address=(self.host, self.port), timeout=self.timeout, **kw)
+                address=(self.host, self.port), timeout=self.timeout,
+                **self.conn_kw)
         except SocketTimeout:
             raise ConnectTimeoutError(
                 self, "Connection to %s timed out. (connect timeout=%s)" %

--- a/urllib3/connectionpool.py
+++ b/urllib3/connectionpool.py
@@ -164,7 +164,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         self.num_connections = 0
         self.num_requests = 0
 
-        if sys.version_info < (2, 7):  # Python 2.6 and earlier.
+        if sys.version_info < (2, 7):  # Python 2.6 and older
             conn_kw.pop('source_address', None)
         self.conn_kw = conn_kw
 
@@ -602,7 +602,7 @@ class HTTPSConnectionPool(HTTPConnectionPool):
                  assert_hostname=None, assert_fingerprint=None,
                  **conn_kw):
 
-        if sys.version_info < (2, 7):  # Python 2.6 and earlier.
+        if sys.version_info < (2, 7):  # Python 2.6 or older
             conn_kw.pop('source_address', None)
 
         HTTPConnectionPool.__init__(self, host, port, strict, timeout, maxsize,


### PR DESCRIPTION
This still doesn't work for `HTTPSConnection`s (the default address is used instead of `source_address`). I'll try to fix this while moving over to using `**connection_kw` instead of an explicit parameter.

issue #9
