### PR TITLE
proof of concept: split ProtocolError into socket.connect, socket.write, socket.read

### DIFF
--- a/test/test_connectionpool.py
+++ b/test/test_connectionpool.py
@@ -140,21 +140,21 @@ class TestConnectionPool(unittest.TestCase):
             raise ex()
 
         def _test(exception, expect):
-            pool._make_request = lambda *args, **kwargs: _raise(exception)
+            pool._make_connect = lambda *args, **kwargs: _raise(exception)
             self.assertRaises(expect, pool.request, 'GET', '/')
 
             self.assertEqual(pool.pool.qsize(), POOL_SIZE)
 
         # Make sure that all of the exceptions return the connection to the pool
         _test(Empty, EmptyPoolError)
-        _test(BaseSSLError, SSLError)
-        _test(CertificateError, SSLError)
+        #_test(BaseSSLError, SSLError)
+        #_test(CertificateError, SSLError)
 
         # The pool should never be empty, and with these two exceptions being raised,
         # a retry will be triggered, but that retry will fail, eventually raising
         # MaxRetryError, not EmptyPoolError
         # See: https://github.com/shazow/urllib3/issues/76
-        pool._make_request = lambda *args, **kwargs: _raise(HTTPException)
+        pool._make_connect = lambda *args, **kwargs: _raise(HTTPException)
         self.assertRaises(MaxRetryError, pool.request,
                           'GET', '/', retries=1, pool_timeout=0.01)
         self.assertEqual(pool.pool.qsize(), POOL_SIZE)

--- a/test/with_dummyserver/test_connectionpool.py
+++ b/test/with_dummyserver/test_connectionpool.py
@@ -372,6 +372,9 @@ class TestConnectionPool(HTTPDummyServerTestCase):
             pool.request('GET', '/', retries=5)
             self.fail("should raise timeout exception here")
         except MaxRetryError as e:
+            print e
+            print e.reason
+            print type(e)
             self.assertTrue(isinstance(e.reason, ProtocolError), e.reason)
 
     def test_keepalive(self):

--- a/test/with_dummyserver/test_connectionpool.py
+++ b/test/with_dummyserver/test_connectionpool.py
@@ -150,6 +150,7 @@ class TestConnectionPool(HTTPDummyServerTestCase):
         # connect to the host provided so we need a dummyserver to be running.
         pool = HTTPConnectionPool(self.host, self.port)
         conn = pool._get_conn()
+        conn = pool._make_connect(conn, 'GET', '/')
         pool._make_request(conn, 'GET', '/')
         tcp_nodelay_setting = conn.sock.getsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY)
         assert tcp_nodelay_setting > 0, ("Expected TCP_NODELAY to be set on the "
@@ -204,8 +205,9 @@ class TestConnectionPool(HTTPDummyServerTestCase):
         pool = HTTPConnectionPool(self.host, self.port, timeout=timeout, retries=False)
 
         conn = pool._get_conn()
+        conn = pool._make_connect(conn, 'GET', url)
         self.assertRaises(ReadTimeoutError, pool._make_request,
-                          conn, 'GET', url)
+                          conn, 'GET', url, timeout)
         pool._put_conn(conn)
 
         time.sleep(0.02) # Wait for server to start receiving again. :(
@@ -216,6 +218,7 @@ class TestConnectionPool(HTTPDummyServerTestCase):
         pool = HTTPConnectionPool(self.host, self.port, timeout=0.1, retries=False)
 
         conn = pool._get_conn()
+        conn = pool._make_connect(conn, 'GET', url, timeout=timeout)
         self.assertRaises(ReadTimeoutError, pool._make_request,
                           conn, 'GET', url, timeout=timeout)
         pool._put_conn(conn)
@@ -230,6 +233,7 @@ class TestConnectionPool(HTTPDummyServerTestCase):
         self.assertRaises(ReadTimeoutError, pool.request,
                           'GET', url, timeout=0.001)
         conn = pool._new_conn()
+        conn = pool._make_connect(conn, 'GET', url)
         self.assertRaises(ReadTimeoutError, pool._make_request, conn,
                           'GET', url, timeout=0.001)
         pool._put_conn(conn)
@@ -247,7 +251,7 @@ class TestConnectionPool(HTTPDummyServerTestCase):
         # Pool-global timeout
         pool = HTTPConnectionPool(TARPIT_HOST, self.port, timeout=timeout)
         conn = pool._get_conn()
-        self.assertRaises(ConnectTimeoutError, pool._make_request, conn, 'GET', url)
+        self.assertRaises(ConnectTimeoutError, pool._make_connect, conn, 'GET', url)
 
         # Retries
         retries = Retry(connect=0)
@@ -259,7 +263,7 @@ class TestConnectionPool(HTTPDummyServerTestCase):
         pool = HTTPConnectionPool(TARPIT_HOST, self.port,
                                   timeout=big_timeout, retries=False)
         conn = pool._get_conn()
-        self.assertRaises(ConnectTimeoutError, pool._make_request, conn, 'GET',
+        self.assertRaises(ConnectTimeoutError, pool._make_connect, conn, 'GET',
                           url, timeout=timeout)
 
         pool._put_conn(conn)
@@ -285,6 +289,7 @@ class TestConnectionPool(HTTPDummyServerTestCase):
         pool = HTTPConnectionPool(self.host, self.port, timeout=timeout)
         conn = pool._get_conn()
         try:
+            conn = pool._make_connect(conn, 'GET', url)
             pool._make_request(conn, 'GET', url)
         except ReadTimeoutError:
             self.fail("This request shouldn't trigger a read timeout.")
@@ -297,19 +302,21 @@ class TestConnectionPool(HTTPDummyServerTestCase):
         timeout = Timeout(connect=3, read=5, total=0.001)
         pool = HTTPConnectionPool(TARPIT_HOST, self.port, timeout=timeout)
         conn = pool._get_conn()
-        self.assertRaises(ConnectTimeoutError, pool._make_request, conn, 'GET', url)
+        self.assertRaises(ConnectTimeoutError, pool._make_connect, conn, 'GET', url)
 
         # This will get the socket to raise an EAGAIN on the read
         timeout = Timeout(connect=3, read=0)
         pool = HTTPConnectionPool(self.host, self.port, timeout=timeout)
         conn = pool._get_conn()
+        pool._make_connect(conn, 'GET', url)
         self.assertRaises(ReadTimeoutError, pool._make_request, conn, 'GET', url)
 
         # The connect should succeed and this should hit the read timeout
         timeout = Timeout(connect=3, read=5, total=0.002)
         pool = HTTPConnectionPool(self.host, self.port, timeout=timeout)
         conn = pool._get_conn()
-        self.assertRaises(ReadTimeoutError, pool._make_request, conn, 'GET', url)
+        conn = pool._make_connect(conn, 'GET', url, timeout=timeout)
+        self.assertRaises(ReadTimeoutError, pool._make_request, conn, 'GET', url, timeout)
 
     @requires_network
     def test_none_total_applies_connect(self):
@@ -317,7 +324,7 @@ class TestConnectionPool(HTTPDummyServerTestCase):
         timeout = Timeout(total=None, connect=0.001)
         pool = HTTPConnectionPool(TARPIT_HOST, self.port, timeout=timeout)
         conn = pool._get_conn()
-        self.assertRaises(ConnectTimeoutError, pool._make_request, conn, 'GET',
+        self.assertRaises(ConnectTimeoutError, pool._make_connect, conn, 'GET',
                           url)
 
     def test_timeout_success(self):
@@ -346,7 +353,7 @@ class TestConnectionPool(HTTPDummyServerTestCase):
             conn._set_tunnel(self.host, self.port)
 
         conn._tunnel = mock.Mock(return_value=None)
-        pool._make_request(conn, 'GET', '/')
+        pool._make_connect(conn, 'GET', '/')
         conn._tunnel.assert_called_once_with()
 
         # test that it's not called when tunnel is not set
@@ -355,7 +362,7 @@ class TestConnectionPool(HTTPDummyServerTestCase):
         conn = pool._get_conn()
 
         conn._tunnel = mock.Mock(return_value=None)
-        pool._make_request(conn, 'GET', '/')
+        pool._make_connect(conn, 'GET', '/')
         self.assertEqual(conn._tunnel.called, False)
 
     def test_redirect(self):
@@ -372,9 +379,6 @@ class TestConnectionPool(HTTPDummyServerTestCase):
             pool.request('GET', '/', retries=5)
             self.fail("should raise timeout exception here")
         except MaxRetryError as e:
-            print e
-            print e.reason
-            print type(e)
             self.assertTrue(isinstance(e.reason, ProtocolError), e.reason)
 
     def test_keepalive(self):
@@ -559,7 +563,7 @@ class TestConnectionPool(HTTPDummyServerTestCase):
         self.assertEqual(pool.num_connections, 1)
 
     def test_for_double_release(self):
-        MAXSIZE=5
+        MAXSIZE = 5
 
         # Check default state
         pool = HTTPConnectionPool(self.host, self.port, maxsize=MAXSIZE)

--- a/test/with_dummyserver/test_https.py
+++ b/test/with_dummyserver/test_https.py
@@ -336,7 +336,7 @@ class TestHTTPS(HTTPSDummyServerTestCase):
         https_pool = new_pool(Timeout(connect=0.001))
         conn = https_pool._new_conn()
         self.assertRaises(ConnectTimeoutError, https_pool.request, 'GET', '/')
-        self.assertRaises(ConnectTimeoutError, https_pool._make_request, conn,
+        self.assertRaises(ConnectTimeoutError, https_pool._make_connect, conn,
                           'GET', '/')
 
         https_pool = new_pool(Timeout(connect=5))
@@ -357,6 +357,7 @@ class TestHTTPS(HTTPSDummyServerTestCase):
                 cert_reqs='CERT_REQUIRED', ca_certs=DEFAULT_CA,
                 assert_fingerprint=fingerprint)
 
+        conn = https_pool._make_connect(conn, 'GET', '/')
         https_pool._make_request(conn, 'GET', '/')
 
     def test_ssl_correct_system_time(self):

--- a/test/with_dummyserver/test_https.py
+++ b/test/with_dummyserver/test_https.py
@@ -309,6 +309,7 @@ class TestHTTPS(HTTPSDummyServerTestCase):
         except AttributeError: # python 2.6
             conn._set_tunnel(self.host, self.port)
         conn._tunnel = mock.Mock()
+        conn = https_pool._make_connect(conn, 'GET', '/')
         https_pool._make_request(conn, 'GET', '/')
         conn._tunnel.assert_called_once_with()
 

--- a/test/with_dummyserver/test_proxy_poolmanager.py
+++ b/test/with_dummyserver/test_proxy_poolmanager.py
@@ -40,6 +40,7 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
         http = proxy_from_url(self.proxy_url)
         hc2 = http.connection_from_host(self.http_host, self.http_port)
         conn = hc2._get_conn()
+        conn = hc2._make_connect(conn, 'GET', '/')
         hc2._make_request(conn, 'GET', '/')
         tcp_nodelay_setting = conn.sock.getsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY)
         self.assertEqual(tcp_nodelay_setting, 0,

--- a/urllib3/connectionpool.py
+++ b/urllib3/connectionpool.py
@@ -593,6 +593,9 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
                 e = ProxyError('Cannot connect to proxy.', e)
             elif isinstance(e, (SocketError, HTTPException)):
                 if hasattr(e, 'errno'):
+                    # Some error codes are shared by socket connect/write. In
+                    # those cases, assume the write failed, since that happens
+                    # later.
                     if e.errno in SocketWriteError.ERROR_CODES:
                         e = SocketWriteError('Connection aborted.', e)
                     else:

--- a/urllib3/exceptions.py
+++ b/urllib3/exceptions.py
@@ -1,3 +1,4 @@
+import errno
 
 ## Base Exceptions
 
@@ -52,6 +53,47 @@ class ProtocolError(HTTPError):
     "Raised when something unexpected happens mid-request/response."
     pass
 
+class SocketConnectError(ProtocolError):
+    "Raised when a socket connect() call fails"
+    # Via http://linux.die.net/man/2/connect
+    ERROR_CODES = [
+        errno.EACCES,
+        errno.EPERM,
+        errno.EADDRINUSE,
+        errno.EAFNOSUPPORT,
+        errno.EAGAIN,
+        errno.EALREADY,
+        errno.EBADF,
+        errno.ECONNREFUSED,
+        errno.EFAULT,
+        errno.EINPROGRESS,
+        errno.EINTR,
+        errno.EISCONN,
+        errno.ENETUNREACH,
+        errno.ENOTSOCK,
+        errno.ETIMEDOUT,
+    ]
+
+class SocketWriteError(ProtocolError):
+    "Raised when a socket write() call fails"
+    # Via http://linux.die.net/man/2/write
+    ERROR_CODES = [
+        errno.EAGAIN,
+        errno.EBADF,
+        errno.EDESTADDRREQ,
+        errno.EDQUOT,
+        errno.EFAULT,
+        errno.EFBIG,
+        errno.EINTR,
+        errno.EINVAL,
+        errno.EIO,
+        errno.ENOSPC,
+        errno.EPIPE,
+    ]
+
+class SocketReadError(ProtocolError):
+    "Raised when a socket read() call fails"
+    pass
 
 #: Renamed to ProtocolError but aliased for backwards compatibility.
 ConnectionError = ProtocolError

--- a/urllib3/util/retry.py
+++ b/urllib3/util/retry.py
@@ -7,6 +7,7 @@ from ..exceptions import (
     ProtocolError,
     ReadTimeoutError,
     ResponseError,
+    SocketConnectError,
 )
 from ..packages import six
 
@@ -181,7 +182,8 @@ class Retry(object):
         """ Errors when we're fairly sure that the server did not receive the
         request, so it should be safe to retry.
         """
-        return isinstance(err, ConnectTimeoutError)
+        return isinstance(err, ConnectTimeoutError) or \
+            isinstance(err, SocketConnectError)
 
     def _is_read_error(self, err):
         """ Errors that occur after the request has been started, so we should


### PR DESCRIPTION
In https://github.com/shazow/urllib3/issues/547 I said we could detect which type of error got raised by httplib. Here is a proof of concept showing how to do this. 

The essential `httplib` calls are both in `_make_request`: the first is `conn.request` and the second is `conn.getresponse()`. In order to distinguish these at the `urlopen` level, I had to split `_make_request` into two functions. Otherwise, you have to distinguish between errors between all three of socket connect/write/read; did the `ETIMEDOUT` occur on the connect or the read?
- This gets ugly since we want to pass a lot of state from the first function to the second function, in particular the `conn` object and the `timeout`. There's a failing test `test_total_timeout` that I couldn't figure out what to do with (besides bail on the feature, which I wouldn't be too against)
- a lot of the tests needed to be updated to call both `_make_` functions, which shouldn't be too terrible, since it's an underscored function.
- what is terrible is most of the exception handling has to be duplicated for `_make_connect` and `_make_request`... some of it could probably be killed if we looked harder at what could be thrown by both methods.

So yeah, I'm not amazingly sure about this, and given that I feel bad about code I felt better about when I submitted it, I'm not sure this is worth going down. 

Still, this is evidence that if we _wanted_ to do this, we _could_ without necessarily rewriting httplib.
