### PR TITLE
Pin pyOpenSSL major version to 17.* for Python 2.6

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,8 @@ provides-extra =
     secure
     socks
 requires-dist =
-    pyOpenSSL>=0.14; python_version<="2.7" and extra == 'secure'
+    pyOpenSSL>=0.14,<18.0.0; python_version=="2.6" and extra == 'secure'
+    pyOpenSSL>=0.14; python_version=="2.7" and extra == 'secure'
     cryptography>=1.3.4; python_version<="2.7" and extra == 'secure'
     idna>=2.0.0; python_version<="2.7" and extra == 'secure'
     certifi; extra == 'secure'

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@
 from setuptools import setup
 
 import os
+import sys
 import re
 import codecs
 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ version = VERSION
 
 # pyOpenSSL version 18.0.0 dropped support for Python 2.6
 if sys.version_info < (2, 7):
-    PYOPENSSL_VERSION += 'pyOpenSSL >= 0.14, < 18.0.0'
+    PYOPENSSL_VERSION = 'pyOpenSSL >= 0.14, < 18.0.0'
 else:
     PYOPENSSL_VERSION = 'pyOpenSSL >= 0.14'
 

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,12 @@ with codecs.open('CHANGES.rst', encoding='utf-8') as fp:
     changes = fp.read()
 version = VERSION
 
+# pyOpenSSL version 18.0.0 dropped support for Python 2.6
+if sys.version_info < (2, 7):
+    PYOPENSSL_VERSION += 'pyOpenSSL >= 0.14, < 18.0.0'
+else:
+    PYOPENSSL_VERSION = 'pyOpenSSL >= 0.14'
+
 setup(name='urllib3',
       version=version,
       description="HTTP library with thread-safe connection pooling, file post, and more.",
@@ -63,7 +69,7 @@ setup(name='urllib3',
       test_suite='test',
       extras_require={
           'secure': [
-              'pyOpenSSL>=0.14',
+              PYOPENSSL_VERSION,
               'cryptography>=1.3.4',
               'idna>=2.0.0',
               'certifi',


### PR DESCRIPTION
See: https://github.com/pyca/pyopenssl/blob/74de8a137d435d45c100b74cc971be556166a559/CHANGELOG.rst#1800-2018-05-16