### PR TITLE
Normalize setup.py and setup.cfg dependencies for extras

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -11,9 +11,9 @@ provides-extra =
     secure
     socks
 requires-dist =
-    pyOpenSSL>=0.14; python_version=="2.7" and extra == 'secure'
-    cryptography>=1.3.4; python_version=="2.7" and extra == 'secure'
-    idna>=2.0.0; python_version=="2.7" and extra == 'secure'
+    pyOpenSSL>=0.14; extra == 'secure'
+    cryptography>=1.3.4; extra == 'secure'
+    idna>=2.0.0; extra == 'secure'
     certifi; extra == 'secure'
     ipaddress; python_version=="2.7" and extra == 'secure'
     PySocks>=1.5.6,<2.0,!=1.5.7; extra == 'socks'

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ setup(name='urllib3',
               'cryptography>=1.3.4',
               'idna>=2.0.0',
               'certifi',
-              "ipaddress; python_version=='2.7' and extra=='secure'",
+              "ipaddress; python_version=='2.7'",
           ],
           'socks': [
               'PySocks>=1.5.6,<2.0,!=1.5.7',

--- a/setup.py
+++ b/setup.py
@@ -65,11 +65,11 @@ setup(name='urllib3',
       test_suite='test',
       extras_require={
           'secure': [
-              'pyOpenSSL >= 0.14',
+              'pyOpenSSL>=0.14',
               'cryptography>=1.3.4',
               'idna>=2.0.0',
               'certifi',
-              "ipaddress",
+              "ipaddress; python_version=='2.7' and extra=='secure'",
           ],
           'socks': [
               'PySocks>=1.5.6,<2.0,!=1.5.7',


### PR DESCRIPTION
We need to install these dependencies because our upstream expects pyOpenSSL support to be available on all platforms when installed with `urllib3[secure]`.

Closes #1460.