### PR TITLE
TLS Verification will break in Python 3.4.1 when using a Proxy

### DIFF
--- a/urllib3/connection.py
+++ b/urllib3/connection.py
@@ -177,12 +177,17 @@ class VerifiedHTTPSConnection(HTTPSConnection):
             # self._tunnel_host below.
             self._tunnel()
 
+            # The name of the host we're requesting data from.
+            actual_host = self._tunnel_host
+        else:
+            actual_host = self.host
+
         # Wrap socket using verification with the root certs in
         # trusted_root_certs
         self.sock = ssl_wrap_socket(sock, self.key_file, self.cert_file,
                                     cert_reqs=resolved_cert_reqs,
                                     ca_certs=self.ca_certs,
-                                    server_hostname=self.host,
+                                    server_hostname=actual_host,
                                     ssl_version=resolved_ssl_version)
 
         if resolved_cert_reqs != ssl.CERT_NONE:
@@ -191,7 +196,7 @@ class VerifiedHTTPSConnection(HTTPSConnection):
                                    self.assert_fingerprint)
             elif self.assert_hostname is not False:
                 match_hostname(self.sock.getpeercert(),
-                               self.assert_hostname or self.host)
+                               self.assert_hostname or actual_host)
 
 
 if ssl:


### PR DESCRIPTION
There is a change in Python 3.4.1 which will break the hostname verification when used in conjunction with a proxy. This got discovered when someone attempted to use pip with 3.4.1rc1.

Take a look at http://bugs.python.org/issue7776 for more details. I'm not entirely familiar with this code but I'm going to try and familarize myself with it to see what can be done here.
