### PR TITLE
document the util module again

### DIFF
--- a/docs/helpers.rst
+++ b/docs/helpers.rst
@@ -8,7 +8,15 @@ code specific to **urllib3**.
 Utilities
 ---------
 
-.. automodule:: urllib3.util
+.. automodule:: urllib3.util.connection
+   :members:
+.. automodule:: urllib3.util.request
+   :members:
+.. automodule:: urllib3.util.response
+   :members:
+.. automodule:: urllib3.util.ssl_
+   :members:
+.. automodule:: urllib3.util.url
    :members:
 
 Filepost


### PR DESCRIPTION
This was never fixed up when `urllib3.util` was broken up. I guess it's minorly annoying that the paths are now listed as `urllib3.util.request` et al but I'm not that familiar with rst to fix it. Also, note that I intentionally didn't include `urllib3.util.timeout` because it's documented elsewhere and seems specific to urllib3 unlike the rest of util.
