### PR TITLE
Change ambiguous description of backoff_factor

### DIFF
--- a/src/urllib3/util/retry.py
+++ b/src/urllib3/util/retry.py
@@ -115,7 +115,7 @@ class Retry(object):
         (most errors are resolved immediately by a second try without a
         delay). urllib3 will sleep for::
 
-            {backoff factor} * (2 ^ ({number of total retries} - 1))
+            {backoff factor} * (2 ** ({number of total retries} - 1))
 
         seconds. If the backoff_factor is 0.1, then :func:`.sleep` will sleep
         for [0.0s, 0.2s, 0.4s, ...] between retries. It will never be longer


### PR DESCRIPTION
Change from `^` to `**`. Programmers not familiar with python might assume the ^ is the exponent operator, when in fact it is the bitwise XOR operator. This change will remove the ambiguity.