### PR TITLE
Fix skip logic for urllib3/contrib tests

### DIFF
--- a/test/contrib/test_pyopenssl.py
+++ b/test/contrib/test_pyopenssl.py
@@ -6,28 +6,35 @@ import mock
 import pytest
 
 try:
+    from urllib3.contrib.pyopenssl import (
+        _dnsname_to_stdlib, get_subj_alt_name
+    )
     from cryptography import x509
     from OpenSSL.crypto import FILETYPE_PEM, load_certificate
-    from urllib3.contrib.pyopenssl import (inject_into_urllib3,
-                                           extract_from_urllib3,
-                                           get_subj_alt_name,
-                                           _dnsname_to_stdlib)
-except ImportError as e:
-    pytestmark = pytest.mark.skip('Could not import PyOpenSSL: %r' % e)
+except ImportError:
+    pass
+
+
+def setup_module():
+    try:
+        from urllib3.contrib.pyopenssl import inject_into_urllib3
+        inject_into_urllib3()
+    except ImportError as e:
+        pytest.skip('Could not import PyOpenSSL: %r' % e)
+
+
+def teardown_module():
+    try:
+        from urllib3.contrib.securetransport import extract_from_urllib3
+        extract_from_urllib3()
+    except ImportError:
+        pass
 
 
 from ..with_dummyserver.test_https import TestHTTPS, TestHTTPS_TLSv1  # noqa: F401
 from ..with_dummyserver.test_socketlevel import (  # noqa: F401
     TestSNI, TestSocketClosing, TestClientCerts
 )
-
-
-def setup_module():
-    inject_into_urllib3()
-
-
-def teardown_module():
-    extract_from_urllib3()
 
 
 class TestPyOpenSSLHelpers(unittest.TestCase):

--- a/test/contrib/test_pyopenssl_dependencies.py
+++ b/test/contrib/test_pyopenssl_dependencies.py
@@ -1,15 +1,23 @@
 # -*- coding: utf-8 -*-
 import unittest
-
 import pytest
 
-try:
-    from urllib3.contrib.pyopenssl import (inject_into_urllib3,
-                                           extract_from_urllib3)
-except ImportError as e:
-    pytestmark = pytest.mark.skip('Could not import PyOpenSSL: %r' % e)
-
 from mock import patch, Mock
+
+try:
+    from urllib3.contrib.pyopenssl import (
+        inject_into_urllib3,
+        extract_from_urllib3
+    )
+except ImportError:
+    pass
+
+
+def setup_module():
+    try:
+        from urllib3.contrib.pyopenssl import inject_into_urllib3
+    except ImportError as e:
+        pytest.skip('Could not import PyOpenSSL: %r' % e)
 
 
 class TestPyOpenSSLInjection(unittest.TestCase):

--- a/test/contrib/test_pyopenssl_dependencies.py
+++ b/test/contrib/test_pyopenssl_dependencies.py
@@ -15,7 +15,7 @@ except ImportError:
 
 def setup_module():
     try:
-        from urllib3.contrib.pyopenssl import inject_into_urllib3
+        from urllib3.contrib.pyopenssl import inject_into_urllib3  # noqa: F401
     except ImportError as e:
         pytest.skip('Could not import PyOpenSSL: %r' % e)
 

--- a/test/contrib/test_securetransport.py
+++ b/test/contrib/test_securetransport.py
@@ -37,4 +37,4 @@ def test_no_crash_with_empty_trust_bundle():
     with contextlib.closing(socket.socket()) as s:
         ws = WrappedSocket(s)
         with pytest.raises(ssl.SSLError):
-ws._custom_validate(True, b"")
+            ws._custom_validate(True, b"")

--- a/test/contrib/test_securetransport.py
+++ b/test/contrib/test_securetransport.py
@@ -6,11 +6,26 @@ import ssl
 import pytest
 
 try:
-    from urllib3.contrib.securetransport import (
-        WrappedSocket, inject_into_urllib3, extract_from_urllib3
-    )
-except ImportError as e:
-    pytestmark = pytest.mark.skip('Could not import SecureTransport: %r' % e)
+    from urllib3.contrib.securetransport import WrappedSocket
+except ImportError:
+    pass
+
+
+def setup_module():
+    try:
+        from urllib3.contrib.securetransport import inject_into_urllib3
+        inject_into_urllib3()
+    except ImportError as e:
+        pytest.skip('Could not import SecureTransport: %r' % e)
+
+
+def teardown_module():
+    try:
+        from urllib3.contrib.securetransport import extract_from_urllib3
+        extract_from_urllib3()
+    except ImportError:
+        pass
+
 
 from ..with_dummyserver.test_https import TestHTTPS, TestHTTPS_TLSv1  # noqa: F401
 from ..with_dummyserver.test_socketlevel import (  # noqa: F401
@@ -18,16 +33,8 @@ from ..with_dummyserver.test_socketlevel import (  # noqa: F401
 )
 
 
-def setup_module():
-    inject_into_urllib3()
-
-
-def teardown_module():
-    extract_from_urllib3()
-
-
 def test_no_crash_with_empty_trust_bundle():
     with contextlib.closing(socket.socket()) as s:
         ws = WrappedSocket(s)
         with pytest.raises(ssl.SSLError):
-            ws._custom_validate(True, b"")
+ws._custom_validate(True, b"")

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ commands=
     python --version
     python -c "import struct; print(struct.calcsize('P') * 8)"
     pip install .[socks,secure]
-    py.test --cov urllib3 test {posargs}
+    py.test -r sx --cov urllib3 test {posargs}
 setenv =
     PYTHONWARNINGS=always::DeprecationWarning
 passenv = CFLAGS LDFLAGS TRAVIS APPVEYOR CRYPTOGRAPHY_OSX_NO_LINK_FLAGS
@@ -25,7 +25,7 @@ basepython = python2.7
 deps=
     {[testenv]deps}
 commands=
-    py.test test/appengine {posargs}
+    py.test -r sx test/appengine {posargs}
 setenv =
     GAE_SDK_PATH={env:GAE_SDK_PATH:}
     {[testenv]setenv}


### PR DESCRIPTION
The skip logic for the contrib tests makes platforms without the proper dependencies skip all their dummyserver tests.