### PR TITLE
Fix inject/extract calls in tests

### DIFF
--- a/test/contrib/test_pyopenssl.py
+++ b/test/contrib/test_pyopenssl.py
@@ -25,7 +25,7 @@ def setup_module():
 
 def teardown_module():
     try:
-        from urllib3.contrib.securetransport import extract_from_urllib3
+        from urllib3.contrib.pyopenssl import extract_from_urllib3
         extract_from_urllib3()
     except ImportError:
         pass

--- a/test/contrib/test_pyopenssl_dependencies.py
+++ b/test/contrib/test_pyopenssl_dependencies.py
@@ -15,9 +15,18 @@ except ImportError:
 
 def setup_module():
     try:
-        from urllib3.contrib.pyopenssl import inject_into_urllib3  # noqa: F401
+        from urllib3.contrib.pyopenssl import inject_into_urllib3
+        inject_into_urllib3()
     except ImportError as e:
         pytest.skip('Could not import PyOpenSSL: %r' % e)
+
+
+def teardown_module():
+    try:
+        from urllib3.contrib.pyopenssl import extract_from_urllib3
+        extract_from_urllib3()
+    except ImportError:
+        pass
 
 
 class TestPyOpenSSLInjection(unittest.TestCase):


### PR DESCRIPTION
Looks like we're injecting and extracting the wrong contrib module in some of our `test/contrib/` tests.