### PR TITLE
Make initial boundaries of multipart encoded form data compliant with RFC 1521

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -114,5 +114,8 @@ In chronological order:
 * Tahia Khan <http://tahia.tk/>
   * Added Timeout examples in docs
 
+* Jay De Lanoy <jay@delanoy.co>
+  * Made initial boundary of multipart form data encoding RFC 1521 compliant
+
 * [Your name or handle] <[email or website]>
   * [Brief summary of your changes]

--- a/test/test_filepost.py
+++ b/test/test_filepost.py
@@ -51,7 +51,7 @@ class TestMultipartEncoding(unittest.TestCase):
             encoded, content_type = encode_multipart_formdata(fields, boundary=BOUNDARY)
 
             self.assertEqual(encoded,
-                b'--' + b(BOUNDARY) + b'\r\n'
+                b'\r\n--' + b(BOUNDARY) + b'\r\n'
                 b'Content-Disposition: form-data; name="k"\r\n'
                 b'\r\n'
                 b'v\r\n'
@@ -72,7 +72,7 @@ class TestMultipartEncoding(unittest.TestCase):
         encoded, content_type = encode_multipart_formdata(fields, boundary=BOUNDARY)
 
         self.assertEqual(encoded,
-            b'--' + b(BOUNDARY) + b'\r\n'
+            b'\r\n--' + b(BOUNDARY) + b'\r\n'
             b'Content-Disposition: form-data; name="k"; filename="somename"\r\n'
             b'Content-Type: application/octet-stream\r\n'
             b'\r\n'
@@ -90,7 +90,7 @@ class TestMultipartEncoding(unittest.TestCase):
         encoded, content_type = encode_multipart_formdata(fields, boundary=BOUNDARY)
 
         self.assertEqual(encoded,
-            b'--' + b(BOUNDARY) + b'\r\n'
+            b'\r\n--' + b(BOUNDARY) + b'\r\n'
             b'Content-Disposition: form-data; name="k"; filename="somefile.txt"\r\n'
             b'Content-Type: text/plain\r\n'
             b'\r\n'
@@ -108,7 +108,7 @@ class TestMultipartEncoding(unittest.TestCase):
         encoded, content_type = encode_multipart_formdata(fields, boundary=BOUNDARY)
 
         self.assertEqual(encoded,
-            b'--' + b(BOUNDARY) + b'\r\n'
+            b'\r\n--' + b(BOUNDARY) + b'\r\n'
             b'Content-Disposition: form-data; name="k"; filename="somefile.txt"\r\n'
             b'Content-Type: image/jpeg\r\n'
             b'\r\n'
@@ -125,7 +125,7 @@ class TestMultipartEncoding(unittest.TestCase):
       encoded, content_type = encode_multipart_formdata(fields, boundary=BOUNDARY)
 
       self.assertEqual(encoded,
-          b'--' + b(BOUNDARY) + b'\r\n'
+          b'\r\n--' + b(BOUNDARY) + b'\r\n'
           b'Content-Type: image/jpeg\r\n'
           b'\r\n'
           b'v\r\n'

--- a/urllib3/filepost.py
+++ b/urllib3/filepost.py
@@ -78,7 +78,7 @@ def encode_multipart_formdata(fields, boundary=None):
         boundary = choose_boundary()
 
     for field in iter_field_objects(fields):
-        body.write(b('--%s\r\n' % (boundary)))
+        body.write(b('\r\n--%s\r\n' % (boundary)))
 
         writer(body).write(field.render_headers())
         data = field.data
@@ -91,9 +91,7 @@ def encode_multipart_formdata(fields, boundary=None):
         else:
             body.write(data)
 
-        body.write(b'\r\n')
-
-    body.write(b('--%s--\r\n' % (boundary)))
+    body.write(b('\r\n--%s--\r\n' % (boundary)))
 
     content_type = str('multipart/form-data; boundary=%s' % boundary)
 


### PR DESCRIPTION
`urllib3.filepost.encode_multipart_formdata` is not fully compliant with [RFC 1521](https://www.ietf.org/rfc/rfc1521.txt); specifically, boundaries technically include `\r\n` at the start, which is omitted for the initial part in what that produces.

The portion of the RFC I'm talking about is in [RFC 1521](https://www.ietf.org/rfc/rfc1521.txt), "MIME (Multipurpose Internet Mail Extensions) Part One: Mechanisms for Specifying and Describing the Format of Internet Message Bodies", Subsection 7.2.1 ("Multipart:  The common syntax"), on page 30:

> Note that the encapsulation boundary must occur at the beginning of a
>   line, i.e., following a CRLF, and that the initial CRLF is considered
>  to be attached to the encapsulation boundary rather than part of the
>  preceding part.  The boundary must be followed immediately either by
>  another CRLF and the header fields for the next part, or by two
>  CRLFs, in which case there are no header fields for the next part
>  (and it is therefore assumed to be of Content-Type text/plain).

Key part there is "the initial CRLF is considered to be attached to the encapsulation boundary rather than part of the preceding part."
