### PR TITLE
Support a servername parameter on HTTPSConnections

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,9 @@ dev (master)
 
 * ... [Short description of non-trivial change.] (Issue #)
 
+* Add a server_hostname parameter to HTTPSConnection which allows for
+  overriding the SNI hostname sent in the handshake. (Pull #1397)
+
 
 1.23 (2018-06-05)
 -----------------

--- a/test/with_dummyserver/test_https.py
+++ b/test/with_dummyserver/test_https.py
@@ -324,6 +324,23 @@ class TestHTTPS(HTTPSDummyServerTestCase):
         https_pool.assert_hostname = 'localhost'
         https_pool.request('GET', '/')
 
+    def test_server_hostname(self):
+        https_pool = HTTPSConnectionPool('127.0.0.1', self.port,
+                                         cert_reqs='CERT_REQUIRED',
+                                         ca_certs=DEFAULT_CA,
+                                         server_hostname='localhost')
+        self.addCleanup(https_pool.close)
+
+        conn = https_pool._new_conn()
+        conn.request('GET', '/')
+
+        # Assert the wrapping socket is using the passed-through SNI name.
+        # pyopenssl doesn't let you pull the server_hostname back off the
+        # socket, so only add this assertion if the attribute is there (i.e.
+        # the python ssl module).
+        if hasattr(conn.sock, 'server_hostname'):
+            self.assertEqual(conn.sock.server_hostname, "localhost")
+
     def test_assert_fingerprint_md5(self):
         https_pool = HTTPSConnectionPool('localhost', self.port,
                                          cert_reqs='CERT_REQUIRED',


### PR DESCRIPTION
The servername parameter allows callers to override the hostname used for SNI. If specified this hostname will also be used as the value for hostname verification instead of the actual hostname (unless assert_hostname is set).

This is the same option and semantics that [node.js provides](https://nodejs.org/api/tls.html#tls_tls_connect_options_callback) via the "servername" attribute, or that [golang provides](https://golang.org/pkg/crypto/tls/#Config) via the "ServerName" option.