### PR TITLE
Update setup.cfg for pytest 4.4 support

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,5 +20,5 @@ requires-dist =
     PySocks>=1.5.6,<2.0,!=1.5.7; extra == 'socks'
     brotlipy>=0.6.0; extra == 'brotli'
 
-[pytest]
+[tool:pytest]
 xfail_strict = true


### PR DESCRIPTION
```
Failed: [pytest] section in setup.cfg files is no longer supported, change to [tool:pytest] instead.
```