### PR TITLE
Update pypi.python.org URLs to pypi.org

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ urllib3
 
 .. image:: https://img.shields.io/pypi/v/urllib3.svg?maxAge=86400
         :alt: PyPI version
-        :target: https://pypi.python.org/pypi/urllib3
+        :target: https://pypi.org/project/urllib3/
 
 .. image:: https://www.bountysource.com/badge/tracker?tracker_id=192525
         :alt: Bountysource

--- a/docs/advanced-usage.rst
+++ b/docs/advanced-usage.rst
@@ -124,7 +124,7 @@ The usage of :class:`~poolmanager.ProxyManager` is the same as
 
 You can use :class:`~contrib.socks.SOCKSProxyManager` to connect to SOCKS4 or
 SOCKS5 proxies. In order to use SOCKS proxies you will need to install
-`PySocks <https://pypi.python.org/pypi/PySocks>`_ or install urllib3 with the
+`PySocks <https://pypi.org/project/PySocks/>`_ or install urllib3 with the
 ``socks`` extra::
 
     pip install urllib3[socks]

--- a/test/test_proxymanager.py
+++ b/test/test_proxymanager.py
@@ -5,12 +5,12 @@ from urllib3.poolmanager import ProxyManager
 
 class TestProxyManager(object):
     def test_proxy_headers(self):
-        url = 'http://pypi.python.org/test'
+        url = 'http://pypi.org/project/urllib3/'
         with ProxyManager('http://something:1234') as p:
 
             # Verify default headers
             default_headers = {'Accept': '*/*',
-                               'Host': 'pypi.python.org'}
+                               'Host': 'pypi.org'}
             headers = p._set_proxy_headers(url)
 
             assert headers == default_headers
@@ -26,8 +26,8 @@ class TestProxyManager(object):
             # Verify proxy with nonstandard port
             provided_headers = {'Accept': 'application/json'}
             expected_headers = provided_headers.copy()
-            expected_headers.update({'Host': 'pypi.python.org:8080'})
-            url_with_port = 'http://pypi.python.org:8080/test'
+            expected_headers.update({'Host': 'pypi.org:8080'})
+            url_with_port = 'http://pypi.org:8080/project/urllib3/'
             headers = p._set_proxy_headers(url_with_port, provided_headers)
 
             assert headers == expected_headers


### PR DESCRIPTION
For details on the new PyPI, see the blog post:

https://pythoninsider.blogspot.ca/2018/04/new-pypi-launched-legacy-pypi-shutting.html