### PR TITLE
Fix coverage upload

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,6 @@ install:
 
 script:
   - ./_travis/run.sh
-
-after_success:
   - ./_travis/upload_coverage.sh
 
 cache:

--- a/_travis/upload_coverage.sh
+++ b/_travis/upload_coverage.sh
@@ -3,6 +3,6 @@
 set -exo pipefail
 
 if [[ -e .coverage ]]; then
-    python3 -m pip install codecov
-    python3 -m codecov --env TRAVIS_OS_NAME,NOX_SESSION
+    python -m pip install codecov
+    python -m codecov --env TRAVIS_OS_NAME,NOX_SESSION
 fi


### PR DESCRIPTION
This pull request fixes two related issues: we were using Python 3 to upload the Python 2 coverages, and uploading issues were not noticed even if the script failed.