### PR TITLE
specify the test folder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ clean:
 	rm -rf docs/_build
 
 test: requirements
-	nosetests
+	nosetests test
 
 test-all: requirements
 	tox


### PR DESCRIPTION
In case tests exist in a virtualenv, they'll get run twice with the base `nosetests` command.
