### PR TITLE
Update references to RFC 2616

### DIFF
--- a/urllib3/_collections.py
+++ b/urllib3/_collections.py
@@ -116,7 +116,7 @@ class HTTPHeaderDict(MutableMapping):
     A ``dict`` like container for storing HTTP Headers.
 
     Field names are stored and compared case-insensitively in compliance with
-    RFC 2616. Iteration provides the first case-sensitive key seen for each
+    RFC 7230. Iteration provides the first case-sensitive key seen for each
     case-insensitive pair.
 
     Using ``__setitem__`` syntax overwrites fields that compare equal

--- a/urllib3/poolmanager.py
+++ b/urllib3/poolmanager.py
@@ -161,7 +161,7 @@ class PoolManager(RequestMethods):
         # Support relative URLs for redirecting.
         redirect_location = urljoin(url, redirect_location)
 
-        # RFC 2616, Section 10.3.4
+        # RFC 7231, Section 6.4.4
         if response.status == 303:
             method = 'GET'
 

--- a/urllib3/response.py
+++ b/urllib3/response.py
@@ -160,8 +160,8 @@ class HTTPResponse(io.IOBase):
             after having ``.read()`` the file object. (Overridden if ``amt`` is
             set.)
         """
-        # Note: content-encoding value should be case-insensitive, per RFC 2616
-        # Section 3.5
+        # Note: content-encoding value should be case-insensitive, per RFC 7230
+        # Section 3.2
         content_encoding = self.headers.get('content-encoding', '').lower()
         if self._decoder is None:
             if content_encoding in self.CONTENT_DECODERS:


### PR DESCRIPTION
This updates all references to RFC 2616 to their new places.

The only reference I left was in the changelog, which I'd argue should be a historical record of the reason for the change, rather than an up-to-date reference of the most recent spec.
