### PR TITLE
Release 1.25.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,8 @@ matrix:
     # Unit tests
     - python: 2.7
       env: NOX_SESSION=test-2.7
+    - python: 3.4
+      env: NOX_SESSION=test-3.4
     - python: 3.5
       env: NOX_SESSION=test-3.5
     - python: 3.6
@@ -65,6 +67,9 @@ matrix:
     - language: generic
       os: osx
       env: NOX_SESSION=test-2.7
+    - language: generic
+      os: osx
+      env: NOX_SESSION=test-3.4
     - language: generic
       os: osx
       env: NOX_SESSION=test-3.5

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,10 +1,11 @@
 Changes
 =======
 
-dev (master)
-------------
+1.25.6 (2019-09-24)
+-------------------
 
-* Dropped Python 3.4 support. (Pull #1686)
+* Fix issue where tilde (``~``) characters were incorrectly
+  percent-encoded in the path. (Pull #1692)
 
 
 1.25.5 (2019-09-19)

--- a/_travis/install.sh
+++ b/_travis/install.sh
@@ -21,6 +21,7 @@ if [[ "$(uname -s)" == 'Darwin' ]]; then
     # Mac OS setup.
     case "${NOX_SESSION}" in
         test-2.7) MACPYTHON=2.7.16 ;;
+        test-3.4) MACPYTHON=3.4.4 ;;
         test-3.5) MACPYTHON=3.5.4 ;;  # last binary release
         test-3.6) MACPYTHON=3.6.8 ;;  # last binary release
         test-3.7) MACPYTHON=3.7.4 ;;

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,6 +12,11 @@ environment:
       PYTHON_ARCH: "64"
       NOX_SESSION: "test-2.7"
 
+    - PYTHON: "C:\\Python34-x64"
+      PYTHON_VERSION: "3.4.x"
+      PYTHON_ARCH: "64"
+      NOX_SESSION: "test-3.4"
+
     - PYTHON: "C:\\Python35-x64"
       PYTHON_VERSION: "3.5.x"
       PYTHON_ARCH: "64"

--- a/noxfile.py
+++ b/noxfile.py
@@ -37,7 +37,7 @@ def tests_impl(session, extras="socks,secure,brotli"):
     session.run("coverage", "report", "-m")
 
 
-@nox.session(python=["2.7", "3.5", "3.6", "3.7", "3.8", "pypy"])
+@nox.session(python=["2.7", "3.4", "3.5", "3.6", "3.7", "3.8", "pypy"])
 def test(session):
     tests_impl(session)
 

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
@@ -62,7 +63,7 @@ setup(
     ],
     package_dir={"": "src"},
     requires=[],
-    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4",
+    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, <4",
     tests_require=[
         # These are a less-specific subset of dev-requirements.txt, for the
         # convenience of distro package maintainers.

--- a/src/urllib3/__init__.py
+++ b/src/urllib3/__init__.py
@@ -22,7 +22,7 @@ from logging import NullHandler
 
 __author__ = "Andrey Petrov (andrey.petrov@shazow.net)"
 __license__ = "MIT"
-__version__ = "1.25.5"
+__version__ = "1.25.6"
 
 __all__ = (
     "HTTPConnectionPool",

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -106,7 +106,7 @@ def notSecureTransport(test):
 
 
 def notOpenSSL098(test):
-    """Skips this test for Python 3.5 macOS python.org distribution"""
+    """Skips this test for Python 3.4 and 3.5 macOS python.org distributions"""
 
     @functools.wraps(test)
     def wrapper(*args, **kwargs):


### PR DESCRIPTION
Reverted the change for dropping 3.4 support so that Python 3.4 can get this fix. We'll drop 3.4 once this set of features can stick without a bug report. :) cc @pquentin 