### PR TITLE
Upgrade coverage to 4.5.2

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -12,9 +12,10 @@ omit =
 
 [paths]
 source =
-   src/urllib3
-   .tox/*/lib/python*/site-packages/urllib3
-   .tox/pypy*/site-packages/urllib3
+    src/urllib3
+    .tox/*/lib/python*/site-packages/urllib3
+    .tox\*\Lib\site-packages\urllib3
+    .tox/pypy*/site-packages/urllib3
 
 [report]
 exclude_lines =

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,5 @@
 mock==2.0.0
-coverage==4.5.2
+coverage~=4.5
 tox==2.9.1
 wheel==0.30.0
 tornado==5.0.2
@@ -8,3 +8,6 @@ pkginfo==1.4.2
 pytest-timeout==1.3.1
 pytest==3.8.2
 pluggy==0.8.0
+# https://github.com/GoogleCloudPlatform/python-repo-tools/issues/23
+pylint<2.0;python_version<="2.7"
+gcp-devrel-py-tools

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,5 @@
 mock==2.0.0
-coverage==4.5.1
+coverage==4.5.2
 tox==2.9.1
 wheel==0.30.0
 tornado==5.0.2

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,14 +1,10 @@
 mock==2.0.0
 coverage==4.5.1
 tox==2.9.1
-twine==1.11.0
 wheel==0.30.0
 tornado==5.0.2
 PySocks==1.6.8
 pkginfo==1.4.2
 pytest-timeout==1.3.1
 pytest==3.8.2
-# https://github.com/GoogleCloudPlatform/python-repo-tools/issues/23
-pylint<2.0;python_version<="2.7"
-gcp-devrel-py-tools==0.0.15
 pluggy==0.8.0

--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,12 @@ passenv = CFLAGS LDFLAGS TRAVIS APPVEYOR CRYPTOGRAPHY_OSX_NO_LINK_FLAGS TRAVIS_I
 basepython = python2.7
 deps=
     {[testenv]deps}
+    # https://github.com/GoogleCloudPlatform/python-repo-tools/issues/23
+    pylint<2.0;python_version<="2.7"
+    gcp-devrel-py-tools==0.0.15
 commands=
+    python -m pip uninstall urllib3
+    python {toxinidir}/setup.py install
     py.test -r sx test/appengine {posargs}
 setenv =
     GAE_SDK_PATH={env:GAE_SDK_PATH:}

--- a/tox.ini
+++ b/tox.ini
@@ -29,8 +29,10 @@ deps=
     pylint<2.0;python_version<="2.7"
     gcp-devrel-py-tools==0.0.15
 commands=
-    python -m pip uninstall urllib3
-    python {toxinidir}/setup.py install
+    python -m pip freeze
+    python -m pip uninstall -y urllib3
+    python -m pip install .
+    python -m pip freeze
     py.test -r sx test/appengine {posargs}
 setenv =
     GAE_SDK_PATH={env:GAE_SDK_PATH:}

--- a/tox.ini
+++ b/tox.ini
@@ -25,14 +25,7 @@ passenv = CFLAGS LDFLAGS TRAVIS APPVEYOR CRYPTOGRAPHY_OSX_NO_LINK_FLAGS TRAVIS_I
 basepython = python2.7
 deps=
     {[testenv]deps}
-    # https://github.com/GoogleCloudPlatform/python-repo-tools/issues/23
-    pylint<2.0;python_version<="2.7"
-    gcp-devrel-py-tools
 commands=
-    python -m pip freeze
-    python -m pip uninstall -y urllib3
-    python -m pip install .
-    python -m pip freeze
     coverage run --parallel-mode -m pytest -r sx test/appengine {posargs}
     coverage combine
     coverage report -m

--- a/tox.ini
+++ b/tox.ini
@@ -27,16 +27,19 @@ deps=
     {[testenv]deps}
     # https://github.com/GoogleCloudPlatform/python-repo-tools/issues/23
     pylint<2.0;python_version<="2.7"
-    gcp-devrel-py-tools==0.0.15
+    gcp-devrel-py-tools
 commands=
     python -m pip freeze
     python -m pip uninstall -y urllib3
     python -m pip install .
     python -m pip freeze
-    py.test -r sx test/appengine {posargs}
+    coverage run --parallel-mode -m pytest -r sx test/appengine {posargs}
+    coverage combine
+    coverage report -m
 setenv =
     GAE_SDK_PATH={env:GAE_SDK_PATH:}
     {[testenv]setenv}
+passenv = TRAVIS TRAVIS_INFRA
 
 [testenv:flake8-py3]
 basepython = python3.4


### PR DESCRIPTION
Turns out per nedbat/coveragepy#714 that phantom lines are generated when running on Python 3.8, that's probably the root of our issues? If you check the report on codecov for this PR it's at 100% now. :)