### PR TITLE
Uninstall oclint if it's installed

### DIFF
--- a/_travis/install.sh
+++ b/_travis/install.sh
@@ -9,6 +9,12 @@ if [[ "$(uname -s)" == 'Darwin' ]]; then
     brew outdated openssl || brew upgrade openssl
     brew install openssl@1.1
 
+    # Uninstall oclint if it's installed. This is
+    # conditional because of build caching.
+    if brew ls --versions oclint >> /dev/null; then
+        brew cask uninstall oclint
+    fi
+
     # install pyenv
     git clone --depth 1 https://github.com/yyuu/pyenv.git ~/.pyenv
     PYENV_ROOT="$HOME/.pyenv"


### PR DESCRIPTION
Doing this because I saw on the Python 3.8 build on master we were having this issue again. I think it's because the builds get cached on success so we need to check if it's installed every time because caches go away on PRs and new branches.