### PR TITLE
Cleanly handle ZeroReturnError as an expected EOF

### DIFF
--- a/urllib3/contrib/pyopenssl.py
+++ b/urllib3/contrib/pyopenssl.py
@@ -192,7 +192,10 @@ class WrappedSocket(object):
             else:
                 raise
         except OpenSSL.SSL.ZeroReturnError as e:
-            return b''
+            if self.connection.get_shutdown() == OpenSSL.SSL.RECEIVED_SHUTDOWN:
+                return b''
+            else:
+                raise
         except OpenSSL.SSL.WantReadError:
             rd, wd, ed = select.select(
                 [self.socket], [], [], self.socket.gettimeout())


### PR DESCRIPTION
Noticed this in requests, actually!

``` python
>>> import requests
>>> requests.get('https://api.tumblr.com/')
Traceback (most recent call last):
  File "<console>", line 1, in <module>
  File "/home/ubuntu/.virtualenvs/zapier/local/lib/python2.7/site-packages/requests/api.py", line 65, in get
    return request('get', url, **kwargs)
  File "/home/ubuntu/.virtualenvs/zapier/local/lib/python2.7/site-packages/requests/api.py", line 49, in request
    response = session.request(method=method, url=url, **kwargs)
  File "/home/ubuntu/.virtualenvs/zapier/local/lib/python2.7/site-packages/requests/sessions.py", line 461, in request
    resp = self.send(prep, **send_kwargs)
  File "/home/ubuntu/.virtualenvs/zapier/local/lib/python2.7/site-packages/requests/sessions.py", line 599, in send
    history = [resp for resp in gen] if allow_redirects else []
  File "/home/ubuntu/.virtualenvs/zapier/local/lib/python2.7/site-packages/requests/sessions.py", line 109, in resolve_redirects
    resp.content  # Consume socket so it can be released
  File "/home/ubuntu/.virtualenvs/zapier/local/lib/python2.7/site-packages/requests/models.py", line 728, in content
    self._content = bytes().join(self.iter_content(CONTENT_CHUNK_SIZE)) or bytes()
  File "/home/ubuntu/.virtualenvs/zapier/local/lib/python2.7/site-packages/requests/models.py", line 653, in generate
    for chunk in self.raw.stream(chunk_size, decode_content=True):
  File "/home/ubuntu/.virtualenvs/zapier/local/lib/python2.7/site-packages/requests/packages/urllib3/response.py", line 256, in stream
    data = self.read(amt=amt, decode_content=decode_content)
  File "/home/ubuntu/.virtualenvs/zapier/local/lib/python2.7/site-packages/requests/packages/urllib3/response.py", line 186, in read
    data = self._fp.read(amt)
  File "/usr/lib/python2.7/httplib.py", line 567, in read
    s = self.fp.read(amt)
  File "/usr/lib/python2.7/socket.py", line 380, in read
    data = self._sock.recv(left)
  File "/home/ubuntu/.virtualenvs/zapier/local/lib/python2.7/site-packages/requests/packages/urllib3/contrib/pyopenssl.py", line 188, in recv
    data = self.connection.recv(*args, **kwargs)
  File "/home/ubuntu/.virtualenvs/zapier/local/lib/python2.7/site-packages/OpenSSL/SSL.py", line 995, in recv
    self._raise_ssl_error(self._ssl, result)
  File "/home/ubuntu/.virtualenvs/zapier/local/lib/python2.7/site-packages/OpenSSL/SSL.py", line 851, in _raise_ssl_error
    raise ZeroReturnError()
ZeroReturnError
```

I haven't been able to reproduce this in pure urllib3, gonna get this and a test case soon!
