### PR TITLE
travis: install MacPython only once

### DIFF
--- a/_travis/install.sh
+++ b/_travis/install.sh
@@ -8,11 +8,6 @@ install_mac_python() {
     local MINOR=$(echo $FULL | cut -d. -f1,2)
     local PYTHON_EXE=/Library/Frameworks/Python.framework/Versions/${MINOR}/bin/python${MINOR}
 
-    # Already installed.
-    if [[ -f "${PYTHON_EXE}" ]]; then
-        return 0;
-    fi
-
     curl -Lo macpython.pkg https://www.python.org/ftp/python/${FULL}/python-${FULL}-macosx10.6.pkg
     sudo installer -pkg macpython.pkg -target /
 
@@ -31,17 +26,13 @@ if [[ "$(uname -s)" == 'Darwin' ]]; then
         test-3.7) MACPYTHON=3.7.4 ;;
     esac
 
-    # Install additional versions as needed.
     install_mac_python $MACPYTHON
-
-    # Always install 3.6 for Nox
-    install_mac_python "3.6.7"
 
     # Enable TLS 1.3 on macOS
     sudo defaults write /Library/Preferences/com.apple.networkd tcp_connect_enable_tls13 1
 
     # Install Nox
-    python3.6 -m pip install nox
+    python3 -m pip install nox
 
 else
     # Linux Setup

--- a/_travis/run.sh
+++ b/_travis/run.sh
@@ -8,8 +8,8 @@ fi
 
 if [ -n "${NOX_SESSION}" ]; then
     if [[ "$(uname -s)" == 'Darwin' ]]; then
-        # Explicitly use Python 3.6 on MacOS, otherwise it won't find Nox properly.
-        python3.6 -m nox -s "${NOX_SESSION}"
+        # Explicitly use python3 on macOS as `nox` is not in the PATH
+        python3 -m nox -s "${NOX_SESSION}"
     else
         nox -s "${NOX_SESSION}"
     fi


### PR DESCRIPTION
The Travis macOS base image is documented to include Python: we can use
it to run nox instead of installing Python 3 explicitly, which should
result in faster builds.