### PR TITLE
free cert_array if it is *not* None

### DIFF
--- a/test/contrib/test_securetransport.py
+++ b/test/contrib/test_securetransport.py
@@ -1,9 +1,13 @@
 # -*- coding: utf-8 -*-
+import socket
+import ssl
+
 import pytest
 
 try:
-    from urllib3.contrib.securetransport import (inject_into_urllib3,
-                                                 extract_from_urllib3)
+    from urllib3.contrib.securetransport import (
+        WrappedSocket, inject_into_urllib3, extract_from_urllib3
+    )
 except ImportError as e:
     pytestmark = pytest.mark.skip('Could not import SecureTransport: %r' % e)
 
@@ -19,3 +23,13 @@ def setup_module():
 
 def teardown_module():
     extract_from_urllib3()
+
+
+def test_no_crash_with_empty_trust_bundle():
+    try:
+        s = socket.socket()
+        ws = WrappedSocket(s)
+        with pytest.raises(ssl.SSLError):
+            ws._custom_validate(True, b"")
+    finally:
+        s.close()

--- a/test/contrib/test_securetransport.py
+++ b/test/contrib/test_securetransport.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import contextlib
 import socket
 import ssl
 
@@ -26,10 +27,7 @@ def teardown_module():
 
 
 def test_no_crash_with_empty_trust_bundle():
-    try:
-        s = socket.socket()
+    with contextlib.closing(socket.socket()) as s:
         ws = WrappedSocket(s)
         with pytest.raises(ssl.SSLError):
             ws._custom_validate(True, b"")
-    finally:
-        s.close()

--- a/urllib3/contrib/securetransport.py
+++ b/urllib3/contrib/securetransport.py
@@ -399,7 +399,7 @@ class WrappedSocket(object):
             if trust:
                 CoreFoundation.CFRelease(trust)
 
-            if cert_array is None:
+            if cert_array is not None:
                 CoreFoundation.CFRelease(cert_array)
 
         # Ok, now we can look at what the result was.


### PR DESCRIPTION
Refs https://github.com/pypa/pip/issues/5131

This fixes both a crash if `cert_array` is `None` and a memory leak if it is not.