### PR TITLE
Change the PY3 detect way for more compatible

### DIFF
--- a/urllib3/connection.py
+++ b/urllib3/connection.py
@@ -8,9 +8,11 @@ import sys
 import socket
 from socket import timeout as SocketTimeout
 
-try:  # Python 3
+from .packages import six
+
+if six.PY3:
     from http.client import HTTPConnection as _HTTPConnection, HTTPException
-except ImportError:
+else:
     from httplib import HTTPConnection as _HTTPConnection, HTTPException
 
 
@@ -34,7 +36,6 @@ from .exceptions import (
     ConnectTimeoutError,
 )
 from .packages.ssl_match_hostname import match_hostname
-from .packages import six
 from .util import (
     assert_fingerprint,
     resolve_cert_reqs,

--- a/urllib3/connectionpool.py
+++ b/urllib3/connectionpool.py
@@ -11,9 +11,11 @@ import logging
 from socket import error as SocketError, timeout as SocketTimeout
 import socket
 
-try:  # Python 3
+from .packages.six import PY3
+
+if PY3:
     from queue import LifoQueue, Empty, Full
-except ImportError:
+else:
     from Queue import LifoQueue, Empty, Full
     import Queue as _  # Platform-specific: Windows
 

--- a/urllib3/poolmanager.py
+++ b/urllib3/poolmanager.py
@@ -6,9 +6,11 @@
 
 import logging
 
-try:  # Python 3
+from .packages import six
+
+if six.PY3:
     from urllib.parse import urljoin
-except ImportError:
+else:
     from urlparse import urljoin
 
 from ._collections import RecentlyUsedContainer


### PR DESCRIPTION
I'm using python 2.7.
I have a file named `http.py`

When start my program, `urllib3.connection` throw an Error,
that's because `urllib3.connection` try import `http.client` module directly.

By this way to detect the python version, and do other imports.
(`http.client`  is a py3 standard library)

So, I make this changes.  using `packages.six.PY3` instead of try import directly.
