### PR TITLE
Remove unreachable line

### DIFF
--- a/src/urllib3/util/url.py
+++ b/src/urllib3/util/url.py
@@ -196,8 +196,6 @@ def parse_url(url):
     def to_input_type(x):
         if x is None:
             return None
-        elif is_string and isinstance(x, six.binary_type):
-            return x.decode('utf-8')
         elif not is_string and not isinstance(x, six.binary_type):
             return x.encode('utf-8')
         return x


### PR DESCRIPTION
rfc3986 only returns Unicode strings, so `to_input_type` only needs to
encode the result back to UTF-8: it never needs to convert from bytes to
unicode.

This restores 100% coverage.