### PR TITLE
Improve implementation of respect_retry_after_header

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,15 @@
 Changes
 =======
 
+dev (master)
+------------
+
+* Propagate Retry-After header settings to subsequent retries. (Pull #1607)
+
+* Fix edge case where Retry-After header was still respected even when
+  explicitly opted out of. (Pull #1607)
+
+
 1.25.3 (2019-05-23)
 -------------------
 

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -275,5 +275,8 @@ In chronological order:
 * Katsuhiko YOSHIDA <https://github.com/kyoshidajp>
   * Remove Authorization header regardless of case when redirecting to cross-site
 
+* James Meickle <https://permadeath.com/>
+  * Improve handling of Retry-After header
+
 * [Your name or handle] <[email or website]>
   * [Brief summary of your changes]

--- a/src/urllib3/util/retry.py
+++ b/src/urllib3/util/retry.py
@@ -210,6 +210,7 @@ class Retry(object):
             raise_on_status=self.raise_on_status,
             history=self.history,
             remove_headers_on_redirect=self.remove_headers_on_redirect,
+            respect_retry_after_header=self.respect_retry_after_header
         )
         params.update(kw)
         return type(self)(**params)
@@ -294,7 +295,7 @@ class Retry(object):
         this method will return immediately.
         """
 
-        if response:
+        if self.respect_retry_after_header and response:
             slept = self.sleep_for_retry(response)
             if slept:
                 return

--- a/src/urllib3/util/retry.py
+++ b/src/urllib3/util/retry.py
@@ -210,7 +210,7 @@ class Retry(object):
             raise_on_status=self.raise_on_status,
             history=self.history,
             remove_headers_on_redirect=self.remove_headers_on_redirect,
-            respect_retry_after_header=self.respect_retry_after_header
+            respect_retry_after_header=self.respect_retry_after_header,
         )
         params.update(kw)
         return type(self)(**params)

--- a/test/test_retry.py
+++ b/test/test_retry.py
@@ -288,34 +288,26 @@ class TestRetry(object):
         retry = Retry()
         assert retry.parse_retry_after(value) == expected
 
-    @pytest.mark.parametrize('respect_retry_after_header', [
-        True,
-        False
-    ])
-    def test_respect_retry_after_header_propagated(self,
-                                                   respect_retry_after_header):
+    @pytest.mark.parametrize("respect_retry_after_header", [True, False])
+    def test_respect_retry_after_header_propagated(self, respect_retry_after_header):
 
         retry = Retry(respect_retry_after_header=respect_retry_after_header)
         new_retry = retry.new()
-        assert new_retry.respect_retry_after_header \
-            == respect_retry_after_header
+        assert new_retry.respect_retry_after_header == respect_retry_after_header
 
     @pytest.mark.parametrize(
-        'retry_after_header,respect_retry_after_header,sleep_duration', [
-            ("3600", True, 3600),
-            ("3600", False, None)
-        ]
+        "retry_after_header,respect_retry_after_header,sleep_duration",
+        [("3600", True, 3600), ("3600", False, None)],
     )
-    def test_respect_retry_after_header_sleep(self, retry_after_header,
-                                              respect_retry_after_header,
-                                              sleep_duration):
+    def test_respect_retry_after_header_sleep(
+        self, retry_after_header, respect_retry_after_header, sleep_duration
+    ):
         retry = Retry(respect_retry_after_header=respect_retry_after_header)
 
         with patch("time.sleep") as sleep_mock:
             # for the default behavior, it must be in RETRY_AFTER_STATUS_CODES
             response = HTTPResponse(
-                status=503,
-                headers={"Retry-After": retry_after_header}
+                status=503, headers={"Retry-After": retry_after_header}
             )
 
             retry.sleep(response)

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -13,7 +13,6 @@ import pytest
 from urllib3 import add_stderr_logger, disable_warnings
 from urllib3.util.request import make_headers, rewind_body, _FAILEDTELL
 from urllib3.util.response import assert_header_parsing
-from urllib3.util.retry import Retry
 from urllib3.util.timeout import Timeout
 from urllib3.util.url import get_host, parse_url, split_first, Url
 from urllib3.util.ssl_ import (
@@ -27,7 +26,6 @@ from urllib3.exceptions import (
     TimeoutStateError,
     InsecureRequestWarning,
     SNIMissingWarning,
-    InvalidHeader,
     UnrewindableBodyError,
 )
 from urllib3.util.connection import allowed_gai_family, _has_ipv6
@@ -781,31 +779,6 @@ class TestUtil(object):
     def test_ip_family_ipv6_disabled(self):
         with patch("urllib3.util.connection.HAS_IPV6", False):
             assert allowed_gai_family() == socket.AF_INET
-
-    @pytest.mark.parametrize("value", ["-1", "+1", "1.0", six.u("\xb2")])  # \xb2 = ^2
-    def test_parse_retry_after_invalid(self, value):
-        retry = Retry()
-        with pytest.raises(InvalidHeader):
-            retry.parse_retry_after(value)
-
-    @pytest.mark.parametrize(
-        "value, expected", [("0", 0), ("1000", 1000), ("\t42 ", 42)]
-    )
-    def test_parse_retry_after(self, value, expected):
-        retry = Retry()
-        assert retry.parse_retry_after(value) == expected
-
-    @pytest.mark.parametrize('respect_retry_after_header', [
-        True,
-        False
-    ])
-    def test_respect_retry_after_header_propagated(self,
-                                                   respect_retry_after_header):
-
-        retry = Retry(respect_retry_after_header=respect_retry_after_header)
-        new_retry = retry.new()
-        assert new_retry.respect_retry_after_header \
-            == respect_retry_after_header
 
     @pytest.mark.parametrize("headers", [b"foo", None, object])
     def test_assert_header_parsing_throws_typeerror_with_non_headers(self, headers):

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -795,6 +795,18 @@ class TestUtil(object):
         retry = Retry()
         assert retry.parse_retry_after(value) == expected
 
+    @pytest.mark.parametrize('respect_retry_after_header', [
+        True,
+        False
+    ])
+    def test_respect_retry_after_header_propagated(self,
+                                                   respect_retry_after_header):
+
+        retry = Retry(respect_retry_after_header=respect_retry_after_header)
+        new_retry = retry.new()
+        assert new_retry.respect_retry_after_header \
+            == respect_retry_after_header
+
     @pytest.mark.parametrize("headers", [b"foo", None, object])
     def test_assert_header_parsing_throws_typeerror_with_non_headers(self, headers):
         with pytest.raises(TypeError):


### PR DESCRIPTION
`respect_retry_after_header` is accepted as an argument to `Retry`, but it isn't propagated on `Retry.new()`. This means that after the first retry is incremented, this setting will be lost.

Additionally, this setting isn't properly applied in cases where the `retry_after` header is present, but the intent is _not_ to respect it. This edge case can occur if you explicitly allow retries for the same codes as `RETRY_AFTER_STATUS_CODES = frozenset([413, 429, 503])`, but _don't_ respect the value in the header, and instead fall back to your `Retry`'s exponential backoff settings. In our case, we're dealing with an API that returns a large static value in this header even though we can actually try again much sooner because rate limits are governed by a token bucket.

I've attached a patch that addresses these two cases and adds a test case for one of them. However, I can't get the test suite to run locally (at all), I'm afraid.