### PR TITLE
Allow starting dummyserver in standalone mode

### DIFF
--- a/dummyserver/server.py
+++ b/dummyserver/server.py
@@ -184,3 +184,17 @@ def get_unreachable_address():
             return sockaddr
         else:
             s.close()
+
+
+if __name__ == '__main__':
+    # For debugging dummyserver itself - python -m dummyserver.server
+    from .testcase import TestingApp
+    host = '127.0.0.1'
+
+    io_loop = tornado.ioloop.IOLoop()
+    app = tornado.wsgi.WSGIContainer(TestingApp())
+    server, port = run_tornado_app(app, io_loop, None,
+                                   'http', host)
+    server_thread = run_loop_in_thread(io_loop)
+
+    print("Listening on http://{host}:{port}".format(host=host, port=port))


### PR DESCRIPTION
I didn't find a way to launch dummyserver stand-alone. Helps writing tests if you can launch the dummyserver and just shoot at it with HTTPie.

Any thoughts how to improve this? Is there a place where this fits on documentation? I'm happy with a doc-only fix if there's another way to run this.

```
(.env)grant:urllib3 joneskoo (dummyserver-standalone) $ python -m dummyserver.server
Listening on http://127.0.0.1:51163
```

```
grant:~ joneskoo $ http get http://127.0.0.1:51163/specific_method?method=GET
HTTP/1.1 200 OK
Content-Length: 0
Content-type: text/plain
Server: TornadoServer/3.1.1

```
