### PR TITLE
Restore comment next to its intended line

### DIFF
--- a/test/__init__.py
+++ b/test/__init__.py
@@ -127,8 +127,8 @@ def requires_network(test):
     def _is_unreachable_err(err):
         return getattr(err, "errno", None) in (
             errno.ENETUNREACH,
-            errno.EHOSTUNREACH,
-        )  # For OSX
+            errno.EHOSTUNREACH,  # For OSX
+        )
 
     def _has_route():
         try:


### PR DESCRIPTION
I don't know what those errors mean, but I can tell that initially `For OSX` was next to `errnor.EHOSTUNREACH`: see #335. @shazow was right five years ago, because we're now using four lines anyway, and doing it from the start would have preserved the correct position. :)