### PR TITLE
Add Tidelift and remove BountySource

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -77,6 +77,13 @@ urllib3 happily accepts contributions. Please see our
 for some tips on getting started.
 
 
+Security Disclosures
+--------------------
+
+To report a security vulnerability, please use the
+`Tidelift security contact <https://tidelift.com/security>`_.
+Tidelift will coordinate the fix and disclosure with maintainers.
+
 Maintainers
 -----------
 
@@ -92,6 +99,22 @@ Maintainers
 
 Sponsorship
 -----------
+
+.. |tideliftlogo| image:: https://nedbatchelder.com/pix/Tidelift_Logos_RGB_Tidelift_Shorthand_On-White_small.png
+   :width: 75
+   :alt: Tidelift
+
+.. list-table::
+   :widths: 10 100
+
+   * - |tideliftlogo|
+     - Professional support for urllib3 is available as part of the `Tidelift
+       Subscription`_.  Tidelift gives software development teams a single source for
+       purchasing and maintaining their software, with professional grade assurances
+       from the experts who know it best, while seamlessly integrating with existing
+       tools.
+
+.. _Tidelift Subscription: https://tidelift.com/subscription/pkg/pypi-urllib3?utm_source=pypi-urllib3&utm_medium=referral&utm_campaign=docs
 
 If your company benefits from this library, please consider `sponsoring its
 development <https://urllib3.readthedocs.io/en/latest/contributing.html#sponsorship-project-grants>`_.

--- a/README.rst
+++ b/README.rst
@@ -21,10 +21,6 @@ urllib3
         :alt: PyPI version
         :target: https://pypi.org/project/urllib3/
 
-.. image:: https://www.bountysource.com/badge/tracker?tracker_id=192525
-        :alt: Bountysource
-        :target: https://www.bountysource.com/trackers/192525-urllib3?utm_source=192525&utm_medium=shield&utm_campaign=TRACKER_BADGE
-
 .. image:: https://badges.gitter.im/python-urllib3/Lobby.svg
         :alt: Gitter
         :target: https://gitter.im/python-urllib3/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge
@@ -98,7 +94,7 @@ Sponsorship
 -----------
 
 If your company benefits from this library, please consider `sponsoring its
-development <https://urllib3.readthedocs.io/en/latest/contributing.html#sponsorship>`_.
+development <https://urllib3.readthedocs.io/en/latest/contributing.html#sponsorship-project-grants>`_.
 
 Sponsors include:
 

--- a/README.rst
+++ b/README.rst
@@ -25,6 +25,10 @@ urllib3
         :alt: Gitter
         :target: https://gitter.im/python-urllib3/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge
 
+.. image:: https://tidelift.com/badges/github/urllib3/urllib3
+        :alt: Tidelift Dependencies
+        :target: https://tidelift.com/subscription/pkg/pypi-urllib3?utm_source=pypi-urllib3&utm_medium=referral&utm_campaign=docs
+
 urllib3 is a powerful, *sanity-friendly* HTTP client for Python. Much of the
 Python ecosystem already uses urllib3 and you should too.
 urllib3 brings many critical features that are missing from the Python
@@ -114,7 +118,7 @@ Sponsorship
        from the experts who know it best, while seamlessly integrating with existing
        tools.
 
-.. _Tidelift Subscription: https://tidelift.com/subscription/pkg/pypi-urllib3?utm_source=pypi-urllib3&utm_medium=referral&utm_campaign=docs
+.. _Tidelift Subscription: https://tidelift.com/subscription/pkg/pypi-urllib3?utm_source=pypi-urllib3&utm_medium=referral&utm_campaign=readme
 
 If your company benefits from this library, please consider `sponsoring its
 development <https://urllib3.readthedocs.io/en/latest/contributing.html#sponsorship-project-grants>`_.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -134,7 +134,7 @@ html_theme = 'alabaster'
 # documentation.
 html_theme_options = {
     'description': 'Sanity-friendly HTTP client.',
-    'github_user': 'shazow',
+    'github_user': 'urllib3',
     'github_repo': 'urllib3',
     'github_button': False,
     'github_banner': True,
@@ -271,4 +271,4 @@ man_pages = [
 ]
 
 intersphinx_mapping = {
-    'python': ('https://docs.python.org/3.5', None),}
+    'python': ('https://docs.python.org/3.7', None),}

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -66,16 +66,11 @@ Our test suite `runs continuously on Travis CI
 <https://travis-ci.org/urllib3/urllib3>`_ with every pull request.
 
 
-Sponsorship
------------
+Sponsorship & Project Grants
+----------------------------
 
 Please consider sponsoring urllib3 development, especially if your company
 benefits from this library.
-
-We welcome your patronage on `Bountysource <https://www.bountysource.com/teams/urllib3>`_:
-
-* `Contribute a recurring amount to the team <https://salt.bountysource.com/checkout/amount?team=urllib3>`_
-* `Place a bounty on a specific feature <https://www.bountysource.com/teams/urllib3>`_
 
 Your contribution will go towards adding new features to urllib3 and making
 sure all functionality continues to meet our high quality standards.
@@ -83,10 +78,6 @@ sure all functionality continues to meet our high quality standards.
 We also welcome sponsorship in the form of time. We greatly appreciate companies
 who encourage employees to contribute on an ongoing basis during their work hours.
 Please let us know and we'll be glad to add you to our sponsors list!
-
-
-Project Grant
--------------
 
 A grant for contiguous full-time development has the biggest impact for
 progress. Periods of 3 to 10 days allow a contributor to tackle substantial
@@ -99,6 +90,8 @@ contributor.
 Huge thanks to all the companies and individuals who financially contributed to
 the development of urllib3. Please send a PR if you've donated and would like
 to be listed.
+
+* `GOVCERT.LU <https://govcert.lu/>`_ (October 23, 2018)
 
 * `Stripe <https://stripe.com/>`_ (June 23, 2014)
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -69,6 +69,22 @@ Our test suite `runs continuously on Travis CI
 Sponsorship & Project Grants
 ----------------------------
 
+.. |tideliftlogo| image:: https://nedbatchelder.com/pix/Tidelift_Logos_RGB_Tidelift_Shorthand_On-White_small.png
+   :width: 75
+   :alt: Tidelift
+
+.. list-table::
+   :widths: 10 100
+
+   * - |tideliftlogo|
+     - Professional support for urllib3 is available as part of the `Tidelift
+       Subscription`_.  Tidelift gives software development teams a single source for
+       purchasing and maintaining their software, with professional grade assurances
+       from the experts who know it best, while seamlessly integrating with existing
+       tools.
+
+.. _Tidelift Subscription: https://tidelift.com/subscription/pkg/pypi-urllib3?utm_source=pypi-urllib3&utm_medium=referral&utm_campaign=docs
+
 Please consider sponsoring urllib3 development, especially if your company
 benefits from this library.
 
@@ -84,8 +100,8 @@ progress. Periods of 3 to 10 days allow a contributor to tackle substantial
 complex issues which are otherwise left to linger until somebody can't afford
 to not fix them.
 
-Contact `@shazow <https://github.com/shazow>`_ to arrange a grant for a core
-contributor.
+Contact `@theacodes <https://github.com/theacodes>`_ or `@shazow <https://github.com/shazow>`_ 
+to arrange a grant for a core contributor.
 
 Huge thanks to all the companies and individuals who financially contributed to
 the development of urllib3. Please send a PR if you've donated and would like

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,4 +2,4 @@
 ndg-httpsclient
 sphinx
 alabaster
-requests>=2.0,<2.16
+requests>=2

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,4 +2,4 @@
 ndg-httpsclient
 sphinx
 alabaster
-requests>=2
+requests>=2,<2.16

--- a/tox.ini
+++ b/tox.ini
@@ -40,7 +40,6 @@ commands=
     flake8 setup.py docs dummyserver src test
 
 [testenv:docs]
-basepython = python2.7
 deps=
     -r{toxinidir}/docs/requirements.txt
 commands=


### PR DESCRIPTION
- BountySource hasn't had much activity so we're removing it (I'll remove labels from the issues as well).
- Combined the section on Grants and Sponsorships.
- Added GOVCERT.LU to the list of financial contributors! :tada: