### PR TITLE
Fix flaky test_timeout

### DIFF
--- a/test/with_dummyserver/test_connectionpool.py
+++ b/test/with_dummyserver/test_connectionpool.py
@@ -97,16 +97,16 @@ class TestConnectionPoolTimeouts(SocketDummyServerTestCase):
 
         # Request-specific timeouts should raise errors
         with HTTPConnectionPool(
-            self.host, self.port, timeout=LONG_TIMEOUT, retries=False
+            self.host, self.port, timeout=short_timeout, retries=False
         ) as pool:
             wait_for_socket(ready_event)
             now = time.time()
             with pytest.raises(ReadTimeoutError):
-                pool.request("GET", "/", timeout=short_timeout)
+                pool.request("GET", "/", timeout=LONG_TIMEOUT)
             delta = time.time() - now
 
-            message = "timeout was pool-level LONG_TIMEOUT rather than request-level SHORT_TIMEOUT"
-            assert delta < LONG_TIMEOUT, message
+            message = "timeout was pool-level SHORT_TIMEOUT rather than request-level LONG_TIMEOUT"
+            assert delta >= LONG_TIMEOUT, message
             block_event.set()  # Release request
 
             # Timeout passed directly to request should raise a request timeout

--- a/test/with_dummyserver/test_connectionpool.py
+++ b/test/with_dummyserver/test_connectionpool.py
@@ -82,20 +82,13 @@ class TestConnectionPoolTimeouts(SocketDummyServerTestCase):
     def test_timeout(self):
         # Requests should time out when expected
         block_event = Event()
-        ready_event = self.start_basic_handler(block_send=block_event, num=6)
+        ready_event = self.start_basic_handler(block_send=block_event, num=3)
 
         # Pool-global timeout
         timeout = Timeout(read=SHORT_TIMEOUT)
         with HTTPConnectionPool(
             self.host, self.port, timeout=timeout, retries=False
         ) as pool:
-            wait_for_socket(ready_event)
-            conn = pool._get_conn()
-            with pytest.raises(ReadTimeoutError):
-                pool._make_request(conn, "GET", "/")
-            pool._put_conn(conn)
-            block_event.set()  # Release request
-
             wait_for_socket(ready_event)
             block_event.clear()
             with pytest.raises(ReadTimeoutError):
@@ -106,18 +99,6 @@ class TestConnectionPoolTimeouts(SocketDummyServerTestCase):
         with HTTPConnectionPool(
             self.host, self.port, timeout=LONG_TIMEOUT, retries=False
         ) as pool:
-            conn = pool._get_conn()
-            wait_for_socket(ready_event)
-            now = time.time()
-            with pytest.raises(ReadTimeoutError):
-                pool._make_request(conn, "GET", "/", timeout=timeout)
-            delta = time.time() - now
-            block_event.set()  # Release request
-
-            message = "timeout was pool-level LONG_TIMEOUT rather than request-level SHORT_TIMEOUT"
-            assert delta < LONG_TIMEOUT, message
-            pool._put_conn(conn)
-
             wait_for_socket(ready_event)
             now = time.time()
             with pytest.raises(ReadTimeoutError):
@@ -128,18 +109,10 @@ class TestConnectionPoolTimeouts(SocketDummyServerTestCase):
             assert delta < LONG_TIMEOUT, message
             block_event.set()  # Release request
 
-            # Timeout int/float passed directly to request and _make_request should
-            # raise a request timeout
+            # Timeout passed directly to request should raise a request timeout
             wait_for_socket(ready_event)
             with pytest.raises(ReadTimeoutError):
                 pool.request("GET", "/", timeout=SHORT_TIMEOUT)
-            block_event.set()  # Release request
-
-            wait_for_socket(ready_event)
-            conn = pool._new_conn()
-            # FIXME: This assert flakes sometimes. Not sure why.
-            with pytest.raises(ReadTimeoutError):
-                pool._make_request(conn, "GET", "/", timeout=SHORT_TIMEOUT)
             block_event.set()  # Release request
 
     def test_connect_timeout(self):

--- a/test/with_dummyserver/test_connectionpool.py
+++ b/test/with_dummyserver/test_connectionpool.py
@@ -85,9 +85,9 @@ class TestConnectionPoolTimeouts(SocketDummyServerTestCase):
         ready_event = self.start_basic_handler(block_send=block_event, num=3)
 
         # Pool-global timeout
-        timeout = Timeout(read=SHORT_TIMEOUT)
+        short_timeout = Timeout(read=SHORT_TIMEOUT)
         with HTTPConnectionPool(
-            self.host, self.port, timeout=timeout, retries=False
+            self.host, self.port, timeout=short_timeout, retries=False
         ) as pool:
             wait_for_socket(ready_event)
             block_event.clear()
@@ -102,7 +102,7 @@ class TestConnectionPoolTimeouts(SocketDummyServerTestCase):
             wait_for_socket(ready_event)
             now = time.time()
             with pytest.raises(ReadTimeoutError):
-                pool.request("GET", "/", timeout=timeout)
+                pool.request("GET", "/", timeout=short_timeout)
             delta = time.time() - now
 
             message = "timeout was pool-level LONG_TIMEOUT rather than request-level SHORT_TIMEOUT"


### PR DESCRIPTION
We had an [interesting test failure in CI](https://ci.appveyor.com/project/pquentin/urllib3/builds/28525448/job/e9nc1ww4d0qyglxe) where this test failed twice in a row: we were expecting a timeout in 0.001 seconds, but both times it took more than one second!

How can this happen? Well, when we ask a request to timeout after N seconds, here's what we know:

 * the request will time out, eventually
 * it won't timeout before those N seconds
 * it could timeout a long time after those N seconds, especially on a busy CI service

Let's take advantage of those facts by specifying a request-specific timeout that's longer than the pool-level timeout and making sure that the timeout was long indeed.

We still test that the request-specific timeout overrides the pool-level timeout, but will stop failing on busy CI services.

(I'd like to think that this is easier to read and merge commit by commit.)