### PR TITLE
test: remove unneeded new lines after with statements

### DIFF
--- a/test/contrib/test_socks.py
+++ b/test/contrib/test_socks.py
@@ -313,7 +313,6 @@ class TestSocks5Proxy(IPV4SocketDummyServerTestCase):
         self._start_server(request_handler)
         proxy_url = "socks5h://%s:%s" % (self.host, self.port)
         with socks.SOCKSProxyManager(proxy_url) as pm:
-
             with pytest.raises(ConnectTimeoutError):
                 pm.request("GET", "http://example.com", timeout=0.001, retries=False)
             event.set()
@@ -328,7 +327,6 @@ class TestSocks5Proxy(IPV4SocketDummyServerTestCase):
         self._start_server(request_handler)
         proxy_url = "socks5h://%s:%s" % (self.host, self.port)
         with socks.SOCKSProxyManager(proxy_url) as pm:
-
             event.wait()
             with pytest.raises(NewConnectionError):
                 pm.request("GET", "http://example.com", retries=False)
@@ -349,7 +347,6 @@ class TestSocks5Proxy(IPV4SocketDummyServerTestCase):
         self._start_server(request_handler)
         proxy_url = "socks5h://%s:%s" % (self.host, self.port)
         with socks.SOCKSProxyManager(proxy_url) as pm:
-
             with pytest.raises(NewConnectionError):
                 pm.request("GET", "http://example.com", retries=False)
             evt.set()
@@ -383,7 +380,6 @@ class TestSocks5Proxy(IPV4SocketDummyServerTestCase):
         self._start_server(request_handler)
         proxy_url = "socks5://%s:%s" % (self.host, self.port)
         with socks.SOCKSProxyManager(proxy_url, username="user", password="pass") as pm:
-
             response = pm.request("GET", "http://16.17.18.19")
 
             assert response.status == 200
@@ -424,7 +420,6 @@ class TestSocks5Proxy(IPV4SocketDummyServerTestCase):
         self._start_server(request_handler)
         proxy_url = "socks5://user:pass@%s:%s" % (self.host, self.port)
         with socks.SOCKSProxyManager(proxy_url) as pm:
-
             response = pm.request("GET", "http://16.17.18.19")
 
             assert response.status == 200
@@ -445,7 +440,6 @@ class TestSocks5Proxy(IPV4SocketDummyServerTestCase):
         with socks.SOCKSProxyManager(
             proxy_url, username="user", password="badpass"
         ) as pm:
-
             try:
                 pm.request("GET", "http://example.com", retries=False)
             except NewConnectionError as e:
@@ -614,7 +608,6 @@ class TestSOCKS4Proxy(IPV4SocketDummyServerTestCase):
         self._start_server(request_handler)
         proxy_url = "socks4a://%s:%s" % (self.host, self.port)
         with socks.SOCKSProxyManager(proxy_url) as pm:
-
             with pytest.raises(NewConnectionError):
                 pm.request("GET", "http://example.com", retries=False)
             evt.set()
@@ -662,7 +655,6 @@ class TestSOCKS4Proxy(IPV4SocketDummyServerTestCase):
         self._start_server(request_handler)
         proxy_url = "socks4a://%s:%s" % (self.host, self.port)
         with socks.SOCKSProxyManager(proxy_url, username="baduser") as pm:
-
             try:
                 pm.request("GET", "http://example.com", retries=False)
             except NewConnectionError as e:

--- a/test/test_connectionpool.py
+++ b/test/test_connectionpool.py
@@ -450,7 +450,6 @@ class TestConnectionPool(object):
 
         def _test(exception):
             with HTTPConnectionPool(host="localhost", maxsize=1, block=True) as pool:
-
                 # Verify that the request succeeds after two attempts, and that the
                 # connection is left on the response object, instead of being
                 # released back into the pool.

--- a/test/test_proxymanager.py
+++ b/test/test_proxymanager.py
@@ -7,7 +7,6 @@ class TestProxyManager(object):
     def test_proxy_headers(self):
         url = "http://pypi.org/project/urllib3/"
         with ProxyManager("http://something:1234") as p:
-
             # Verify default headers
             default_headers = {"Accept": "*/*", "Host": "pypi.org"}
             headers = p._set_proxy_headers(url)

--- a/test/with_dummyserver/test_chunked_transfer.py
+++ b/test/with_dummyserver/test_chunked_transfer.py
@@ -42,7 +42,6 @@ class TestChunkedTransfer(SocketDummyServerTestCase):
     def _test_body(self, data):
         self.start_chunked_handler()
         with HTTPConnectionPool(self.host, self.port, retries=False) as pool:
-
             pool.urlopen("GET", "/", data, chunked=True)
             header, body = self.buffer.split(b"\r\n\r\n", 1)
 

--- a/test/with_dummyserver/test_connectionpool.py
+++ b/test/with_dummyserver/test_connectionpool.py
@@ -94,7 +94,6 @@ class TestConnectionPoolTimeouts(SocketDummyServerTestCase):
         with HTTPConnectionPool(
             self.host, self.port, timeout=timeout, retries=False
         ) as pool:
-
             wait_for_socket(ready_event)
             conn = pool._get_conn()
             with pytest.raises(ReadTimeoutError):
@@ -112,7 +111,6 @@ class TestConnectionPoolTimeouts(SocketDummyServerTestCase):
         with HTTPConnectionPool(
             self.host, self.port, timeout=LONG_TIMEOUT, retries=False
         ) as pool:
-
             conn = pool._get_conn()
             wait_for_socket(ready_event)
             now = time.time()
@@ -460,7 +458,6 @@ class TestConnectionPool(HTTPDummyServerTestCase):
         with HTTPConnectionPool(
             self.host, self.port, block=True, maxsize=1, timeout=2
         ) as pool:
-
             r = pool.request(
                 "GET", "/keepalive?close=1", retries=0, headers={"Connection": "close"}
             )
@@ -624,7 +621,6 @@ class TestConnectionPool(HTTPDummyServerTestCase):
         with HTTPConnectionPool(
             self.host, self.port, block=True, maxsize=1, timeout=2
         ) as pool:
-
             payload_size = 1024 * 2
             first_chunk = 512
 

--- a/test/with_dummyserver/test_https.py
+++ b/test/with_dummyserver/test_https.py
@@ -179,7 +179,6 @@ class TestHTTPS(HTTPSDummyServerTestCase):
             cert_file=client_cert,
             key_password=None,
         ) as https_pool:
-
             with pytest.raises(MaxRetryError) as e:
                 https_pool.request("GET", "/certificate")
 
@@ -190,7 +189,6 @@ class TestHTTPS(HTTPSDummyServerTestCase):
         with HTTPSConnectionPool(
             self.host, self.port, cert_reqs="CERT_REQUIRED", ca_certs=DEFAULT_CA
         ) as https_pool:
-
             conn = https_pool._new_conn()
             assert conn.__class__ == VerifiedHTTPSConnection
 
@@ -219,7 +217,6 @@ class TestHTTPS(HTTPSDummyServerTestCase):
         ctx = util.ssl_.create_urllib3_context(cert_reqs=ssl.CERT_REQUIRED)
         ctx.load_verify_locations(cafile=DEFAULT_CA)
         with HTTPSConnectionPool(self.host, self.port, ssl_context=ctx) as https_pool:
-
             conn = https_pool._new_conn()
             assert conn.__class__ == VerifiedHTTPSConnection
 
@@ -249,7 +246,6 @@ class TestHTTPS(HTTPSDummyServerTestCase):
         with HTTPSConnectionPool(
             self.host, self.port, ca_certs=DEFAULT_CA, ssl_context=ctx
         ) as https_pool:
-
             conn = https_pool._new_conn()
             assert conn.__class__ == VerifiedHTTPSConnection
 
@@ -281,7 +277,6 @@ class TestHTTPS(HTTPSDummyServerTestCase):
         with HTTPSConnectionPool(
             self.host, self.port, cert_reqs="CERT_REQUIRED", ca_cert_dir=DEFAULT_CA_DIR
         ) as https_pool:
-
             conn = https_pool._new_conn()
             assert conn.__class__ == VerifiedHTTPSConnection
 
@@ -294,7 +289,6 @@ class TestHTTPS(HTTPSDummyServerTestCase):
         with HTTPSConnectionPool(
             "127.0.0.1", self.port, cert_reqs="CERT_REQUIRED", ca_certs=DEFAULT_CA
         ) as https_pool:
-
             try:
                 https_pool.request("GET", "/")
                 self.fail("Didn't raise SSL invalid common name")
@@ -308,7 +302,6 @@ class TestHTTPS(HTTPSDummyServerTestCase):
         with HTTPSConnectionPool(
             self.host, self.port, cert_reqs="CERT_REQUIRED", ca_certs=DEFAULT_CA_BAD
         ) as https_pool:
-
             try:
                 https_pool.request("GET", "/")
                 self.fail("Didn't raise SSL error with bad CA certs")
@@ -323,7 +316,6 @@ class TestHTTPS(HTTPSDummyServerTestCase):
         with HTTPSConnectionPool(
             self.host, self.port, cert_reqs="CERT_REQUIRED"
         ) as https_pool:
-
             try:
                 https_pool.request("GET", "/")
                 self.fail(
@@ -358,7 +350,6 @@ class TestHTTPS(HTTPSDummyServerTestCase):
     def test_unverified_ssl(self):
         """ Test that bare HTTPSConnection can connect, make requests """
         with HTTPSConnectionPool(self.host, self.port, cert_reqs=ssl.CERT_NONE) as pool:
-
             with mock.patch("warnings.warn") as warn:
                 r = pool.request("GET", "/")
                 assert r.status == 200
@@ -374,7 +365,6 @@ class TestHTTPS(HTTPSDummyServerTestCase):
         with HTTPSConnectionPool(
             self.host, self.port, cert_reqs="CERT_NONE", ca_certs=DEFAULT_CA_BAD
         ) as pool:
-
             with mock.patch("warnings.warn") as warn:
                 r = pool.request("GET", "/")
                 assert r.status == 200
@@ -400,7 +390,6 @@ class TestHTTPS(HTTPSDummyServerTestCase):
         with HTTPSConnectionPool(
             "localhost", self.port, cert_reqs="CERT_REQUIRED", ca_certs=DEFAULT_CA
         ) as https_pool:
-
             https_pool.assert_hostname = False
             https_pool.request("GET", "/")
 
@@ -408,7 +397,6 @@ class TestHTTPS(HTTPSDummyServerTestCase):
         with HTTPSConnectionPool(
             "localhost", self.port, cert_reqs="CERT_REQUIRED", ca_certs=DEFAULT_CA
         ) as https_pool:
-
             https_pool.assert_hostname = "localhost"
             https_pool.request("GET", "/")
 
@@ -420,7 +408,6 @@ class TestHTTPS(HTTPSDummyServerTestCase):
             ca_certs=DEFAULT_CA,
             server_hostname="localhost",
         ) as https_pool:
-
             conn = https_pool._new_conn()
             conn.request("GET", "/")
 
@@ -435,7 +422,6 @@ class TestHTTPS(HTTPSDummyServerTestCase):
         with HTTPSConnectionPool(
             "localhost", self.port, cert_reqs="CERT_REQUIRED", ca_certs=DEFAULT_CA
         ) as https_pool:
-
             https_pool.assert_fingerprint = (
                 "F2:06:5A:42:10:3F:45:1C:17:FE:E6:07:1E:8A:86:E5"
             )
@@ -446,7 +432,6 @@ class TestHTTPS(HTTPSDummyServerTestCase):
         with HTTPSConnectionPool(
             "localhost", self.port, cert_reqs="CERT_REQUIRED", ca_certs=DEFAULT_CA
         ) as https_pool:
-
             https_pool.assert_fingerprint = (
                 "92:81:FE:85:F7:0C:26:60:EC:D6:B3:BF:93:CF:F9:71:CC:07:7D:0A"
             )
@@ -456,7 +441,6 @@ class TestHTTPS(HTTPSDummyServerTestCase):
         with HTTPSConnectionPool(
             "localhost", self.port, cert_reqs="CERT_REQUIRED", ca_certs=DEFAULT_CA
         ) as https_pool:
-
             https_pool.assert_fingerprint = (
                 "C5:4D:0B:83:84:89:2E:AE:B4:58:BB:12:"
                 "F7:A6:C4:76:05:03:88:D8:57:65:51:F3:"
@@ -468,7 +452,6 @@ class TestHTTPS(HTTPSDummyServerTestCase):
         with HTTPSConnectionPool(
             "127.0.0.1", self.port, cert_reqs="CERT_REQUIRED", ca_certs=DEFAULT_CA
         ) as https_pool:
-
             https_pool.assert_fingerprint = (
                 "AA:AA:AA:AA:AA:AAAA:AA:AAAA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA"
             )
@@ -494,7 +477,6 @@ class TestHTTPS(HTTPSDummyServerTestCase):
         with HTTPSConnectionPool(
             "127.0.0.1", self.port, cert_reqs="CERT_NONE", ca_certs=DEFAULT_CA_BAD
         ) as https_pool:
-
             https_pool.assert_fingerprint = (
                 "AA:AA:AA:AA:AA:AAAA:AA:AAAA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA"
             )
@@ -506,7 +488,6 @@ class TestHTTPS(HTTPSDummyServerTestCase):
         with HTTPSConnectionPool(
             "127.0.0.1", self.port, cert_reqs="CERT_NONE", ca_certs=DEFAULT_CA_BAD
         ) as https_pool:
-
             https_pool.assert_fingerprint = (
                 "92:81:FE:85:F7:0C:26:60:EC:D6:B3:BF:93:CF:F9:71:CC:07:7D:0A"
             )
@@ -521,7 +502,6 @@ class TestHTTPS(HTTPSDummyServerTestCase):
         with HTTPSConnectionPool(
             "127.0.0.1", self.port, cert_reqs="CERT_REQUIRED", ca_certs=DEFAULT_CA
         ) as https_pool:
-
             https_pool.assert_fingerprint = (
                 "92:81:FE:85:F7:0C:26:60:EC:D6:B3:BF:93:CF:F9:71:CC:07:7D:0A"
             )
@@ -566,7 +546,6 @@ class TestHTTPS(HTTPSDummyServerTestCase):
         with HTTPSConnectionPool(
             self.host, self.port, timeout=timeout, cert_reqs="CERT_NONE"
         ) as https_pool:
-
             conn = https_pool._new_conn()
             try:
                 conn.set_tunnel(self.host, self.port)
@@ -630,7 +609,6 @@ class TestHTTPS(HTTPSDummyServerTestCase):
             ca_certs=DEFAULT_CA,
             assert_fingerprint=fingerprint,
         ) as https_pool:
-
             r = https_pool.request("GET", "/")
             assert r.status == 200
 

--- a/test/with_dummyserver/test_poolmanager.py
+++ b/test/with_dummyserver/test_poolmanager.py
@@ -39,7 +39,6 @@ class TestPoolManager(HTTPDummyServerTestCase):
 
     def test_redirect_twice(self):
         with PoolManager() as http:
-
             r = http.request(
                 "GET",
                 "%s/redirect" % self.base_url,
@@ -62,7 +61,6 @@ class TestPoolManager(HTTPDummyServerTestCase):
 
     def test_redirect_to_relative_url(self):
         with PoolManager() as http:
-
             r = http.request(
                 "GET",
                 "%s/redirect" % self.base_url,
@@ -81,7 +79,6 @@ class TestPoolManager(HTTPDummyServerTestCase):
 
     def test_cross_host_redirect(self):
         with PoolManager() as http:
-
             cross_host_location = "%s/echo?a=b" % self.base_url_alt
             try:
                 http.request(
@@ -110,7 +107,6 @@ class TestPoolManager(HTTPDummyServerTestCase):
 
     def test_too_many_redirects(self):
         with PoolManager() as http:
-
             try:
                 r = http.request(
                     "GET",
@@ -145,7 +141,6 @@ class TestPoolManager(HTTPDummyServerTestCase):
 
     def test_redirect_cross_host_remove_headers(self):
         with PoolManager() as http:
-
             r = http.request(
                 "GET",
                 "%s/redirect" % self.base_url,
@@ -175,7 +170,6 @@ class TestPoolManager(HTTPDummyServerTestCase):
 
     def test_redirect_cross_host_no_remove_headers(self):
         with PoolManager() as http:
-
             r = http.request(
                 "GET",
                 "%s/redirect" % self.base_url,
@@ -192,7 +186,6 @@ class TestPoolManager(HTTPDummyServerTestCase):
 
     def test_redirect_cross_host_set_removed_headers(self):
         with PoolManager() as http:
-
             r = http.request(
                 "GET",
                 "%s/redirect" % self.base_url,
@@ -226,7 +219,6 @@ class TestPoolManager(HTTPDummyServerTestCase):
 
     def test_raise_on_redirect(self):
         with PoolManager() as http:
-
             r = http.request(
                 "GET",
                 "%s/redirect" % self.base_url,
@@ -240,7 +232,6 @@ class TestPoolManager(HTTPDummyServerTestCase):
 
     def test_raise_on_status(self):
         with PoolManager() as http:
-
             try:
                 # the default is to raise
                 r = http.request(
@@ -288,7 +279,6 @@ class TestPoolManager(HTTPDummyServerTestCase):
         # will all such URLs fail with an error?
 
         with PoolManager() as http:
-
             # By globally adjusting `port_by_scheme` we pretend for a moment
             # that HTTP's default port is not 80, but is the port at which
             # our test server happens to be listening.
@@ -303,7 +293,6 @@ class TestPoolManager(HTTPDummyServerTestCase):
 
     def test_headers(self):
         with PoolManager(headers={"Foo": "bar"}) as http:
-
             r = http.request("GET", "%s/headers" % self.base_url)
             returned_headers = json.loads(r.data.decode())
             assert returned_headers.get("Foo") == "bar"
@@ -336,13 +325,11 @@ class TestPoolManager(HTTPDummyServerTestCase):
 
     def test_http_with_ssl_keywords(self):
         with PoolManager(ca_certs="REQUIRED") as http:
-
             r = http.request("GET", "http://%s:%s/" % (self.host, self.port))
             assert r.status == 200
 
     def test_http_with_ca_cert_dir(self):
         with PoolManager(ca_certs="REQUIRED", ca_cert_dir="/nosuchdir") as http:
-
             r = http.request("GET", "http://%s:%s/" % (self.host, self.port))
             assert r.status == 200
 

--- a/test/with_dummyserver/test_proxy_poolmanager.py
+++ b/test/with_dummyserver/test_proxy_poolmanager.py
@@ -25,7 +25,6 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
 
     def test_basic_proxy(self):
         with proxy_from_url(self.proxy_url, ca_certs=DEFAULT_CA) as http:
-
             r = http.request("GET", "%s/" % self.http_url)
             assert r.status == 200
 
@@ -69,7 +68,6 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
         with ProxyManager(
             connection_from_url(self.proxy_url), ca_certs=DEFAULT_CA
         ) as http:
-
             r = http.request("GET", "%s/" % self.http_url)
             assert r.status == 200
 
@@ -113,7 +111,6 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
 
     def test_redirect(self):
         with proxy_from_url(self.proxy_url) as http:
-
             r = http.request(
                 "GET",
                 "%s/redirect" % self.http_url,
@@ -134,7 +131,6 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
 
     def test_cross_host_redirect(self):
         with proxy_from_url(self.proxy_url) as http:
-
             cross_host_location = "%s/echo?a=b" % self.http_url_alt
             try:
                 http.request(
@@ -160,7 +156,6 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
 
     def test_cross_protocol_redirect(self):
         with proxy_from_url(self.proxy_url, ca_certs=DEFAULT_CA) as http:
-
             cross_protocol_location = "%s/echo?a=b" % self.https_url
             try:
                 http.request(
@@ -284,7 +279,6 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
         with proxy_from_url(
             self.proxy_url, headers=default_headers, proxy_headers=proxy_headers
         ) as http:
-
             request_headers = HTTPHeaderDict(baz="quux")
             r = http.request(
                 "GET", "%s/headers" % self.http_url, headers=request_headers
@@ -295,7 +289,6 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
 
     def test_proxy_pooling(self):
         with proxy_from_url(self.proxy_url, cert_reqs="NONE") as http:
-
             for x in range(2):
                 http.urlopen("GET", self.http_url)
             assert len(http.pools) == 1
@@ -314,7 +307,6 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
 
     def test_proxy_pooling_ext(self):
         with proxy_from_url(self.proxy_url) as http:
-
             hc1 = http.connection_from_url(self.http_url)
             hc2 = http.connection_from_host(self.http_host, self.http_port)
             hc3 = http.connection_from_url(self.http_url_alt)
@@ -360,7 +352,6 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
     def test_scheme_host_case_insensitive(self):
         """Assert that upper-case schemes and hosts are normalized."""
         with proxy_from_url(self.proxy_url.upper(), ca_certs=DEFAULT_CA) as http:
-
             r = http.request("GET", "%s/" % self.http_url.upper())
             assert r.status == 200
 
@@ -380,7 +371,6 @@ class TestIPv6HTTPProxyManager(IPv6HTTPDummyProxyTestCase):
 
     def test_basic_ipv6_proxy(self):
         with proxy_from_url(self.proxy_url, ca_certs=DEFAULT_CA) as http:
-
             r = http.request("GET", "%s/" % self.http_url)
             assert r.status == 200
 

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -346,7 +346,6 @@ class TestSocketClosing(SocketDummyServerTestCase):
 
         self._start_server(socket_handler)
         with HTTPConnectionPool(self.host, self.port) as pool:
-
             response = pool.request("GET", "/", retries=0)
             assert response.status == 200
             assert response.data == b"Response 0"
@@ -380,7 +379,6 @@ class TestSocketClosing(SocketDummyServerTestCase):
         with HTTPConnectionPool(
             self.host, self.port, timeout=0.01, retries=False, maxsize=3, block=True
         ) as http:
-
             try:
                 with pytest.raises(ReadTimeoutError):
                     http.request("GET", "/", release_conn=False)
@@ -402,7 +400,6 @@ class TestSocketClosing(SocketDummyServerTestCase):
         with HTTPConnectionPool(
             self.host, self.port, timeout=0.01, retries=True
         ) as pool:
-
             try:
                 with pytest.raises(ReadTimeoutError):
                     pool.request("POST", "/")
@@ -469,7 +466,6 @@ class TestSocketClosing(SocketDummyServerTestCase):
             self._start_server(socket_handler)
             t = Timeout(connect=0.001, read=0.01)
             with HTTPConnectionPool(self.host, self.port, timeout=t) as pool:
-
                 response = pool.request("GET", "/", retries=1)
                 assert response.status == 200
                 assert response.data == b"Response 2"
@@ -500,7 +496,6 @@ class TestSocketClosing(SocketDummyServerTestCase):
 
         self._start_server(socket_handler)
         with HTTPConnectionPool(self.host, self.port) as pool:
-
             response = pool.urlopen(
                 "GET",
                 "/",
@@ -537,7 +532,6 @@ class TestSocketClosing(SocketDummyServerTestCase):
 
         self._start_server(socket_handler)
         with HTTPConnectionPool(self.host, self.port) as pool:
-
             try:
                 with pytest.raises(ReadTimeoutError):
                     pool.urlopen(
@@ -572,7 +566,6 @@ class TestSocketClosing(SocketDummyServerTestCase):
 
         self._start_server(socket_handler)
         with HTTPConnectionPool(self.host, self.port) as pool:
-
             response = pool.request("GET", "/", retries=0, preload_content=False)
             with pytest.raises(ProtocolError):
                 response.read()
@@ -810,7 +803,6 @@ class TestSocketClosing(SocketDummyServerTestCase):
 
         self._start_server(socket_handler)
         with HTTPConnectionPool(self.host, self.port) as pool:
-
             response = pool.request("GET", "/", retries=0, preload_content=False)
             assert response.status == 200
             response.close()
@@ -913,7 +905,6 @@ class TestProxyManager(SocketDummyServerTestCase):
         self._start_server(echo_socket_handler)
         base_url = "http://%s:%d" % (self.host, self.port)
         with proxy_from_url(base_url) as proxy:
-
             r = proxy.request("GET", "http://google.com/")
 
             assert r.status == 200
@@ -956,7 +947,6 @@ class TestProxyManager(SocketDummyServerTestCase):
         # Define some proxy headers.
         proxy_headers = HTTPHeaderDict({"For The Proxy": "YEAH!"})
         with proxy_from_url(base_url, proxy_headers=proxy_headers) as proxy:
-
             conn = proxy.connection_from_url("http://www.google.com/")
 
             r = conn.urlopen("GET", "http://www.google.com/", assert_same_host=False)
@@ -1069,7 +1059,6 @@ class TestProxyManager(SocketDummyServerTestCase):
         base_url = "http://%s:%d" % (self.host, self.port)
 
         with proxy_from_url(base_url, ca_certs=DEFAULT_CA) as proxy:
-
             url = "https://{0}".format(self.host)
             conn = proxy.connection_from_url(url)
             r = conn.urlopen("GET", url, retries=0)
@@ -1116,7 +1105,6 @@ class TestProxyManager(SocketDummyServerTestCase):
         base_url = "http://%s:%d" % (self.host, self.port)
 
         with proxy_from_url(base_url, cert_reqs="NONE") as proxy:
-
             url = "https://[{0}]".format(ipv6_addr)
             conn = proxy.connection_from_url(url)
             try:
@@ -1158,7 +1146,6 @@ class TestSSL(SocketDummyServerTestCase):
 
         self._start_server(socket_handler)
         with HTTPSConnectionPool(self.host, self.port) as pool:
-
             with pytest.raises(MaxRetryError) as cm:
                 pool.request("GET", "/", retries=0)
             assert isinstance(cm.value.reason, SSLError)
@@ -1196,7 +1183,6 @@ class TestSSL(SocketDummyServerTestCase):
 
         self._start_server(socket_handler)
         with HTTPSConnectionPool(self.host, self.port, ca_certs=DEFAULT_CA) as pool:
-
             response = pool.urlopen(
                 "GET",
                 "/",
@@ -1342,13 +1328,10 @@ class TestSSL(SocketDummyServerTestCase):
         context.options = 0
 
         with mock.patch("urllib3.util.ssl_.SSLContext", lambda *_, **__: context):
-
             self._start_server(socket_handler)
             with HTTPSConnectionPool(self.host, self.port) as pool:
-
                 with pytest.raises(MaxRetryError):
                     pool.request("GET", "/", timeout=0.01)
-
                 context.load_default_certs.assert_called_with()
 
     def test_ssl_dont_load_default_certs_when_given(self):
@@ -1395,10 +1378,8 @@ class TestSSL(SocketDummyServerTestCase):
                 self._start_server(socket_handler)
 
                 with HTTPSConnectionPool(self.host, self.port, **kwargs) as pool:
-
                     with pytest.raises(MaxRetryError):
                         pool.request("GET", "/", timeout=0.01)
-
                     context.load_default_certs.assert_not_called()
 
 
@@ -1598,7 +1579,6 @@ class TestBrokenHeaders(SocketDummyServerTestCase):
         )
 
         with HTTPConnectionPool(self.host, self.port, retries=False) as pool:
-
             with LogRecorder() as logs:
                 pool.request("GET", "/")
 
@@ -1633,7 +1613,6 @@ class TestHeaderParsingContentType(SocketDummyServerTestCase):
         )
 
         with HTTPConnectionPool(self.host, self.port, retries=False) as pool:
-
             with LogRecorder() as logs:
                 pool.request("GET", "/")
 
@@ -1729,7 +1708,6 @@ class TestBadContentLength(SocketDummyServerTestCase):
 
         self._start_server(socket_handler)
         with HTTPConnectionPool(self.host, self.port, maxsize=1) as conn:
-
             # Test stream read when content length less than headers claim
             get_response = conn.request(
                 "GET", url="/", preload_content=False, enforce_content_length=True
@@ -1767,7 +1745,6 @@ class TestBadContentLength(SocketDummyServerTestCase):
 
         self._start_server(socket_handler)
         with HTTPConnectionPool(self.host, self.port, maxsize=1) as conn:
-
             # Test stream on 0 length body
             head_response = conn.request(
                 "HEAD", url="/", preload_content=False, enforce_content_length=True
@@ -1801,6 +1778,5 @@ class TestRetryPoolSizeDrainFail(SocketDummyServerTestCase):
         with HTTPConnectionPool(
             self.host, self.port, maxsize=10, retries=retries, block=True
         ) as pool:
-
             pool.urlopen("GET", "/not_found", preload_content=False)
             assert pool.num_connections == 1


### PR DESCRIPTION
We recently switched to using context managers in tests, but the extra
indentation means that the newlines that were there before are no longer
needed.

(And this is how I did it in the bleach-spike branch, so it should help with merges.)

As always, you don't have to agree that this is a valid change!