### PR TITLE
Fix codecov coverage by collapsing paths in tox

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,6 @@
 [run]
-include =
-    *urllib3/*
+source =
+    urllib3
 
 omit =
     *urllib3/packages/*
@@ -9,6 +9,11 @@ omit =
     *urllib3/contrib/pyopenssl.py
     *urllib3/contrib/securetransport.py
     *urllib3/contrib/_securetransport/*
+
+[paths]
+source =
+   src/urllib3
+   .tox/*/site-packages/urllib3
 
 [report]
 exclude_lines =

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -7,7 +7,6 @@ tornado==5.0.2; python_version>"2.6"
 tornado==4.2.1; python_version<="2.6"
 PySocks==1.6.8
 pkginfo==1.4.2
-pytest-cov==2.5.1
 pytest-timeout==1.3.1; python_version>"2.6"
 pytest-timeout==1.2.0; python_version<="2.6"
 pytest==3.6.4; python_version>"2.6"

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,13 @@ commands=
     pip --version
     python --version
     python -c "import struct; print(struct.calcsize('P') * 8)"
-    py.test -r sx --cov=urllib3 --cov-config={toxinidir}/.coveragerc test {posargs}
+    # Inspired from https://github.com/pyca/cryptography
+    # We use parallel mode and then combine here so that coverage.py will take
+    # the paths like .tox/pyXY/lib/pythonX.Y/site-packages/urllib3/__init__.py
+    # and collapse them into src/urllib3/__init__.py.
+    coverage run --parallel-mode -m pytest -r sx test {posargs}
+    coverage combine
+    coverage report -m
 setenv =
     PYTHONWARNINGS=always::DeprecationWarning
 passenv = CFLAGS LDFLAGS TRAVIS APPVEYOR CRYPTOGRAPHY_OSX_NO_LINK_FLAGS


### PR DESCRIPTION
It turns out that pyca/cryptography uses a very similar setup, so I was able to steal from https://github.com/pyca/cryptography/pull/1468 to fix codecov coverage for urllib3.