### PR TITLE
Fix lint

### DIFF
--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -45,7 +45,6 @@ import mock
 import pytest
 
 from test import (
-    notPyPy2,
     fails_on_travis_gce,
     requires_ssl_context_keyfile_password,
     SHORT_TIMEOUT,


### PR DESCRIPTION
#1724 and #1725 added "notPyPy2" at different places. They both succeeded individually, but their merge caused a flake8 lint error. This was noticed by @jalopezsilva in #1679.