### PR TITLE
fix test failures on newest pythons

### DIFF
--- a/test/__init__.py
+++ b/test/__init__.py
@@ -25,7 +25,7 @@ def onlyPy26OrOlder(test):
     @functools.wraps(test)
     def wrapper(*args, **kwargs):
         msg = "{name} only runs on Python2.6.x or older".format(name=test.__name__)
-        if sys.version_info > (2, 6):
+        if sys.version_info >= (2, 7):
             raise SkipTest(msg)
         return test(*args, **kwargs)
     return wrapper

--- a/test/with_dummyserver/test_https.py
+++ b/test/with_dummyserver/test_https.py
@@ -246,6 +246,7 @@ class TestHTTPS(HTTPSDummyServerTestCase):
         conn._tunnel.assert_called_once_with()
 
 
+    @onlyPy26OrOlder
     def test_tunnel_old_python(self):
         """HTTPSConnection can still make connections if _tunnel_host isn't set
 


### PR DESCRIPTION
The newly released versions of python put self._tunnel_host in the _make_request critical path causing this test to fail with an attribute error. Since this is only a 2.6 feature we are testing it makes sense to only run the test on 2.6. The decorator was also wrong because (2, 6, 1) > (2, 6).
