### PR TITLE
Add CodeFund Sponsorship to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,11 @@
+.. raw:: html
+
+   <p align="center">
+      <a href="https://codefund.io/properties/451/visit-sponsor">
+         <img src="https://codefund.io/properties/451/sponsor" />
+      </a>
+   </p>
+
 urllib3
 =======
 


### PR DESCRIPTION
CodeFund provides ethical sponsorships to open source maintainers. This PR will place the "Sponsored by" image at the top of the README. The sponsoring companies are not paying per click nor impression. They are paying the maintainer(s) on a per-month basis to be the primary sponsor of this project.

For an example, see https://github.com/gitcoinco/code_fund_ads/blob/master/README.md