### PR TITLE
add disable_cache to make_headers

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ dev (master)
 
 * Fix TLS verification when using a proxy in Python 3.4.1. (Issue #385)
 
+* Add ``disable_cache`` option to ``urllib3.util.make_headers``. (Issue #393)
+
 * ... [Short description of non-trivial change.] (Issue #)
 
 

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -179,6 +179,10 @@ class TestUtil(unittest.TestCase):
             make_headers(proxy_basic_auth='foo:bar'),
             {'proxy-authorization': 'Basic Zm9vOmJhcg=='})
 
+        self.assertEqual(
+            make_headers(disable_cache=True),
+            {'cache-control': 'no-cache'})
+
     def test_split_first(self):
         test_cases = {
             ('abcd', 'b'): ('a', 'cd', 'b'),

--- a/urllib3/util/request.py
+++ b/urllib3/util/request.py
@@ -7,7 +7,7 @@ ACCEPT_ENCODING = 'gzip,deflate'
 
 
 def make_headers(keep_alive=None, accept_encoding=None, user_agent=None,
-                 basic_auth=None, proxy_basic_auth=None):
+                 basic_auth=None, proxy_basic_auth=None, disable_cache=None):
     """
     Shortcuts for generating request headers.
 
@@ -31,6 +31,9 @@ def make_headers(keep_alive=None, accept_encoding=None, user_agent=None,
     :param proxy_basic_auth:
         Colon-separated username:password string for 'proxy-authorization: basic ...'
         auth header.
+
+    :param disable_cache:
+        If ``True``, adds 'cache-control: no-cache' header.
 
     Example: ::
 
@@ -62,6 +65,9 @@ def make_headers(keep_alive=None, accept_encoding=None, user_agent=None,
     if proxy_basic_auth:
         headers['proxy-authorization'] = 'Basic ' + \
             b64encode(six.b(proxy_basic_auth)).decode('utf-8')
+
+    if disable_cache:
+        headers['cache-control'] = 'no-cache'
 
     return headers
 


### PR DESCRIPTION
Woohoo I get to add a feature! This is for #393 which we talked about on that issue. I did some research about which headers to add and what I discovered is that this is all we need to be HTTP/1.1 compatible. Things like 'pragma: no-cache' is actually HTTP/1.0 and 'expires: 1994 etc' is even earlier, I can't imagine there are many web servers that aren't 1.1 compatible at this point in the world...interestingly though the spec does say the following about pragma:

> Clients SHOULD include both header fields when a no-cache request is sent to a server not known to be HTTP/1.1 compliant. 

Meh.
