### PR TITLE
Speed up queue test by using a zero timeout

### DIFF
--- a/test/test_queue_monkeypatch.py
+++ b/test/test_queue_monkeypatch.py
@@ -26,6 +26,6 @@ class TestMonkeypatchResistance(object):
     def test_queue_monkeypatching(self):
         with mock.patch.object(queue, "Empty", BadError):
             with HTTPConnectionPool(host="localhost", block=True) as http:
-                http._get_conn(timeout=1)
+                http._get_conn()
                 with pytest.raises(EmptyPoolError):
-                    http._get_conn(timeout=1)
+                    http._get_conn(timeout=0)


### PR DESCRIPTION
Queue.get() accepts any non-negative number, so 0 works. It's also not
arbitrary like 1 was, and the test suite now takes one less second to
run!

I've workon on this as part of #1706