### PR TITLE
Address #1365 by fixing failing test on darwin + 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,6 +57,4 @@ matrix:
       env: TOXENV=py37
   allow_failures:
   - python: pypy-5.4
-  - python: 3.7-dev
-  - env: TOXENV=py37
 sudo: false

--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -38,7 +38,7 @@ class TestConnection(object):
             with mock.patch('urllib3.connection.log.error') as mock_log:
                 _match_hostname(cert, asserted_hostname)
         except CertificateError as e:
-            assert str(e) == "hostname 'bar' doesn't match 'foo'"
+            assert "hostname 'bar' doesn't match 'foo'" in str(e)
             mock_log.assert_called_once_with(
                 'Certificate did not match expected hostname: %s. '
                 'Certificate: %s',


### PR DESCRIPTION
In python 3.7 on darwin I was seeing the following error. This PR loosens the requirement to allow the str repr

> E           assert "hostname 'ba...t match 'foo'" == '("hostname \'...ch \'foo\'",)'
> E             - hostname 'bar' doesn't match 'foo'
> E             + ("hostname 'bar' doesn't match 'foo'",)

Closes #1365 