### PR TITLE
WIP: Ensure PyOpenSSLContext.load_verify_locations raises ssl.SSLError

### DIFF
--- a/src/urllib3/contrib/pyopenssl.py
+++ b/src/urllib3/contrib/pyopenssl.py
@@ -425,9 +425,12 @@ class PyOpenSSLContext(object):
             cafile = cafile.encode('utf-8')
         if capath is not None:
             capath = capath.encode('utf-8')
-        self._ctx.load_verify_locations(cafile, capath)
-        if cadata is not None:
-            self._ctx.load_verify_locations(BytesIO(cadata))
+        try:
+            self._ctx.load_verify_locations(cafile, capath)
+            if cadata is not None:
+                self._ctx.load_verify_locations(BytesIO(cadata))
+        except OpenSSL.SSL.Error as e:
+            raise ssl.SSLError('unable to load trusted certificates: %r' % e)
 
     def load_cert_chain(self, certfile, keyfile=None, password=None):
         self._ctx.use_certificate_chain_file(certfile)

--- a/test/contrib/test_pyopenssl.py
+++ b/test/contrib/test_pyopenssl.py
@@ -97,3 +97,4 @@ class TestPyOpenSSLException(unittest.TestCase):
         with pytest.raises(urllib3.exceptions.SSLError) as exc:
             urllib3.util.ssl_wrap_socket(None, ca_certs=os.devnull)
         self.assertIsInstance(exc.value.args[0], ssl.SSLError)
+        self.assertIn('unable to load trusted certificates', str(exc.value.args[0]))

--- a/test/contrib/test_pyopenssl.py
+++ b/test/contrib/test_pyopenssl.py
@@ -4,6 +4,7 @@ import unittest
 
 import mock
 import pytest
+import ssl
 
 try:
     from urllib3.contrib.pyopenssl import (
@@ -13,6 +14,8 @@ try:
     from OpenSSL.crypto import FILETYPE_PEM, load_certificate
 except ImportError:
     pass
+
+import urllib3
 
 
 def setup_module():
@@ -84,3 +87,13 @@ class TestPyOpenSSLHelpers(unittest.TestCase):
         self.assertEqual(mock_warning.call_count, 1)
         self.assertIsInstance(mock_warning.call_args[0][1],
                               x509.DuplicateExtension)
+
+class TestPyOpenSSLException(unittest.TestCase):
+    def test_load_verify_locations_exception(self):
+        """
+        Ensure PyOpenSSLContext.load_verify_locations raises ssl.SSLError, which is
+        later wrapped in urllib3.exceptions.SSLError.
+        """
+        with pytest.raises(urllib3.exceptions.SSLError) as exc:
+            urllib3.util.ssl_wrap_socket(None, ca_certs=os.devnull)
+        self.assertIsInstance(exc.value.args[0], ssl.SSLError)

--- a/test/contrib/test_pyopenssl.py
+++ b/test/contrib/test_pyopenssl.py
@@ -4,7 +4,6 @@ import unittest
 
 import mock
 import pytest
-import ssl
 
 try:
     from urllib3.contrib.pyopenssl import (
@@ -14,8 +13,6 @@ try:
     from OpenSSL.crypto import FILETYPE_PEM, load_certificate
 except ImportError:
     pass
-
-import urllib3
 
 
 def setup_module():
@@ -87,14 +84,3 @@ class TestPyOpenSSLHelpers(unittest.TestCase):
         self.assertEqual(mock_warning.call_count, 1)
         self.assertIsInstance(mock_warning.call_args[0][1],
                               x509.DuplicateExtension)
-
-class TestPyOpenSSLException(unittest.TestCase):
-    def test_load_verify_locations_exception(self):
-        """
-        Ensure PyOpenSSLContext.load_verify_locations raises ssl.SSLError, which is
-        later wrapped in urllib3.exceptions.SSLError.
-        """
-        with pytest.raises(urllib3.exceptions.SSLError) as exc:
-            urllib3.util.ssl_wrap_socket(None, ca_certs=os.devnull)
-        self.assertIsInstance(exc.value.args[0], ssl.SSLError)
-        self.assertIn('unable to load trusted certificates', str(exc.value.args[0]))

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -11,6 +11,7 @@ from urllib3.exceptions import (
         ProtocolError,
 )
 from urllib3.response import httplib
+from urllib3.util import ssl_wrap_socket
 from urllib3.util.ssl_ import HAS_SNI
 from urllib3.util.timeout import Timeout
 from urllib3.util.retry import Retry
@@ -29,6 +30,7 @@ except ImportError:
         pass
 from collections import OrderedDict
 from threading import Event
+import os
 import select
 import socket
 import ssl
@@ -230,6 +232,16 @@ class TestClientCerts(SocketDummyServerTestCase):
                 "Expected server to reject connection due to missing client "
                 "certificates"
             )
+
+    def test_load_verify_locations_exception(self):
+        """
+        Ensure that load_verify_locations raises urllib3.exceptions.SSLError in
+        case of error.
+        """
+        with pytest.raises(SSLError) as exc:
+            ssl_wrap_socket(None, ca_certs=os.devnull)
+        self.assertIsInstance(exc.value.args[0], ssl.SSLError)
+        self.assertIn('unable to load trusted certificates', str(exc.value.args[0]))
 
 
 class TestSocketClosing(SocketDummyServerTestCase):


### PR DESCRIPTION
Without this patch, an `OpenSSL.SSL.Error` is raised when `PyOpenSSLContext.load_verify_locations` fails:
```
$ python -c "import os; import urllib3; import urllib3.contrib.pyopenssl; urllib3.contrib.pyopenssl.inject_into_urllib3(); urllib3.util.ssl_wrap_socket(None, ca_certs=os.devnull)"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/tmp/urllib3/local/lib/python2.7/site-packages/urllib3/util/ssl_.py", line 321, in ssl_wrap_socket
    context.load_verify_locations(ca_certs, ca_cert_dir)
  File "/tmp/urllib3/local/lib/python2.7/site-packages/urllib3/contrib/pyopenssl.py", line 428, in load_verify_locations
    self._ctx.load_verify_locations(cafile, capath)
  File "/tmp/urllib3/local/lib/python2.7/site-packages/OpenSSL/SSL.py", line 781, in load_verify_locations
    _raise_current_error()
  File "/tmp/urllib3/local/lib/python2.7/site-packages/OpenSSL/_util.py", line 53, in exception_from_error_queue
    raise exception_type(errors)
OpenSSL.SSL.Error: []
```

With this patch, an `ssl.SSLError` is raised, in the same way [`do_handshake` errors are handled](https://github.com/pilou-/urllib3/blob/f17a64dbd052be6cdbdbd8b03f01ad0bc09a5ab3/src/urllib3/contrib/pyopenssl.py#L461-L462):
```
$ python -c "import os; import urllib3; import urllib3.contrib.pyopenssl; urllib3.contrib.pyopenssl.inject_into_urllib3(); urllib3.util.ssl_wrap_socket(None, ca_certs=os.devnull)"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/pilou/src/urllib3/src/urllib3/util/ssl_.py", line 313, in ssl_wrap_socket
    raise SSLError(e)
urllib3.exceptions.SSLError: ('unable to load trusted certificates: Error([('x509 certificate routines', 'X509_load_cert_crl_file', 'no certificate or crl found')],)',)
```

then:
1. this `ssl.SSLError` is caught by [`ssl_wrap_socket`](https://github.com/pilou-/urllib3/blob/f17a64dbd052be6cdbdbd8b03f01ad0bc09a5ab3/src/urllib3/util/ssl_.py#L310-L313)
2. an `urllib3.exceptions.SSLError` error is raised
    * which is the same exception that the one raised when pyOpenSSL isn't available
    * and which is what users of urllib3 library expect (this can be tested with `python -c "import requests, os; requests.get('https://github.com', verify=os.devnull)"`)