### PR TITLE
Use unittest.mock if available

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,7 +27,10 @@ sys.path.insert(0, root_path)
 # Mock some expensive/platform-specific modules so build will work.
 # (https://read-the-docs.readthedocs.io/en/latest/faq.html#\
 #  i-get-import-errors-on-libraries-that-depend-on-c-modules)
-import mock
+try:
+    import unittest.mock as mock
+except ImportError:
+    import mock
 
 
 class MockModule(mock.Mock):

--- a/setup.py
+++ b/setup.py
@@ -52,12 +52,15 @@ setup(name='urllib3',
                 ],
       package_dir={'': 'src'},
       requires=[],
+      install_requires=[
+          'setuptools>=20.8.1'
+      ],
       python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, <4",
       tests_require=[
           # These are a less-specific subset of dev-requirements.txt, for the
           # convenience of distro package maintainers.
           'pytest',
-          'mock',
+          'mock;python_version<"3.3"',
           'tornado',
       ],
       test_suite='test',

--- a/test/appengine/test_urlfetch.py
+++ b/test/appengine/test_urlfetch.py
@@ -6,7 +6,10 @@ import httplib
 import StringIO
 import unittest
 
-from mock import patch
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 import pytest
 
 from ..test_no_ssl import TestWithoutSSL

--- a/test/contrib/test_pyopenssl.py
+++ b/test/contrib/test_pyopenssl.py
@@ -2,7 +2,10 @@
 import os
 import unittest
 
-import mock
+try:
+    import unittest.mock as mock
+except ImportError:
+    import mock
 import pytest
 
 try:

--- a/test/contrib/test_pyopenssl_dependencies.py
+++ b/test/contrib/test_pyopenssl_dependencies.py
@@ -2,7 +2,10 @@
 import unittest
 import pytest
 
-from mock import patch, Mock
+try:
+    from unittest.mock import patch, Mock
+except ImportError:
+    from mock import patch, Mock
 
 try:
     from urllib3.contrib.pyopenssl import (

--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -1,5 +1,8 @@
 import datetime
-import mock
+try:
+    import unittest.mock as mock
+except ImportError:
+    import mock
 
 import pytest
 

--- a/test/test_queue_monkeypatch.py
+++ b/test/test_queue_monkeypatch.py
@@ -1,6 +1,9 @@
 from __future__ import absolute_import
 
-import mock
+try:
+    import unittest.mock as mock
+except ImportError:
+    import mock
 
 import pytest
 

--- a/test/test_response.py
+++ b/test/test_response.py
@@ -4,7 +4,10 @@ import zlib
 from io import BytesIO, BufferedReader
 
 import pytest
-import mock
+try:
+    import unittest.mock as mock
+except ImportError:
+    import mock
 
 from urllib3.response import HTTPResponse
 from urllib3.exceptions import (

--- a/test/test_ssl.py
+++ b/test/test_ssl.py
@@ -1,4 +1,7 @@
-import mock
+try:
+    import unittest.mock as mock
+except ImportError:
+    import mock
 import pytest
 from urllib3.util import ssl_
 from urllib3.exceptions import SNIMissingWarning

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -6,7 +6,10 @@ import ssl
 import socket
 from itertools import chain
 
-from mock import patch, Mock
+try:
+    from unittest.mock import patch, Mock
+except ImportError:
+    from mock import patch, Mock
 import pytest
 
 from urllib3 import add_stderr_logger, disable_warnings

--- a/test/with_dummyserver/test_connectionpool.py
+++ b/test/with_dummyserver/test_connectionpool.py
@@ -7,7 +7,10 @@ import time
 import warnings
 import pytest
 
-import mock
+try:
+    import unittest.mock as mock
+except ImportError:
+    import mock
 
 from .. import (
     TARPIT_HOST, VALID_SOURCE_ADDRESSES, INVALID_SOURCE_ADDRESSES,

--- a/test/with_dummyserver/test_https.py
+++ b/test/with_dummyserver/test_https.py
@@ -6,7 +6,10 @@ import sys
 import unittest
 import warnings
 
-import mock
+try:
+    import unittest.mock as mock
+except ImportError:
+    import mock
 import pytest
 
 from dummyserver.testcase import (


### PR DESCRIPTION
Mock is in python 3.3+, use that if possible.  Make mock package conditional on python < 3.3.  Specify setuptools version requirement for use of environment markers.