### PR TITLE
Remove TLS 1.3 support in SecureTransport

### DIFF
--- a/_travis/install.sh
+++ b/_travis/install.sh
@@ -29,9 +29,6 @@ if [[ "$(uname -s)" == 'Darwin' ]]; then
 
     install_mac_python $MACPYTHON
 
-    # Enable TLS 1.3 on macOS
-    sudo defaults write /Library/Preferences/com.apple.networkd tcp_connect_enable_tls13 1
-
     # Install Nox
     python3 -m pip install nox
 

--- a/src/urllib3/contrib/_securetransport/bindings.py
+++ b/src/urllib3/contrib/_securetransport/bindings.py
@@ -415,6 +415,7 @@ class SecurityConst(object):
     kTLSProtocol1 = 4
     kTLSProtocol11 = 7
     kTLSProtocol12 = 8
+    # SecureTransport does not support TLS 1.3 even if there's a constant for it
     kTLSProtocol13 = 10
     kTLSProtocolMaxSupported = 999
 

--- a/test/contrib/test_securetransport.py
+++ b/test/contrib/test_securetransport.py
@@ -29,9 +29,8 @@ def teardown_module():
         pass
 
 
-# Currently TLSv1.3 doesn't work with SecureTransport despite
-# Apple previously documenting support. See:
-# https://github.com/python-trio/trio/issues/1165#issuecomment-526563135
+# SecureTransport does not support TLSv1.3
+# https://github.com/urllib3/urllib3/issues/1674
 from ..with_dummyserver.test_https import (  # noqa: F401
     TestHTTPS,
     TestHTTPS_TLSv1,


### PR DESCRIPTION
It's not actually supported by the OS. In other words, instead of trying
TLS 1.3 and being forced to fallback on TLS 1.2, we just use TLS 1.2 by
default.

Closes #1674.