### PR TITLE
Remove leftover Python 2.6 variable

### DIFF
--- a/src/urllib3/util/ssl_.py
+++ b/src/urllib3/util/ssl_.py
@@ -115,8 +115,6 @@ except ImportError:
     import sys
 
     class SSLContext(object):  # Platform-specific: Python 2
-        supports_set_ciphers = True
-
         def __init__(self, protocol_version):
             self.protocol = protocol_version
             # Use default values from a real SSLContext


### PR DESCRIPTION
set_ciphers is always supported in Python 2.7+, so this is no longer needed.

(I noticed this because the v2 branch dropped supports_set_ciphers when dropping Python 2.6 support.)