### PR TITLE
DO NOT MERGE - properly close connections and apply pool certs for https pools

### DIFF
--- a/test/with_dummyserver/test_https.py
+++ b/test/with_dummyserver/test_https.py
@@ -74,6 +74,22 @@ class TestHTTPS(HTTPSDummyServerTestCase):
         except SSLError as e:
             self.assertTrue("doesn't match" in str(e))
 
+    def test_cert_changes_propagated(self):
+        https_pool = HTTPSConnectionPool(self.host, self.port,
+                                         cert_reqs='CERT_REQUIRED',
+                                         ca_certs=DEFAULT_CA)
+
+        https_pool.request('GET', '/')
+
+        https_pool.ca_certs = DEFAULT_CA_BAD
+        try:
+            https_pool.request('GET', '/')
+            self.fail("Didn't raise SSL error with wrong CA")
+        except SSLError as e:
+            self.assertTrue('certificate verify failed' in str(e),
+                            "Expected 'certificate verify failed',"
+                            "instead got: %r" % e)
+
     def test_no_ssl(self):
         OriginalConnectionCls = self._pool.ConnectionCls
         try:

--- a/urllib3/connectionpool.py
+++ b/urllib3/connectionpool.py
@@ -619,11 +619,9 @@ class HTTPSConnectionPool(HTTPConnectionPool):
         self.assert_fingerprint = assert_fingerprint
         self.conn_kw = conn_kw
 
-    def _prepare_conn(self, conn):
-        """
-        Prepare the ``connection`` for :meth:`urllib3.util.ssl_wrap_socket`
-        and establish the tunnel if proxy is used.
-        """
+    def _get_conn(self, timeout=None):
+
+        conn = super(HTTPSConnectionPool, self)._get_conn(timeout)
 
         if isinstance(conn, VerifiedHTTPSConnection):
             conn.set_cert(key_file=self.key_file,
@@ -680,7 +678,7 @@ class HTTPSConnectionPool(HTTPConnectionPool):
             # fragmentation.
             conn.tcp_nodelay = 0
 
-        return self._prepare_conn(conn)
+        return conn
 
 
 def connection_from_url(url, **kw):

--- a/urllib3/util/connection.py
+++ b/urllib3/util/connection.py
@@ -22,7 +22,7 @@ def is_connection_dropped(conn):  # Platform-specific
     if sock is False:  # Platform-specific: AppEngine
         return False
     if sock is None:  # Connection already closed (such as by httplib).
-        return False
+        return True
 
     if not poll:
         if not select:  # Platform-specific: AppEngine


### PR DESCRIPTION
cc @Lukasa @shazow

In my debugging of #369 I came across the fact that we aren't propagating changes to connections if we change the pool certs settings. This change fixes all of the current test but adds a failing test that illustrates a case that my change does not fix; since we are reusing the connection object (and its underlying connected socket) `connect` will never get invoked again and thus neither will `ssl_wrap_socket`. I don't see a great way of fixing this outside of some fairly hacky things (e.g. make `self.ca_certs` a property and trigger a `.close` on every connection when it gets set) and I'm not sure about the ramifications this has on proxies.
