### PR TITLE
Add integration tests for Google's Brotli package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -103,6 +103,16 @@ matrix:
       sudo: required
       stage: integration
 
+    - python: 2.7
+      env: DOWNSTREAM=google-brotli
+      stage: integration
+
+    - python: 3.7
+      env: DOWNSTREAM=google-brotli
+      dist: xenial
+      sudo: required
+      stage: integration
+
   allow_failures:
   - python: pypy-5.4
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Changes
 dev (master)
 ------------
 
+* Add support for Google's ``Brotli`` package. (Pull #1752)
+
 * ... [Short description of non-trivial change.] (Issue #)
 
 

--- a/_travis/downstream/google-brotli.sh
+++ b/_travis/downstream/google-brotli.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -exo pipefail
+
+case "${1}" in
+    install)
+        # Because Google's 'Brotli' package shares an importable name with
+        # 'brotlipy' we need to make sure both implementations don't break.
+        python -m pip install Brotli
+        ;;
+    run)
+        pytest tests/
+        ;;
+    *)
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
Will have to release 1.25.1 to avoid breaking users upgrading that are also using the `Brotli` package. cc: @elprans 