### PR TITLE
Change how ssl_wrap_socket handles certfiles and keyfiles to match the r...

### DIFF
--- a/urllib3/contrib/pyopenssl.py
+++ b/urllib3/contrib/pyopenssl.py
@@ -261,6 +261,7 @@ def ssl_wrap_socket(sock, keyfile=None, certfile=None, cert_reqs=None,
                     ssl_version=None):
     ctx = OpenSSL.SSL.Context(_openssl_versions[ssl_version])
     if certfile:
+        keyfile = keyfile or certfile  # Match behaviour of the normal python ssl library
         ctx.use_certificate_file(certfile)
     if keyfile:
         ctx.use_privatekey_file(keyfile)


### PR DESCRIPTION
...egular python ssl library

I first noticed this when I started getting my requests rejected by the server when I started using pyopenssl. I had been using requests and had been passing a client certificate in like `requests.get(..., cert='foo.pem')`

When using the regular ssl library, we call ssl.wrap_socket, which uses the certfile as both the certfile and the keyfile if the keyfile is None [1].

When using pyopenssl, we should keep the same expectation.

[1] https://github.com/python/cpython/blob/455a24625d461ea841ea42b277aa0fb72065a04a/Lib/ssl.py#L491-L492
