### PR TITLE
be tolerant of non-unix line endings for securetransport cert bundles

### DIFF
--- a/urllib3/contrib/_securetransport/low_level.py
+++ b/urllib3/contrib/_securetransport/low_level.py
@@ -111,6 +111,9 @@ def _cert_array_from_pem(pem_bundle):
     Given a bundle of certs in PEM format, turns them into a CFArray of certs
     that can be used to validate a cert chain.
     """
+    # Normalize the PEM bundle's line endings.
+    pem_bundle = pem_bundle.replace(b"\r\n", b"\n")
+
     der_certs = [
         base64.b64decode(match.group(1))
         for match in _PEM_CERTS_RE.finditer(pem_bundle)


### PR DESCRIPTION
While pip is resolving this for their use case, we should probably just make it so `\r\n` linefeeds get rewritten. I'm not handling the `\r` classic mac case because I hope that world no longer exists?