### PR TITLE
Drop Python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,8 +42,6 @@ matrix:
     # Unit tests
     - python: 2.7
       env: NOX_SESSION=test-2.7
-    - python: 3.4
-      env: NOX_SESSION=test-3.4
     - python: 3.5
       env: NOX_SESSION=test-3.5
     - python: 3.6
@@ -69,9 +67,6 @@ matrix:
     - language: generic
       os: osx
       env: NOX_SESSION=test-2.7
-    - language: generic
-      os: osx
-      env: NOX_SESSION=test-3.4
     - language: generic
       os: osx
       env: NOX_SESSION=test-3.5

--- a/_travis/install.sh
+++ b/_travis/install.sh
@@ -26,7 +26,6 @@ if [[ "$(uname -s)" == 'Darwin' ]]; then
     # Mac OS setup.
     case "${NOX_SESSION}" in
         test-2.7) MACPYTHON=2.7.15 ;;
-        test-3.4) MACPYTHON=3.4.4 ;;
         test-3.5) MACPYTHON=3.5.4 ;;
         test-3.6) MACPYTHON=3.6.7 ;;
         test-3.7) MACPYTHON=3.7.1 ;;

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,11 +12,6 @@ environment:
       PYTHON_ARCH: "64"
       NOX_SESSION: "test-2.7"
 
-    - PYTHON: "C:\\Python34-x64"
-      PYTHON_VERSION: "3.4.x"
-      PYTHON_ARCH: "64"
-      NOX_SESSION: "test-3.4"
-
     - PYTHON: "C:\\Python35-x64"
       PYTHON_VERSION: "3.5.x"
       PYTHON_ARCH: "64"

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -13,6 +13,4 @@ lazy-object-proxy==1.4.0
 
 # https://github.com/GoogleCloudPlatform/python-repo-tools/issues/23
 pylint<2.0;python_version<="2.7"
-
-# Because typed-ast doesn't provide Python 3.4+Windows wheels
-gcp-devrel-py-tools;python_version>='3.5' or sys_platform != 'win32'
+gcp-devrel-py-tools

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,6 @@ setup(
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
@@ -63,7 +62,7 @@ setup(
     ],
     package_dir={"": "src"},
     requires=[],
-    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, <4",
+    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4",
     tests_require=[
         # These are a less-specific subset of dev-requirements.txt, for the
         # convenience of distro package maintainers.

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -106,7 +106,7 @@ def notSecureTransport(test):
 
 
 def notOpenSSL098(test):
-    """Skips this test for Python 3.4 and 3.5 macOS python.org distributions"""
+    """Skips this test for Python 3.5 macOS python.org distribution"""
 
     @functools.wraps(test)
     def wrapper(*args, **kwargs):


### PR DESCRIPTION
It reached its end-of-life on 2019-03-18.

As far as I can tell, remaining references are either still valid (eg. ssl.create_default_context exists since Python 3.4) or in contrib packages like rfc3986 or scripts like _appveyor/install.ps1.