### PR TITLE
Release 1.25.1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,12 +1,12 @@
 Changes
 =======
 
-dev (master)
-------------
+1.25.1 (2019-04-24)
+-------------------
 
 * Add support for Google's ``Brotli`` package. (Pull #1572, Pull #1579)
 
-* ... [Short description of non-trivial change.] (Issue #)
+* Upgrade bundled rfc3986 to v1.3.1 (Pull #1578)
 
 
 1.25 (2019-04-22)

--- a/src/urllib3/__init__.py
+++ b/src/urllib3/__init__.py
@@ -26,7 +26,7 @@ from logging import NullHandler
 
 __author__ = 'Andrey Petrov (andrey.petrov@shazow.net)'
 __license__ = 'MIT'
-__version__ = 'dev'
+__version__ = '1.25.1'
 
 __all__ = (
     'HTTPConnectionPool',


### PR DESCRIPTION
Minor release that adds support for the Brotli package and fixes our bundled rfc3986 package.