### PR TITLE
Add `enforce_content_length` for responses

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -37,6 +37,9 @@ dev (master)
 
 * Removed the cipher suite fallback to allow HIGH ciphers. (PR #958)
 
+* Implemented ``length_remaining`` to determine remaining content
+  to be read. (PR #949)
+
 * ... [Short description of non-trivial change.] (Issue #)
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -40,6 +40,9 @@ dev (master)
 * Implemented ``length_remaining`` to determine remaining content
   to be read. (PR #949)
 
+* Implemented ``enforce_content_length`` to enable exceptions when
+  incomplete data chunks are received. (PR #949)
+
 * ... [Short description of non-trivial change.] (Issue #)
 
 

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -210,6 +210,7 @@ In chronological order:
   * Ensure timeouts are not booleans and greater than zero.
   * Fixed infinite loop in ``stream`` when amt=None.
   * Added length_remaining to determine remaining data to be read.
+  * Added enforce_content_length to raise exception when incorrect content-length received.
 
 * [Your name or handle] <[email or website]>
   * [Brief summary of your changes]

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -209,6 +209,7 @@ In chronological order:
 * Nate Prewitt <nate.prewitt@gmail.com>
   * Ensure timeouts are not booleans and greater than zero.
   * Fixed infinite loop in ``stream`` when amt=None.
+  * Added length_remaining to determine remaining data to be read.
 
 * [Your name or handle] <[email or website]>
   * [Brief summary of your changes]

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -1076,3 +1076,68 @@ class TestStream(SocketDummyServerTestCase):
         self.assertEqual([b'hello, world'], list(r.stream(None)))
 
         done_event.set()
+
+class TestBadContentLength(SocketDummyServerTestCase):
+    def test_enforce_content_length_get(self):
+        done_event = Event()
+
+        def socket_handler(listener):
+            sock = listener.accept()[0]
+
+            buf = b''
+            while not buf.endswith(b'\r\n\r\n'):
+                buf += sock.recv(65536)
+
+            sock.send(
+                b'HTTP/1.1 200 OK\r\n'
+                b'Content-Length: 22\r\n'
+                b'Content-type: text/plain\r\n'
+                b'\r\n'
+                b'hello, world'
+            )
+            done_event.wait(1)
+            sock.close()
+
+        self._start_server(socket_handler)
+        conn = HTTPConnectionPool(self.host, self.port, maxsize=1)
+
+        # Test stream read when content length less than headers claim
+        get_response = conn.request('GET', url='/', preload_content=False,
+                                    enforce_content_length=True)
+        data = get_response.stream(100)
+        # Read "good" data before we try to read again.
+        # This won't trigger till generator is exhausted.
+        next(data)
+        self.assertRaises(ProtocolError, next, data)
+
+        done_event.set()
+
+    def test_enforce_content_length_no_body(self):
+        done_event = Event()
+
+        def socket_handler(listener):
+            sock = listener.accept()[0]
+
+            buf = b''
+            while not buf.endswith(b'\r\n\r\n'):
+                buf += sock.recv(65536)
+
+            sock.send(
+                b'HTTP/1.1 200 OK\r\n'
+                b'Content-Length: 22\r\n'
+                b'Content-type: text/plain\r\n'
+                b'\r\n'
+            )
+            done_event.wait(1)
+            sock.close()
+
+        self._start_server(socket_handler)
+        conn = HTTPConnectionPool(self.host, self.port, maxsize=1)
+
+        #Test stream on 0 length body
+        head_response = conn.request('HEAD', url='/', preload_content=False,
+                                     enforce_content_length=True)
+        data = [chunk for chunk in head_response.stream(1)]
+        self.assertEqual(len(data), 0)
+
+        done_event.set()

--- a/urllib3/connectionpool.py
+++ b/urllib3/connectionpool.py
@@ -599,6 +599,9 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
             # mess.
             response_conn = conn if not release_conn else None
 
+            # Pass method to Response for length checking
+            response_kw['request_method'] = method
+
             # Import httplib's response into our own wrapper object
             response = self.ResponseCls.from_httplib(httplib_response,
                                                      pool=self,

--- a/urllib3/exceptions.py
+++ b/urllib3/exceptions.py
@@ -1,4 +1,7 @@
 from __future__ import absolute_import
+from .packages.six.moves.http_client import (
+    IncompleteRead as httplib_IncompleteRead
+)
 # Base Exceptions
 
 
@@ -191,6 +194,20 @@ class DependencyWarning(HTTPWarning):
 class ResponseNotChunked(ProtocolError, ValueError):
     "Response needs to be chunked in order to read it as chunks."
     pass
+
+
+class IncompleteRead(HTTPError, httplib_IncompleteRead):
+    """
+    Response length doesn't match expected Content-Length
+
+    Subclass of http_client.IncompleteRead to allow int value
+    for `partial` to avoid creating large objects on streamed
+    reads.
+    """
+    def __init__(self, partial, expected):
+        message = ('IncompleteRead(%i bytes read, '
+                   '%i more expected)' % (partial, expected))
+        httplib_IncompleteRead.__init__(self, message)
 
 
 class InvalidHeader(HTTPError):

--- a/urllib3/exceptions.py
+++ b/urllib3/exceptions.py
@@ -193,6 +193,11 @@ class ResponseNotChunked(ProtocolError, ValueError):
     pass
 
 
+class InvalidHeader(HTTPError):
+    "The header provided was somehow invalid."
+    pass
+
+
 class ProxySchemeUnknown(AssertionError, ValueError):
     "ProxyManager does not support the supplied scheme"
     # TODO(t-8ch): Stop inheriting from AssertionError in v2.0.

--- a/urllib3/response.py
+++ b/urllib3/response.py
@@ -2,17 +2,21 @@ from __future__ import absolute_import
 from contextlib import contextmanager
 import zlib
 import io
+import logging
 from socket import timeout as SocketTimeout
 from socket import error as SocketError
 
 from ._collections import HTTPHeaderDict
 from .exceptions import (
-    ProtocolError, DecodeError, ReadTimeoutError, ResponseNotChunked
+    ProtocolError, DecodeError, ReadTimeoutError,
+    ResponseNotChunked, InvalidHeader
 )
 from .packages.six import string_types as basestring, binary_type, PY3
 from .packages.six.moves import http_client as httplib
 from .connection import HTTPException, BaseSSLError
 from .util.response import is_fp_closed, is_response_to_head
+
+log = logging.getLogger(__name__)
 
 
 class DeflateDecoder(object):
@@ -100,7 +104,8 @@ class HTTPResponse(io.IOBase):
 
     def __init__(self, body='', headers=None, status=0, version=0, reason=None,
                  strict=0, preload_content=True, decode_content=True,
-                 original_response=None, pool=None, connection=None, retries=None):
+                 original_response=None, pool=None, connection=None,
+                 retries=None, request_method=None):
 
         if isinstance(headers, HTTPHeaderDict):
             self.headers = headers
@@ -136,6 +141,9 @@ class HTTPResponse(io.IOBase):
         encodings = (enc.strip() for enc in tr_enc.split(","))
         if "chunked" in encodings:
             self.chunked = True
+
+        # Determine length of response
+        self.length_remaining = self._init_length(request_method)
 
         # If requested, preload the body.
         if preload_content and not self._body:
@@ -182,9 +190,57 @@ class HTTPResponse(io.IOBase):
         """
         return self._fp_bytes_read
 
+    def _init_length(self, request_method):
+        """
+        Set initial length value for Response content if available.
+        """
+        length = self.headers.get('content-length')
+
+        if length is not None and self.chunked:
+            # This Response will fail with an IncompleteRead if it can't be
+            # received as chunked. This method falls back to attempt reading
+            # the response before raising an exception.
+            log.warning("Received response with both Content-Length and "
+                        "Transfer-Encoding set. This is expressly forbidden "
+                        "by RFC 7230 sec 3.3.2. Ignoring Content-Length and "
+                        "attempting to process response as Transfer-Encoding: "
+                        "chunked.")
+            return None
+
+        elif length is not None:
+            try:
+                # RFC 7230 section 3.3.2 specifies multiple content lengths can
+                # be sent in a single Content-Length header
+                # (e.g. Content-Length: 42, 42). This line ensures the values
+                # are all valid ints and that as long as the `set` length is 1,
+                # all values are the same. Otherwise, the header is invalid.
+                lengths = set([int(val) for val in length.split(',')])
+                if len(lengths) > 1:
+                    raise InvalidHeader("Content-Length contained multiple "
+                                        "unmatching values (%s)" % length)
+                length = lengths.pop()
+            except ValueError:
+                length = None
+            else:
+                if length < 0:
+                    length = None
+
+        # Convert status to int for comparison
+        # In some cases, httplib returns a status of "_UNKNOWN"
+        try:
+            status = int(self.status)
+        except ValueError:
+            status = 0
+
+        # Check for responses that shouldn't include a body
+        if status in (204, 304) or 100 <= status < 200 or request_method == 'HEAD':
+            length = 0
+
+        return length
+
     def _init_decoder(self):
         """
-        Set-up the _decoder attribute if necessar.
+        Set-up the _decoder attribute if necessary.
         """
         # Note: content-encoding value should be case-insensitive, per RFC 7230
         # Section 3.2
@@ -330,6 +386,8 @@ class HTTPResponse(io.IOBase):
 
         if data:
             self._fp_bytes_read += len(data)
+            if self.length_remaining is not None:
+                self.length_remaining -= len(data)
 
             data = self._decode(data, decode_content, flush_decoder)
 


### PR DESCRIPTION
So here's a pass at #723. This is kind of a weird edge case but it particularly prominent in the default configuration of Requests. Most calls performed by `urllib3` will raise a `IncompleteRead` error from `httplib` when the number of bytes in the body doesn't match the `Content-Length`. 
# The Skinny

`httplib` raises `IncompleteRead`s appropriately everywhere except on incrementally read data. This is the primary way Requests uses `urlopen` with `preload_content=False` and then reading with `iter_content()`. Retrieving data this way hits the flaw in `httplib`. I've added a flag to enable this functionality, so as not to break `stream(amt)` and `read(amt)` calls presently. In the next major release, I would advise the flag being removed to make all `read` operations uniform by default.

Notes:
- My unfamiliarity with the testing harness is definitely showing in `test_strict_content_length` but the test does prove the changes are working correctly. Tornado won't allow you to send uneven data, so this was the only other solution I could come up with. Any suggestions on alternative methods of simulating this problem would be appreciated.
- ~~I implemented `length` as a property to match the attribute nature of `httplib.HTTPResponse.length`. I realize an int that we modify may be preferred to a property, but felt it would be more likely to break if we implement int updates everywhere IO might happen in the code.~~
