### PR TITLE
Prefer pytest.raises to self.fail

### DIFF
--- a/test/contrib/test_socks.py
+++ b/test/contrib/test_socks.py
@@ -440,12 +440,9 @@ class TestSocks5Proxy(IPV4SocketDummyServerTestCase):
         with socks.SOCKSProxyManager(
             proxy_url, username="user", password="badpass"
         ) as pm:
-            try:
+            with pytest.raises(NewConnectionError) as e:
                 pm.request("GET", "http://example.com", retries=False)
-            except NewConnectionError as e:
-                assert "SOCKS5 authentication failed" in str(e)
-            else:
-                self.fail("Did not raise")
+            assert "SOCKS5 authentication failed" in str(e.value)
 
     def test_source_address_works(self):
         expected_port = _get_free_port(self.host)
@@ -655,12 +652,9 @@ class TestSOCKS4Proxy(IPV4SocketDummyServerTestCase):
         self._start_server(request_handler)
         proxy_url = "socks4a://%s:%s" % (self.host, self.port)
         with socks.SOCKSProxyManager(proxy_url, username="baduser") as pm:
-            try:
+            with pytest.raises(NewConnectionError) as e:
                 pm.request("GET", "http://example.com", retries=False)
-            except NewConnectionError as e:
-                assert "different user-ids" in str(e)
-            else:
-                self.fail("Did not raise")
+                assert "different user-ids" in str(e.value)
 
 
 class TestSOCKSWithTLS(IPV4SocketDummyServerTestCase):

--- a/test/with_dummyserver/test_https.py
+++ b/test/with_dummyserver/test_https.py
@@ -289,54 +289,45 @@ class TestHTTPS(HTTPSDummyServerTestCase):
         with HTTPSConnectionPool(
             "127.0.0.1", self.port, cert_reqs="CERT_REQUIRED", ca_certs=DEFAULT_CA
         ) as https_pool:
-            try:
+            with pytest.raises(MaxRetryError) as e:
                 https_pool.request("GET", "/")
-                self.fail("Didn't raise SSL invalid common name")
-            except MaxRetryError as e:
-                assert isinstance(e.reason, SSLError)
-                assert "doesn't match" in str(
-                    e.reason
-                ) or "certificate verify failed" in str(e.reason)
+            assert isinstance(e.value.reason, SSLError)
+            assert "doesn't match" in str(
+                e.value.reason
+            ) or "certificate verify failed" in str(e.value.reason)
 
     def test_verified_with_bad_ca_certs(self):
         with HTTPSConnectionPool(
             self.host, self.port, cert_reqs="CERT_REQUIRED", ca_certs=DEFAULT_CA_BAD
         ) as https_pool:
-            try:
+            with pytest.raises(MaxRetryError) as e:
                 https_pool.request("GET", "/")
-                self.fail("Didn't raise SSL error with bad CA certs")
-            except MaxRetryError as e:
-                assert isinstance(e.reason, SSLError)
-                assert "certificate verify failed" in str(e.reason), (
-                    "Expected 'certificate verify failed', instead got: %r" % e.reason
-                )
+            assert isinstance(e.value.reason, SSLError)
+            assert "certificate verify failed" in str(e.value.reason), (
+                "Expected 'certificate verify failed', instead got: %r" % e.value.reason
+            )
 
     def test_verified_without_ca_certs(self):
         # default is cert_reqs=None which is ssl.CERT_NONE
         with HTTPSConnectionPool(
             self.host, self.port, cert_reqs="CERT_REQUIRED"
         ) as https_pool:
-            try:
+            with pytest.raises(MaxRetryError) as e:
                 https_pool.request("GET", "/")
-                self.fail(
-                    "Didn't raise SSL error with no CA certs when"
-                    "CERT_REQUIRED is set"
-                )
-            except MaxRetryError as e:
-                assert isinstance(e.reason, SSLError)
-                # there is a different error message depending on whether or
-                # not pyopenssl is injected
-                assert (
-                    "No root certificates specified" in str(e.reason)
-                    # PyPy sometimes uses all-caps here
-                    or "certificate verify failed" in str(e.reason).lower()
-                    or "invalid certificate chain" in str(e.reason)
-                ), (
-                    "Expected 'No root certificates specified',  "
-                    "'certificate verify failed', or "
-                    "'invalid certificate chain', "
-                    "instead got: %r" % e.reason
-                )
+            assert isinstance(e.value.reason, SSLError)
+            # there is a different error message depending on whether or
+            # not pyopenssl is injected
+            assert (
+                "No root certificates specified" in str(e.value.reason)
+                # PyPy sometimes uses all-caps here
+                or "certificate verify failed" in str(e.value.reason).lower()
+                or "invalid certificate chain" in str(e.value.reason)
+            ), (
+                "Expected 'No root certificates specified',  "
+                "'certificate verify failed', or "
+                "'invalid certificate chain', "
+                "instead got: %r" % e.value.reason
+            )
 
     def test_no_ssl(self):
         with HTTPSConnectionPool(self.host, self.port) as pool:

--- a/test/with_dummyserver/test_poolmanager.py
+++ b/test/with_dummyserver/test_poolmanager.py
@@ -80,7 +80,7 @@ class TestPoolManager(HTTPDummyServerTestCase):
     def test_cross_host_redirect(self):
         with PoolManager() as http:
             cross_host_location = "%s/echo?a=b" % self.base_url_alt
-            try:
+            with pytest.raises(MaxRetryError):
                 http.request(
                     "GET",
                     "%s/redirect" % self.base_url,
@@ -88,12 +88,6 @@ class TestPoolManager(HTTPDummyServerTestCase):
                     timeout=1,
                     retries=0,
                 )
-                self.fail(
-                    "Request succeeded instead of raising an exception like it should."
-                )
-
-            except MaxRetryError:
-                pass
 
             r = http.request(
                 "GET",
@@ -107,8 +101,8 @@ class TestPoolManager(HTTPDummyServerTestCase):
 
     def test_too_many_redirects(self):
         with PoolManager() as http:
-            try:
-                r = http.request(
+            with pytest.raises(MaxRetryError):
+                http.request(
                     "GET",
                     "%s/redirect" % self.base_url,
                     fields={
@@ -117,14 +111,9 @@ class TestPoolManager(HTTPDummyServerTestCase):
                     },
                     retries=1,
                 )
-                self.fail(
-                    "Failed to raise MaxRetryError exception, returned %r" % r.status
-                )
-            except MaxRetryError:
-                pass
 
-            try:
-                r = http.request(
+            with pytest.raises(MaxRetryError):
+                http.request(
                     "GET",
                     "%s/redirect" % self.base_url,
                     fields={
@@ -133,11 +122,6 @@ class TestPoolManager(HTTPDummyServerTestCase):
                     },
                     retries=Retry(total=None, redirect=1),
                 )
-                self.fail(
-                    "Failed to raise MaxRetryError exception, returned %r" % r.status
-                )
-            except MaxRetryError:
-                pass
 
     def test_redirect_cross_host_remove_headers(self):
         with PoolManager() as http:
@@ -232,7 +216,7 @@ class TestPoolManager(HTTPDummyServerTestCase):
 
     def test_raise_on_status(self):
         with PoolManager() as http:
-            try:
+            with pytest.raises(MaxRetryError):
                 # the default is to raise
                 r = http.request(
                     "GET",
@@ -240,13 +224,8 @@ class TestPoolManager(HTTPDummyServerTestCase):
                     fields={"status": "500 Internal Server Error"},
                     retries=Retry(total=1, status_forcelist=range(500, 600)),
                 )
-                self.fail(
-                    "Failed to raise MaxRetryError exception, returned %r" % r.status
-                )
-            except MaxRetryError:
-                pass
 
-            try:
+            with pytest.raises(MaxRetryError):
                 # raise explicitly
                 r = http.request(
                     "GET",
@@ -256,11 +235,6 @@ class TestPoolManager(HTTPDummyServerTestCase):
                         total=1, status_forcelist=range(500, 600), raise_on_status=True
                     ),
                 )
-                self.fail(
-                    "Failed to raise MaxRetryError exception, returned %r" % r.status
-                )
-            except MaxRetryError:
-                pass
 
             # don't raise
             r = http.request(

--- a/test/with_dummyserver/test_proxy_poolmanager.py
+++ b/test/with_dummyserver/test_proxy_poolmanager.py
@@ -58,11 +58,9 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
             with pytest.raises(MaxRetryError):
                 http.request("GET", "%s/" % self.http_url)
 
-            try:
+            with pytest.raises(MaxRetryError) as e:
                 http.request("GET", "%s/" % self.http_url)
-                self.fail("Failed to raise retry error.")
-            except MaxRetryError as e:
-                assert type(e.reason) == ProxyError
+            assert type(e.value.reason) == ProxyError
 
     def test_oldapi(self):
         with ProxyManager(
@@ -79,14 +77,12 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
             self.proxy_url, cert_reqs="REQUIRED", ca_certs=DEFAULT_CA_BAD
         ) as http:
             https_pool = http._new_pool("https", self.https_host, self.https_port)
-            try:
+            with pytest.raises(MaxRetryError) as e:
                 https_pool.request("GET", "/", retries=0)
-                self.fail("Didn't raise SSL error with wrong CA")
-            except MaxRetryError as e:
-                assert isinstance(e.reason, SSLError)
-                assert "certificate verify failed" in str(e.reason), (
-                    "Expected 'certificate verify failed', instead got: %r" % e.reason
-                )
+            assert isinstance(e.value.reason, SSLError)
+            assert "certificate verify failed" in str(e.value.reason), (
+                "Expected 'certificate verify failed', instead got: %r" % e.value.reason
+            )
 
             http = proxy_from_url(
                 self.proxy_url, cert_reqs="REQUIRED", ca_certs=DEFAULT_CA
@@ -102,12 +98,10 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
             )
             https_fail_pool = http._new_pool("https", "127.0.0.1", self.https_port)
 
-            try:
+            with pytest.raises(MaxRetryError) as e:
                 https_fail_pool.request("GET", "/", retries=0)
-                self.fail("Didn't raise SSL invalid common name")
-            except MaxRetryError as e:
-                assert isinstance(e.reason, SSLError)
-                assert "doesn't match" in str(e.reason)
+            assert isinstance(e.value.reason, SSLError)
+            assert "doesn't match" in str(e.value.reason)
 
     def test_redirect(self):
         with proxy_from_url(self.proxy_url) as http:
@@ -132,7 +126,7 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
     def test_cross_host_redirect(self):
         with proxy_from_url(self.proxy_url) as http:
             cross_host_location = "%s/echo?a=b" % self.http_url_alt
-            try:
+            with pytest.raises(MaxRetryError):
                 http.request(
                     "GET",
                     "%s/redirect" % self.http_url,
@@ -140,10 +134,6 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
                     timeout=1,
                     retries=0,
                 )
-                self.fail("We don't want to follow redirects here.")
-
-            except MaxRetryError:
-                pass
 
             r = http.request(
                 "GET",
@@ -157,7 +147,7 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
     def test_cross_protocol_redirect(self):
         with proxy_from_url(self.proxy_url, ca_certs=DEFAULT_CA) as http:
             cross_protocol_location = "%s/echo?a=b" % self.https_url
-            try:
+            with pytest.raises(MaxRetryError):
                 http.request(
                     "GET",
                     "%s/redirect" % self.http_url,
@@ -165,10 +155,6 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
                     timeout=1,
                     retries=0,
                 )
-                self.fail("We don't want to follow redirects here.")
-
-            except MaxRetryError:
-                pass
 
             r = http.request(
                 "GET",
@@ -331,11 +317,9 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
     @requires_network
     def test_https_proxy_timeout(self):
         with proxy_from_url("https://{host}".format(host=TARPIT_HOST)) as https:
-            try:
+            with pytest.raises(MaxRetryError) as e:
                 https.request("GET", self.http_url, timeout=0.001)
-                self.fail("Failed to raise retry error.")
-            except MaxRetryError as e:
-                assert type(e.reason) == ConnectTimeoutError
+            assert type(e.value.reason) == ConnectTimeoutError
 
     @pytest.mark.timeout(0.5)
     @requires_network
@@ -343,11 +327,9 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
         with proxy_from_url(
             "https://{host}".format(host=TARPIT_HOST), timeout=0.001
         ) as https:
-            try:
+            with pytest.raises(MaxRetryError) as e:
                 https.request("GET", self.http_url)
-                self.fail("Failed to raise retry error.")
-            except MaxRetryError as e:
-                assert type(e.reason) == ConnectTimeoutError
+            assert type(e.value.reason) == ConnectTimeoutError
 
     def test_scheme_host_case_insensitive(self):
         """Assert that upper-case schemes and hosts are normalized."""

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -226,16 +226,10 @@ class TestClientCerts(SocketDummyServerTestCase):
         with HTTPSConnectionPool(
             self.host, self.port, cert_reqs="REQUIRED", ca_certs=DEFAULT_CA
         ) as pool:
-            try:
+            with pytest.raises(MaxRetryError):
                 pool.request("GET", "/", retries=0)
-            except MaxRetryError:
                 done_receiving.set()
-            else:
-                done_receiving.set()
-                self.fail(
-                    "Expected server to reject connection due to missing client "
-                    "certificates"
-                )
+            done_receiving.set()
 
     @requires_ssl_context_keyfile_password
     def test_client_cert_with_string_password(self):
@@ -809,8 +803,7 @@ class TestSocketClosing(SocketDummyServerTestCase):
 
             done_closing.set()  # wait until the socket in our pool gets closed
             successful = complete.wait(timeout=1)
-            if not successful:
-                self.fail("Timed out waiting for connection close")
+            assert successful, "Timed out waiting for connection close"
 
     def test_release_conn_param_is_respected_after_timeout_retry(self):
         """For successful ```urlopen(release_conn=False)```,


### PR DESCRIPTION
It reuses a standard mechanism, is less verbose and avoids including
code that is never executed.