### PR TITLE
Don't pin dependency to exact version

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,4 @@
-nose==1.3
-mock==1.0.1
-tornado==3.1.1
-coverage==3.6
+nose>=1.3
+mock>=1.0.1
+tornado>=3.1.1
+coverage>=3.6


### PR DESCRIPTION
While this expresses with which versions urllib3 is tested to work with,
almost all distros ship different package versions. To accomodate that
(and to avoid having them to patch away these hard requirements) only
use '>='.
