### PR TITLE
disable tunneling for https proxy

### DIFF
--- a/dummyserver/testcase.py
+++ b/dummyserver/testcase.py
@@ -93,6 +93,10 @@ class HTTPDummyProxyTestCase(unittest.TestCase):
     proxy_host = 'localhost'
     proxy_host_alt = '127.0.0.1'
 
+    proxys_host = 'localhost'
+    proxys_host_alt = '127.0.0.1'
+    proxys_certs = DEFAULT_CERTS
+
     @classmethod
     def setUpClass(cls):
         cls.io_loop = ioloop.IOLoop()
@@ -108,6 +112,10 @@ class HTTPDummyProxyTestCase(unittest.TestCase):
         app = web.Application([(r'.*', ProxyHandler)])
         cls.proxy_server, cls.proxy_port = run_tornado_app(
             app, cls.io_loop, None, 'http', cls.proxy_host)
+
+        app = web.Application([(r'.*', ProxyHandler)])
+        cls.proxys_server, cls.proxys_port = run_tornado_app(
+            app, cls.io_loop, cls.proxys_certs, 'https', cls.proxy_host)
 
         cls.server_thread = run_loop_in_thread(cls.io_loop)
 

--- a/test/with_dummyserver/test_proxy_poolmanager.py
+++ b/test/with_dummyserver/test_proxy_poolmanager.py
@@ -149,7 +149,7 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
         self.assertEqual(r._pool.host, self.https_host)
 
     def test_headers(self):
-        http = proxy_from_url(self.proxy_url,headers={'Foo': 'bar'},
+        http = proxy_from_url(self.proxy_url, headers={'Foo': 'bar'},
                 proxy_headers={'Hickory': 'dickory'})
 
         r = http.request_encode_url('GET', '%s/headers' % self.http_url)
@@ -157,35 +157,35 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
         self.assertEqual(returned_headers.get('Foo'), 'bar')
         self.assertEqual(returned_headers.get('Hickory'), 'dickory')
         self.assertEqual(returned_headers.get('Host'),
-                '%s:%s'%(self.http_host,self.http_port))
+                '%s:%s' % (self.http_host, self.http_port))
 
         r = http.request_encode_url('GET', '%s/headers' % self.http_url_alt)
         returned_headers = json.loads(r.data.decode())
         self.assertEqual(returned_headers.get('Foo'), 'bar')
         self.assertEqual(returned_headers.get('Hickory'), 'dickory')
         self.assertEqual(returned_headers.get('Host'),
-                '%s:%s'%(self.http_host_alt,self.http_port))
+                '%s:%s' % (self.http_host_alt, self.http_port))
 
         r = http.request_encode_url('GET', '%s/headers' % self.https_url)
         returned_headers = json.loads(r.data.decode())
         self.assertEqual(returned_headers.get('Foo'), 'bar')
         self.assertEqual(returned_headers.get('Hickory'), None)
         self.assertEqual(returned_headers.get('Host'),
-                '%s:%s'%(self.https_host,self.https_port))
+                '%s:%s' % (self.https_host, self.https_port))
 
         r = http.request_encode_url('GET', '%s/headers' % self.https_url_alt)
         returned_headers = json.loads(r.data.decode())
         self.assertEqual(returned_headers.get('Foo'), 'bar')
         self.assertEqual(returned_headers.get('Hickory'), None)
         self.assertEqual(returned_headers.get('Host'),
-                '%s:%s'%(self.https_host_alt,self.https_port))
+                '%s:%s' % (self.https_host_alt, self.https_port))
 
         r = http.request_encode_body('POST', '%s/headers' % self.http_url)
         returned_headers = json.loads(r.data.decode())
         self.assertEqual(returned_headers.get('Foo'), 'bar')
         self.assertEqual(returned_headers.get('Hickory'), 'dickory')
         self.assertEqual(returned_headers.get('Host'),
-                '%s:%s'%(self.http_host,self.http_port))
+                '%s:%s' % (self.http_host, self.http_port))
 
         r = http.request_encode_url('GET', '%s/headers' % self.http_url, headers={'Baz': 'quux'})
         returned_headers = json.loads(r.data.decode())
@@ -193,7 +193,7 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
         self.assertEqual(returned_headers.get('Baz'), 'quux')
         self.assertEqual(returned_headers.get('Hickory'), 'dickory')
         self.assertEqual(returned_headers.get('Host'),
-                '%s:%s'%(self.http_host,self.http_port))
+                '%s:%s' % (self.http_host, self.http_port))
 
         r = http.request_encode_url('GET', '%s/headers' % self.https_url, headers={'Baz': 'quux'})
         returned_headers = json.loads(r.data.decode())
@@ -201,7 +201,7 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
         self.assertEqual(returned_headers.get('Baz'), 'quux')
         self.assertEqual(returned_headers.get('Hickory'), None)
         self.assertEqual(returned_headers.get('Host'),
-                '%s:%s'%(self.https_host,self.https_port))
+                '%s:%s' % (self.https_host, self.https_port))
 
         r = http.request_encode_body('GET', '%s/headers' % self.http_url, headers={'Baz': 'quux'})
         returned_headers = json.loads(r.data.decode())
@@ -209,7 +209,7 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
         self.assertEqual(returned_headers.get('Baz'), 'quux')
         self.assertEqual(returned_headers.get('Hickory'), 'dickory')
         self.assertEqual(returned_headers.get('Host'),
-                '%s:%s'%(self.http_host,self.http_port))
+                '%s:%s' % (self.http_host, self.http_port))
 
         r = http.request_encode_body('GET', '%s/headers' % self.https_url, headers={'Baz': 'quux'})
         returned_headers = json.loads(r.data.decode())
@@ -217,7 +217,7 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
         self.assertEqual(returned_headers.get('Baz'), 'quux')
         self.assertEqual(returned_headers.get('Hickory'), None)
         self.assertEqual(returned_headers.get('Host'),
-                '%s:%s'%(self.https_host,self.https_port))
+                '%s:%s' % (self.https_host, self.https_port))
 
     def test_proxy_pooling(self):
         http = proxy_from_url(self.proxy_url)
@@ -244,19 +244,35 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
         hc2 = http.connection_from_host(self.http_host, self.http_port)
         hc3 = http.connection_from_url(self.http_url_alt)
         hc4 = http.connection_from_host(self.http_host_alt, self.http_port)
-        self.assertEqual(hc1,hc2)
-        self.assertEqual(hc2,hc3)
-        self.assertEqual(hc3,hc4)
+        self.assertEqual(hc1, hc2)
+        self.assertEqual(hc2, hc3)
+        self.assertEqual(hc3, hc4)
 
         sc1 = http.connection_from_url(self.https_url)
         sc2 = http.connection_from_host(self.https_host,
-                self.https_port,scheme='https')
+                self.https_port, scheme='https')
         sc3 = http.connection_from_url(self.https_url_alt)
         sc4 = http.connection_from_host(self.https_host_alt,
-                self.https_port,scheme='https')
-        self.assertEqual(sc1,sc2)
-        self.assertNotEqual(sc2,sc3)
-        self.assertEqual(sc3,sc4)
+                self.https_port, scheme='https')
+        self.assertEqual(sc1, sc2)
+        self.assertNotEqual(sc2, sc3)
+        self.assertEqual(sc3, sc4)
+
+
+class TestHTTPSProxyManager(HTTPDummyProxyTestCase):
+
+    def setUp(self):
+        self.http_url = 'http://%s:%d' % (self.http_host, self.http_port)
+        self.http_url_alt = 'http://%s:%d' % (self.http_host_alt,
+                                              self.http_port)
+        self.proxys_url = 'https://%s:%d' % (self.proxys_host,
+                                             self.proxys_port)
+
+    def test_basic_proxy(self):
+        https = proxy_from_url(self.proxys_url)
+
+        r = https.request('GET', '%s/' % self.http_url)
+        self.assertEqual(r.status, 200)
 
 
 if __name__ == '__main__':

--- a/urllib3/poolmanager.py
+++ b/urllib3/poolmanager.py
@@ -177,7 +177,8 @@ class PoolManager(RequestMethods):
 class ProxyManager(PoolManager):
     """
     Behaves just like :class:`PoolManager`, but sends all requests through
-    the defined proxy, using the CONNECT method for HTTPS URLs.
+    the defined proxy. If the proxy is HTTP the CONNECT method is used for
+    HTTPS URLs.
 
     :param proxy_url:
         The URL of the proxy to be used.
@@ -220,6 +221,11 @@ class ProxyManager(PoolManager):
 
         connection_pool_kw['_proxy'] = self.proxy
         connection_pool_kw['_proxy_headers'] = self.proxy_headers
+
+        # Disable tunneling for HTTP URLs through HTTPS proxy so behavior is
+        # the same as HTTP URLs through HTTP proxy. In future we may want to
+        # support HTTPS URLs through HTTPS proxy.
+        connection_pool_kw['_proxy_disable_tunnel'] = proxy.scheme == 'https'
 
         super(ProxyManager, self).__init__(
             num_pools, headers, **connection_pool_kw)


### PR DESCRIPTION
i dont think https proxying http reqs works now anyway (added test fails without patch). by disabling tunneling for https proxies we can now: https proxy http requests (no http connect tunnel est needed).

closes #476
