### PR TITLE
Add missing key_server_hostname variable

### DIFF
--- a/src/urllib3/poolmanager.py
+++ b/src/urllib3/poolmanager.py
@@ -47,6 +47,7 @@ _key_fields = (
     'key__socks_options',  # dict
     'key_assert_hostname',  # bool or string
     'key_assert_fingerprint',  # str
+    'key_server_hostname', #str
 )
 
 #: The namedtuple class used to construct keys for the connection pool.


### PR DESCRIPTION
Allow key_server_hostname to be specified when initializing a PoolManager to allow custom SNI to be overridden.