### PR TITLE
Don't install gcp-devrel-py-tools on Windows+Python 3.4

### DIFF
--- a/_travis/upload_coverage.sh
+++ b/_travis/upload_coverage.sh
@@ -4,5 +4,5 @@ set -exo pipefail
 
 if [[ -e .coverage ]]; then
     python3.6 -m pip install codecov
-    codecov --env TRAVIS_OS_NAME,NOX_SESSION
+    python3.6 -m codecov --env TRAVIS_OS_NAME,NOX_SESSION
 fi

--- a/_travis/upload_coverage.sh
+++ b/_travis/upload_coverage.sh
@@ -3,6 +3,6 @@
 set -exo pipefail
 
 if [[ -e .coverage ]]; then
-    python3 -m pip install codecov
+    python3.6 -m pip install codecov
     codecov --env TRAVIS_OS_NAME,NOX_SESSION
 fi

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -14,4 +14,6 @@ lazy-object-proxy==1.4.0
 
 # https://github.com/GoogleCloudPlatform/python-repo-tools/issues/23
 pylint<2.0;python_version<="2.7"
-gcp-devrel-py-tools
+
+# Because typed-ast doesn't provide Python 3.4+Windows wheels
+gcp-devrel-py-tools;python_version>='3.5' or sys_platform != 'win32'


### PR DESCRIPTION
Because typed-ast<1.4 doesn't provide Windows wheels and typed-ast>=1.4 provides Windows wheels for Python 3.5+