### PR TITLE
Fix AttributeError when the brotli module is installed

### DIFF
--- a/src/urllib3/response.py
+++ b/src/urllib3/response.py
@@ -341,7 +341,7 @@ class HTTPResponse(io.IOBase):
 
     DECODER_ERROR_CLASSES = (IOError, zlib.error)
     if brotli is not None:
-        DECODER_ERROR_CLASSES += (brotli.Error,)
+        DECODER_ERROR_CLASSES += (brotli.error,)
 
     def _decode(self, data, decode_content, flush_decoder):
         """


### PR DESCRIPTION
The recent addition of Brotli support is broken, since it uses an
incorrect spelling of `brotli.error`, resulting in:

    Python 2.7.16 (default, Mar  8 2019, 14:51:39)
    [GCC 8.2.0] on linux2
    Type "help", "copyright", "credits" or "license" for more information.
    >>> import urllib3.response
    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
      File "site-packages/urllib3/__init__.py", line 7, in <module>
        from .connectionpool import (
      File "site-packages/urllib3/connectionpool.py", line 37, in <module>
        from .response import HTTPResponse
      File "site-packages/urllib3/response.py", line 144, in <module>
        class HTTPResponse(io.IOBase):
      File "site-packages/urllib3/response.py", line 344, in HTTPResponse
        DECODER_ERROR_CLASSES += (brotli.Error,)
    AttributeError: 'module' object has no attribute 'Error'