### PR TITLE
Retry.from_int() checks whether its argument is an int, not a Retry

### DIFF
--- a/urllib3/util/retry.py
+++ b/urllib3/util/retry.py
@@ -202,7 +202,7 @@ class Retry(object):
         if retries is None:
             retries = default if default is not None else cls.DEFAULT
 
-        if isinstance(retries, Retry):
+        if not isinstance(retries, int):
             return retries
 
         redirect = bool(redirect) and None


### PR DESCRIPTION
This solves a recurring problem when two versions of urllib3 are
installed, and a Retry object created by one is passed to the from_int()
of another. The intended behaviour is to return that Retry object
unchanged, but at present we test

	if isintance(retries, Retry):

The test fails, because "retries" is a Retry object from a
different installation of urllib3. So we get a new Retry whose
"total" member is nonsensically another Retry object. This causes
a baffling-looking exception:

	TypeError: unsupported operand type(s) for -=: 'Retry' and 'int'

See, for example, #3560.

The solution is to return "retries" if it's *not* an integer.