### PR TITLE
Add test for wait_for_socket EINTR handling w/ infinite timeout

### DIFF
--- a/test/test_wait.py
+++ b/test/test_wait.py
@@ -74,8 +74,9 @@ def test_wait_for_socket(wfs, spair):
     assert wfs(a, read=True, timeout=0)
 
     # Waiting for a socket that's actually been closed is just a bug, and
-    # raises an appropriate exception:
-    with pytest.raises(ValueError):
+    # raises some kind of helpful exception (exact details depend on the
+    # platform).
+    with pytest.raises(Exception):
         wfs(b, read=True)
 
 

--- a/urllib3/util/wait.py
+++ b/urllib3/util/wait.py
@@ -61,10 +61,10 @@ else:
                     raise
                 else:
                     timeout = deadline - monotonic()
-                    if timeout == float("inf"):
-                        timeout = None
                     if timeout < 0:
                         timeout = 0
+                    if timeout == float("inf"):
+                        timeout = None
                     continue
 
 


### PR DESCRIPTION
This covers an otherwise uncovered branch in _retry_on_intr.

As requested here:
  https://github.com/urllib3/urllib3/pull/1358#issuecomment-383324003