### PR TITLE
Change deploy stage to have it's own job and not run unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 sudo: false
 stage: test
+dist: xenial
 
 before_install:
   - env
@@ -50,16 +51,10 @@ matrix:
       env: TOXENV=py36
     - python: 3.7
       env: TOXENV=py37
-      dist: xenial
-      sudo: required
     - python: 3.7
       env: TOXENV=py37-nobrotli
-      dist: xenial
-      sudo: required
     - python: 3.8-dev
       env: TOXENV=py38
-      dist: xenial
-      sudo: required
 
     - python: pypy-5.4
       env: TOXENV=pypy
@@ -89,8 +84,6 @@ matrix:
 
     - python: 3.7
       env: DOWNSTREAM=requests
-      dist: xenial
-      sudo: required
       stage: integration
 
     - python: 2.7
@@ -99,8 +92,6 @@ matrix:
 
     - python: 3.7
       env: DOWNSTREAM=botocore
-      dist: xenial
-      sudo: required
       stage: integration
 
     - python: 3.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -103,38 +103,22 @@ matrix:
       sudo: required
       stage: integration
 
+    - python: 3.7
+      stage: deploy
+      script:
+        - ./_travis/deploy.sh
+
   allow_failures:
   - python: pypy-5.4
 
 stages:
-  - test
+  - name: test
+    if: tag IS blank
 
   # Run integration tests for release candidates
   - name: integration
-    if: type = pull_request AND head_branch =~ ^release-[\d.]+$
+    if: type = pull_request AND head_branch =~ ^release-[\d.]+$ AND tag IS blank
 
-deploy:
-  - provider: script
-    script: bash _travis/deploy.sh
-    skip_cleanup: true
-    on:
-      branch: master
-      repo: urllib3/urllib3
-      tags: true
-      python: 3.7
-
-  - provider: releases
-    api_key:
-      secure: ...  # GitHub access token
-    name: "$TRAVIS_TAG"
-    body: "Release $TRAVIS_TAG"
-    draft: true
-    skip_cleanup: true
-    file_glob: true
-    file: dist/*
-    overwrite: true
-    on:
-      branch: master
-      repo: urllib3/urllib3
-      tags: true
-      python: 3.7
+  # Deploy on any tags
+  - name: deploy
+    if: branch = master AND tag IS present

--- a/_travis/upload_coverage.sh
+++ b/_travis/upload_coverage.sh
@@ -2,6 +2,8 @@
 
 set -exo pipefail
 
-source .tox/${TOXENV}/bin/activate
-pip install codecov
-codecov --env TRAVIS_OS_NAME,TOXENV
+if [[ -e .coverage ]]; then
+    source .tox/${TOXENV}/bin/activate
+    pip install codecov
+    codecov --env TRAVIS_OS_NAME,TOXENV
+fi


### PR DESCRIPTION
Having just used the new deployment setup it worked great! But I have a few improvements I'd like to make:

- Have the deploy script be it's own job in a separate build stage so that every build stage that is Python 3.7 doesn't *try* to deploy.
- Don't run unit tests on a tag, just run the deploy script.
