### PR TITLE
Fix for Python 4

### DIFF
--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -99,7 +99,7 @@ class HTTPConnection(_HTTPConnection, object):
     is_verified = False
 
     def __init__(self, *args, **kw):
-        if six.PY3:
+        if not six.PY2:
             kw.pop("strict", None)
 
         # Pre-set source_address.

--- a/src/urllib3/fields.py
+++ b/src/urllib3/fields.py
@@ -47,7 +47,7 @@ def format_header_param_rfc2231(name, value):
         else:
             return result
 
-    if not six.PY3:  # Python 2:
+    if six.PY2:  # Python 2:
         value = value.encode("utf-8")
 
     # encode_rfc2231 accepts an encoded string and returns an ascii-encoded
@@ -55,7 +55,7 @@ def format_header_param_rfc2231(name, value):
     value = email.utils.encode_rfc2231(value, "utf-8")
     value = "%s*=%s" % (name, value)
 
-    if not six.PY3:  # Python 2:
+    if six.PY2:  # Python 2:
         value = value.decode("utf-8")
 
     return value

--- a/src/urllib3/filepost.py
+++ b/src/urllib3/filepost.py
@@ -17,7 +17,7 @@ def choose_boundary():
     Our embarrassingly-simple replacement for mimetools.choose_boundary.
     """
     boundary = binascii.hexlify(os.urandom(16))
-    if six.PY3:
+    if not six.PY2:
         boundary = boundary.decode("ascii")
     return boundary
 

--- a/src/urllib3/util/ssl_.py
+++ b/src/urllib3/util/ssl_.py
@@ -385,7 +385,7 @@ def is_ipaddress(hostname):
     :param str hostname: Hostname to examine.
     :return: True if the hostname is an IP address, False otherwise.
     """
-    if six.PY3 and isinstance(hostname, bytes):
+    if not six.PY2 and isinstance(hostname, bytes):
         # IDN A-label bytes are ASCII compatible.
         hostname = hostname.decode("ascii")
     return bool(IPV4_RE.match(hostname) or BRACELESS_IPV6_ADDRZ_RE.match(hostname))

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -62,7 +62,7 @@ def onlyPy2(test):
     @functools.wraps(test)
     def wrapper(*args, **kwargs):
         msg = "{name} requires Python 2.x to run".format(name=test.__name__)
-        if six.PY3:
+        if not six.PY2:
             pytest.skip(msg)
         return test(*args, **kwargs)
 
@@ -75,7 +75,7 @@ def onlyPy3(test):
     @functools.wraps(test)
     def wrapper(*args, **kwargs):
         msg = "{name} requires Python3.x to run".format(name=test.__name__)
-        if not six.PY3:
+        if six.PY2:
             pytest.skip(msg)
         return test(*args, **kwargs)
 

--- a/test/appengine/conftest.py
+++ b/test/appengine/conftest.py
@@ -72,7 +72,7 @@ def sandbox(testbed):
 def pytest_ignore_collect(path, config):
     """Skip App Engine tests in python 3 or if no SDK is available."""
     if "appengine" in str(path):
-        if six.PY3:
+        if not six.PY2:
             return True
         if not os.environ.get("GAE_SDK_PATH"):
             return True

--- a/test/test_collections.py
+++ b/test/test_collections.py
@@ -344,7 +344,7 @@ class TestHTTPHeaderDict(object):
             HTTPHeaderDict({3: 3})
 
     @pytest.mark.skipif(
-        six.PY3, reason="python3 has a different internal header implementation"
+        not six.PY2, reason="python3 has a different internal header implementation"
     )
     def test_from_httplib_py2(self):
         msg = """


### PR DESCRIPTION
We don't yet know if 3.10 or 4.0 will follow Python 3.9, but it will probably happen in [2020 (when Python 3.9 reaches beta)](https://www.python.org/dev/peps/pep-0596/#schedule).

There's several places in the codebase like:

```python
if six.PY3:
    pass  # Python 3+ stuff

if not six.PY3:
    pass  # Python 2 stuff
```

But when run on Python 4, it will skip the Python 3+ stuff and run the Python 2 stuff!

This PR flips it around:

```python
if not six.PY2:
    pass  # Python 3+ stuff

if six.PY2:
    pass  # Python 2 stuff
```

Found using:
```bash
pip install -U flake8-2020
flake8 --select YTT
```
