### PR TITLE
make our WrappedSocket compatible with pypy

### DIFF
--- a/urllib3/contrib/pyopenssl.py
+++ b/urllib3/contrib/pyopenssl.py
@@ -155,7 +155,11 @@ def get_subj_alt_name(peer_cert):
 
 
 class WrappedSocket(object):
-    '''API-compatibility wrapper for Python OpenSSL's Connection-class.'''
+    '''API-compatibility wrapper for Python OpenSSL's Connection-class.
+
+    Note: _makefile_refs, _drop() and _reuse() are needed for the garbage
+    collector of pypy.
+    '''
 
     def __init__(self, connection, socket, suppress_ragged_eofs=True):
         self.connection = connection


### PR DESCRIPTION
The changes are inspired by socket.py from pypy and the implementation is
lifted from ssl.py from pypy.

I have another branch where we actually test pyopenssl with tox and travis, we should probably wait until that one is done.

Adresses #449
