### PR TITLE
Preserve chunked parameter

### DIFF
--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -755,6 +755,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
                 timeout=timeout,
                 pool_timeout=pool_timeout,
                 release_conn=release_conn,
+                chunked=chunked,
                 body_pos=body_pos,
                 **response_kw
             )

--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -806,6 +806,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
                 timeout=timeout,
                 pool_timeout=pool_timeout,
                 release_conn=release_conn,
+                chunked=chunked,
                 body_pos=body_pos,
                 **response_kw
             )

--- a/test/with_dummyserver/test_chunked_transfer.py
+++ b/test/with_dummyserver/test_chunked_transfer.py
@@ -122,3 +122,30 @@ class TestChunkedTransfer(SocketDummyServerTestCase):
                 "GET", "/", chunked=True, preload_content=False, retries=retries
             )
         assert self.chunked_requests == 2
+
+    def test_preserve_chunked_on_redirect(self):
+        self.chunked_requests = 0
+
+        def socket_handler(listener):
+            for i in range(2):
+                sock = listener.accept()[0]
+                request = consume_socket(sock)
+                if b"Transfer-Encoding: chunked" in request.split(b"\r\n"):
+                    self.chunked_requests += 1
+
+                if i == 0:
+                    sock.send(
+                        b"HTTP/1.1 301 Moved Permanently\r\n"
+                        b"Location: /redirect\r\n\r\n"
+                    )
+                else:
+                    sock.send(b"HTTP/1.1 200 OK\r\n\r\n")
+                sock.close()
+
+        self._start_server(socket_handler)
+        with HTTPConnectionPool(self.host, self.port) as pool:
+            retries = Retry(redirect=1)
+            pool.urlopen(
+                "GET", "/", chunked=True, preload_content=False, retries=retries
+            )
+        assert self.chunked_requests == 2

--- a/test/with_dummyserver/test_chunked_transfer.py
+++ b/test/with_dummyserver/test_chunked_transfer.py
@@ -149,3 +149,28 @@ class TestChunkedTransfer(SocketDummyServerTestCase):
                 "GET", "/", chunked=True, preload_content=False, retries=retries
             )
         assert self.chunked_requests == 2
+
+    def test_preserve_chunked_on_broken_connection(self):
+        self.chunked_requests = 0
+
+        def socket_handler(listener):
+            for i in range(2):
+                sock = listener.accept()[0]
+                request = consume_socket(sock)
+                if b"Transfer-Encoding: chunked" in request.split(b"\r\n"):
+                    self.chunked_requests += 1
+
+                if i == 0:
+                    # Bad HTTP version will trigger a connection close
+                    sock.send(b"HTTP/0.5 200 OK\r\n\r\n")
+                else:
+                    sock.send(b"HTTP/1.1 200 OK\r\n\r\n")
+                sock.close()
+
+        self._start_server(socket_handler)
+        with HTTPConnectionPool(self.host, self.port) as pool:
+            retries = Retry(read=1)
+            pool.urlopen(
+                "GET", "/", chunked=True, preload_content=False, retries=retries
+            )
+        assert self.chunked_requests == 2


### PR DESCRIPTION
As promised in #1715 

cc @lmvlmv @sethmlarson 

The lint fails because of #1733.