### PR TITLE
Clear Cookie header when redirecting to cross-site

### DIFF
--- a/src/urllib3/util/retry.py
+++ b/src/urllib3/util/retry.py
@@ -151,7 +151,7 @@ class Retry(object):
 
     RETRY_AFTER_STATUS_CODES = frozenset([413, 429, 503])
 
-    DEFAULT_REDIRECT_HEADERS_BLACKLIST = frozenset(['Authorization'])
+    DEFAULT_REDIRECT_HEADERS_BLACKLIST = frozenset(['Authorization', 'Cookie'])
 
     #: Maximum backoff time.
     BACKOFF_MAX = 120

--- a/test/with_dummyserver/test_poolmanager.py
+++ b/test/with_dummyserver/test_poolmanager.py
@@ -115,17 +115,20 @@ class TestPoolManager(HTTPDummyServerTestCase):
 
         r = http.request('GET', '%s/redirect' % self.base_url,
                          fields={'target': '%s/headers' % self.base_url_alt},
-                         headers={'Authorization': 'foo'})
+                         headers={'Authorization': 'foo',
+                                  'Cookie': 'bar'})
 
         self.assertEqual(r.status, 200)
 
         data = json.loads(r.data.decode('utf-8'))
 
         self.assertNotIn('Authorization', data)
+        self.assertNotIn('Cookie', data)
 
         r = http.request('GET', '%s/redirect' % self.base_url,
                          fields={'target': '%s/headers' % self.base_url_alt},
-                         headers={'authorization': 'foo'})
+                         headers={'authorization': 'foo',
+                                  'cookie': 'bar'})
 
         self.assertEqual(r.status, 200)
 
@@ -133,6 +136,8 @@ class TestPoolManager(HTTPDummyServerTestCase):
 
         self.assertNotIn('authorization', data)
         self.assertNotIn('Authorization', data)
+        self.assertNotIn('cookie', data)
+        self.assertNotIn('Cookie', data)
 
     def test_redirect_cross_host_no_remove_headers(self):
         http = PoolManager()


### PR DESCRIPTION
Cookie header with confidential data should be cleared when redirecting to cross-site, not only Authorization header.