### PR TITLE
Extra connection diags

### DIFF
--- a/urllib3/util/connection.py
+++ b/urllib3/util/connection.py
@@ -1,3 +1,4 @@
+import logging
 import socket
 try:
     from select import poll, POLLIN
@@ -7,6 +8,9 @@ except ImportError:  # `poll` doesn't exist on OSX and other platforms
         from select import select
     except ImportError:  # `select` doesn't exist on AppEngine.
         select = False
+
+
+log = logging.getLogger(__name__)
 
 
 def is_connection_dropped(conn):  # Platform-specific
@@ -76,6 +80,11 @@ def create_connection(address, timeout=socket._GLOBAL_DEFAULT_TIMEOUT,
             if source_address:
                 sock.bind(source_address)
             sock.connect(sa)
+
+            if log.isEnabledFor(logging.DEBUG):
+                local_addr = sock.getsockname()
+                log.debug("Connected to %s:%s from %s:%s",
+                          sa[0], sa[1], local_addr[0], local_addr[1])
             return sock
 
         except socket.error as _:


### PR DESCRIPTION
When debugging a heavily loaded system, I wanted to find the TCP stream associated with a specific connection. However, it was hard to correlate that with an individual request from the logs. It would have been useful if we logged out four of the five fields of the connection five-tuple, making it possible to easily identify what TCP stream is associated with a request.

I appreciate this adds some SLOC for something that might be of minimal value, but I wanted to offer it as an option. It's totally reasonable to reject this, won't bother me overmuch: only took 5 minutes to whip up anyway. =)
