### PR TITLE
Stamp out a bunch of warnings in the tests

### DIFF
--- a/test/contrib/test_socks.py
+++ b/test/contrib/test_socks.py
@@ -1,10 +1,13 @@
 import threading
 import socket
 
+from urllib3 import disable_warnings
 from urllib3.contrib import socks
-from urllib3.exceptions import ConnectTimeoutError, NewConnectionError
+from urllib3.exceptions import (
+    ConnectTimeoutError, InsecureRequestWarning, NewConnectionError,
+)
 
-from dummyserver.server import DEFAULT_CERTS
+from dummyserver.server import DEFAULT_CERTS, NoIPv6Warning
 from dummyserver.testcase import IPV4SocketDummyServerTestCase
 
 from nose.plugins.skip import SkipTest
@@ -199,6 +202,8 @@ class TestSocks5Proxy(IPV4SocketDummyServerTestCase):
     Test the SOCKS proxy in SOCKS5 mode.
     """
     def test_basic_request(self):
+        disable_warnings(NoIPv6Warning)
+
         def request_handler(listener):
             sock = listener.accept()[0]
 
@@ -231,6 +236,8 @@ class TestSocks5Proxy(IPV4SocketDummyServerTestCase):
         self.assertEqual(response.headers['Server'], 'SocksTestServer')
 
     def test_local_dns(self):
+        disable_warnings(NoIPv6Warning)
+
         def request_handler(listener):
             sock = listener.accept()[0]
 
@@ -263,6 +270,8 @@ class TestSocks5Proxy(IPV4SocketDummyServerTestCase):
         self.assertEqual(response.headers['Server'], 'SocksTestServer')
 
     def test_correct_header_line(self):
+        disable_warnings(NoIPv6Warning)
+
         def request_handler(listener):
             sock = listener.accept()[0]
 
@@ -296,6 +305,8 @@ class TestSocks5Proxy(IPV4SocketDummyServerTestCase):
         self.assertEqual(response.status, 200)
 
     def test_connection_timeouts(self):
+        disable_warnings(NoIPv6Warning)
+
         event = threading.Event()
 
         def request_handler(listener):
@@ -313,6 +324,8 @@ class TestSocks5Proxy(IPV4SocketDummyServerTestCase):
         event.set()
 
     def test_connection_failure(self):
+        disable_warnings(NoIPv6Warning)
+
         event = threading.Event()
 
         def request_handler(listener):
@@ -331,6 +344,8 @@ class TestSocks5Proxy(IPV4SocketDummyServerTestCase):
         )
 
     def test_proxy_rejection(self):
+        disable_warnings(NoIPv6Warning)
+
         evt = threading.Event()
 
         def request_handler(listener):
@@ -355,6 +370,8 @@ class TestSocks5Proxy(IPV4SocketDummyServerTestCase):
         evt.set()
 
     def test_socks_with_password(self):
+        disable_warnings(NoIPv6Warning)
+
         def request_handler(listener):
             sock = listener.accept()[0]
 
@@ -391,6 +408,8 @@ class TestSocks5Proxy(IPV4SocketDummyServerTestCase):
         self.assertEqual(response.headers['Server'], 'SocksTestServer')
 
     def test_socks_with_invalid_password(self):
+        disable_warnings(NoIPv6Warning)
+
         def request_handler(listener):
             sock = listener.accept()[0]
 
@@ -413,6 +432,8 @@ class TestSocks5Proxy(IPV4SocketDummyServerTestCase):
             self.fail("Did not raise")
 
     def test_source_address_works(self):
+        disable_warnings(NoIPv6Warning)
+
         expected_port = _get_free_port(self.host)
 
         def request_handler(listener):
@@ -456,6 +477,8 @@ class TestSOCKS4Proxy(IPV4SocketDummyServerTestCase):
     negotiation is done the two cases behave identically.
     """
     def test_basic_request(self):
+        disable_warnings(NoIPv6Warning)
+
         def request_handler(listener):
             sock = listener.accept()[0]
 
@@ -488,6 +511,8 @@ class TestSOCKS4Proxy(IPV4SocketDummyServerTestCase):
         self.assertEqual(response.data, b'')
 
     def test_local_dns(self):
+        disable_warnings(NoIPv6Warning)
+
         def request_handler(listener):
             sock = listener.accept()[0]
 
@@ -520,6 +545,8 @@ class TestSOCKS4Proxy(IPV4SocketDummyServerTestCase):
         self.assertEqual(response.data, b'')
 
     def test_correct_header_line(self):
+        disable_warnings(NoIPv6Warning)
+
         def request_handler(listener):
             sock = listener.accept()[0]
 
@@ -553,6 +580,8 @@ class TestSOCKS4Proxy(IPV4SocketDummyServerTestCase):
         self.assertEqual(response.status, 200)
 
     def test_proxy_rejection(self):
+        disable_warnings(NoIPv6Warning)
+
         evt = threading.Event()
 
         def request_handler(listener):
@@ -577,6 +606,8 @@ class TestSOCKS4Proxy(IPV4SocketDummyServerTestCase):
         evt.set()
 
     def test_socks4_with_username(self):
+        disable_warnings(NoIPv6Warning)
+
         def request_handler(listener):
             sock = listener.accept()[0]
 
@@ -609,6 +640,8 @@ class TestSOCKS4Proxy(IPV4SocketDummyServerTestCase):
         self.assertEqual(response.headers['Server'], 'SocksTestServer')
 
     def test_socks_with_invalid_username(self):
+        disable_warnings(NoIPv6Warning)
+
         def request_handler(listener):
             sock = listener.accept()[0]
 
@@ -633,6 +666,9 @@ class TestSOCKSWithTLS(IPV4SocketDummyServerTestCase):
     Test that TLS behaves properly for SOCKS proxies.
     """
     def test_basic_request(self):
+        disable_warnings(InsecureRequestWarning)
+        disable_warnings(NoIPv6Warning)
+
         if not HAS_SSL:
             raise SkipTest("No TLS available")
 

--- a/test/contrib/test_socks.py
+++ b/test/contrib/test_socks.py
@@ -1,10 +1,14 @@
 import threading
 import socket
+import sys
 
 from urllib3 import disable_warnings
 from urllib3.contrib import socks
 from urllib3.exceptions import (
-    ConnectTimeoutError, InsecureRequestWarning, NewConnectionError,
+    ConnectTimeoutError,
+    InsecurePlatformWarning,
+    InsecureRequestWarning,
+    NewConnectionError,
 )
 
 from dummyserver.server import DEFAULT_CERTS, NoIPv6Warning
@@ -668,6 +672,8 @@ class TestSOCKSWithTLS(IPV4SocketDummyServerTestCase):
     def test_basic_request(self):
         disable_warnings(InsecureRequestWarning)
         disable_warnings(NoIPv6Warning)
+        if sys.version_info < (2, 7):
+            disable_warnings(InsecurePlatformWarning)
 
         if not HAS_SSL:
             raise SkipTest("No TLS available")

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -4,6 +4,7 @@ import logging
 import io
 import ssl
 import socket
+import sys
 from itertools import chain
 
 from mock import patch, Mock
@@ -454,6 +455,8 @@ class TestUtil(object):
             is_fp_closed(NotReallyAFile())
 
     def test_ssl_wrap_socket_loads_the_cert_chain(self):
+        if sys.version_info < (2, 7):
+            disable_warnings(SNIMissingWarning)
         socket = object()
         mock_context = Mock()
         ssl_wrap_socket(ssl_context=mock_context, sock=socket,

--- a/test/with_dummyserver/test_connectionpool.py
+++ b/test/with_dummyserver/test_connectionpool.py
@@ -1000,7 +1000,7 @@ class TestRetryPoolSize(HTTPDummyServerTestCase):
 
     def test_pool_size_retry(self):
         self.pool.urlopen('GET', '/not_found', preload_content=False)
-        self.assertEquals(self.pool.num_connections, 1)
+        self.assertEqual(self.pool.num_connections, 1)
 
 
 class TestRedirectPoolSize(HTTPDummyServerTestCase):
@@ -1017,7 +1017,7 @@ class TestRedirectPoolSize(HTTPDummyServerTestCase):
 
     def test_pool_size_redirect(self):
         self.pool.urlopen('GET', '/redirect', preload_content=False)
-        self.assertEquals(self.pool.num_connections, 1)
+        self.assertEqual(self.pool.num_connections, 1)
 
 
 if __name__ == '__main__':

--- a/test/with_dummyserver/test_https.py
+++ b/test/with_dummyserver/test_https.py
@@ -24,7 +24,7 @@ from test import (
     requires_network,
     TARPIT_HOST,
 )
-from urllib3 import HTTPSConnectionPool
+from urllib3 import disable_warnings, HTTPSConnectionPool
 from urllib3.connection import (
     VerifiedHTTPSConnection,
     UnverifiedHTTPSConnection,
@@ -37,6 +37,7 @@ from urllib3.exceptions import (
     SystemTimeWarning,
     InsecurePlatformWarning,
     MaxRetryError,
+    SubjectAltNameWarning,
 )
 from urllib3.packages import six
 from urllib3.util.timeout import Timeout
@@ -59,10 +60,12 @@ class TestHTTPS(HTTPSDummyServerTestCase):
         self.addCleanup(self._pool.close)
 
     def test_simple(self):
+        disable_warnings(InsecureRequestWarning)
         r = self._pool.request('GET', '/')
         self.assertEqual(r.status, 200, r.data)
 
     def test_set_ssl_version_to_tlsv1(self):
+        disable_warnings(InsecureRequestWarning)
         self._pool.ssl_version = ssl.PROTOCOL_TLSv1
         r = self._pool.request('GET', '/')
         self.assertEqual(r.status, 200, r.data)
@@ -386,6 +389,8 @@ class TestHTTPS(HTTPSDummyServerTestCase):
 
     @requires_network
     def test_https_timeout(self):
+        disable_warnings(InsecureRequestWarning)
+
         timeout = Timeout(connect=0.001)
         https_pool = HTTPSConnectionPool(TARPIT_HOST, self.port,
                                          timeout=timeout, retries=False,
@@ -416,6 +421,7 @@ class TestHTTPS(HTTPSDummyServerTestCase):
 
     def test_tunnel(self):
         """ test the _tunnel behavior """
+        disable_warnings(InsecureRequestWarning)
         timeout = Timeout(total=None)
         https_pool = HTTPSConnectionPool(self.host, self.port, timeout=timeout,
                                          cert_reqs='CERT_NONE')
@@ -469,6 +475,8 @@ class TestHTTPS(HTTPSDummyServerTestCase):
                           timeout=Timeout(total=None, connect=0.001))
 
     def test_enhanced_ssl_connection(self):
+        disable_warnings(InsecureRequestWarning)
+
         fingerprint = '92:81:FE:85:F7:0C:26:60:EC:D6:B3:BF:93:CF:F9:71:CC:07:7D:0A'
 
         conn = VerifiedHTTPSConnection(self.host, self.port)
@@ -575,6 +583,8 @@ class TestHTTPS_IPv6Addr(IPV6HTTPSDummyServerTestCase):
 
     def test_strip_square_brackets_before_validating(self):
         """Test that the fix for #760 works."""
+        disable_warnings(SubjectAltNameWarning)
+
         if not HAS_IPV6:
             raise SkipTest("Only runs on IPv6 systems")
         https_pool = HTTPSConnectionPool('[::1]', self.port,

--- a/test/with_dummyserver/test_no_ssl.py
+++ b/test/with_dummyserver/test_no_ssl.py
@@ -9,6 +9,8 @@ from dummyserver.testcase import (
         HTTPDummyServerTestCase, HTTPSDummyServerTestCase)
 
 import urllib3
+from urllib3 import disable_warnings
+from urllib3.exceptions import InsecureRequestWarning
 
 
 class TestHTTPWithoutSSL(HTTPDummyServerTestCase, TestWithoutSSL):
@@ -21,6 +23,7 @@ class TestHTTPWithoutSSL(HTTPDummyServerTestCase, TestWithoutSSL):
 
 class TestHTTPSWithoutSSL(HTTPSDummyServerTestCase, TestWithoutSSL):
     def test_simple(self):
+        disable_warnings(InsecureRequestWarning)
         pool = urllib3.HTTPSConnectionPool(self.host, self.port)
         self.addCleanup(pool.close)
         try:

--- a/test/with_dummyserver/test_proxy_poolmanager.py
+++ b/test/with_dummyserver/test_proxy_poolmanager.py
@@ -9,10 +9,16 @@ from dummyserver.server import (
     DEFAULT_CA, DEFAULT_CA_BAD, get_unreachable_address)
 from .. import TARPIT_HOST, requires_network
 
+from urllib3 import disable_warnings
 from urllib3._collections import HTTPHeaderDict
 from urllib3.poolmanager import proxy_from_url, ProxyManager
 from urllib3.exceptions import (
-    MaxRetryError, SSLError, ProxyError, ConnectTimeoutError)
+    ConnectTimeoutError,
+    InsecureRequestWarning,
+    MaxRetryError,
+    ProxyError,
+    SSLError,
+)
 from urllib3.connectionpool import connection_from_url, VerifiedHTTPSConnection
 
 
@@ -28,6 +34,8 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
         self.proxy_url = 'http://%s:%d' % (self.proxy_host, self.proxy_port)
 
     def test_basic_proxy(self):
+        disable_warnings(InsecureRequestWarning)
+
         http = proxy_from_url(self.proxy_url)
         self.addCleanup(http.clear)
 
@@ -66,6 +74,8 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
             self.assertEqual(type(e.reason), ProxyError)
 
     def test_oldapi(self):
+        disable_warnings(InsecureRequestWarning)
+
         http = ProxyManager(connection_from_url(self.proxy_url))
         self.addCleanup(http.clear)
 
@@ -94,6 +104,7 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
                               ca_certs=DEFAULT_CA)
         https_pool = http._new_pool('https', self.https_host,
                                     self.https_port)
+        self.addCleanup(https_pool.close)
 
         conn = https_pool._new_conn()
         self.assertEqual(conn.__class__, VerifiedHTTPSConnection)
@@ -146,6 +157,8 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
         self.assertNotEqual(r._pool.host, self.http_host_alt)
 
     def test_cross_protocol_redirect(self):
+        disable_warnings(InsecureRequestWarning)
+
         http = proxy_from_url(self.proxy_url)
         self.addCleanup(http.clear)
 
@@ -165,6 +178,8 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
         self.assertEqual(r._pool.host, self.https_host)
 
     def test_headers(self):
+        disable_warnings(InsecureRequestWarning)
+
         http = proxy_from_url(self.proxy_url, headers={'Foo': 'bar'},
                               proxy_headers={'Hickory': 'dickory'})
         self.addCleanup(http.clear)
@@ -254,6 +269,8 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
         self.assertEqual(returned_headers.get('Baz'), 'quux')
 
     def test_proxy_pooling(self):
+        disable_warnings(InsecureRequestWarning)
+
         http = proxy_from_url(self.proxy_url)
         self.addCleanup(http.clear)
 
@@ -320,6 +337,8 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
 
     def test_scheme_host_case_insensitive(self):
         """Assert that upper-case schemes and hosts are normalized."""
+        disable_warnings(InsecureRequestWarning)
+
         http = proxy_from_url(self.proxy_url.upper())
         self.addCleanup(http.clear)
 
@@ -342,6 +361,8 @@ class TestIPv6HTTPProxyManager(IPv6HTTPDummyProxyTestCase):
         self.proxy_url = 'http://[%s]:%d' % (self.proxy_host, self.proxy_port)
 
     def test_basic_ipv6_proxy(self):
+        disable_warnings(InsecureRequestWarning)
+
         http = proxy_from_url(self.proxy_url)
         self.addCleanup(http.clear)
 

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -1470,4 +1470,4 @@ class TestRetryPoolSizeDrainFail(SocketDummyServerTestCase):
         self.addCleanup(pool.close)
 
         pool.urlopen('GET', '/not_found', preload_content=False)
-        self.assertEquals(pool.num_connections, 1)
+        self.assertEqual(pool.num_connections, 1)

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -1,9 +1,10 @@
 # TODO: Break this module up into pieces. Maybe group by functionality tested
 # rather than the socket level-ness of it.
 
-from urllib3 import HTTPConnectionPool, HTTPSConnectionPool
+from urllib3 import disable_warnings, HTTPConnectionPool, HTTPSConnectionPool
 from urllib3.poolmanager import proxy_from_url
 from urllib3.exceptions import (
+        InsecureRequestWarning,
         MaxRetryError,
         ProxyError,
         ReadTimeoutError,
@@ -857,6 +858,8 @@ class TestProxyManager(SocketDummyServerTestCase):
                           assert_same_host=False, retries=False)
 
     def test_connect_reconn(self):
+        disable_warnings(InsecureRequestWarning)
+
         def proxy_ssl_one(listener):
             sock = listener.accept()[0]
 
@@ -912,6 +915,8 @@ class TestProxyManager(SocketDummyServerTestCase):
         self.assertEqual(r.status, 200)
 
     def test_connect_ipv6_addr(self):
+        disable_warnings(InsecureRequestWarning)
+
         ipv6_addr = '2001:4998:c:a06::2:4008'
 
         def echo_socket_handler(listener):
@@ -960,6 +965,8 @@ class TestProxyManager(SocketDummyServerTestCase):
 class TestSSL(SocketDummyServerTestCase):
 
     def test_ssl_failure_midway_through_conn(self):
+        disable_warnings(InsecureRequestWarning)
+
         def socket_handler(listener):
             sock = listener.accept()[0]
             sock2 = sock.dup()
@@ -992,6 +999,8 @@ class TestSSL(SocketDummyServerTestCase):
         self.assertIsInstance(cm.exception.reason, SSLError)
 
     def test_ssl_read_timeout(self):
+        disable_warnings(InsecureRequestWarning)
+
         timed_out = Event()
 
         def socket_handler(listener):
@@ -1070,6 +1079,8 @@ class TestSSL(SocketDummyServerTestCase):
         self.assertRaises(MaxRetryError, request)
 
     def test_retry_ssl_error(self):
+        disable_warnings(InsecureRequestWarning)
+
         def socket_handler(listener):
             # first request, trigger an SSLError
             sock = listener.accept()[0]
@@ -1317,6 +1328,7 @@ class TestHEAD(SocketDummyServerTestCase):
         pool = HTTPConnectionPool(self.host, self.port, retries=False)
         self.addCleanup(pool.close)
         r = pool.request('HEAD', '/', timeout=1, preload_content=False)
+        self.addCleanup(r.close)
 
         # stream will use the read_chunked method here.
         self.assertEqual([], list(r.stream()))


### PR DESCRIPTION
The test suite emits a lot of warnings (63 on [this recent Travis run](https://travis-ci.org/shazow/urllib3/jobs/254519138)).

These warnings are mostly benign, but they’re mixed in with real problems, such as #1100. This patch causes the test suite to emit substantially fewer warnings, meaning the interesting ones will be easier to spot. It also cleans up another two leaked FDs.