### PR TITLE
make it more clear why we are closing connections

### DIFF
--- a/urllib3/util/connection.py
+++ b/urllib3/util/connection.py
@@ -19,7 +19,10 @@ def is_connection_dropped(conn):  # Platform-specific
     let the platform handle connection recycling transparently for us.
     """
     sock = getattr(conn, 'sock', False)
-    if not sock: # Platform-specific: AppEngine
+    if sock is False: # Platform-specific: AppEngine
+        return False
+
+    if sock is None: # Connection already closed by e.g. httplib.
         return False
 
     if not poll:


### PR DESCRIPTION
I/Lukasa noticed this while investigating #295. Basically the `getattr(conn, 'sock', False)` followed by `if not sock` is catching the case where the Connection: close header is set because calling `response.close()`  sets `sock=None`. This pull request makes it clearer when we are passing on closing due to AppEngine craziness as opposed to do to someone already calling `response.close` such as `httplib` doing it for us.
