### PR TITLE
Support using tornado-5 for tests

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,7 +3,8 @@ coverage==3.7.1
 tox==2.1.1
 twine==1.5.0
 wheel==0.24.0
-tornado==4.2.1
+tornado==5.0.2; python_version>"2.6"
+tornado==4.2.1; python_version<="2.6"
 PySocks==1.5.6
 pkginfo>=1.0,!=1.3.0
 pytest-cov==2.5.1

--- a/dummyserver/server.py
+++ b/dummyserver/server.py
@@ -226,15 +226,16 @@ def bind_sockets(port, address=None, family=socket.AF_UNSPEC, backlog=128,
 
 
 def run_tornado_app(app, io_loop, certs, scheme, host):
+    assert io_loop == tornado.ioloop.IOLoop.current()
+
     # We can't use fromtimestamp(0) because of CPython issue 29097, so we'll
     # just construct the datetime object directly.
     app.last_req = datetime(1970, 1, 1)
 
     if scheme == 'https':
-        http_server = tornado.httpserver.HTTPServer(app, ssl_options=certs,
-                                                    io_loop=io_loop)
+        http_server = tornado.httpserver.HTTPServer(app, ssl_options=certs)
     else:
-        http_server = tornado.httpserver.HTTPServer(app, io_loop=io_loop)
+        http_server = tornado.httpserver.HTTPServer(app)
 
     sockets = bind_sockets(None, address=host)
     port = sockets[0].getsockname()[1]
@@ -268,7 +269,7 @@ if __name__ == '__main__':
     from .testcase import TestingApp
     host = '127.0.0.1'
 
-    io_loop = tornado.ioloop.IOLoop()
+    io_loop = tornado.ioloop.IOLoop.current()
     app = tornado.web.Application([(r".*", TestingApp)])
     server, port = run_tornado_app(app, io_loop, None,
                                    'http', host)

--- a/dummyserver/testcase.py
+++ b/dummyserver/testcase.py
@@ -124,7 +124,7 @@ class HTTPDummyServerTestCase(unittest.TestCase):
 
     @classmethod
     def _start_server(cls):
-        cls.io_loop = ioloop.IOLoop()
+        cls.io_loop = ioloop.IOLoop.current()
         app = web.Application([(r".*", TestingApp)])
         cls.server, cls.port = run_tornado_app(app, cls.io_loop, cls.certs,
                                                cls.scheme, cls.host)
@@ -170,7 +170,7 @@ class HTTPDummyProxyTestCase(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.io_loop = ioloop.IOLoop()
+        cls.io_loop = ioloop.IOLoop.current()
 
         app = web.Application([(r'.*', TestingApp)])
         cls.http_server, cls.http_port = run_tornado_app(


### PR DESCRIPTION
Here's a minimal change that makes the test support compatible with tornado-5. Apparently, the io_loop parameter to server classes has been [removed in 5.0.0](http://www.tornadoweb.org/en/stable/releases/v5.0.0.html) in favor of using a single event loop everywhere.

I've kept the `io_loop` parameter inside internal API to make this change as small as possible. I can remove the parameters and inline `tornado.ioloop.IOLoop.current()` everywhere if you prefer that.