### PR TITLE
Create a more efficient HTTPResponse.__iter__() method

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,11 +4,17 @@ Changes
 dev (master)
 ------------
 
+* Implemented a more efficient ``HTTPResponse.__iter__()`` method (Issue #1483)
+
+* ... [Short description of non-trivial change.] (Issue #)
+
+
+1.24.1 (2018-11-02)
+-------------------
+
 * Remove quadratic behavior within ``GzipDecoder.decompress()`` (Issue #1467)
 
 * Restored functionality of `ciphers` parameter for `create_urllib3_context()`. (Issue #1462)
-
-* ... [Short description of non-trivial change.] (Issue #)
 
 
 1.24 (2018-10-16)

--- a/src/urllib3/response.py
+++ b/src/urllib3/response.py
@@ -705,3 +705,20 @@ class HTTPResponse(io.IOBase):
             return self.retries.history[-1].redirect_location
         else:
             return self._request_url
+
+    def __iter__(self):
+        buffer = [b""]
+        for chunk in self.stream(decode_content=True):
+            if b"\n" in chunk:
+                chunk = chunk.split(b"\n")
+                yield b"".join(buffer) + chunk[0] + b"\n"
+                for x in chunk[1:-1]:
+                    yield x + b"\n"
+                if chunk[-1]:
+                    buffer = [chunk[-1]]
+                else:
+                    buffer = []
+            else:
+                buffer.append(chunk)
+        if buffer:
+            yield b"".join(buffer)

--- a/test/with_dummyserver/test_connectionpool.py
+++ b/test/with_dummyserver/test_connectionpool.py
@@ -512,6 +512,23 @@ class TestConnectionPool(HTTPDummyServerTestCase):
 
             self.assertEqual(body[i], expected_body[i])
 
+    def test_post_with_multipart__iter__(self):
+        data = {'hello': 'world'}
+        r = self.pool.request('POST', '/echo',
+                              fields=data,
+                              preload_content=False,
+                              multipart_boundary="boundary",
+                              encode_multipart=True)
+
+        chunks = [chunk for chunk in r]
+        assert chunks == [
+            b"--boundary\r\n",
+            b'Content-Disposition: form-data; name="hello"\r\n',
+            b'\r\n',
+            b'world\r\n',
+            b"--boundary--\r\n"
+        ]
+
     def test_check_gzip(self):
         r = self.pool.request('GET', '/encodingrequest',
                               headers={'accept-encoding': 'gzip'})


### PR DESCRIPTION
Per #1483 if you iterate over the response object you get single-byte reads over and over again. This implementation maintains the same functionality of splitting by line but doesn't use single-byte reads. Closes #1483.