### PR TITLE
Use Brotli instead of brotlipy by default

### DIFF
--- a/docs/advanced-usage.rst
+++ b/docs/advanced-usage.rst
@@ -279,7 +279,7 @@ Brotli Encoding
 
 Brotli is a compression algorithm created by Google with better compression
 than gzip and deflate and is supported by urllib3 if the
-`brotlipy <https://github.com/python-hyper/brotlipy>`_ package is installed.
+`Brotli <https://pypi.org/project/Brotli>`_ package is installed.
 You may also request the package be installed via the ``urllib3[brotli]`` extra::
 
     python -m pip install urllib3[brotli]

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ requires-dist =
     certifi; extra == 'secure'
     ipaddress; python_version=="2.7" and extra == 'secure'
     PySocks>=1.5.6,<2.0,!=1.5.7; extra == 'socks'
-    brotlipy>=0.6.0; extra == 'brotli'
+    Brotli>=1.0.0; extra == 'brotli'
 
 [pytest]
 xfail_strict = true

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ setup(
     ],
     test_suite="test",
     extras_require={
-        "brotli": ["brotlipy>=0.6.0"],
+        "brotli": ["brotli>=1.0.0"],
         "secure": [
             "pyOpenSSL>=0.14",
             "cryptography>=1.3.4",

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -82,13 +82,13 @@ def onlyPy3(test):
     return wrapper
 
 
-def onlyBrotlipy():
-    return pytest.mark.skipif(brotli is None, reason="only run if brotlipy is present")
+def onlyBrotli():
+    return pytest.mark.skipif(brotli is None, reason="only run if Brotli is present")
 
 
-def notBrotlipy():
+def notBrotli():
     return pytest.mark.skipif(
-        brotli is not None, reason="only run if brotlipy is absent"
+        brotli is not None, reason="only run if Brotli is absent"
     )
 
 

--- a/test/test_response.py
+++ b/test/test_response.py
@@ -17,7 +17,7 @@ from urllib3.packages.six.moves import http_client as httplib
 from urllib3.util.retry import Retry, RequestHistory
 from urllib3.util.response import is_fp_closed
 
-from test import onlyBrotlipy
+from test import onlyBrotli
 
 from base64 import b64decode
 
@@ -219,7 +219,7 @@ class TestResponse(object):
 
         assert r.data == b"foofoofoo"
 
-    @onlyBrotlipy()
+    @onlyBrotli()
     def test_decode_brotli(self):
         data = brotli.compress(b"foo")
 
@@ -227,7 +227,7 @@ class TestResponse(object):
         r = HTTPResponse(fp, headers={"content-encoding": "br"})
         assert r.data == b"foo"
 
-    @onlyBrotlipy()
+    @onlyBrotli()
     def test_chunked_decoding_brotli(self):
         data = brotli.compress(b"foobarbaz")
 
@@ -241,7 +241,7 @@ class TestResponse(object):
                 break
         assert ret == b"foobarbaz"
 
-    @onlyBrotlipy()
+    @onlyBrotli()
     def test_decode_brotli_error(self):
         fp = BytesIO(b"foo")
         with pytest.raises(DecodeError):

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -36,7 +36,7 @@ from urllib3.packages import six
 
 from . import clear_warnings
 
-from test import onlyPy3, onlyPy2, onlyBrotlipy, notBrotlipy
+from test import onlyPy3, onlyPy2, onlyBrotli, notBrotli
 
 # This number represents a time in seconds, it doesn't mean anything in
 # isolation. Setting to a high-ish value to avoid conflicts with the smaller
@@ -436,24 +436,24 @@ class TestUtil(object):
             pytest.param(
                 {"accept_encoding": True},
                 {"accept-encoding": "gzip,deflate,br"},
-                marks=onlyBrotlipy(),
+                marks=onlyBrotli(),
             ),
             pytest.param(
                 {"accept_encoding": True},
                 {"accept-encoding": "gzip,deflate"},
-                marks=notBrotlipy(),
+                marks=notBrotli(),
             ),
             ({"accept_encoding": "foo,bar"}, {"accept-encoding": "foo,bar"}),
             ({"accept_encoding": ["foo", "bar"]}, {"accept-encoding": "foo,bar"}),
             pytest.param(
                 {"accept_encoding": True, "user_agent": "banana"},
                 {"accept-encoding": "gzip,deflate,br", "user-agent": "banana"},
-                marks=onlyBrotlipy(),
+                marks=onlyBrotli(),
             ),
             pytest.param(
                 {"accept_encoding": True, "user_agent": "banana"},
                 {"accept-encoding": "gzip,deflate", "user-agent": "banana"},
-                marks=notBrotlipy(),
+                marks=notBrotli(),
             ),
             ({"user_agent": "banana"}, {"user-agent": "banana"}),
             ({"keep_alive": True}, {"connection": "keep-alive"}),


### PR DESCRIPTION
brotlipy is stuck at brotli 0.6 and upstream is inactive. Let's switch
to the official binding by default which is up-to-date.