### PR TITLE
Handle httplib implementations that don't set _tunnel_host

### DIFF
--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -171,7 +171,8 @@ class HTTPConnection(_HTTPConnection, object):
 
     def _prepare_conn(self, conn):
         self.sock = conn
-        if self._tunnel_host:
+        # Google App Engine's httplib does not define _tunnel_host
+        if getattr(self, '_tunnel_host', None):
             # TODO: Fix tunnel so it doesn't depend on self.sock state.
             self._tunnel()
             # Mark this connection as not reusable
@@ -305,7 +306,8 @@ class VerifiedHTTPSConnection(HTTPSConnection):
         conn = self._new_conn()
         hostname = self.host
 
-        if self._tunnel_host:
+        # Google App Engine's httplib does not define _tunnel_host
+        if getattr(self, '_tunnel_host', None):
             self.sock = conn
             # Calls self._set_hostport(), so self.host is
             # self._tunnel_host below.


### PR DESCRIPTION
urllib3 removed support for Python versions before 2.7 in a previous
pull request, unfortunately, this broke environments that use a
different implementation of httplib than the one in Python's standard
library as well. This includes Google App Engine's urlfetch-based
implementation
(https://github.com/GoogleCloudPlatform/python-compat-runtime/blob/master/appengine-compat/exported_appengine_sdk/google/appengine/dist27/gae_override/httplib.py#L362)

This pull request is nearly identical to urllib3/urllib3#1504 which was
closed due to its author not responding to comments.

Fixes urllib3/urllib3#1503