### PR TITLE
Remove race conditions in PoolManager causing ClosedPoolErrors (#1252)

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -243,5 +243,8 @@ In chronological order:
   * Fix ``util.selectors._fileobj_to_fd`` to accept ``long``.
   * Update appveyor tox setup to use the 64bit python.
 
+* Justin Patrin <papercrane@reversefold.com>
+  * Fix PoolManager and ConnectionPool to close race condition which can cause ClosedPoolError on retry
+
 * [Your name or handle] <[email or website]>
   * [Brief summary of your changes]

--- a/dummyserver/handlers.py
+++ b/dummyserver/handlers.py
@@ -283,7 +283,7 @@ class TestingApp(RequestHandler):
         if datetime.now() - self.application.last_req < timedelta(seconds=1):
             status = request.params.get("status", "429 Too Many Requests")
             return Response(
-                    status=status.decode('utf-8'),
+                    status=status.decode('utf-8') if hasattr(status, 'decode') else status,
                     headers=[('Retry-After', '1')])
 
         self.application.last_req = datetime.now()

--- a/test/with_dummyserver/test_poolmanager.py
+++ b/test/with_dummyserver/test_poolmanager.py
@@ -216,6 +216,24 @@ class TestPoolManager(HTTPDummyServerTestCase):
         r = http.request('GET', 'http://%s:%s/' % (self.host, self.port))
         self.assertEqual(r.status, 200)
 
+    def test_retry_with_too_many_pools(self):
+        http = PoolManager(num_pools=1, retries=5)
+        import threading
+        import time
+        threads = []
+        http.request('GET', '%s/retry_after' % (self.base_url,))
+        def invalidate_pool():
+            time.sleep(0.5)
+            http.request('GET', self.base_url_alt)
+        t = threading.Thread(target=invalidate_pool)
+        t.start()
+        threads.append(t)
+        try:
+            http.request('GET', '%s/retry_after' % (self.base_url,))
+        finally:
+            for t in threads:
+                t.join()
+
 
 @pytest.mark.skipif(
     not HAS_IPV6,

--- a/test/with_dummyserver/test_poolmanager.py
+++ b/test/with_dummyserver/test_poolmanager.py
@@ -222,6 +222,7 @@ class TestPoolManager(HTTPDummyServerTestCase):
         import time
         threads = []
         http.request('GET', '%s/retry_after' % (self.base_url,))
+
         def invalidate_pool():
             time.sleep(0.5)
             http.request('GET', self.base_url_alt)

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ commands=
     python --version
     python -c "import struct; print(struct.calcsize('P') * 8)"
     pip install .[socks,secure]
-    py.test --cov urllib3 test
+    py.test --cov urllib3 test {posargs}
 setenv =
     PYTHONWARNINGS=always::DeprecationWarning
 passenv = CFLAGS LDFLAGS TRAVIS APPVEYOR CRYPTOGRAPHY_OSX_NO_LINK_FLAGS
@@ -35,7 +35,9 @@ commands=
     py.test test/appengine {posargs}
 setenv =
     GAE_SDK_PATH={env:GAE_SDK_PATH:}
-    {[testenv]setenv}
+    # Causes a parsing error...
+    # {[testenv]setenv}
+    PYTHONWARNINGS=always::DeprecationWarning
 
 [testenv:flake8-py3]
 basepython = python3.4

--- a/urllib3/connectionpool.py
+++ b/urllib3/connectionpool.py
@@ -444,7 +444,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
 
         return (scheme, host, port) == (self.scheme, self.host, self.port)
 
-    def _do_urlopen(
+    def urlopen_only(
         self, method, url, body=None, headers=None, retries=None,
         assert_same_host=True, timeout=_Default,
         pool_timeout=None, release_conn=None, chunked=False,
@@ -642,7 +642,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
             Additional parameters are passed to
             :meth:`urllib3.response.HTTPResponse.from_httplib`
         """
-        url_open_with_retries = URLOpenWithRetries(self.proxy, self.retries, self._do_urlopen)
+        url_open_with_retries = URLOpenWithRetries(self.proxy, self.retries, self.urlopen_only)
         return url_open_with_retries.urlopen(
             method, url, body, headers, retries,
             redirect, assert_same_host, timeout,
@@ -652,10 +652,10 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
 
 
 class URLOpenWithRetries(object):
-    def __init__(self, proxy, retries, do_urlopen_func):
+    def __init__(self, proxy, retries, urlopen_only_func):
         self.proxy = proxy
         self.retries = retries
-        self.do_urlopen_func = do_urlopen_func
+        self.urlopen_only_func = urlopen_only_func
 
     def urlopen(self, method, url, body=None, headers=None, retries=None,
                 redirect=True, assert_same_host=True, timeout=_Default,
@@ -686,7 +686,7 @@ class URLOpenWithRetries(object):
             body_pos = set_file_position(body, body_pos)
 
             try:
-                response = self.do_urlopen_func(
+                response = self.urlopen_only_func(
                     method, url, body=body, headers=headers, retries=retries,
                     assert_same_host=assert_same_host, timeout=timeout,
                     pool_timeout=pool_timeout, release_conn=release_conn, chunked=chunked,

--- a/urllib3/connectionpool.py
+++ b/urllib3/connectionpool.py
@@ -38,7 +38,7 @@ from .response import HTTPResponse
 from .util.connection import is_connection_dropped
 from .util.request import set_file_position
 from .util.response import assert_header_parsing
-from .util.retry import Retry
+from .util.retry import Retry, PersistentRetry
 from .util.timeout import Timeout
 from .util.url import get_host, Url
 
@@ -444,6 +444,96 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
 
         return (scheme, host, port) == (self.scheme, self.host, self.port)
 
+    def _do_urlopen(
+        self, method, url, body=None, headers=None, retries=None,
+        timeout=_Default,
+        pool_timeout=None, release_conn=None, chunked=False,
+        **response_kw
+    ):
+        conn = None
+
+        # Keep track of whether we cleanly exited the except block. This
+        # ensures we do proper cleanup in finally.
+        clean_exit = False
+
+        # Track whether `conn` needs to be released before
+        # returning/raising/recursing. Update this variable if necessary, and
+        # leave `release_conn` constant throughout the function. That way, if
+        # the function recurses, the original value of `release_conn` will be
+        # passed down into the recursive call, and its value will be respected.
+        #
+        # See issue #651 [1] for details.
+        #
+        # [1] <https://github.com/shazow/urllib3/issues/651>
+        release_this_conn = release_conn
+
+        try:
+            # Request a connection from the queue.
+            timeout_obj = self._get_timeout(timeout)
+            conn = self._get_conn(timeout=pool_timeout)
+
+            conn.timeout = timeout_obj.connect_timeout
+
+            is_new_proxy_conn = self.proxy is not None and not getattr(conn, 'sock', None)
+            if is_new_proxy_conn:
+                self._prepare_proxy(conn)
+
+            # Make the request on the httplib connection object.
+            httplib_response = self._make_request(conn, method, url,
+                                                  timeout=timeout_obj,
+                                                  body=body, headers=headers,
+                                                  chunked=chunked)
+
+            # If we're going to release the connection in ``finally:``, then
+            # the response doesn't need to know about the connection. Otherwise
+            # it will also try to release it and we'll have a double-release
+            # mess.
+            response_conn = conn if not release_conn else None
+
+            # Pass method to Response for length checking
+            response_kw['request_method'] = method
+
+            # Import httplib's response into our own wrapper object
+            response = self.ResponseCls.from_httplib(
+                httplib_response,
+                pool=self,
+                connection=response_conn,
+                retries=retries,
+                **response_kw
+            )
+
+            # Everything went great!
+            clean_exit = True
+
+            return response
+
+        except queue.Empty:
+            # Timed out by queue.
+            raise EmptyPoolError(self, "No pool connections are available.")
+
+        # clean_exit can't be True if we're in this except block
+        # except (TimeoutError, HTTPException, SocketError, ProtocolError,
+        #         BaseSSLError, SSLError, CertificateError):
+        #     # Discard the connection for these exceptions. It will be
+        #     # replaced during the next _get_conn() call.
+        #     clean_exit = False
+        #     raise
+
+        finally:
+            if not clean_exit:
+                # We hit some kind of exception, handled or otherwise. We need
+                # to throw the connection away unless explicitly told not to.
+                # Close the connection, set the variable to None, and make sure
+                # we put the None back in the pool to avoid leaking it.
+                conn = conn and conn.close()
+                release_this_conn = True
+
+            if release_this_conn:
+                # Put the connection back to be reused. If the connection is
+                # expired then it will be None, which will get replaced with a
+                # fresh connection during _get_conn.
+                self._put_conn(conn)
+
     def urlopen(self, method, url, body=None, headers=None, retries=None,
                 redirect=True, assert_same_host=True, timeout=_Default,
                 pool_timeout=None, release_conn=None, chunked=False,
@@ -542,8 +632,13 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
             if headers is None:
                 headers = self.headers
 
-            if not isinstance(retries, Retry):
-                retries = Retry.from_int(retries, redirect=redirect, default=self.retries)
+            if not isinstance(retries, PersistentRetry):
+                if not isinstance(retries, Retry):
+                    retries = PersistentRetry(
+                        Retry.from_int(retries, redirect=redirect, default=self.retries)
+                    )
+                else:
+                    retries = PersistentRetry(retries)
 
             if release_conn is None:
                 release_conn = response_kw.get('preload_content', True)
@@ -551,19 +646,6 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
             # Check host
             if assert_same_host and not self.is_same_host(url):
                 raise HostChangedError(self, url, retries)
-
-            conn = None
-
-            # Track whether `conn` needs to be released before
-            # returning/raising/recursing. Update this variable if necessary, and
-            # leave `release_conn` constant throughout the function. That way, if
-            # the function recurses, the original value of `release_conn` will be
-            # passed down into the recursive call, and its value will be respected.
-            #
-            # See issue #651 [1] for details.
-            #
-            # [1] <https://github.com/shazow/urllib3/issues/651>
-            release_this_conn = release_conn
 
             # Merge the proxy headers. Only do this in HTTP. We have to copy the
             # headers dict so we can safely change it without those changes being
@@ -585,50 +667,14 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
             body_pos = set_file_position(body, body_pos)
 
             try:
-                # Request a connection from the queue.
-                timeout_obj = self._get_timeout(timeout)
-                conn = self._get_conn(timeout=pool_timeout)
-
-                conn.timeout = timeout_obj.connect_timeout
-
-                is_new_proxy_conn = self.proxy is not None and not getattr(conn, 'sock', None)
-                if is_new_proxy_conn:
-                    self._prepare_proxy(conn)
-
-                # Make the request on the httplib connection object.
-                httplib_response = self._make_request(conn, method, url,
-                                                      timeout=timeout_obj,
-                                                      body=body, headers=headers,
-                                                      chunked=chunked)
-
-                # If we're going to release the connection in ``finally:``, then
-                # the response doesn't need to know about the connection. Otherwise
-                # it will also try to release it and we'll have a double-release
-                # mess.
-                response_conn = conn if not release_conn else None
-
-                # Pass method to Response for length checking
-                response_kw['request_method'] = method
-
-                # Import httplib's response into our own wrapper object
-                response = self.ResponseCls.from_httplib(httplib_response,
-                                                         pool=self,
-                                                         connection=response_conn,
-                                                         retries=retries,
-                                                         **response_kw)
-
-                # Everything went great!
+                response = self._do_urlopen(
+                    method, url, body=body, headers=headers, retries=retries,
+                    timeout=timeout,
+                    pool_timeout=pool_timeout, release_conn=release_conn, chunked=chunked,
+                    **response_kw)
                 clean_exit = True
-
-            except queue.Empty:
-                # Timed out by queue.
-                raise EmptyPoolError(self, "No pool connections are available.")
-
             except (TimeoutError, HTTPException, SocketError, ProtocolError,
                     BaseSSLError, SSLError, CertificateError) as e:
-                # Discard the connection for these exceptions. It will be
-                # replaced during the next _get_conn() call.
-                clean_exit = False
                 if isinstance(e, (BaseSSLError, CertificateError)):
                     e = SSLError(e)
                 elif isinstance(e, (SocketError, NewConnectionError)) and self.proxy:
@@ -636,29 +682,14 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
                 elif isinstance(e, (SocketError, HTTPException)):
                     e = ProtocolError('Connection aborted.', e)
 
-                retries = retries.increment(method, url, error=e, _pool=self,
-                                            _stacktrace=sys.exc_info()[2])
+                retries.increment(method, url, error=e, _pool=self,
+                                  _stacktrace=sys.exc_info()[2])
                 retries.sleep()
 
                 # Keep track of the error for the retry warning.
                 err = e
 
-            finally:
-                if not clean_exit:
-                    # We hit some kind of exception, handled or otherwise. We need
-                    # to throw the connection away unless explicitly told not to.
-                    # Close the connection, set the variable to None, and make sure
-                    # we put the None back in the pool to avoid leaking it.
-                    conn = conn and conn.close()
-                    release_this_conn = True
-
-                if release_this_conn:
-                    # Put the connection back to be reused. If the connection is
-                    # expired then it will be None, which will get replaced with a
-                    # fresh connection during _get_conn.
-                    self._put_conn(conn)
-
-            if not conn:
+            if not clean_exit:
                 # Try again
                 log.warning("Retrying (%r) after connection "
                             "broken by '%r': %s", retries, err, url)
@@ -680,7 +711,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
                     method = 'GET'
 
                 try:
-                    retries = retries.increment(method, url, response=response, _pool=self)
+                    retries.increment(method, url, response=response, _pool=self)
                 except MaxRetryError:
                     if retries.raise_on_redirect:
                         # Drain and release the connection for this response, since
@@ -694,13 +725,14 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
 
                 retries.sleep_for_retry(response)
                 log.debug("Redirecting %s -> %s", url, redirect_location)
+                url = redirect_location
                 continue
 
             # Check if we should retry the HTTP response.
             has_retry_after = bool(response.getheader('Retry-After'))
             if retries.is_retry(method, response.status, has_retry_after):
                 try:
-                    retries = retries.increment(method, url, response=response, _pool=self)
+                    retries.increment(method, url, response=response, _pool=self)
                 except MaxRetryError:
                     if retries.raise_on_status:
                         # Drain and release the connection for this response, since

--- a/urllib3/connectionpool.py
+++ b/urllib3/connectionpool.py
@@ -448,6 +448,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         self, method, url, body=None, headers=None, retries=None,
         assert_same_host=True, timeout=_Default,
         pool_timeout=None, release_conn=None, chunked=False,
+        conn_lock=None,
         **response_kw
     ):
         if headers is None:
@@ -485,6 +486,8 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
             # Request a connection from the queue.
             timeout_obj = self._get_timeout(timeout)
             conn = self._get_conn(timeout=pool_timeout)
+            if conn_lock is not None:
+                conn_lock.release()
 
             conn.timeout = timeout_obj.connect_timeout
 

--- a/urllib3/poolmanager.py
+++ b/urllib3/poolmanager.py
@@ -4,13 +4,11 @@ import functools
 import logging
 
 from ._collections import RecentlyUsedContainer
-from .connectionpool import HTTPConnectionPool, HTTPSConnectionPool, URLOpenRetryWrapper, _Default
+from .connectionpool import HTTPConnectionPool, HTTPSConnectionPool, URLOpenRetryWrapper
 from .connectionpool import port_by_scheme
-from .exceptions import LocationValueError, MaxRetryError, ProxySchemeUnknown
-from .packages.six.moves.urllib.parse import urljoin
+from .exceptions import LocationValueError, ProxySchemeUnknown
 from .request import RequestMethods
 from .util.url import parse_url
-from .util.retry import Retry
 
 
 __all__ = ['PoolManager', 'ProxyManager', 'proxy_from_url']

--- a/urllib3/util/retry.py
+++ b/urllib3/util/retry.py
@@ -397,17 +397,5 @@ class Retry(object):
                     cls=type(self), self=self)
 
 
-class PersistentRetry(object):
-    def __init__(self, retry):
-        self._retry = retry
-
-    def increment(self, *a, **k):
-        self._retry = self._retry.increment(*a, **k)
-        return self
-
-    def __getattr__(self, name):
-        return getattr(self._retry, name)
-
-
 # For backwards compatibility (equivalent to pre-v1.9):
 Retry.DEFAULT = Retry(3)

--- a/urllib3/util/retry.py
+++ b/urllib3/util/retry.py
@@ -397,5 +397,17 @@ class Retry(object):
                     cls=type(self), self=self)
 
 
+class PersistentRetry(object):
+    def __init__(self, retry):
+        self._retry = retry
+
+    def increment(self, *a, **k):
+        self._retry = self._retry.increment(*a, **k)
+        return self
+
+    def __getattr__(self, name):
+        return getattr(self._retry, name)
+
+
 # For backwards compatibility (equivalent to pre-v1.9):
 Retry.DEFAULT = Retry(3)


### PR DESCRIPTION
Fix for #1252. The implementation here is a little clunky for now as I was trying to change the existing code/logic as little as possible to avoid regressions.

List of changes:
* Introduces `test_retry_with_too_many_pools` which shows the `ClosedPoolError` happening in master
* Fixes an issue in the dummyserver's `retry_after` handler in Python 3 when using the default value for status
* Adds a `PersistentRetry` class which wraps `Retry` and allows for the same object to be used after `increment` is called
* Changes the retry logic in `HTTPConnectionPool` and `PoolManager` to loop instead of recurse
* Moves the base `HTTPConnectionPool.urlopen` functionality to `HTTPConnectionPool.urlopen_only` to allow for it to be called by `PoolManager` with no retry logic
* Refactors all retry logic in `HTTPConnectionPool.urlopen` into `URLOpenWithRetries` which takes a function to call for `urlopen_only` functionality.
  * Both `PoolManager` and `HTTPConnectionPool` end up calling `HTTPConnectionPool.urlopen_only` eventually
  * `HTTPConnectionPool`'s logic should be pretty much exactly the same as it was
  * `PoolManager` passes in a function for `urlopen_only` which acquires a pool from `self.pools` then calls `urlopen_only` on it. This means that if `URLOpenWithRetries` ends up retrying (currently will only happen if a `Retry-After` header is received) then `PoolManager` will create a new pool if the old one has been removed, avoiding the `ClosedPoolError` that can happen.
* `PoolManager` acquires `self.pools.lock` a second time now, before running its internal `urlopen_only` logic, to ensure that the lock stays acquired until the `HTTPConnectionPool` calls `_get_conn`. It passes the lock to `HTTPConnectionPool.urlopen_only` so that it can release the lock immediately once `_get_conn` is called.

Caveats/Potential improvements:
* Both URLOpenWithRetries and PoolManager still implement different redirect/retry logic. It would be nice to move all retry logic into URLOpenWithRetries.
  * Since `PoolManager` forces `redirect=False` when calling `HTTPConnectionPool.urlopen(_only)` there is only the `Retry-After` logic which can potentially cause a race condition on retry. Refactoring this further would reduce the complexity and remove the need for setting `redirect=False`.
* Passing the lock into `HTTPConnectionPool.urlopen_only` is a little hacky as currently implemented. It would be nice to have the connection acquiring logic also refactored out so that passing it through like this isn't needed and we can use the lock as a context manager.
* `PersistentRetry` may not be needed. This was implemented to ensure that the retries were maintained properly through the refactor as there are extra calls it may need to be passed through to maintain the context.
* Retry logic changed to loops makes the tracebacks slightly less informative with regards to retries but reduces the frame stack when retrying.
  * This should be able to be reverted if wanted. I originally made this change to make the logic a little easier to reason about and avoid potential issues when refactoring.
* `URLOpenWithRetries` is an odd name
* `URLOpenWithRetries` could possibly be changed to be a mixin, parent class, or wrapper instead of taking a function as a parameter to make its use more obvious
* `{[testenv]setenv}` change may not be needed but I ran into a lot of parsing errors with tox in some environments due to this.

I tested these changes on OSX (10.12.2) and on Ubuntu 16.04 with tox, as well as on travis-ci. There are random test failures, as mentioned in #1256, but the failures seem to correspond with those seen randomly on master in my tests. I have had each tox environment pass with no errors multiple times so I am fairly sure that there are no regressions.

https://travis-ci.org/reversefold/urllib3/builds/271452531 shows a fully passing run of this branch (except for gae, which appears to be broken).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shazow/urllib3/1257)
<!-- Reviewable:end -->
