### PR TITLE
refactor ssl tests

### DIFF
--- a/test/test_util.py
+++ b/test/test_util.py
@@ -1,5 +1,6 @@
 import logging
 import unittest
+import ssl
 
 from mock import patch
 
@@ -11,6 +12,7 @@ from urllib3.util import (
     parse_url,
     Timeout,
     Url,
+    resolve_cert_reqs,
 )
 from urllib3.exceptions import LocationParseError, TimeoutStateError
 
@@ -294,4 +296,11 @@ class TestUtil(unittest.TestCase):
         current_time.return_value = TIMEOUT_EPOCH + 37
         self.assertEqual(timeout.get_connect_duration(), 37)
 
+    def test_resolve_cert_reqs(self):
+        self.assertEqual(resolve_cert_reqs(None), ssl.CERT_NONE)
+        self.assertEqual(resolve_cert_reqs(ssl.CERT_NONE), ssl.CERT_NONE)
+
+        self.assertEqual(resolve_cert_reqs(ssl.CERT_REQUIRED), ssl.CERT_REQUIRED)
+        self.assertEqual(resolve_cert_reqs('REQUIRED'), ssl.CERT_REQUIRED)
+        self.assertEqual(resolve_cert_reqs('CERT_REQUIRED'), ssl.CERT_REQUIRED)
 


### PR DESCRIPTION
Changing the verified tests so that we aren't changing the certs of a pool after we've used the pool. It produces weird undefined behavior and logic that we shouldn't support.

cc @t-8ch Is there anything stupid I'm doing?
