### PR TITLE
fix skip test copy/paste typo

### DIFF
--- a/test/__init__.py
+++ b/test/__init__.py
@@ -24,7 +24,7 @@ def onlyPy26OrOlder(test):
 
     @functools.wraps(test)
     def wrapper(*args, **kwargs):
-        msg = "{name} requires Python2.7.x+ to run".format(name=test.__name__)
+        msg = "{name} only runs on Python2.6.x or older".format(name=test.__name__)
         if sys.version_info > (2, 6):
             raise SkipTest(msg)
         return test(*args, **kwargs)


### PR DESCRIPTION
There was a copy paste error where the 2.6 tests say they need to be run on 2.7, was kind of confusing.
