### PR TITLE
make active ssl backend accessible to users

### DIFF
--- a/urllib3/contrib/pyopenssl.py
+++ b/urllib3/contrib/pyopenssl.py
@@ -96,6 +96,7 @@ DEFAULT_SSL_CIPHER_LIST = "ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:" + \
 
 
 orig_util_HAS_SNI = util.HAS_SNI
+orig_ssl_backend = util._ssl_backend
 orig_connection_ssl_wrap_socket = connection.ssl_wrap_socket
 
 
@@ -104,6 +105,7 @@ def inject_into_urllib3():
 
     connection.ssl_wrap_socket = ssl_wrap_socket
     util.HAS_SNI = HAS_SNI
+    util._ssl_backend = 'PyOpenSSL'
 
 
 def extract_from_urllib3():
@@ -111,6 +113,7 @@ def extract_from_urllib3():
 
     connection.ssl_wrap_socket = orig_connection_ssl_wrap_socket
     util.HAS_SNI = orig_util_HAS_SNI
+    util._ssl_backend = orig_ssl_backend
 
 
 ### Note: This is a slightly bug-fixed version of same from ndg-httpsclient.

--- a/urllib3/util/__init__.py
+++ b/urllib3/util/__init__.py
@@ -14,6 +14,7 @@ from .ssl_ import (
     resolve_cert_reqs,
     resolve_ssl_version,
     ssl_wrap_socket,
+    _ssl_backend,
 )
 from .timeout import (
     current_time,

--- a/urllib3/util/ssl_.py
+++ b/urllib3/util/ssl_.py
@@ -7,13 +7,14 @@ from ..exceptions import SSLError
 try:  # Test for SSL features
     SSLContext = None
     HAS_SNI = False
+    _ssl_backend = 'stdlib'
 
     import ssl
     from ssl import wrap_socket, CERT_NONE, PROTOCOL_SSLv23
     from ssl import SSLContext  # Modern SSL?
     from ssl import HAS_SNI  # Has SNI?
 except ImportError:
-    pass
+    _ssl_backend = 'none'
 
 
 def assert_fingerprint(cert, fingerprint):


### PR DESCRIPTION
This especially useful for requests users, as they get whatever gets
autodetected without knowing what.

Also see kennethreitz/requests#2023
