### PR TITLE
Don't require "branch = master" for tag pushes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -118,4 +118,4 @@ stages:
 
   # Deploy on any tags
   - name: deploy
-    if: branch = master AND tag IS present
+    if: tag IS present AND tag =~ /^(\d+\.\d+(?:.\d+)?)$/ AND repo = urllib3/urllib3


### PR DESCRIPTION
My only thought on why the deploy conditional build didn't fire is that it didn't count the push of tags as a `"branch = master"` push since there was no commits? Makes sense I guess. 