### PR TITLE
Add NameResolutionError for failed DNS lookups

### DIFF
--- a/urllib3/connection.py
+++ b/urllib3/connection.py
@@ -31,6 +31,7 @@ except NameError:  # Python 2:
 from .exceptions import (
     NewConnectionError,
     ConnectTimeoutError,
+    NameLookupError,
     SubjectAltNameWarning,
     SystemTimeWarning,
 )
@@ -124,6 +125,9 @@ class HTTPConnection(_HTTPConnection, object):
     def _new_conn(self):
         """ Establish a socket connection and set nodelay settings on it.
 
+        :raises ConnectTimeoutError:
+        :raises NewConnectionError:
+        :raises NameLookupError:
         :return: New socket connection.
         """
         extra_kw = {}
@@ -145,6 +149,9 @@ class HTTPConnection(_HTTPConnection, object):
         except SocketError as e:
             raise NewConnectionError(
                 self, "Failed to establish a new connection: %s" % e)
+
+        except socket.gaierror as e:
+            raise NameLookupError(self.host, e)
 
         return conn
 

--- a/urllib3/connection.py
+++ b/urllib3/connection.py
@@ -141,6 +141,9 @@ class HTTPConnection(_HTTPConnection, object):
             conn = connection.create_connection(
                 (self.host, self.port), self.timeout, **extra_kw)
 
+        except socket.gaierror as e:
+            raise NameLookupError(self.host, e)
+
         except SocketTimeout as e:
             raise ConnectTimeoutError(
                 self, "Connection to %s timed out. (connect timeout=%s)" %
@@ -149,9 +152,6 @@ class HTTPConnection(_HTTPConnection, object):
         except SocketError as e:
             raise NewConnectionError(
                 self, "Failed to establish a new connection: %s" % e)
-
-        except socket.gaierror as e:
-            raise NameLookupError(self.host, e)
 
         return conn
 

--- a/urllib3/connectionpool.py
+++ b/urllib3/connectionpool.py
@@ -18,6 +18,7 @@ from .exceptions import (
     MaxRetryError,
     ProxyError,
     ReadTimeoutError,
+    NameResolutionError,
     SSLError,
     TimeoutError,
     InsecureRequestWarning,
@@ -629,7 +630,8 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
             clean_exit = False
             raise
 
-        except (TimeoutError, HTTPException, SocketError, ProtocolError) as e:
+        except (TimeoutError, HTTPException, SocketError, ProtocolError,
+                NameResolutionError) as e:
             # Discard the connection for these exceptions. It will be
             # be replaced during the next _get_conn() call.
             clean_exit = False

--- a/urllib3/connectionpool.py
+++ b/urllib3/connectionpool.py
@@ -18,7 +18,7 @@ from .exceptions import (
     MaxRetryError,
     ProxyError,
     ReadTimeoutError,
-    NameResolutionError,
+    NameLookupError,
     SSLError,
     TimeoutError,
     InsecureRequestWarning,
@@ -631,7 +631,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
             raise
 
         except (TimeoutError, HTTPException, SocketError, ProtocolError,
-                NameResolutionError) as e:
+                NameLookupError) as e:
             # Discard the connection for these exceptions. It will be
             # be replaced during the next _get_conn() call.
             clean_exit = False

--- a/urllib3/exceptions.py
+++ b/urllib3/exceptions.py
@@ -37,7 +37,7 @@ class RequestError(PoolError):
         return self.__class__, (None, self.url, None)
 
 
-class NameResolutionError(HTTPError):
+class NameLookupError(HTTPError):
     "Raised when host name resolution fails"
     def __init__(self, name, exc):
         self.message = "address '%s' not found" % name

--- a/urllib3/exceptions.py
+++ b/urllib3/exceptions.py
@@ -37,6 +37,16 @@ class RequestError(PoolError):
         return self.__class__, (None, self.url, None)
 
 
+class NameResolutionError(HTTPError):
+    "Raised when host name resolution fails"
+    def __init__(self, name, exc):
+        self.message = "address '%s' not found" % name
+        self.reason = exc
+
+    def __str__(self):
+        return self.message + " (%s)" % self.reason
+
+
 class SSLError(HTTPError):
     "Raised when SSL certificate fails in an HTTPS connection."
     pass

--- a/urllib3/util/connection.py
+++ b/urllib3/util/connection.py
@@ -3,8 +3,6 @@ import socket
 from .wait import wait_for_read
 from .selectors import HAS_SELECT, SelectorError
 
-from ..exceptions import NameLookupError
-
 
 def is_connection_dropped(conn):  # Platform-specific
     """
@@ -50,7 +48,7 @@ def create_connection(address, timeout=socket._GLOBAL_DEFAULT_TIMEOUT,
 
     :raises SocketTimeout:
     :raises SocketError:
-    :raises NameLookupError:
+    :raises socket.gaierror:
     """
 
     host, port = address
@@ -68,7 +66,7 @@ def create_connection(address, timeout=socket._GLOBAL_DEFAULT_TIMEOUT,
     except socket.gaierror as e:
         # Windows gives "socket.gaierror: [Errno 11001] getaddrinfo failed"
         #   if DNS lookup fails
-        raise NameLookupError(host, e)
+        raise
 
     for af, socktype, proto, canonname, sa in addrlist:
         sock = None

--- a/urllib3/util/connection.py
+++ b/urllib3/util/connection.py
@@ -46,9 +46,9 @@ def create_connection(address, timeout=socket._GLOBAL_DEFAULT_TIMEOUT,
     for the socket to bind as a source address before making the connection.
     An host of '' or port 0 tells the OS to use the default.
 
+    :raises socket.gaierror:
     :raises SocketTimeout:
     :raises SocketError:
-    :raises socket.gaierror:
     """
 
     host, port = address

--- a/urllib3/util/connection.py
+++ b/urllib3/util/connection.py
@@ -47,6 +47,10 @@ def create_connection(address, timeout=socket._GLOBAL_DEFAULT_TIMEOUT,
     is used.  If *source_address* is set it must be a tuple of (host, port)
     for the socket to bind as a source address before making the connection.
     An host of '' or port 0 tells the OS to use the default.
+
+    :raises SocketTimeout:
+    :raises SocketError:
+    :raises NameLookupError:
     """
 
     host, port = address

--- a/urllib3/util/connection.py
+++ b/urllib3/util/connection.py
@@ -3,7 +3,7 @@ import socket
 from .wait import wait_for_read
 from .selectors import HAS_SELECT, SelectorError
 
-from ..exceptions import NameResolutionError
+from ..exceptions import NameLookupError
 
 
 def is_connection_dropped(conn):  # Platform-specific
@@ -64,7 +64,7 @@ def create_connection(address, timeout=socket._GLOBAL_DEFAULT_TIMEOUT,
     except socket.gaierror as e:
         # Windows gives "socket.gaierror: [Errno 11001] getaddrinfo failed"
         #   if DNS lookup fails
-        raise NameResolutionError(host, e)
+        raise NameLookupError(host, e)
 
     for af, socktype, proto, canonname, sa in addrlist:
         sock = None


### PR DESCRIPTION
Fixes #1003 for Windows. Test case for:

```
from urllib3.util.connection import create_connection
create_connection(('wowsucherror', 80))
```

On Windows, it gives:

```
Traceback (most recent call last):
  File "test.py", line 3, in <module>
    create_connection(('wowsucherror', 80))
  File "E:\urllib3\urllib3\util\connection.py", line 81, in create_connection
    raise NameResolutionError(host, e)
urllib3.exceptions.NameResolutionError: address 'wowsucherror' not found ([Errno 11001] getaddrinfo failed)
```
