### PR TITLE
Allow missing SERVER_SOFTWARE in appengine checks

### DIFF
--- a/src/urllib3/contrib/_appengine_environ.py
+++ b/src/urllib3/contrib/_appengine_environ.py
@@ -17,12 +17,12 @@ def is_appengine_sandbox():
 
 def is_local_appengine():
     return ('APPENGINE_RUNTIME' in os.environ and
-            'Development/' in os.environ['SERVER_SOFTWARE'])
+            os.getenv('SERVER_SOFTWARE', '').startswith('Development'))
 
 
 def is_prod_appengine():
     return ('APPENGINE_RUNTIME' in os.environ and
-            'Google App Engine/' in os.environ['SERVER_SOFTWARE'] and
+            os.getenv('SERVER_SOFTWARE', '').startswith('Google App Engine/') and
             not is_prod_appengine_mvms())
 
 


### PR DESCRIPTION
Closes https://github.com/urllib3/urllib3/issues/1470

I've taken inspiration from https://github.com/urllib3/urllib3/issues/1470, https://github.com/urllib3/urllib3/pull/1471 and https://cloud.google.com/appengine/docs/standard/python/tools/using-local-server#detecting_application_runtime_environment. The tests pass, but does it fix @wittfabian's original issue? I don't know.