### PR TITLE
added workaround for missing gzip support under IronPython

### DIFF
--- a/urllib3/response.py
+++ b/urllib3/response.py
@@ -7,6 +7,7 @@
 
 import zlib
 import io
+import sys
 from socket import timeout as SocketTimeout
 
 from ._collections import HTTPHeaderDict


### PR DESCRIPTION
This has been discovered as part of the IronPython pip/ensurepip porting effort.
