### PR TITLE
test: switch from 'self' to 'cls' in class methods

### DIFF
--- a/test/test_no_ssl.py
+++ b/test/test_no_ssl.py
@@ -65,14 +65,14 @@ module_stash = ModuleStash("urllib3")
 
 class TestWithoutSSL(object):
     @classmethod
-    def setup_class(self):
+    def setup_class(cls):
         sys.modules.pop("ssl", None)
         sys.modules.pop("_ssl", None)
 
         module_stash.stash()
         sys.meta_path.insert(0, ssl_blocker)
 
-    def teardown_class(self):
+    def teardown_class(cls):
         sys.meta_path.remove(ssl_blocker)
         module_stash.pop()
 

--- a/test/with_dummyserver/test_poolmanager.py
+++ b/test/with_dummyserver/test_poolmanager.py
@@ -12,10 +12,10 @@ from urllib3.util.retry import Retry
 
 class TestPoolManager(HTTPDummyServerTestCase):
     @classmethod
-    def setup_class(self):
-        super(TestPoolManager, self).setup_class()
-        self.base_url = "http://%s:%d" % (self.host, self.port)
-        self.base_url_alt = "http://%s:%d" % (self.host_alt, self.port)
+    def setup_class(cls):
+        super(TestPoolManager, cls).setup_class()
+        cls.base_url = "http://%s:%d" % (cls.host, cls.port)
+        cls.base_url_alt = "http://%s:%d" % (cls.host_alt, cls.port)
 
     def test_redirect(self):
         with PoolManager() as http:
@@ -350,9 +350,9 @@ class TestPoolManager(HTTPDummyServerTestCase):
 @pytest.mark.skipif(not HAS_IPV6, reason="IPv6 is not supported on this system")
 class TestIPv6PoolManager(IPv6HTTPDummyServerTestCase):
     @classmethod
-    def setup_class(self):
-        super(TestIPv6PoolManager, self).setup_class()
-        self.base_url = "http://[%s]:%d" % (self.host, self.port)
+    def setup_class(cls):
+        super(TestIPv6PoolManager, cls).setup_class()
+        cls.base_url = "http://[%s]:%d" % (cls.host, cls.port)
 
     def test_ipv6(self):
         with PoolManager() as http:

--- a/test/with_dummyserver/test_proxy_poolmanager.py
+++ b/test/with_dummyserver/test_proxy_poolmanager.py
@@ -15,13 +15,13 @@ from urllib3.connectionpool import connection_from_url, VerifiedHTTPSConnection
 
 class TestHTTPProxyManager(HTTPDummyProxyTestCase):
     @classmethod
-    def setup_class(self):
-        super(TestHTTPProxyManager, self).setup_class()
-        self.http_url = "http://%s:%d" % (self.http_host, self.http_port)
-        self.http_url_alt = "http://%s:%d" % (self.http_host_alt, self.http_port)
-        self.https_url = "https://%s:%d" % (self.https_host, self.https_port)
-        self.https_url_alt = "https://%s:%d" % (self.https_host_alt, self.https_port)
-        self.proxy_url = "http://%s:%d" % (self.proxy_host, self.proxy_port)
+    def setup_class(cls):
+        super(TestHTTPProxyManager, cls).setup_class()
+        cls.http_url = "http://%s:%d" % (cls.http_host, cls.http_port)
+        cls.http_url_alt = "http://%s:%d" % (cls.http_host_alt, cls.http_port)
+        cls.https_url = "https://%s:%d" % (cls.https_host, cls.https_port)
+        cls.https_url_alt = "https://%s:%d" % (cls.https_host_alt, cls.https_port)
+        cls.proxy_url = "http://%s:%d" % (cls.proxy_host, cls.proxy_port)
 
     def test_basic_proxy(self):
         with proxy_from_url(self.proxy_url, ca_certs=DEFAULT_CA) as http:
@@ -370,13 +370,13 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
 
 class TestIPv6HTTPProxyManager(IPv6HTTPDummyProxyTestCase):
     @classmethod
-    def setup_class(self):
+    def setup_class(cls):
         HTTPDummyProxyTestCase.setup_class()
-        self.http_url = "http://%s:%d" % (self.http_host, self.http_port)
-        self.http_url_alt = "http://%s:%d" % (self.http_host_alt, self.http_port)
-        self.https_url = "https://%s:%d" % (self.https_host, self.https_port)
-        self.https_url_alt = "https://%s:%d" % (self.https_host_alt, self.https_port)
-        self.proxy_url = "http://[%s]:%d" % (self.proxy_host, self.proxy_port)
+        cls.http_url = "http://%s:%d" % (cls.http_host, cls.http_port)
+        cls.http_url_alt = "http://%s:%d" % (cls.http_host_alt, cls.http_port)
+        cls.https_url = "https://%s:%d" % (cls.https_host, cls.https_port)
+        cls.https_url_alt = "https://%s:%d" % (cls.https_host_alt, cls.https_port)
+        cls.proxy_url = "http://[%s]:%d" % (cls.proxy_host, cls.proxy_port)
 
     def test_basic_ipv6_proxy(self):
         with proxy_from_url(self.proxy_url, ca_certs=DEFAULT_CA) as http:


### PR DESCRIPTION
What do you think? I'd say this makes more sense, even if the class attributes are accessed using `self` in the test methods themselves.