### PR TITLE
Handle EINTR from poll with zero timeout

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -259,5 +259,5 @@ In chronological order:
   * Improve contribution guide
   * Add ``HTTPResponse.geturl`` method to provide ``urllib2.urlopen().geturl()`` behavior
 
-* [Your name or handle] <[email or website]>
-  * [Brief summary of your changes]
+* Bruce Merry <http://www.brucemerry.org.za>
+  * Fix leaking exceptions when system calls are interrupted with zero timeout

--- a/test/test_wait.py
+++ b/test/test_wait.py
@@ -142,6 +142,43 @@ def test_eintr(wfs, spair):
     reason="need setitimer() support"
 )
 @pytest.mark.parametrize("wfs", variants)
+def test_eintr_zero_timeout(wfs, spair):
+    a, b = spair
+    interrupt_count = [0]
+
+    def handler(sig, frame):
+        assert sig == signal.SIGALRM
+        interrupt_count[0] += 1
+
+    old_handler = signal.signal(signal.SIGALRM, handler)
+    try:
+        assert not wfs(a, read=True, timeout=0)
+        start = monotonic()
+        try:
+            # Start delivering SIGALRM 1000 times per second,
+            # to trigger race conditions such as
+            # https://github.com/urllib3/urllib3/issues/1396.
+            signal.setitimer(signal.ITIMER_REAL, 0.001, 0.001)
+            # Hammer the system call for a while to trigger the
+            # race.
+            for i in range(100000):
+                wfs(a, read=True, timeout=0)
+        finally:
+            # Stop delivering SIGALRM
+            signal.setitimer(signal.ITIMER_REAL, 0)
+        end = monotonic()
+        dur = end - start
+    finally:
+        signal.signal(signal.SIGALRM, old_handler)
+
+    assert interrupt_count[0] > 0
+
+
+@pytest.mark.skipif(
+    not hasattr(signal, "setitimer"),
+    reason="need setitimer() support"
+)
+@pytest.mark.parametrize("wfs", variants)
 def test_eintr_infinite_timeout(wfs, spair):
     a, b = spair
     interrupt_count = [0]

--- a/urllib3/util/wait.py
+++ b/urllib3/util/wait.py
@@ -43,11 +43,10 @@ if sys.version_info >= (3, 5):
 else:
     # Old and broken Pythons.
     def _retry_on_intr(fn, timeout):
-        if timeout is not None and timeout <= 0:
-            return fn(timeout)
-
         if timeout is None:
             deadline = float("inf")
+        elif timeout <= 0:
+            deadline = 0.0
         else:
             deadline = monotonic() + timeout
 
@@ -117,7 +116,7 @@ def _have_working_poll():
     # from libraries like eventlet/greenlet.
     try:
         poll_obj = select.poll()
-        poll_obj.poll(0)
+        _retry_on_intr(poll_obj.poll, 0)
     except (AttributeError, OSError):
         return False
     else:


### PR DESCRIPTION
While common sense says that it should be impossible, it seems that
poll() can indeed fail with EINTR on Linux even when the timeout is
zero. There was logic in _retry_on_intr which bypassed the restart
handling when the timeout was zero, which led to EINTRs leaking out.

Fixed by setting the deadline to 0 when the timeout is 0. This avoids an
extra system call to get monotonic(). It assumes that monotonic() is
always non-negative; that isn't documented but seems a reasonable
assumption given that the reference point tends to be something like
boot time.

Closes #1396.