### PR TITLE
Fix AppVeyor build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -50,7 +50,7 @@ install:
 
   # Upgrade to the latest version of pip to avoid it displaying warnings
   # about it being out of date.
-  - pip install --disable-pip-version-check --user --upgrade pip wheel
+  - python -m pip install --upgrade pip wheel
   - pip install tox virtualenv
 
 test_script:


### PR DESCRIPTION
Windows cannot replace a running executable. It's not clear why this was
working until now.

Closes the first part of #1364.