### PR TITLE
Stop using unittest

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,9 +5,8 @@ wheel==0.30.0
 tornado==5.1.1
 PySocks==1.6.8
 pkginfo==1.4.2
-pytest-timeout==1.3.1
-pytest==4.0.0
-pluggy==0.11.0
+pytest-timeout==1.3.3
+pytest==4.6.4
 
 # https://github.com/ionelmc/python-lazy-object-proxy/issues/30
 lazy-object-proxy==1.4.0

--- a/dummyserver/testcase.py
+++ b/dummyserver/testcase.py
@@ -1,5 +1,4 @@
 import threading
-import unittest
 
 import pytest
 from tornado import ioloop, web
@@ -20,7 +19,7 @@ def consume_socket(sock, chunks=65536):
         pass
 
 
-class SocketDummyServerTestCase(unittest.TestCase):
+class SocketDummyServerTestCase(object):
     """
     A simple socket-based server is created for this class that is good for
     exactly one request.
@@ -67,7 +66,7 @@ class SocketDummyServerTestCase(unittest.TestCase):
         )
 
     @classmethod
-    def tearDownClass(cls):
+    def teardown_class(cls):
         if hasattr(cls, "server_thread"):
             cls.server_thread.join(0.1)
 
@@ -101,10 +100,10 @@ class IPV4SocketDummyServerTestCase(SocketDummyServerTestCase):
         cls.port = cls.server_thread.port
 
 
-class HTTPDummyServerTestCase(unittest.TestCase):
+class HTTPDummyServerTestCase(object):
     """ A simple HTTP server that runs when your test class runs
 
-    Have your unittest class inherit from this one, and then a simple server
+    Have your test class inherit from this one, and then a simple server
     will start when your tests run, and automatically shut down when they
     complete. For examples of what test requests you can send to the server,
     see the TestingApp in dummyserver/handlers.py.
@@ -131,11 +130,11 @@ class HTTPDummyServerTestCase(unittest.TestCase):
         cls.server_thread.join()
 
     @classmethod
-    def setUpClass(cls):
+    def setup_class(cls):
         cls._start_server()
 
     @classmethod
-    def tearDownClass(cls):
+    def teardown_class(cls):
         cls._stop_server()
 
 
@@ -150,7 +149,7 @@ class IPV6HTTPSDummyServerTestCase(HTTPSDummyServerTestCase):
     host = "::1"
 
 
-class HTTPDummyProxyTestCase(unittest.TestCase):
+class HTTPDummyProxyTestCase(object):
 
     http_host = "localhost"
     http_host_alt = "127.0.0.1"
@@ -163,7 +162,7 @@ class HTTPDummyProxyTestCase(unittest.TestCase):
     proxy_host_alt = "127.0.0.1"
 
     @classmethod
-    def setUpClass(cls):
+    def setup_class(cls):
         cls.io_loop = ioloop.IOLoop.current()
 
         app = web.Application([(r".*", TestingApp)])
@@ -184,7 +183,7 @@ class HTTPDummyProxyTestCase(unittest.TestCase):
         cls.server_thread = run_loop_in_thread(cls.io_loop)
 
     @classmethod
-    def tearDownClass(cls):
+    def teardown_class(cls):
         cls.io_loop.add_callback(cls.http_server.stop)
         cls.io_loop.add_callback(cls.https_server.stop)
         cls.io_loop.add_callback(cls.proxy_server.stop)

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,3 +23,4 @@ requires-dist =
 
 [tool:pytest]
 xfail_strict = true
+python_classes = Test *TestCase

--- a/test/appengine/test_gae_manager.py
+++ b/test/appengine/test_gae_manager.py
@@ -37,7 +37,7 @@ class MockPool(object):
 # that URLFetch is used by the connection manager.
 @pytest.mark.usefixtures("testbed")
 class TestGAEConnectionManager(test_connectionpool.TestConnectionPool):
-    def setUp(self):
+    def setup_method(self, method):
         self.manager = appengine.AppEngineManager()
         self.pool = MockPool(self.host, self.port, self.manager)
 
@@ -105,7 +105,7 @@ class TestGAEConnectionManager(test_connectionpool.TestConnectionPool):
 
 @pytest.mark.usefixtures("testbed")
 class TestGAEConnectionManagerWithSSL(dummyserver.testcase.HTTPSDummyServerTestCase):
-    def setUp(self):
+    def setup_method(self, method):
         self.manager = appengine.AppEngineManager()
         self.pool = MockPool(self.host, self.port, self.manager, "https")
 
@@ -119,7 +119,7 @@ class TestGAEConnectionManagerWithSSL(dummyserver.testcase.HTTPSDummyServerTestC
 
 @pytest.mark.usefixtures("testbed")
 class TestGAERetry(test_connectionpool.TestRetry):
-    def setUp(self):
+    def setup_method(self, method):
         self.manager = appengine.AppEngineManager()
         self.pool = MockPool(self.host, self.port, self.manager)
 
@@ -159,7 +159,7 @@ class TestGAERetry(test_connectionpool.TestRetry):
 
 @pytest.mark.usefixtures("testbed")
 class TestGAERetryAfter(test_connectionpool.TestRetryAfter):
-    def setUp(self):
+    def setup_method(self, method):
         # Disable urlfetch which doesn't respect Retry-After header.
         self.manager = appengine.AppEngineManager(urlfetch_retries=False)
         self.pool = MockPool(self.host, self.port, self.manager)

--- a/test/appengine/test_urlfetch.py
+++ b/test/appengine/test_urlfetch.py
@@ -4,7 +4,6 @@ Engine-patched version of httplib to make requests."""
 
 import httplib
 import StringIO
-import unittest
 
 from mock import patch
 import pytest
@@ -45,7 +44,7 @@ class TestHTTP(TestWithoutSSL):
 
 
 @pytest.mark.usefixtures("sandbox")
-class TestHTTPS(unittest.TestCase):
+class TestHTTPS(object):
     @pytest.mark.xfail(
         reason="This is not yet supported by urlfetch, presence of the ssl "
         "module will bypass urlfetch."

--- a/test/contrib/test_pyopenssl.py
+++ b/test/contrib/test_pyopenssl.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import os
-import unittest
 
 import mock
 import pytest
@@ -49,7 +48,7 @@ from ..with_dummyserver.test_socketlevel import (  # noqa: F401
 )
 
 
-class TestPyOpenSSLHelpers(unittest.TestCase):
+class TestPyOpenSSLHelpers(object):
     """
     Tests for PyOpenSSL helper functions.
     """

--- a/test/contrib/test_pyopenssl_dependencies.py
+++ b/test/contrib/test_pyopenssl_dependencies.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import unittest
 import pytest
 
 from mock import patch, Mock
@@ -28,7 +27,7 @@ def teardown_module():
         pass
 
 
-class TestPyOpenSSLInjection(unittest.TestCase):
+class TestPyOpenSSLInjection(object):
     """
     Tests for error handling in pyopenssl's 'inject_into urllib3'
     """

--- a/test/test_no_ssl.py
+++ b/test/test_no_ssl.py
@@ -6,7 +6,6 @@ Test what happens if Python was built without SSL
 """
 
 import sys
-import unittest
 import pytest
 
 
@@ -64,15 +63,16 @@ ssl_blocker = ImportBlocker("ssl", "_ssl")
 module_stash = ModuleStash("urllib3")
 
 
-class TestWithoutSSL(unittest.TestCase):
-    def setUp(self):
+class TestWithoutSSL(object):
+    @classmethod
+    def setup_class(self):
         sys.modules.pop("ssl", None)
         sys.modules.pop("_ssl", None)
 
         module_stash.stash()
         sys.meta_path.insert(0, ssl_blocker)
 
-    def tearDown(self):
+    def teardown_class(self):
         sys.meta_path.remove(ssl_blocker)
         module_stash.pop()
 

--- a/test/with_dummyserver/test_connectionpool.py
+++ b/test/with_dummyserver/test_connectionpool.py
@@ -2,7 +2,6 @@ import io
 import logging
 import socket
 import sys
-import unittest
 import time
 import warnings
 import pytest
@@ -1159,7 +1158,3 @@ class TestRedirectPoolSize(HTTPDummyServerTestCase):
         ) as pool:
             pool.urlopen("GET", "/redirect", preload_content=False)
             assert pool.num_connections == 1
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/test/with_dummyserver/test_https.py
+++ b/test/with_dummyserver/test_https.py
@@ -3,7 +3,6 @@ import json
 import logging
 import ssl
 import sys
-import unittest
 import warnings
 
 import mock
@@ -784,7 +783,3 @@ class TestHTTPS_IPV6SAN(IPV6HTTPSDummyServerTestCase):
         ) as https_pool:
             r = https_pool.request("GET", "/")
             assert r.status == 200
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/test/with_dummyserver/test_poolmanager.py
+++ b/test/with_dummyserver/test_poolmanager.py
@@ -1,4 +1,3 @@
-import unittest
 import json
 
 import pytest
@@ -12,7 +11,9 @@ from urllib3.util.retry import Retry
 
 
 class TestPoolManager(HTTPDummyServerTestCase):
-    def setUp(self):
+    @classmethod
+    def setup_class(self):
+        super(TestPoolManager, self).setup_class()
         self.base_url = "http://%s:%d" % (self.host, self.port)
         self.base_url_alt = "http://%s:%d" % (self.host_alt, self.port)
 
@@ -348,13 +349,11 @@ class TestPoolManager(HTTPDummyServerTestCase):
 
 @pytest.mark.skipif(not HAS_IPV6, reason="IPv6 is not supported on this system")
 class TestIPv6PoolManager(IPv6HTTPDummyServerTestCase):
-    def setUp(self):
+    @classmethod
+    def setup_class(self):
+        super(TestIPv6PoolManager, self).setup_class()
         self.base_url = "http://[%s]:%d" % (self.host, self.port)
 
     def test_ipv6(self):
         with PoolManager() as http:
             http.request("GET", self.base_url)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/test/with_dummyserver/test_proxy_poolmanager.py
+++ b/test/with_dummyserver/test_proxy_poolmanager.py
@@ -1,6 +1,5 @@
 import json
 import socket
-import unittest
 
 import pytest
 
@@ -15,7 +14,9 @@ from urllib3.connectionpool import connection_from_url, VerifiedHTTPSConnection
 
 
 class TestHTTPProxyManager(HTTPDummyProxyTestCase):
-    def setUp(self):
+    @classmethod
+    def setup_class(self):
+        super(TestHTTPProxyManager, self).setup_class()
         self.http_url = "http://%s:%d" % (self.http_host, self.http_port)
         self.http_url_alt = "http://%s:%d" % (self.http_host_alt, self.http_port)
         self.https_url = "https://%s:%d" % (self.https_host, self.https_port)
@@ -368,7 +369,9 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
 
 
 class TestIPv6HTTPProxyManager(IPv6HTTPDummyProxyTestCase):
-    def setUp(self):
+    @classmethod
+    def setup_class(self):
+        HTTPDummyProxyTestCase.setup_class()
         self.http_url = "http://%s:%d" % (self.http_host, self.http_port)
         self.http_url_alt = "http://%s:%d" % (self.http_host_alt, self.http_port)
         self.https_url = "https://%s:%d" % (self.https_host, self.https_port)
@@ -383,7 +386,3 @@ class TestIPv6HTTPProxyManager(IPv6HTTPDummyProxyTestCase):
 
             r = http.request("GET", "%s/" % self.https_url)
             assert r.status == 200
-
-
-if __name__ == "__main__":
-    unittest.main()


### PR DESCRIPTION
This pull request builds on the work of @RatanShreshtha, specifically pull requests #1614 and #1624 that contain the bulk of the work.

This allows us to switch to the latest pytest version compatible with Python 2.7: https://docs.pytest.org/en/latest/py27-py34-deprecation.html. One benefit is that warnings are now grouped by source, which makes them easier to read (and hopefully to fix).