### PR TITLE
Allow _prepare_conn() to run on Python 2.6.4

### DIFF
--- a/urllib3/connectionpool.py
+++ b/urllib3/connectionpool.py
@@ -644,7 +644,7 @@ class HTTPSConnectionPool(HTTPConnectionPool):
             if sys.version_info <= (2, 6, 4) and not self.proxy_headers:   # Python 2.6.4 and older
                 set_tunnel(self.host, self.port)
             else:
-                set_tunnel(self.host, self.port, self.proxy_headers):    
+                set_tunnel(self.host, self.port, self.proxy_headers)
 
             # Establish tunnel connection early, because otherwise httplib
             # would improperly set Host: header to proxy's IP:port.


### PR DESCRIPTION
When running on Python 2.6.4, a TypeError is thrown in _prepare_conn() 
because httplib's _set_tunnel() only takes two parameters.  This change 
will let the code run on Python 2.6.4 if proxy_headers are not set.
