### PR TITLE
travis: use python.org MacPython builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,9 +58,6 @@ matrix:
     - language: generic
       os: osx
       env: TOXENV=py37
-    - language: generic
-      os: osx
-      env: TOXENV=py38
   allow_failures:
   - python: pypy-5.4
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ script:
 before_install:
   - env
   - openssl version
+  - python -c "import ssl; print(ssl.OPENSSL_VERSION)"
 after_success:
   - ./_travis/upload_coverage.sh
 cache:

--- a/_travis/install.sh
+++ b/_travis/install.sh
@@ -4,50 +4,23 @@ set -e
 set -x
 
 if [[ "$(uname -s)" == 'Darwin' ]]; then
-    sw_vers
-    brew update || brew update
-    brew outdated openssl || brew upgrade openssl
-    brew install openssl@1.1
-
-    # install pyenv
-    git clone --depth 1 https://github.com/yyuu/pyenv.git ~/.pyenv
-    PYENV_ROOT="$HOME/.pyenv"
-    PATH="$PYENV_ROOT/bin:$PATH"
-    eval "$(pyenv init -)"
-
     case "${TOXENV}" in
-        py27)
-            pyenv install 2.7.14
-            pyenv global 2.7.14
-            ;;
-        py34)
-            pyenv install 3.4.7
-            pyenv global 3.4.7
-            ;;
-        py35)
-            pyenv install 3.5.4
-            pyenv global 3.5.4
-            ;;
-        py36)
-            pyenv install 3.6.3
-            pyenv global 3.6.3
-            ;;
-        py37)
-            pyenv install 3.7-dev
-            pyenv global 3.7-dev
-            ;;
-        py38)
-            pyenv install 3.8-dev
-            pyenv global 3.8-dev
-            ;;
-        pypy*)
-            pyenv install "pypy-5.4.1"
-            pyenv global "pypy-5.4.1"
-            ;;
+        py27) MACPYTHON=2.7.15 ;;
+        py34) MACPYTHON=3.4.4 ;;
+        py35) MACPYTHON=3.5.4 ;;
+        py36) MACPYTHON=3.6.7 ;;
+        py37) MACPYTHON=3.7.1 ;;
     esac
-    pyenv rehash
-    pip install -U setuptools
-    pip install --user virtualenv
+
+    MINOR=$(echo $MACPYTHON | cut -d. -f1,2)
+
+    curl -Lo macpython.pkg https://www.python.org/ftp/python/${MACPYTHON}/python-${MACPYTHON}-macosx10.6.pkg
+    sudo installer -pkg macpython.pkg -target /
+    ls /Library/Frameworks/Python.framework/Versions/$MINOR/bin/
+    PYTHON_EXE=/Library/Frameworks/Python.framework/Versions/$MINOR/bin/python$MINOR
+    # The pip in older MacPython releases doesn't support a new enough TLS
+    curl https://bootstrap.pypa.io/get-pip.py | sudo $PYTHON_EXE
+    $PYTHON_EXE -m pip install virtualenv
 else
     pip install virtualenv
 fi

--- a/_travis/install.sh
+++ b/_travis/install.sh
@@ -20,7 +20,6 @@ if [[ "$(uname -s)" == 'Darwin' ]]; then
     PYTHON_EXE=/Library/Frameworks/Python.framework/Versions/$MINOR/bin/python$MINOR
     # The pip in older MacPython releases doesn't support a new enough TLS
     curl https://bootstrap.pypa.io/get-pip.py | sudo $PYTHON_EXE
-    $PYTHON_EXE -c "import ssl; print(ssl.OPENSSL_VERSION)"
     $PYTHON_EXE -m pip install virtualenv
 else
     pip install virtualenv

--- a/_travis/install.sh
+++ b/_travis/install.sh
@@ -20,6 +20,7 @@ if [[ "$(uname -s)" == 'Darwin' ]]; then
     PYTHON_EXE=/Library/Frameworks/Python.framework/Versions/$MINOR/bin/python$MINOR
     # The pip in older MacPython releases doesn't support a new enough TLS
     curl https://bootstrap.pypa.io/get-pip.py | sudo $PYTHON_EXE
+    $PYTHON_EXE -c "import ssl; print(ssl.OPENSSL_VERSION)"
     $PYTHON_EXE -m pip install virtualenv
 else
     pip install virtualenv

--- a/_travis/run.sh
+++ b/_travis/run.sh
@@ -3,17 +3,8 @@
 set -e
 set -x
 
-if [[ "$(uname -s)" == "Darwin" ]]; then
-    # initialize our pyenv
-    PYENV_ROOT="$HOME/.pyenv"
-    PATH="$PYENV_ROOT/bin:$PATH"
-    eval "$(pyenv init -)"
-
-    # Use the good OpenSSL for PyOpenSSL. This also links it statically into
-    # cryptography, which more accurately reflects the way the wheel is used.
-    export CRYPTOGRAPHY_OSX_NO_LINK_FLAGS="1"
-    export LDFLAGS="$(brew --prefix openssl@1.1)/lib/libcrypto.a $(brew --prefix openssl@1.1)/lib/libssl.a"
-    export CFLAGS="-I$(brew --prefix openssl@1.1)/include"
+if [[ "$(uname -s)" == "Darwin" && "$TOXENV" == "py27" ]]; then
+    export PATH="/Library/Frameworks/Python.framework/Versions/2.7/bin":$PATH
 fi
 
 tox

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,4 +1,5 @@
 import warnings
+import platform
 import sys
 import errno
 import functools
@@ -135,6 +136,17 @@ def fails_on_travis_gce(test):
     def wrapper(*args, **kwargs):
         if os.environ.get("TRAVIS_INFRA") == "gce":
             pytest.xfail("%s is expected to fail on Travis GCE builds" % test.__name__)
+        return test(*args, **kwargs)
+    return wrapper
+
+
+def requires_bundled_OpenSSL_on_mac(test):
+    """Skips this test unless your MacPython bundles OpenSSL"""
+
+    @functools.wraps(test)
+    def wrapper(*args, **kwargs):
+        if platform.system() == 'Darwin' and sys.version_info[0:2] < (3, 6):
+            pytest.skip("{name} requires MacPython >= 3.6".format(name=test.__name__))
         return test(*args, **kwargs)
     return wrapper
 

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -145,8 +145,10 @@ def requires_bundled_OpenSSL_on_mac(test):
 
     @functools.wraps(test)
     def wrapper(*args, **kwargs):
-        if platform.system() == 'Darwin' and sys.version_info[0:2] < (3, 6):
-            pytest.skip("{name} requires MacPython >= 3.6".format(name=test.__name__))
+        major, minor = sys.version_info[0:2]
+        if platform.system() == 'Darwin' and major == 3 and minor < 6:
+            msg = "{name} requires MacPython 2.7 or >= 3.6".format(name=test.__name__)
+            pytest.skip(msg)
         return test(*args, **kwargs)
     return wrapper
 

--- a/test/with_dummyserver/test_https.py
+++ b/test/with_dummyserver/test_https.py
@@ -22,6 +22,7 @@ from dummyserver.server import (DEFAULT_CA, DEFAULT_CA_BAD, DEFAULT_CERTS,
 from test import (
     onlyPy279OrNewer,
     notSecureTransport,
+    requires_bundled_OpenSSL_on_mac,
     requires_network,
     fails_on_travis_gce,
     TARPIT_HOST,
@@ -197,6 +198,7 @@ class TestHTTPS(HTTPSDummyServerTestCase):
 
     @onlyPy279OrNewer
     @notSecureTransport  # SecureTransport does not support cert directories
+    @requires_bundled_OpenSSL_on_mac  # older MacPython builds don't bundle OpenSSL
     def test_ca_dir_verified(self):
         https_pool = HTTPSConnectionPool(self.host, self.port,
                                          cert_reqs='CERT_REQUIRED',

--- a/test/with_dummyserver/test_https.py
+++ b/test/with_dummyserver/test_https.py
@@ -22,7 +22,7 @@ from dummyserver.server import (DEFAULT_CA, DEFAULT_CA_BAD, DEFAULT_CERTS,
 from test import (
     onlyPy279OrNewer,
     notSecureTransport,
-    requires_bundled_OpenSSL_on_mac,
+    notOpenSSL098,
     requires_network,
     fails_on_travis_gce,
     TARPIT_HOST,
@@ -198,7 +198,7 @@ class TestHTTPS(HTTPSDummyServerTestCase):
 
     @onlyPy279OrNewer
     @notSecureTransport  # SecureTransport does not support cert directories
-    @requires_bundled_OpenSSL_on_mac  # older MacPython builds don't bundle OpenSSL
+    @notOpenSSL098  # OpenSSL 0.9.8 does not support cert directories
     def test_ca_dir_verified(self):
         https_pool = HTTPSConnectionPool(self.host, self.port,
                                          cert_reqs='CERT_REQUIRED',

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ commands=
     pip --version
     python --version
     python -c "import struct; print(struct.calcsize('P') * 8)"
+    python -m OpenSSL.debug
     # Inspired from https://github.com/pyca/cryptography
     # We use parallel mode and then combine here so that coverage.py will take
     # the paths like .tox/pyXY/lib/pythonX.Y/site-packages/urllib3/__init__.py


### PR DESCRIPTION
It's about ten minutes faster than using homebrew, but means we need to drop 3.8-dev on macOS and only run test_ca_dir_verified on recent MacPython builds (currently 2.7, 3,6 and 3.7).

Inspiration comes from https://github.com/python-trio/trio/blob/master/ci/travis.sh#L7-L17