### PR TITLE
Stop using uuid for choose_boundary()

### DIFF
--- a/urllib3/filepost.py
+++ b/urllib3/filepost.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
+import binascii
 import codecs
+import os
 
 from io import BytesIO
 
@@ -13,16 +15,11 @@ writer = codecs.lookup('utf-8')[3]
 def choose_boundary():
     """
     Our embarrassingly-simple replacement for mimetools.choose_boundary.
-
-    We are lazily loading uuid here, because we don't want its issues
-
-    https://bugs.python.org/issue5885
-    https://bugs.python.org/issue11063
-
-    to affect our entire library.
     """
-    from uuid import uuid4
-    return uuid4().hex
+    boundary = binascii.hexlify(os.urandom(16))
+    if six.PY3:
+        boundary = boundary.decode('ascii')
+    return boundary
 
 
 def iter_field_objects(fields):
@@ -72,7 +69,7 @@ def encode_multipart_formdata(fields, boundary=None):
 
     :param boundary:
         If not specified, then a random boundary will be generated using
-        :func:`mimetools.choose_boundary`.
+        :func:`urllib3.filepost.choose_boundary`.
     """
     body = BytesIO()
     if boundary is None:


### PR DESCRIPTION
This solution is experimentally about 4 times faster than `uuid.uuid4().hex` method and doesn't require us to import `uuid` module and produces identical results. If you look at what `uuid.uuid4().hex` is doing anyways it's basically exactly this.