### PR TITLE
App Engine: Don't raise an exception if the header instance type is incorrect

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -272,5 +272,8 @@ In chronological order:
 * Justin Bramley <https://github.com/jbramleycl>
   * Add ability to handle multiple Content-Encodings
 
+* Michael Sander (speedplane) <michael.sander@docketalarm.com>
+  * Quiet warning on App Engine.
+  
 * [Your name or handle] <[email or website]>
   * [Brief summary of your changes]

--- a/src/urllib3/util/response.py
+++ b/src/urllib3/util/response.py
@@ -4,6 +4,7 @@ from ..packages.six.moves import http_client as httplib
 from ..exceptions import HeaderParsingError
 from ..contrib import _appengine_environ
 
+
 def is_fp_closed(obj):
     """
     Checks whether a given file-like object is closed.

--- a/src/urllib3/util/response.py
+++ b/src/urllib3/util/response.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 from ..packages.six.moves import http_client as httplib
 
 from ..exceptions import HeaderParsingError
-
+from ..contrib import _appengine_environ
 
 def is_fp_closed(obj):
     """
@@ -51,7 +51,8 @@ def assert_header_parsing(headers):
 
     # This will fail silently if we pass in the wrong kind of parameter.
     # To make debugging easier add an explicit check.
-    if not isinstance(headers, httplib.HTTPMessage):
+    if not _appengine_environ.is_appengine() and \
+            not isinstance(headers, httplib.HTTPMessage):
         raise TypeError('expected httplib.Message, got {0}.'.format(
             type(headers)))
 


### PR DESCRIPTION
App Engine uses its own httplib, which are (generally) compatible with standard httplib, but with different names. Addresses #1501.