### PR TITLE
Fix test failures with latest openssl

### DIFF
--- a/test/with_dummyserver/test_https.py
+++ b/test/with_dummyserver/test_https.py
@@ -155,6 +155,7 @@ class TestHTTPS(HTTPSDummyServerTestCase):
                     # Python 3.7.4+
                     or "WSAECONNRESET" in str(e)  # Windows
                     or "EPIPE" in str(e)  # macOS
+                    or "ECONNRESET" in str(e)  # OpenSSL
                 ):
                     raise
 


### PR DESCRIPTION
The test appears to fail with new openssl (1.1.1d here):

```
self = <urllib3.contrib.pyopenssl.WrappedSocket object at 0x7fe48b2c8640>
data = b'GET /certificate HTTP/1.1\r\nHost: localhost:42919\r\nAccept-Encoding: identity\r\n\r\n'

    def _send_until_done(self, data):
        while True:
            try:
                return self.connection.send(data)
            except OpenSSL.SSL.WantWriteError:
                if not util.wait_for_write(self.socket, self.socket.gettimeout()):
                    raise timeout()
                continue
            except OpenSSL.SSL.SysCallError as e:
>               raise SocketError(str(e))
E               OSError: (104, 'ECONNRESET')

src/urllib3/contrib/pyopenssl.py:346: OSError

During handling of the above exception, another exception occurred:

self = <test.with_dummyserver.test_https.TestHTTPS object at 0x7fe48ad665e0>
certs_dir = PosixPath('/tmp/pytest-of-felix/pytest-14/certs0')

    def test_client_no_intermediate(self, certs_dir):
        """Check that missing links in certificate chains indeed break

        The only difference with test_client_intermediate is that we don't send the
        intermediate CA to the server, only the client cert.
        """
        with HTTPSConnectionPool(
            self.host,
            self.port,
            cert_file=str(certs_dir / CLIENT_NO_INTERMEDIATE_PEM),
            key_file=str(certs_dir / CLIENT_INTERMEDIATE_KEY),
            ca_certs=DEFAULT_CA,
        ) as https_pool:
            try:
>               https_pool.request("GET", "/certificate", retries=False)

test/with_dummyserver/test_https.py:139:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
src/urllib3/request.py:75: in request
    return self.request_encode_url(
src/urllib3/request.py:97: in request_encode_url
    return self.urlopen(method, url, **extra_kw)
src/urllib3/connectionpool.py:719: in urlopen
    retries = retries.increment(
src/urllib3/util/retry.py:376: in increment
    raise six.reraise(type(error), error, _stacktrace)
src/urllib3/packages/six.py:734: in reraise
    raise value.with_traceback(tb)
src/urllib3/connectionpool.py:665: in urlopen
    httplib_response = self._make_request(
src/urllib3/connectionpool.py:387: in _make_request
    conn.request(method, url, **httplib_request_kw)
/usr/lib/python3.8/http/client.py:1230: in request
    self._send_request(method, url, body, headers, encode_chunked)
/usr/lib/python3.8/http/client.py:1276: in _send_request
    self.endheaders(body, encode_chunked=encode_chunked)
/usr/lib/python3.8/http/client.py:1225: in endheaders
    self._send_output(message_body, encode_chunked=encode_chunked)
/usr/lib/python3.8/http/client.py:1004: in _send_output
    self.send(msg)
/usr/lib/python3.8/http/client.py:965: in send
    self.sock.sendall(data)
src/urllib3/contrib/pyopenssl.py:351: in sendall
    sent = self._send_until_done(
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <urllib3.contrib.pyopenssl.WrappedSocket object at 0x7fe48b2c8640>
data = b'GET /certificate HTTP/1.1\r\nHost: localhost:42919\r\nAccept-Encoding: identity\r\n\r\n'

    def _send_until_done(self, data):
        while True:
            try:
                return self.connection.send(data)
            except OpenSSL.SSL.WantWriteError:
                if not util.wait_for_write(self.socket, self.socket.gettimeout()):
                    raise timeout()
                continue
            except OpenSSL.SSL.SysCallError as e:
>               raise SocketError(str(e))
E               urllib3.exceptions.ProtocolError: ('Connection aborted.', OSError("(104, 'ECONNRESET')"))

src/urllib3/contrib/pyopenssl.py:346: ProtocolError
---------------------------------------------------------- Captured log call -----------------------------------------------------------
WARNING  tornado.general:iostream.py:1406 SSL Error on 19 ('127.0.0.1', 50546): [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1108)
```