### PR TITLE
Refactor tox & travis settings to include gevent #482

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,17 @@
 language: python
-python:
-  - "2.6"
-  - "2.7"
-  - "3.2"
-  - "3.3"
-  - "3.4"
-  - "pypy"
-script: make test
+script: tox
 install:
   - make
 notifications:
   email: false
-env: PYTHONWARNINGS=always::DeprecationWarning
+env:
+    global:
+      - PYTHONWARNINGS=always::DeprecationWarning
+    matrix:
+    - TOXENV=py26
+    - TOXENV=py27
+    - TOXENV=py27gevent
+    - TOXENV=py32
+    - TOXENV=py33
+    - TOXENV=py34
+    - TOXENV=pypy

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,3 +1,9 @@
+import os
+if os.environ.get('USE_GEVENT', False):
+    import gevent
+    from gevent import monkey
+    monkey.patch_all()
+
 import warnings
 import sys
 import errno

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, py32, py33, py34, pypy
+envlist = py26, py27, py27gevent, py32, py33, py34, pypy
 
 [testenv]
 deps= -r{toxinidir}/dev-requirements.txt
@@ -8,3 +8,11 @@ commands=
    []
 setenv =
     PYTHONWARNINGS=always::DeprecationWarning
+
+[testenv:py27gevent]
+basepython=python2.7
+deps= 
+    -r{toxinidir}/dev-requirements.txt
+    gevent
+setenv=
+    USE_GEVENT=1


### PR DESCRIPTION
- Add test env with gevent for python 2.7

Other changes:
- Use tox command to run tests from travis
- Set environment variables on .travis.yml to run tests
