### PR TITLE
String-ify more OpenSSL errors to fix TypeError: __str__ returned non-string (type Error)

### DIFF
--- a/test/contrib/test_pyopenssl.py
+++ b/test/contrib/test_pyopenssl.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 import unittest
+import urllib3
 
 from nose.plugins.skip import SkipTest
+from urllib3.exceptions import SSLError
 from urllib3.packages import six
 
 try:
@@ -55,3 +57,15 @@ class TestPyOpenSSLHelpers(unittest.TestCase):
         expected_result = '*.xn--p1b6ci4b4b3a.xn--11b5bs8d'
 
         self.assertEqual(_dnsname_to_stdlib(name), expected_result)
+
+class TestPyOpenSSLErrorHandling(unittest.TestCase):
+    """
+    Tests for wrapping OpenSSL errors in urllib3 errors
+    """
+    def test_invalid_ca_certs(self):
+        """
+        Checks that we get an urllib3.exceptions.SSLError and not openssl.Error with missing ca_certs.
+        """
+        with self.assertRaises(SSLError):
+            http = urllib3.PoolManager(ca_certs='/no/path', cert_reqs='CERT_REQUIRED')
+            http.request('GET', 'https://python.org')

--- a/urllib3/contrib/pyopenssl.py
+++ b/urllib3/contrib/pyopenssl.py
@@ -386,7 +386,10 @@ class PyOpenSSLContext(object):
             cafile = cafile.encode('utf-8')
         if capath is not None:
             capath = capath.encode('utf-8')
-        self._ctx.load_verify_locations(cafile, capath)
+        try:
+            self._ctx.load_verify_locations(cafile, capath)
+        except OpenSSL.SSL.Error as e:
+            raise ssl.SSLError('bad ca_certs ("%s"): %r' % (cafile or capath, e))
         if cadata is not None:
             self._ctx.load_verify_locations(BytesIO(cadata))
 
@@ -442,10 +445,7 @@ def ssl_wrap_socket(sock, keyfile=None, certfile=None, cert_reqs=None,
     if cert_reqs != ssl.CERT_NONE:
         ctx.set_verify(_openssl_verify[cert_reqs], _verify_callback)
     if ca_certs or ca_cert_dir:
-        try:
-            ctx.load_verify_locations(ca_certs, ca_cert_dir)
-        except OpenSSL.SSL.Error as e:
-            raise ssl.SSLError('bad ca_certs: %r' % ca_certs, e)
+        ctx.load_verify_locations(ca_certs, ca_cert_dir)
     else:
         ctx.set_default_verify_paths()
 

--- a/urllib3/contrib/pyopenssl.py
+++ b/urllib3/contrib/pyopenssl.py
@@ -389,7 +389,7 @@ class PyOpenSSLContext(object):
         try:
             self._ctx.load_verify_locations(cafile, capath)
         except OpenSSL.SSL.Error as e:
-            raise ssl.SSLError('bad ca_certs ("%s"): %r' % (cafile or capath, e))
+            raise ssl.SSLError('bad certs (CAfile: "%s", CApath: "%s"): %r' % (cafile, capath, e))
         if cadata is not None:
             self._ctx.load_verify_locations(BytesIO(cadata))
 


### PR DESCRIPTION
Addresses the rather cryptic message:

```
  File "/usr/local/lib/python2.7/site-packages/requests/api.py", line 70, in get
    return request('get', url, params=params, **kwargs)
  <...>
  File "/usr/local/lib/python2.7/site-packages/requests/packages/urllib3/connectionpool.py", line 355, in _make_request
    self._raise_timeout(err=e, url=url, timeout_value=conn.timeout)
  File "/usr/local/lib/python2.7/site-packages/requests/packages/urllib3/connectionpool.py", line 325, in _raise_timeout
    if 'timed out' in str(err) or 'did not complete (read)' in str(err):  # Python 2.6
TypeError: __str__ returned non-string (type Error)
```

Which can arise when using the `pyopenssl` contrib module and setting bad verification paths (e.g. file not found, invalid format, etc.).

An easy way to reproduce:

```
$ pip install requests ndg-httpsclient
$ python -c "import requests; requests.get('https://python.org', verify='/no/file')"
```

I think this is a similar issue as to #556? At least, I started down this rabbit hole from kennethreitz/requests#2524, but #792 wasn't quite enough to address it. With this change, I see the much better (though not quite good) error:

```
requests.exceptions.SSLError: ('bad ca_certs ("/no/file"): Error([(\'system library\', \'fopen\', \'No such file or directory\'), (\'BIO routines\', \'BIO_new_file\', \'no such file\'), (\'x509 certificate routines\', \'X509_load_cert_crl_file\', \'system lib\')],)',)
```

Feedback appreciated!
