### PR TITLE
Stop trying 'buffering' arg after TypeError

### DIFF
--- a/dummyserver/testcase.py
+++ b/dummyserver/testcase.py
@@ -1,8 +1,12 @@
-import unittest
 import socket
 import threading
 from nose.plugins.skip import SkipTest
 from tornado import ioloop, web
+
+if str is bytes:
+    import unittest2 as unittest
+else:
+    import unittest
 
 from dummyserver.server import (
     SocketServerThread,

--- a/dummyserver/testcase.py
+++ b/dummyserver/testcase.py
@@ -3,11 +3,6 @@ import threading
 from nose.plugins.skip import SkipTest
 from tornado import ioloop, web
 
-if str is bytes:
-    import unittest2 as unittest
-else:
-    import unittest
-
 from dummyserver.server import (
     SocketServerThread,
     run_tornado_app,
@@ -16,6 +11,11 @@ from dummyserver.server import (
 )
 from dummyserver.handlers import TestingApp
 from dummyserver.proxy import ProxyHandler
+
+if str is bytes:
+    import unittest2 as unittest
+else:
+    import unittest
 
 
 def consume_socket(sock, chunks=65536):

--- a/test/test_connectionpool.py
+++ b/test/test_connectionpool.py
@@ -10,7 +10,7 @@ from urllib3.connectionpool import (
 )
 from urllib3.response import httplib, HTTPResponse
 from urllib3.util.timeout import Timeout
-from urllib3.packages.six.moves.http_client import HTTPException
+from urllib3.packages.six.moves.http_client import HTTPException, HTTPMessage
 from urllib3.packages.six.moves.queue import Empty
 from urllib3.packages.ssl_match_hostname import CertificateError
 from urllib3.exceptions import (
@@ -383,6 +383,96 @@ class TestConnectionPool(unittest.TestCase):
         response = pool.request('GET', '/', retries=False, chunked=True,
                                 preload_content=False)
         self.assertTrue(isinstance(response, CustomHTTPResponse))
+
+    def test_getresponse_buffering_parameter(self):
+        # CPython 2.7 doesn't buffer response by default, but will do so
+        # if the undocumented "buffering" parameter is set to True.
+        # ConnectionPool should try that initially, but then stop calling it
+        # once it raises TypeError
+
+        class CustomConnection:
+            """Mock out HTTPConnection well enough for HTTPConnectionPool"""
+            mocked_response_count = 0
+            explicitly_buffered_call_count = 0
+            reject_buffering_arg = False
+            rejected_call_count = 0
+
+            # Ignore all settings and indicate no socket is available
+            def __init__(self, *args, **kwds):
+                self.sock = None
+
+            # Allow close calls
+            def close(self):
+                pass
+
+            # Don't actually issue any requests
+            def request(self, *args, **kwds):
+                pass
+
+            # Return a mock response unless configured to fail
+            def getresponse(self, buffering=None):
+                cls = type(self)
+                cls.mocked_response_count += 1
+                if buffering is not None:
+                    cls.explicitly_buffered_call_count += 1
+                    if cls.reject_buffering_arg:
+                        cls.rejected_call_count += 1
+                        raise TypeError("Buffering argument not supported!")
+                response = httplib.HTTPResponse(MockSock)
+                response.fp = MockChunkedEncodingResponse([b'f', b'o', b'o'])
+                response.msg = HTTPMessage()
+                response.headers = HTTPHeaderDict()
+                return response
+
+        class CustomResponse(HTTPResponse):
+            @classmethod
+            def from_httplib(cls, httplib_response, pool, connection, **kwds):
+                return cls(pool=pool, connection=connection)
+
+        class CustomConnectionPool(HTTPConnectionPool):
+            ConnectionCls = CustomConnection
+            ResponseCls = CustomResponse
+
+            def _validate_conn(self, conn):
+                return True
+
+        # Set up a custom pool that lets us test the getresponse() handling
+        pool = CustomConnectionPool(host='localhost', maxsize=1, block=True)
+        def _make_new_request(**request_kwds):
+            return pool.request('GET', '/',
+                                redirect=False,
+                                retries=False,
+                                **request_kwds,
+            )
+        # First check the behaviour with the buffering argument accepted
+        # This also checks that the custom connection and response are used
+        response = _make_new_request(release_conn=False)
+        self.assertIsInstance(response, CustomResponse)
+        self.assertIsInstance(response.connection, CustomConnection)
+        self.assertEqual(CustomConnection.explicitly_buffered_call_count, 1)
+        self.assertEqual(CustomConnection.rejected_call_count, 0)
+        response.release_conn()
+        # Then check the first time it fails
+        CustomConnection.reject_buffering_arg = True
+        response = _make_new_request()
+        self.assertEqual(CustomConnection.explicitly_buffered_call_count, 2)
+        self.assertEqual(CustomConnection.rejected_call_count, 1)
+        # Then check the argument isn't even tried on subsequent calls
+        response = _make_new_request()
+        self.assertEqual(CustomConnection.explicitly_buffered_call_count, 2)
+        self.assertEqual(CustomConnection.rejected_call_count, 1)
+        # Finally, check a completely broken custom pool raises TypeError
+        class BadConnectionPool(HTTPConnectionPool):
+            ConnectionCls = CustomConnection
+            ResponseCls = CustomResponse
+
+            def _validate_conn(self, conn):
+                self.ConnectionCls = HTTPConnection
+                return True
+        bad_pool = BadConnectionPool(host='localhost', maxsize=1, block=True)
+        error_structure = 'expected.*HTTPConnection.*got.*CustomConnection'
+        with self.assertRaisesRegex(TypeError, error_structure):
+            bad_pool.request('GET', '/', redirect=False, retries=False)
 
 
 if __name__ == '__main__':

--- a/test/test_custom_connectionpool.py
+++ b/test/test_custom_connectionpool.py
@@ -2,34 +2,11 @@ from __future__ import absolute_import
 
 import unittest
 
-from urllib3.connectionpool import (
-    connection_from_url,
-    HTTPConnection,
-    HTTPConnectionPool,
-    HTTPSConnectionPool,
-)
+from urllib3.connectionpool import HTTPConnection, HTTPConnectionPool
 from urllib3.response import httplib, HTTPResponse
-from urllib3.util.timeout import Timeout
-from urllib3.packages.six.moves.http_client import HTTPException, HTTPMessage
-from urllib3.packages.six.moves.queue import Empty
-from urllib3.packages.ssl_match_hostname import CertificateError
-from urllib3.exceptions import (
-    ClosedPoolError,
-    EmptyPoolError,
-    HostChangedError,
-    LocationValueError,
-    MaxRetryError,
-    ProtocolError,
-    SSLError,
-    TimeoutError,
-)
+from urllib3.packages.six.moves.http_client import HTTPMessage
 from urllib3._collections import HTTPHeaderDict
 from .test_response import MockChunkedEncodingResponse, MockSock
-
-from socket import error as SocketError
-from ssl import SSLError as BaseSSLError
-
-from dummyserver.server import DEFAULT_CA
 
 def make_custom_pool(pool_cls):
     """Instantiate the given custom pool class"""

--- a/test/test_custom_connectionpool.py
+++ b/test/test_custom_connectionpool.py
@@ -2,6 +2,8 @@ from __future__ import absolute_import
 
 if str is bytes:
     import unittest2 as unittest
+else:
+    import unittest
 
 from urllib3.connectionpool import HTTPConnection, HTTPConnectionPool
 from urllib3.response import httplib, HTTPResponse

--- a/test/test_custom_connectionpool.py
+++ b/test/test_custom_connectionpool.py
@@ -1,0 +1,203 @@
+from __future__ import absolute_import
+
+import unittest
+
+from urllib3.connectionpool import (
+    connection_from_url,
+    HTTPConnection,
+    HTTPConnectionPool,
+    HTTPSConnectionPool,
+)
+from urllib3.response import httplib, HTTPResponse
+from urllib3.util.timeout import Timeout
+from urllib3.packages.six.moves.http_client import HTTPException, HTTPMessage
+from urllib3.packages.six.moves.queue import Empty
+from urllib3.packages.ssl_match_hostname import CertificateError
+from urllib3.exceptions import (
+    ClosedPoolError,
+    EmptyPoolError,
+    HostChangedError,
+    LocationValueError,
+    MaxRetryError,
+    ProtocolError,
+    SSLError,
+    TimeoutError,
+)
+from urllib3._collections import HTTPHeaderDict
+from .test_response import MockChunkedEncodingResponse, MockSock
+
+from socket import error as SocketError
+from ssl import SSLError as BaseSSLError
+
+from dummyserver.server import DEFAULT_CA
+
+def make_custom_pool(pool_cls):
+    """Instantiate the given custom pool class"""
+    return pool_cls(host='localhost', maxsize=1, block=True)
+
+def make_pool_request(pool, **request_kwds):
+    """Make a request via the given pool without redirects or retries"""
+    return pool.request('GET', '/',
+                        redirect=False,
+                        retries=False,
+                        **request_kwds
+    )
+
+
+class CustomHTTPResponse(HTTPResponse):
+    """Alternative HTTPResponse implementation"""
+    @classmethod
+    def from_httplib(cls, httplib_response, pool, connection, **kwds):
+        """Pass through the pool and connection, ignore everything else"""
+        return cls(pool=pool, connection=connection)
+
+
+class DummyRequestPool(HTTPConnectionPool):
+    """Connection pool that doesn't initiate any real network requests"""
+    def _make_request(*args, **kwargs):
+        """Construct a dummy httplib level request response"""
+        # Note that this can also be used as "DummyRequestPool._make_request()"
+        httplib_response = httplib.HTTPResponse(MockSock)
+        httplib_response.fp = MockChunkedEncodingResponse([b'f', b'o', b'o'])
+        httplib_response.msg = HTTPMessage()
+        httplib_response.headers = HTTPHeaderDict()
+        return httplib_response
+
+
+class CustomConnection:
+    """Mock out HTTPConnection well enough for customisation testing"""
+
+    def __init__(self, *args, **kwds):
+        # Ignore all settings and indicate no socket is available
+        self.sock = None
+        # Allow configuring the behaviour of getresponse()
+        self.reject_buffering_arg = False
+        # Track statistics about calls to getresponse()
+        self.mocked_response_count = 0
+        self.explicitly_buffered_call_count = 0
+        self.rejected_call_count = 0
+
+    # Allow close calls
+    def close(self):
+        pass
+
+    # Don't actually issue any requests
+    def request(self, *args, **kwds):
+        pass
+
+    # Return a mock response unless configured to fail
+    def getresponse(self, buffering=None):
+        self.mocked_response_count += 1
+        if buffering is not None:
+            self.explicitly_buffered_call_count += 1
+            if self.reject_buffering_arg:
+                self.rejected_call_count += 1
+                raise TypeError("Buffering argument not supported!")
+        return DummyRequestPool._make_request()
+
+class DummyConnectionPool(HTTPConnectionPool):
+    """Connection pool that doesn't create any real network connections"""
+    ConnectionCls = CustomConnection
+    ResponseCls = CustomHTTPResponse
+
+    def _validate_conn(self, conn):
+        return True
+
+class TestCustomisedConnectionPool(unittest.TestCase):
+    """
+    Tests in this suite should exercise the ConnectionPool customisation
+    functionality without actually making any network requests or
+    connections.
+    """
+    def test_invalid_connection_class_fails(self):
+        class BrokenConnectionPool(HTTPConnectionPool):
+            ConnectionCls = None
+        pool = make_custom_pool(BrokenConnectionPool)
+        with self.assertRaises((TypeError, AttributeError)):
+            make_pool_request(pool)
+
+    def test_invalid_response_class_fails(self):
+        class BrokenResponsePool(DummyRequestPool):
+            ResponseCls = None
+        pool = make_custom_pool(BrokenResponsePool)
+        with self.assertRaises((TypeError, AttributeError)):
+            make_pool_request(pool)
+
+    def test_custom_http_response_class(self):
+        class CustomResponsePool(DummyRequestPool):
+            ResponseCls = CustomHTTPResponse
+
+        pool = make_custom_pool(CustomResponsePool)
+        response = make_pool_request(
+            pool,
+            chunked=True,
+            preload_content=False
+        )
+        self.assertIsInstance(response, CustomHTTPResponse)
+
+    # CPython 2.7 doesn't buffer responses by default, but will do so
+    # if the undocumented "buffering" parameter is set to True.
+    # ConnectionPool should try that initially, but then stop calling it
+    # as soon as it raises TypeError on a given pool instance
+    def test_getresponse_with_buffering_parameter(self):
+        # Check the behaviour with the buffering parameter accepted
+        # This also checks that the custom connection and response are used
+        pool = make_custom_pool(DummyConnectionPool)
+        response = make_pool_request(pool, release_conn=False)
+        self.assertIsInstance(response, CustomHTTPResponse)
+        conn = response.connection
+        self.assertIsInstance(conn, CustomConnection)
+        self.assertEqual(conn.mocked_response_count, 1)
+        self.assertEqual(conn.explicitly_buffered_call_count, 1)
+        self.assertEqual(conn.rejected_call_count, 0)
+        response.release_conn()
+        # Check the behaviour is maintained for subsequent requests
+        response = make_pool_request(pool, release_conn=False)
+        conn = response.connection
+        self.assertEqual(conn.mocked_response_count, 2)
+        self.assertEqual(conn.explicitly_buffered_call_count, 2)
+        self.assertEqual(conn.rejected_call_count, 0)
+        response.release_conn()
+
+    def test_getresponse_without_buffering_parameter(self):
+        # Set the pool's connection to reject the buffering parameter
+        pool = make_custom_pool(DummyConnectionPool)
+        response = make_pool_request(pool, release_conn=False)
+        response.connection.reject_buffering_arg = True
+        response.release_conn()
+        # Check the behaviour with the buffering parameter rejected
+        # is to try it, then fall back to leaving it out
+        response = make_pool_request(pool, release_conn=False)
+        conn = response.connection
+        self.assertEqual(conn.mocked_response_count, 3)
+        self.assertEqual(conn.explicitly_buffered_call_count, 2)
+        self.assertEqual(conn.rejected_call_count, 1)
+        response.release_conn()
+        # Also check the argument isn't even supplied on subsequent calls
+        response = make_pool_request(pool, release_conn=False)
+        conn = response.connection
+        self.assertEqual(conn.mocked_response_count, 4)
+        self.assertEqual(conn.explicitly_buffered_call_count, 2)
+        self.assertEqual(conn.rejected_call_count, 1)
+        response.release_conn()
+
+    def test_getresponse_with_broken_customisation(self):
+        # Check TypeError is raised if a subclass creates a mismatch
+        # between the connection type declared and the one actually used
+        class BadConnectionPool(DummyConnectionPool):
+            def _validate_conn(self, conn):
+                self.ConnectionCls = HTTPConnection
+                return True
+        # Check the mismatch is tolerated when using the getresponse wrapper
+        bad_pool = make_custom_pool(BadConnectionPool)
+        response = make_pool_request(bad_pool, release_conn=False)
+        response.connection.reject_buffering_arg = True
+        response.release_conn()
+        # Check it's disallowed when attempting to bypass the wrapper
+        error_structure = 'expected.*HTTPConnection.*got.*CustomConnection'
+        with self.assertRaisesRegex(TypeError, error_structure):
+            make_pool_request(bad_pool)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_custom_connectionpool.py
+++ b/test/test_custom_connectionpool.py
@@ -1,6 +1,10 @@
 from __future__ import absolute_import
 
-import unittest
+import sys
+if sys.version_info >= (2, 7):
+    import unittest
+else:
+    import unittest2 as unittest
 
 from urllib3.connectionpool import HTTPConnection, HTTPConnectionPool
 from urllib3.response import httplib, HTTPResponse
@@ -185,7 +189,7 @@ class TestCustomisedConnectionPool(unittest.TestCase):
         response.release_conn()
         # Check it's disallowed when attempting to bypass the wrapper
         error_structure = 'expected.*HTTPConnection.*got.*CustomConnection'
-        with self.assertRaisesRegex(TypeError, error_structure):
+        with self.assertRaisesRegexp(TypeError, error_structure):
             make_pool_request(bad_pool)
 
 

--- a/test/test_custom_connectionpool.py
+++ b/test/test_custom_connectionpool.py
@@ -1,9 +1,6 @@
 from __future__ import absolute_import
 
-import sys
-if sys.version_info >= (2, 7):
-    import unittest
-else:
+if str is bytes:
     import unittest2 as unittest
 
 from urllib3.connectionpool import HTTPConnection, HTTPConnectionPool
@@ -189,7 +186,7 @@ class TestCustomisedConnectionPool(unittest.TestCase):
         response.release_conn()
         # Check it's disallowed when attempting to bypass the wrapper
         error_structure = 'expected.*HTTPConnection.*got.*CustomConnection'
-        with self.assertRaisesRegexp(TypeError, error_structure):
+        with self.assertRaisesRegex(TypeError, error_structure):
             make_pool_request(bad_pool)
 
 

--- a/test/with_dummyserver/test_connectionpool.py
+++ b/test/with_dummyserver/test_connectionpool.py
@@ -130,6 +130,12 @@ class TestConnectionPoolTimeouts(SocketDummyServerTestCase):
         block_event.set() # Release request
 
         self.assertLess(delta, LONG_TIMEOUT, "timeout was pool-level LONG_TIMEOUT rather than request-level SHORT_TIMEOUT")
+        # TEMPORARY CI DEBUGGING
+        # Pre-emptively close the connection & make a new one
+        conn.close()
+        pool._put_conn(conn)
+        conn = pool._get_conn()
+        # END TEMPORARY CI DEBUGGING
         pool._put_conn(conn)
 
         wait_for_socket(ready_event)

--- a/test/with_dummyserver/test_connectionpool.py
+++ b/test/with_dummyserver/test_connectionpool.py
@@ -3,9 +3,18 @@ import io
 import logging
 import socket
 import sys
-import unittest
-import time
 import warnings
+
+if str is bytes:
+    import unittest2 as unittest
+else:
+    import unittest
+
+from time import time as _get_absolute_time
+try:
+    from time import monotonic as _get_relative_time
+except ImportError:
+    _get_relative_time = _get_absolute_time
 
 from datetime import datetime
 from datetime import timedelta
@@ -115,18 +124,18 @@ class TestConnectionPoolTimeouts(SocketDummyServerTestCase):
 
         conn = pool._get_conn()
         wait_for_socket(ready_event)
-        now = time.time()
+        now = _get_relative_time()
         self.assertRaises(ReadTimeoutError, pool._make_request, conn, 'GET', '/', timeout=timeout)
-        delta = time.time() - now
+        delta = _get_relative_time() - now
         block_event.set() # Release request
 
         self.assertLess(delta, LONG_TIMEOUT, "timeout was pool-level LONG_TIMEOUT rather than request-level SHORT_TIMEOUT")
         pool._put_conn(conn)
 
         wait_for_socket(ready_event)
-        now = time.time()
+        now = _get_relative_time()
         self.assertRaises(ReadTimeoutError, pool.request, 'GET', '/', timeout=timeout)
-        delta = time.time() - now
+        delta = _get_relative_time() - now
 
         self.assertLess(delta, LONG_TIMEOUT, "timeout was pool-level LONG_TIMEOUT rather than request-level SHORT_TIMEOUT")
         block_event.set() # Release request
@@ -854,24 +863,24 @@ class TestRetryAfter(HTTPDummyServerTestCase):
         r = self.pool.request('GET', '/redirect_after', retries=False)
         self.assertEqual(r.status, 303)
 
-        t = time.time()
+        t = _get_relative_time()
         r = self.pool.request('GET', '/redirect_after')
         self.assertEqual(r.status, 200)
-        delta = time.time() - t
+        delta = _get_relative_time() - t
         self.assertTrue(delta >= 1)
 
-        t = time.time()
-        timestamp = t + 2
+        t = _get_relative_time()
+        timestamp = _get_absolute_time() + 2
         r = self.pool.request('GET', '/redirect_after?date=' + str(timestamp))
         self.assertEqual(r.status, 200)
-        delta = time.time() - t
+        delta = _get_relative_time() - t
         self.assertTrue(delta >= 1)
 
         # Retry-After is past
-        t = time.time()
-        timestamp = t - 1
+        t = _get_relative_time()
+        timestamp = _get_absolute_time() - 1
         r = self.pool.request('GET', '/redirect_after?date=' + str(timestamp))
-        delta = time.time() - t
+        delta = _get_relative_time() - t
         self.assertEqual(r.status, 200)
         self.assertTrue(delta < 1)
 

--- a/test/with_dummyserver/test_connectionpool.py
+++ b/test/with_dummyserver/test_connectionpool.py
@@ -120,7 +120,7 @@ class TestConnectionPoolTimeouts(SocketDummyServerTestCase):
         delta = time.time() - now
         block_event.set() # Release request
 
-        self.assertTrue(delta < LONG_TIMEOUT, "timeout was pool-level LONG_TIMEOUT rather than request-level SHORT_TIMEOUT")
+        self.assertLess(delta, LONG_TIMEOUT, "timeout was pool-level LONG_TIMEOUT rather than request-level SHORT_TIMEOUT")
         pool._put_conn(conn)
 
         wait_for_socket(ready_event)
@@ -128,7 +128,7 @@ class TestConnectionPoolTimeouts(SocketDummyServerTestCase):
         self.assertRaises(ReadTimeoutError, pool.request, 'GET', '/', timeout=timeout)
         delta = time.time() - now
 
-        self.assertTrue(delta < LONG_TIMEOUT, "timeout was pool-level LONG_TIMEOUT rather than request-level SHORT_TIMEOUT")
+        self.assertLess(delta, LONG_TIMEOUT, "timeout was pool-level LONG_TIMEOUT rather than request-level SHORT_TIMEOUT")
         block_event.set() # Release request
 
         # Timeout int/float passed directly to request and _make_request should

--- a/test/with_dummyserver/test_connectionpool.py
+++ b/test/with_dummyserver/test_connectionpool.py
@@ -47,7 +47,7 @@ log.addHandler(logging.StreamHandler(sys.stdout))
 
 
 SHORT_TIMEOUT = 0.001
-LONG_TIMEOUT = 0.01
+LONG_TIMEOUT = 0.02
 
 
 def wait_for_socket(ready_event):

--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,7 @@ deps=
 [testenv:gae]
 basepython = python2.7
 deps=
-    {[testenv]deps}
+    {[testenv:py27]deps}
     -r{toxinidir}/test/appengine/requirements.txt
 commands=
     nosetests \

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,12 @@ deps=
     {[testenv]deps}
     unittest2
 
+[testenv:py27]
+# Additional dependency on unittest2 for Python 2.7 as well
+deps=
+    {[testenv]deps}
+    unittest2
+
 [testenv:gae]
 basepython = python2.7
 deps=

--- a/urllib3/connectionpool.py
+++ b/urllib3/connectionpool.py
@@ -336,6 +336,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
             if not class_ok:
                 msg = 'expected {0!r} connection, got {1!r}.'
                 raise TypeError(msg.format(self.ConnectionCls, conn.__class__))
+
             # Don't try to use buffering when retrieving any future responses
             # for this connection pool.
             # Note: we can't use the unbound method directly, as that won't

--- a/urllib3/connectionpool.py
+++ b/urllib3/connectionpool.py
@@ -341,6 +341,9 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
             # for this connection pool.
             # Note: we can't use the unbound method directly, as that won't
             # always work with Python 2.x classes
+            msg = ("TypeError in (%r).getresponse(buffering=True): "
+                   "shadowing (%r)._getresponse()")
+            log.debug(msg, conn, self)
             def _unbuffered_get_response(conn):
                 return conn.getresponse()
             self._getresponse = _unbuffered_get_response


### PR DESCRIPTION
If `conn.getresponse(buffering=True)` throws TypeError once,
it's always going to throw it on all future calls.

The new HTTPConnectionPool._getresponse helper method added in
this patch instead replaces itself on the instance with the
underlying ConnectionCls method so all future calls on that
particular pool instance will use that instead of the pool
level helper method.

A runtime sanity check is included to detect the case where
a connection that isn't an instance of ConnectionCls is somehow
accessed through the pool.

Closes #1047 