### PR TITLE
Remove unneeded dependency psutil

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -6,7 +6,6 @@ wheel==0.24.0
 tornado==4.2.1
 PySocks==1.5.6
 pkginfo>=1.0,!=1.3.0
-psutil==4.3.1
 pytest-cov==2.5.1
 pytest-timeout==1.2.0
 pytest==3.1.0


### PR DESCRIPTION
Hello.

I tried to remove `psutil` from RPM specfile in Fedora and it seems that it's unneeded dependency because everything works without it.

I cannot find any usage in the source code, only in git history, so it's probably just forgotten.

Will see if the CI tests pass.