### PR TITLE
Implement max_retry_wait_length for Retry objects

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ dev (master)
 ------------
 
 * Change ``is_ipaddress`` to not detect IPvFuture addresses. (Pull #1583)
+* Implement ``max_retry_wait_length`` for Retry objects. (Pull #1587)
 
 
 1.25.1 (2019-04-24)

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -275,5 +275,8 @@ In chronological order:
 * Katsuhiko YOSHIDA <https://github.com/kyoshidajp>
   * Remove Authorization header regardless of case when redirecting to cross-site
 
+* Batuhan Taskaya <batuhanosmantaskaya@gmail.com>
+  * Implement max_retry_wait_length for Retry objects.
+
 * [Your name or handle] <[email or website]>
   * [Brief summary of your changes]

--- a/src/urllib3/exceptions.py
+++ b/src/urllib3/exceptions.py
@@ -244,3 +244,6 @@ class HeaderParsingError(HTTPError):
 class UnrewindableBodyError(HTTPError):
     "urllib3 encountered an error when trying to rewind a body"
     pass
+
+class ExceedingWaitTime(ResponseError):
+    "Raised when response's Retry-After length greater than specified max_retry_wait_length"

--- a/src/urllib3/exceptions.py
+++ b/src/urllib3/exceptions.py
@@ -245,5 +245,6 @@ class UnrewindableBodyError(HTTPError):
     "urllib3 encountered an error when trying to rewind a body"
     pass
 
+
 class ExceedingWaitTime(ResponseError):
     "Raised when response's Retry-After length greater than specified max_retry_wait_length"

--- a/src/urllib3/util/retry.py
+++ b/src/urllib3/util/retry.py
@@ -149,6 +149,7 @@ class Retry(object):
     :param int max_retry_wait_length:
         :raises urllib3.exceptions.ExceedingWaitTime: if response attempts to give
         longer wait length than specified.
+
     """
 
     DEFAULT_METHOD_WHITELIST = frozenset([
@@ -165,7 +166,8 @@ class Retry(object):
                  method_whitelist=DEFAULT_METHOD_WHITELIST, status_forcelist=None,
                  backoff_factor=0, raise_on_redirect=True, raise_on_status=True,
                  history=None, respect_retry_after_header=True,
-                 remove_headers_on_redirect=DEFAULT_REDIRECT_HEADERS_BLACKLIST, max_retry_wait_length=-1):
+                 remove_headers_on_redirect=DEFAULT_REDIRECT_HEADERS_BLACKLIST,
+                 max_retry_wait_length=-1):
 
         self.total = total
         self.connect = connect
@@ -258,7 +260,10 @@ class Retry(object):
         retry_after = self.parse_retry_after(retry_after)
 
         if self.max_retry_wait_length != -1 and retry_after > self.max_retry_wait_length:
-            raise ExceedingWaitTime("Retry-After header gave a wait length (%d) that exceeds specified (%d)." % (retry_after, self.max_retry_wait_length))
+            raise ExceedingWaitTime(
+                "Retry-After header gave a wait length (%d) that exceeds specified (%d)."
+                % (retry_after, self.max_retry_wait_length)
+            )
 
         return retry_after
 

--- a/src/urllib3/util/retry.py
+++ b/src/urllib3/util/retry.py
@@ -147,8 +147,9 @@ class Retry(object):
         request.
 
     :param int max_retry_wait_length:
-        :raises urllib3.exceptions.ExceedingWaitTime: if response attempts to give
-        longer wait length than specified.
+        Defines max retry wait length, :raises urllib3.exceptions.ExceedingWaitTime:
+        if response attempts to give longer wait length than specified.
+
     """
 
     DEFAULT_METHOD_WHITELIST = frozenset([

--- a/src/urllib3/util/retry.py
+++ b/src/urllib3/util/retry.py
@@ -149,7 +149,6 @@ class Retry(object):
     :param int max_retry_wait_length:
         :raises urllib3.exceptions.ExceedingWaitTime: if response attempts to give
         longer wait length than specified.
-
     """
 
     DEFAULT_METHOD_WHITELIST = frozenset([

--- a/test/test_retry.py
+++ b/test/test_retry.py
@@ -273,4 +273,3 @@ class TestRetry(object):
 
         retry.max_retry_wait_length = 6
         assert retry.get_retry_after(response) == 5
-


### PR DESCRIPTION
Retry object gets an extra parameter at initalization for max_retry_wait_length
and when it calls get_retry_after with a response that contains Retry-After header
it checks if the value of that greater than max_retry_wait_length. If it
is, then a ExceedingWaitTime exception will be raised.

Fixes #1338