### PR TITLE
Inject into urllib3.util.SSLContext

### DIFF
--- a/src/urllib3/contrib/pyopenssl.py
+++ b/src/urllib3/contrib/pyopenssl.py
@@ -117,6 +117,7 @@ def inject_into_urllib3():
 
     _validate_dependencies_met()
 
+    util.SSLContext = PyOpenSSLContext
     util.ssl_.SSLContext = PyOpenSSLContext
     util.HAS_SNI = HAS_SNI
     util.ssl_.HAS_SNI = HAS_SNI
@@ -127,6 +128,7 @@ def inject_into_urllib3():
 def extract_from_urllib3():
     'Undo monkey-patching by :func:`inject_into_urllib3`.'
 
+    util.SSLContext = orig_util_SSLContext
     util.ssl_.SSLContext = orig_util_SSLContext
     util.HAS_SNI = orig_util_HAS_SNI
     util.ssl_.HAS_SNI = orig_util_HAS_SNI

--- a/src/urllib3/contrib/securetransport.py
+++ b/src/urllib3/contrib/securetransport.py
@@ -155,6 +155,7 @@ def inject_into_urllib3():
     """
     Monkey-patch urllib3 with SecureTransport-backed SSL-support.
     """
+    util.SSLContext = SecureTransportContext
     util.ssl_.SSLContext = SecureTransportContext
     util.HAS_SNI = HAS_SNI
     util.ssl_.HAS_SNI = HAS_SNI
@@ -166,6 +167,7 @@ def extract_from_urllib3():
     """
     Undo monkey-patching by :func:`inject_into_urllib3`.
     """
+    util.SSLContext = orig_util_SSLContext
     util.ssl_.SSLContext = orig_util_SSLContext
     util.HAS_SNI = orig_util_HAS_SNI
     util.ssl_.HAS_SNI = orig_util_HAS_SNI


### PR DESCRIPTION
Previously we weren't injecting into `urllib3.util.SSLContext` when we inject pyOpenSSL or SecureTransport and we should do that.