### PR TITLE
avoid CVE-2019-9740 in 1.24.x by percent-encoding invalid path characters

### DIFF
--- a/src/urllib3/util/url.py
+++ b/src/urllib3/util/url.py
@@ -3,6 +3,7 @@ from collections import namedtuple
 import re
 
 from ..exceptions import LocationParseError
+from ..packages.six.moves.urllib.parse import quote
 
 
 url_attrs = ['scheme', 'auth', 'host', 'port', 'path', 'query', 'fragment']
@@ -160,8 +161,7 @@ def parse_url(url):
 
     # Prevent CVE-2019-9740.
     # adapted from https://github.com/python/cpython/pull/12755
-    if _contains_disallowed_url_pchar_re.search(url):
-        raise LocationParseError("URL can't contain control characters. {!r}".format(url))
+    url = _contains_disallowed_url_pchar_re.sub(lambda match: quote(match.group()), url)
 
     scheme = None
     auth = None

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -200,10 +200,26 @@ class TestUtil(object):
         with pytest.raises(ValueError):
             parse_url('[::1')
 
-    def test_parse_url_contains_control_characters(self):
+    @pytest.mark.parametrize('url, expected_url', [
+        (
+            'http://localhost/ HTTP/1.1\r\nHEADER: INJECTED\r\nIgnore:',
+            Url('http', host='localhost', port=None,
+                path='/%20HTTP/1.1%0D%0AHEADER:%20INJECTED%0D%0AIgnore:')
+        ),
+        (
+            u'http://localhost/ HTTP/1.1\r\nHEADER: INJECTED\r\nIgnore:',
+            Url('http', host='localhost', port=None,
+                path='/%20HTTP/1.1%0D%0AHEADER:%20INJECTED%0D%0AIgnore:')
+        ),
+        (
+            'http://localhost/ ?q=\r\n',
+            Url('http', host='localhost', path='/%20', query='q=%0D%0A')
+        ),
+    ])
+    def test_parse_url_contains_control_characters(self, url, expected_url):
         # see CVE-2019-9740
-        url = parse_url('http://localhost:8000/ HTTP/1.1\r\nHEADER: INJECTED\r\nIgnore:')
-        assert url.path == '/%20HTTP/1.1%0D%0AHEADER:%20INJECTED%0D%0AIgnore:'
+        url = parse_url(url)
+        assert url == expected_url
 
     def test_Url_str(self):
         U = Url('http', host='google.com')

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -202,8 +202,8 @@ class TestUtil(object):
 
     def test_parse_url_contains_control_characters(self):
         # see CVE-2019-9740
-        with pytest.raises(LocationParseError):
-            parse_url('http://localhost:8000/ HTTP/1.1\r\nHEADER: INJECTED\r\nIgnore:')
+        url = parse_url('http://localhost:8000/ HTTP/1.1\r\nHEADER: INJECTED\r\nIgnore:')
+        assert url.path == '/%20HTTP/1.1%0D%0AHEADER:%20INJECTED%0D%0AIgnore:'
 
     def test_Url_str(self):
         U = Url('http', host='google.com')


### PR DESCRIPTION
this is to avoid breaking changes in downstream libraries like requests