### PR TITLE
Add support for HTTPS connections to proxies.

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -282,5 +282,8 @@ In chronological order:
   * Remove a spurious TypeError from the exception chain inside
     HTTPConnectionPool._make_request(), also for BaseExceptions.
 
+* Jorge Lopez Silva<https://github.com/jalopezsilva>
+  * Added support for forwarding requests through HTTPS proxies.
+
 * [Your name or handle] <[email or website]>
   * [Brief summary of your changes]

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -282,7 +282,7 @@ In chronological order:
   * Remove a spurious TypeError from the exception chain inside
     HTTPConnectionPool._make_request(), also for BaseExceptions.
 
-* Jorge Lopez Silva<https://github.com/jalopezsilva>
+* Jorge Lopez Silva <https://github.com/jalopezsilva>
   * Added support for forwarding requests through HTTPS proxies.
 
 * [Your name or handle] <[email or website]>

--- a/docs/advanced-usage.rst
+++ b/docs/advanced-usage.rst
@@ -136,10 +136,6 @@ with the destination and your request will be sent.
 
 Contacting HTTPS websites through HTTPS proxies is currently not supported.
 
-To enable connecting to an HTTPS proxy you need to provide the flag
-``_enable_https_proxies``. In a future release we will change this to be the
-default behavior.
-
 For SOCKS, you can use :class:`~contrib.socks.SOCKSProxyManager` to connect to
 SOCKS4 or SOCKS5 proxies. In order to use SOCKS proxies you will need to
 install `PySocks <https://pypi.org/project/PySocks/>`_ or install urllib3 with

--- a/docs/advanced-usage.rst
+++ b/docs/advanced-usage.rst
@@ -133,8 +133,7 @@ When contacting a HTTPS website through a HTTP proxy, a TCP tunnel will be
 established with a HTTP CONNECT. Afterward a TLS connection will be established
 with the destination and your request will be sent.
 
-Contacting HTTPS websites through HTTPS proxies is currently not supported but
-is being developed at this time.
+Contacting HTTPS websites through HTTPS proxies is currently not supported.
 
 For SOCKS, you can use :class:`~contrib.socks.SOCKSProxyManager` to connect to
 SOCKS4 or SOCKS5 proxies. In order to use SOCKS proxies you will need to

--- a/docs/advanced-usage.rst
+++ b/docs/advanced-usage.rst
@@ -126,14 +126,19 @@ You can connect to a proxy using HTTP, HTTPS or SOCKS. urllib3's behavior will
 be different depending on the type of proxy you selected and the destination
 you're contacting.
 
-When contacting a HTTP website through a HTTP or HTTPS proxy, the request
-will be forwarded with the `absolute URI <https://tools.ietf.org/html/rfc7230#section-5.3.2>`_.
+When contacting a HTTP website through a HTTP or HTTPS proxy, the request will
+be forwarded with the `absolute URI
+<https://tools.ietf.org/html/rfc7230#section-5.3.2>`_.  
 
 When contacting a HTTPS website through a HTTP proxy, a TCP tunnel will be
 established with a HTTP CONNECT. Afterward a TLS connection will be established
 with the destination and your request will be sent.
 
 Contacting HTTPS websites through HTTPS proxies is currently not supported.
+
+To enable connecting to an HTTPS proxy you need to provide the flag
+``_enable_https_proxies``. In a future release we will change this to be the
+default behavior.
 
 For SOCKS, you can use :class:`~contrib.socks.SOCKSProxyManager` to connect to
 SOCKS4 or SOCKS5 proxies. In order to use SOCKS proxies you will need to

--- a/docs/advanced-usage.rst
+++ b/docs/advanced-usage.rst
@@ -72,7 +72,7 @@ Setting ``preload_content`` to ``False`` means that urllib3 will stream the
 response content. :meth:`~response.HTTPResponse.stream` lets you iterate over
 chunks of the response content.
 
-.. note:: When using ``preload_content=False``, you should call 
+.. note:: When using ``preload_content=False``, you should call
     :meth:`~response.HTTPResponse.release_conn` to release the http connection
     back to the connection pool so that it can be re-used.
 
@@ -87,7 +87,7 @@ a file-like object. This allows you to do buffering::
     b'\x88\x1f\x8b\xe5'
 
 Calls to :meth:`~response.HTTPResponse.read()` will block until more response
-data is available. 
+data is available.
 
     >>> import io
     >>> reader = io.BufferedReader(r, 8)
@@ -122,10 +122,24 @@ HTTP proxy::
 The usage of :class:`~poolmanager.ProxyManager` is the same as
 :class:`~poolmanager.PoolManager`.
 
-You can use :class:`~contrib.socks.SOCKSProxyManager` to connect to SOCKS4 or
-SOCKS5 proxies. In order to use SOCKS proxies you will need to install
-`PySocks <https://pypi.org/project/PySocks/>`_ or install urllib3 with the
-``socks`` extra::
+You can connect to a proxy using HTTP, HTTPS or SOCKS. urllib3's behavior will
+be different depending on the type of proxy you selected and the destination
+you're contacting.
+
+When contacting a HTTP website through a HTTP or HTTPS proxy, the request
+will be forwarded with the `absolute URI <https://tools.ietf.org/html/rfc7230#section-5.3.2>`_.
+
+When contacting a HTTPS website through a HTTP proxy, a TCP tunnel will be
+established with a HTTP CONNECT. Afterward a TLS connection will be established
+with the destination and your request will be sent.
+
+Contacting HTTPS websites through HTTPS proxies is currently not supported but
+is being developed at this time.
+
+For SOCKS, you can use :class:`~contrib.socks.SOCKSProxyManager` to connect to
+SOCKS4 or SOCKS5 proxies. In order to use SOCKS proxies you will need to
+install `PySocks <https://pypi.org/project/PySocks/>`_ or install urllib3 with
+the ``socks`` extra::
 
     pip install urllib3[socks]
 

--- a/dummyserver/proxy.py
+++ b/dummyserver/proxy.py
@@ -34,6 +34,7 @@ import tornado.ioloop
 import tornado.iostream
 import tornado.web
 import tornado.httpclient
+import ssl
 
 __all__ = ["ProxyHandler", "run_proxy"]
 
@@ -66,6 +67,12 @@ class ProxyHandler(tornado.web.RequestHandler):
                     self.write(response.body)
                 self.finish()
 
+        upstream_ca_certs = self.application.settings.get("upstream_ca_certs", None)
+        ssl_options = None
+
+        if upstream_ca_certs:
+            ssl_options = ssl.create_default_context(cafile=upstream_ca_certs)
+
         req = tornado.httpclient.HTTPRequest(
             url=self.request.uri,
             method=self.request.method,
@@ -73,6 +80,7 @@ class ProxyHandler(tornado.web.RequestHandler):
             headers=self.request.headers,
             follow_redirects=False,
             allow_nonstandard_methods=True,
+            ssl_options=ssl_options,
         )
 
         client = tornado.httpclient.AsyncHTTPClient()

--- a/dummyserver/testcase.py
+++ b/dummyserver/testcase.py
@@ -180,6 +180,14 @@ class HTTPDummyProxyTestCase(object):
             app, cls.io_loop, None, "http", cls.proxy_host
         )
 
+        upstream_ca_certs = cls.https_certs.get("ca_certs", None)
+        app = web.Application(
+            [(r".*", ProxyHandler)], upstream_ca_certs=upstream_ca_certs
+        )
+        cls.https_proxy_server, cls.https_proxy_port = run_tornado_app(
+            app, cls.io_loop, cls.https_certs, "https", cls.proxy_host
+        )
+
         cls.server_thread = run_loop_in_thread(cls.io_loop)
 
     @classmethod
@@ -187,6 +195,7 @@ class HTTPDummyProxyTestCase(object):
         cls.io_loop.add_callback(cls.http_server.stop)
         cls.io_loop.add_callback(cls.https_server.stop)
         cls.io_loop.add_callback(cls.proxy_server.stop)
+        cls.io_loop.add_callback(cls.https_proxy_server.stop)
         cls.io_loop.add_callback(cls.io_loop.stop)
         cls.server_thread.join()
 

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -112,6 +112,9 @@ class HTTPConnection(_HTTPConnection, object):
         #: provided, we use the default options.
         self.socket_options = kw.pop("socket_options", self.default_socket_options)
 
+        # Protocol used to talk to the proxy.
+        self.proxy_scheme = kw.pop("proxy_scheme", None)
+
         _HTTPConnection.__init__(self, *args, **kw)
 
     @property
@@ -174,10 +177,13 @@ class HTTPConnection(_HTTPConnection, object):
 
         return conn
 
+    def _is_using_tunnel(self):
+        # Google App Engine's httplib does not define _tunnel_host
+        return getattr(self, "_tunnel_host", None)
+
     def _prepare_conn(self, conn):
         self.sock = conn
-        # Google App Engine's httplib does not define _tunnel_host
-        if getattr(self, "_tunnel_host", None):
+        if self._is_using_tunnel():
             # TODO: Fix tunnel so it doesn't depend on self.sock state.
             self._tunnel()
             # Mark this connection as not reusable
@@ -314,9 +320,9 @@ class VerifiedHTTPSConnection(HTTPSConnection):
         conn = self._new_conn()
         hostname = self.host
 
-        # Google App Engine's httplib does not define _tunnel_host
-        if getattr(self, "_tunnel_host", None):
+        if self._is_using_tunnel():
             self.sock = conn
+
             # Calls self._set_hostport(), so self.host is
             # self._tunnel_host below.
             self._tunnel()

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -111,10 +111,6 @@ class HTTPConnection(_HTTPConnection, object):
         #: The socket options provided by the user. If no options are
         #: provided, we use the default options.
         self.socket_options = kw.pop("socket_options", self.default_socket_options)
-
-        # Protocol used to talk to the proxy.
-        self.proxy_scheme = kw.pop("proxy_scheme", None)
-
         _HTTPConnection.__init__(self, *args, **kw)
 
     @property

--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -632,7 +632,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         # Merge the proxy headers. Only done when not using HTTP CONNECT. We
         # have to copy the headers dict so we can safely change it without those
         # changes being reflected in anyone else's copy.
-        if self.scheme == "http" or self.proxy and self.proxy.scheme == "https":
+        if self.scheme == "http" or (self.proxy and self.proxy.scheme == "https"):
             headers = headers.copy()
             headers.update(self.proxy_headers)
 

--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -212,8 +212,6 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
             # We cannot know if the user has added default socket options, so we cannot replace the
             # list.
             self.conn_kw.setdefault("socket_options", [])
-            # Capture the proxy scheme to properly establish the connection.
-            self.conn_kw["proxy_scheme"] = self.proxy.scheme
 
     def _new_conn(self):
         """

--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -631,10 +631,10 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         # [1] <https://github.com/urllib3/urllib3/issues/651>
         release_this_conn = release_conn
 
-        # Merge the proxy headers. Only do this in HTTP. We have to copy the
-        # headers dict so we can safely change it without those changes being
-        # reflected in anyone else's copy.
-        if self.scheme == "http":
+        # Merge the proxy headers. Only done when not using HTTP CONNECT. We
+        # have to copy the headers dict so we can safely change it without those
+        # changes being reflected in anyone else's copy.
+        if self.scheme == "http" or self.proxy and self.proxy.scheme == 'https':
             headers = headers.copy()
             headers.update(self.proxy_headers)
 

--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -634,7 +634,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         # Merge the proxy headers. Only done when not using HTTP CONNECT. We
         # have to copy the headers dict so we can safely change it without those
         # changes being reflected in anyone else's copy.
-        if self.scheme == "http" or self.proxy and self.proxy.scheme == 'https':
+        if self.scheme == "http" or self.proxy and self.proxy.scheme == "https":
             headers = headers.copy()
             headers.update(self.proxy_headers)
 

--- a/src/urllib3/exceptions.py
+++ b/src/urllib3/exceptions.py
@@ -242,6 +242,11 @@ class ProxySchemeUnknown(AssertionError, ValueError):
         super(ProxySchemeUnknown, self).__init__(message)
 
 
+class ProxySchemeUnsupported(ValueError):
+    "Fetching HTTPS resources through HTTPS proxies is unsupported"
+    pass
+
+
 class HeaderParsingError(HTTPError):
     "Raised by assert_header_parsing, but we convert it to a log.warning statement."
 

--- a/src/urllib3/poolmanager.py
+++ b/src/urllib3/poolmanager.py
@@ -468,7 +468,7 @@ class ProxyManager(PoolManager):
         "Same as HTTP(S)ConnectionPool.urlopen, ``url`` must be absolute."
         u = parse_url(url)
 
-        if u.scheme == "http" or self.proxy.scheme == 'https':
+        if u.scheme == "http" or self.proxy.scheme == "https":
             # For connections using HTTP CONNECT, httplib sets the necessary
             # headers on the CONNECT to the proxy. For HTTP or when talking
             # HTTPS to the proxy, we'll definitely need to set 'Host' at the

--- a/src/urllib3/poolmanager.py
+++ b/src/urllib3/poolmanager.py
@@ -306,6 +306,18 @@ class PoolManager(RequestMethods):
                     base_pool_kwargs[key] = value
         return base_pool_kwargs
 
+    def _proxy_requires_complete_url(self, parsed_url):
+        """
+        Indicates if the proxy requires the complete destination URL in the
+        request.
+
+        Normally this is only needed when not using an HTTP CONNECT tunnel.
+        """
+        if self.proxy is None:
+            return False
+
+        return parsed_url.scheme == "http" or self.proxy.scheme == "https"
+
     def urlopen(self, method, url, redirect=True, **kw):
         """
         Same as :meth:`urllib3.connectionpool.HTTPConnectionPool.urlopen`
@@ -324,7 +336,7 @@ class PoolManager(RequestMethods):
         if "headers" not in kw:
             kw["headers"] = self.headers.copy()
 
-        if self.proxy is not None and u.scheme == "http":
+        if self._proxy_requires_complete_url(u):
             response = conn.urlopen(method, url, **kw)
         else:
             response = conn.urlopen(method, u.request_uri, **kw)

--- a/src/urllib3/poolmanager.py
+++ b/src/urllib3/poolmanager.py
@@ -400,10 +400,11 @@ class ProxyManager(PoolManager):
         HTTPS/CONNECT case they are sent only once. Could be used for proxy
         authentication.
 
-    :param allow_https_proxy_to_see_traffic:
+    :param _allow_https_proxy_to_see_traffic:
         Allows forwarding of HTTPS requests to HTTPS proxies. The proxy will
         have visibility of all the traffic sent. ONLY USE IF YOU KNOW WHAT
-        YOU'RE DOING.
+        YOU'RE DOING. This flag might be removed at any time in any future
+        update.
 
     Example:
         >>> proxy = urllib3.ProxyManager('http://localhost:3128/')
@@ -424,7 +425,7 @@ class ProxyManager(PoolManager):
         num_pools=10,
         headers=None,
         proxy_headers=None,
-        allow_https_proxy_to_see_traffic=False,
+        _allow_https_proxy_to_see_traffic=False,
         **connection_pool_kw
     ):
 
@@ -448,7 +449,7 @@ class ProxyManager(PoolManager):
         connection_pool_kw["_proxy"] = self.proxy
         connection_pool_kw["_proxy_headers"] = self.proxy_headers
 
-        self.allow_insecure_proxy = allow_https_proxy_to_see_traffic
+        self.allow_insecure_proxy = _allow_https_proxy_to_see_traffic
 
         super(ProxyManager, self).__init__(num_pools, headers, **connection_pool_kw)
 

--- a/src/urllib3/poolmanager.py
+++ b/src/urllib3/poolmanager.py
@@ -468,10 +468,11 @@ class ProxyManager(PoolManager):
         "Same as HTTP(S)ConnectionPool.urlopen, ``url`` must be absolute."
         u = parse_url(url)
 
-        if u.scheme == "http":
-            # For proxied HTTPS requests, httplib sets the necessary headers
-            # on the CONNECT to the proxy. For HTTP, we'll definitely
-            # need to set 'Host' at the very least.
+        if u.scheme == "http" or self.proxy.scheme == 'https':
+            # For connections using HTTP CONNECT, httplib sets the necessary
+            # headers on the CONNECT to the proxy. For HTTP or when talking
+            # HTTPS to the proxy, we'll definitely need to set 'Host' at the
+            # very least.
             headers = kw.get("headers", self.headers)
             kw["headers"] = self._set_proxy_headers(url, headers)
 

--- a/test/test_proxymanager.py
+++ b/test/test_proxymanager.py
@@ -38,11 +38,8 @@ class TestProxyManager(object):
     def test_default_port(self):
         with ProxyManager("http://something") as p:
             assert p.proxy.port == 80
-        with ProxyManager("https://something", _enable_https_proxies=True) as p:
-            assert p.proxy.port == 443
-        # HTTPS proxy without properly enabling it should default to HTTP.
         with ProxyManager("https://something") as p:
-            assert p.proxy.port == 80
+            assert p.proxy.port == 443
 
     def test_invalid_scheme(self):
         with pytest.raises(AssertionError):
@@ -54,9 +51,9 @@ class TestProxyManager(object):
         http_url = parse_url("http://example.com")
         https_url = parse_url("https://example.com")
         with ProxyManager("http://proxy:8080") as p:
-            assert p._proxy_requires_complete_url(http_url)
-            assert p._proxy_requires_complete_url(https_url) is False
+            assert p._proxy_requires_url_absolute_form(http_url)
+            assert p._proxy_requires_url_absolute_form(https_url) is False
 
-        with ProxyManager("https://proxy:8080", _enable_https_proxies=True) as p:
-            assert p._proxy_requires_complete_url(http_url)
-            assert p._proxy_requires_complete_url(https_url)
+        with ProxyManager("https://proxy:8080") as p:
+            assert p._proxy_requires_url_absolute_form(http_url)
+            assert p._proxy_requires_url_absolute_form(https_url)

--- a/test/test_proxymanager.py
+++ b/test/test_proxymanager.py
@@ -1,6 +1,7 @@
 import pytest
 
 from urllib3.poolmanager import ProxyManager
+from urllib3.util.url import parse_url
 
 
 class TestProxyManager(object):
@@ -43,3 +44,14 @@ class TestProxyManager(object):
             ProxyManager("invalid://host/p")
         with pytest.raises(ValueError):
             ProxyManager("invalid://host/p")
+
+    def test_proxy_tunnel(self):
+        http_url = parse_url("http://example.com")
+        https_url = parse_url("https://example.com")
+        with ProxyManager("http://proxy:8080") as p:
+            assert p._proxy_requires_complete_url(http_url)
+            assert p._proxy_requires_complete_url(https_url) is False
+
+        with ProxyManager("https://proxy:8080") as p:
+            assert p._proxy_requires_complete_url(http_url)
+            assert p._proxy_requires_complete_url(https_url)

--- a/test/test_proxymanager.py
+++ b/test/test_proxymanager.py
@@ -5,10 +5,7 @@ from urllib3.util.url import parse_url
 
 
 class TestProxyManager(object):
-    @pytest.mark.parametrize("proxy_scheme", [
-        "http",
-        "https"
-    ])
+    @pytest.mark.parametrize("proxy_scheme", ["http", "https"])
     def test_proxy_headers(self, proxy_scheme):
         url = "http://pypi.org/project/urllib3/"
         proxy_url = "{}://something:1234".format(proxy_scheme)

--- a/test/test_proxymanager.py
+++ b/test/test_proxymanager.py
@@ -5,9 +5,14 @@ from urllib3.util.url import parse_url
 
 
 class TestProxyManager(object):
-    def test_proxy_headers(self):
+    @pytest.mark.parametrize("proxy_scheme", [
+        "http",
+        "https"
+    ])
+    def test_proxy_headers(self, proxy_scheme):
         url = "http://pypi.org/project/urllib3/"
-        with ProxyManager("http://something:1234") as p:
+        proxy_url = "{}://something:1234".format(proxy_scheme)
+        with ProxyManager(proxy_url) as p:
             # Verify default headers
             default_headers = {"Accept": "*/*", "Host": "pypi.org"}
             headers = p._set_proxy_headers(url)

--- a/test/test_proxymanager.py
+++ b/test/test_proxymanager.py
@@ -38,8 +38,11 @@ class TestProxyManager(object):
     def test_default_port(self):
         with ProxyManager("http://something") as p:
             assert p.proxy.port == 80
-        with ProxyManager("https://something") as p:
+        with ProxyManager("https://something", _enable_https_proxies=True) as p:
             assert p.proxy.port == 443
+        # HTTPS proxy without properly enabling it should default to HTTP.
+        with ProxyManager("https://something") as p:
+            assert p.proxy.port == 80
 
     def test_invalid_scheme(self):
         with pytest.raises(AssertionError):
@@ -54,6 +57,6 @@ class TestProxyManager(object):
             assert p._proxy_requires_complete_url(http_url)
             assert p._proxy_requires_complete_url(https_url) is False
 
-        with ProxyManager("https://proxy:8080") as p:
+        with ProxyManager("https://proxy:8080", _enable_https_proxies=True) as p:
             assert p._proxy_requires_complete_url(http_url)
             assert p._proxy_requires_complete_url(https_url)

--- a/test/with_dummyserver/test_proxy_poolmanager.py
+++ b/test/with_dummyserver/test_proxy_poolmanager.py
@@ -32,10 +32,7 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
         cls.https_url = "https://%s:%d" % (cls.https_host, cls.https_port)
         cls.https_url_alt = "https://%s:%d" % (cls.https_host_alt, cls.https_port)
         cls.proxy_url = "http://%s:%d" % (cls.proxy_host, cls.proxy_port)
-        cls.https_proxy_url = "https://%s:%d" % (
-            cls.proxy_host,
-            cls.https_proxy_port,
-        )
+        cls.https_proxy_url = "https://%s:%d" % (cls.proxy_host, cls.https_proxy_port,)
 
         # Generate another CA to test verification failure
         cls.certs_dir = tempfile.mkdtemp()

--- a/test/with_dummyserver/test_proxy_poolmanager.py
+++ b/test/with_dummyserver/test_proxy_poolmanager.py
@@ -32,6 +32,10 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
         cls.https_url = "https://%s:%d" % (cls.https_host, cls.https_port)
         cls.https_url_alt = "https://%s:%d" % (cls.https_host_alt, cls.https_port)
         cls.proxy_url = "http://%s:%d" % (cls.proxy_host, cls.proxy_port)
+        self.https_proxy_url = "https://%s:%d" % (
+            self.proxy_host,
+            self.https_proxy_port,
+        )
 
         # Generate another CA to test verification failure
         cls.certs_dir = tempfile.mkdtemp()
@@ -51,6 +55,14 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
             assert r.status == 200
 
             r = http.request("GET", "%s/" % self.https_url)
+            assert r.status == 200
+
+    def test_https_proxy(self):
+        with proxy_from_url(self.https_proxy_url, ca_certs=DEFAULT_CA) as https:
+            r = https.request("GET", "%s/" % self.http_url)
+            assert r.status == 200
+
+            r = https.request("GET", "%s/" % self.https_url)
             assert r.status == 200
 
     def test_nagle_proxy(self):

--- a/test/with_dummyserver/test_proxy_poolmanager.py
+++ b/test/with_dummyserver/test_proxy_poolmanager.py
@@ -61,9 +61,7 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
             assert r.status == 200
 
     def test_https_proxy(self):
-        with proxy_from_url(
-            self.https_proxy_url, ca_certs=DEFAULT_CA, _enable_https_proxies=True
-        ) as https:
+        with proxy_from_url(self.https_proxy_url, ca_certs=DEFAULT_CA) as https:
             r = https.request("GET", "%s/" % self.http_url)
             assert r.status == 200
 
@@ -74,19 +72,9 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
             self.https_proxy_url,
             ca_certs=DEFAULT_CA,
             _allow_https_proxy_to_see_traffic=True,
-            _enable_https_proxies=True,
         ) as https:
             r = https.request("GET", "%s/" % self.http_url)
             https.request("GET", "%s/" % self.https_url)
-            assert r.status == 200
-
-    def test_http_proxy_with_https_scheme(self):
-        invalid_proxy_url = "https://%s:%d" % (self.proxy_host, self.proxy_port)
-        with proxy_from_url(invalid_proxy_url, ca_certs=DEFAULT_CA) as http:
-            r = http.request("GET", "%s/" % self.http_url)
-            assert r.status == 200
-
-            r = http.request("GET", "%s/" % self.https_url)
             assert r.status == 200
 
     def test_nagle_proxy(self):
@@ -317,7 +305,6 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
             headers={"Foo": "bar"},
             proxy_headers={"Hickory": "dickory"},
             ca_certs=DEFAULT_CA,
-            _enable_https_proxies=True,
         ) as http:
 
             r = http.request_encode_url("GET", "%s/headers" % self.http_url)

--- a/test/with_dummyserver/test_proxy_poolmanager.py
+++ b/test/with_dummyserver/test_proxy_poolmanager.py
@@ -71,7 +71,7 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
         with proxy_from_url(
             self.https_proxy_url,
             ca_certs=DEFAULT_CA,
-            allow_https_proxy_to_see_traffic=True,
+            _allow_https_proxy_to_see_traffic=True,
         ) as https:
             r = https.request("GET", "%s/" % self.http_url)
             https.request("GET", "%s/" % self.https_url)

--- a/test/with_dummyserver/test_proxy_poolmanager.py
+++ b/test/with_dummyserver/test_proxy_poolmanager.py
@@ -61,7 +61,9 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
             assert r.status == 200
 
     def test_https_proxy(self):
-        with proxy_from_url(self.https_proxy_url, ca_certs=DEFAULT_CA) as https:
+        with proxy_from_url(
+            self.https_proxy_url, ca_certs=DEFAULT_CA, _enable_https_proxies=True
+        ) as https:
             r = https.request("GET", "%s/" % self.http_url)
             assert r.status == 200
 
@@ -72,9 +74,19 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
             self.https_proxy_url,
             ca_certs=DEFAULT_CA,
             _allow_https_proxy_to_see_traffic=True,
+            _enable_https_proxies=True,
         ) as https:
             r = https.request("GET", "%s/" % self.http_url)
             https.request("GET", "%s/" % self.https_url)
+            assert r.status == 200
+
+    def test_http_proxy_with_https_scheme(self):
+        invalid_proxy_url = "https://%s:%d" % (self.proxy_host, self.proxy_port)
+        with proxy_from_url(invalid_proxy_url, ca_certs=DEFAULT_CA) as http:
+            r = http.request("GET", "%s/" % self.http_url)
+            assert r.status == 200
+
+            r = http.request("GET", "%s/" % self.https_url)
             assert r.status == 200
 
     def test_nagle_proxy(self):
@@ -305,6 +317,7 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
             headers={"Foo": "bar"},
             proxy_headers={"Hickory": "dickory"},
             ca_certs=DEFAULT_CA,
+            _enable_https_proxies=True,
         ) as http:
 
             r = http.request_encode_url("GET", "%s/headers" % self.http_url)


### PR DESCRIPTION
Currently there's no way to validate the identify of the proxy you are connecting to.  Proxies supporting HTTPS endpoints are becoming more common and extending support for them is necessary.

This commit adds the ability to establish an HTTPS connection to a proxy. 

When an HTTPS proxy is provided, instead of doing an HTTP CONNECT, we'll forward any requests directly to the proxy and ultimately to the destination, similar to how HTTP connections through a proxy are handled.

Another implementation alternative would have been to do TLS to the proxy, later an HTTP CONNECT and within the tunnel, another TLS connection to the destination. This is more complex and requires us to use the ``SSLContext.wrap_bio`` methods (i.e TLS within TLS).  I opted for this simpler approach as a start but I'm happy to extend if needed.
