### PR TITLE
Enable TLS 1.3 post-handshake authentication

### DIFF
--- a/src/urllib3/util/ssl_.py
+++ b/src/urllib3/util/ssl_.py
@@ -271,6 +271,13 @@ def create_urllib3_context(
 
     context.options |= options
 
+    # Enable post-handshake authentication for TLS 1.3, see GH #1634. PHA is
+    # necessary for conditional client cert authentication with TLS 1.3.
+    # The attribute is None for OpenSSL <= 1.1.0 or does not exist in older
+    # versions of Python.
+    if getattr(context, "post_handshake_auth", None) is not None:
+        context.post_handshake_auth = True
+
     context.verify_mode = cert_reqs
     if (
         getattr(context, "check_hostname", None) is not None

--- a/test/test_ssl.py
+++ b/test/test_ssl.py
@@ -149,3 +149,18 @@ def test_wrap_socket_default_loads_default_certs(monkeypatch):
     ssl_.ssl_wrap_socket(sock)
 
     context.load_default_certs.assert_called_with()
+
+
+@pytest.mark.parametrize(
+    ["pha", "expected_pha"], [(None, None), (False, True), (True, True)]
+)
+def test_create_urllib3_context_pha(monkeypatch, pha, expected_pha):
+    context = mock.create_autospec(ssl_.SSLContext)
+    context.set_ciphers = mock.Mock()
+    context.options = 0
+    context.post_handshake_auth = pha
+    monkeypatch.setattr(ssl_, "SSLContext", lambda *_, **__: context)
+
+    assert ssl_.create_urllib3_context() is context
+
+    assert context.post_handshake_auth == expected_pha


### PR DESCRIPTION
Fixes: https://github.com/urllib3/urllib3/issues/1634
Signed-off-by: Christian Heimes <christian@python.org>