### PR TITLE
Add hostname to insecure connection warning.

### DIFF
--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -996,12 +996,10 @@ class HTTPSConnectionPool(HTTPConnectionPool):
         if not conn.is_verified:
             warnings.warn(
                 (
-                    "Unverified HTTPS request is being made to host '"
-                    + conn.host
-                    + "'. "
+                    "Unverified HTTPS request is being made to host '%s'. "
                     "Adding certificate verification is strongly advised. See: "
                     "https://urllib3.readthedocs.io/en/latest/advanced-usage.html"
-                    "#ssl-warnings"
+                    "#ssl-warnings" % conn.host
                 ),
                 InsecureRequestWarning,
             )

--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -996,7 +996,9 @@ class HTTPSConnectionPool(HTTPConnectionPool):
         if not conn.is_verified:
             warnings.warn(
                 (
-                    "Unverified HTTPS request is being made. "
+                    "Unverified HTTPS request is being made to host '"
+                    + conn.host
+                    + "'. "
                     "Adding certificate verification is strongly advised. See: "
                     "https://urllib3.readthedocs.io/en/latest/advanced-usage.html"
                     "#ssl-warnings"


### PR DESCRIPTION
Sometimes, you're not the one who wrote the code, or urllib3 is being used within existing software, and it will give off the 'Unverified HTTPS request' warning, leaving the end user confused and unable to trace why they are getting it. (Example: Home Assistant components calling out to various hosts)

This PR adds the hostname to the warning, making it more obvious to end users where the source of the request lies.

(Very bad coder here so this is my second attempt. I doubt the code quality is up to standards, but it's what "black" gave me, and it does pass the Travis CI and AppVeyor builds on my end now.)