### PR TITLE
Fix test_delayed_body_read_timeout flaky test

### DIFF
--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -506,7 +506,7 @@ class TestSocketClosing(SocketDummyServerTestCase):
                 "/",
                 retries=0,
                 preload_content=False,
-                timeout=Timeout(connect=1, read=SHORT_TIMEOUT),
+                timeout=Timeout(connect=1, read=LONG_TIMEOUT),
             )
             try:
                 with pytest.raises(ReadTimeoutError):


### PR DESCRIPTION
This test makes sure that reading the body of a response respects time
out, which is why we were using a SHORT_TIMEOUT.

However, the initial urlopen() still performs a read (to read the status
and headers), and we want a long timeout here.

For this reason, we're switching to LONG_TIMEOUT for the read. And it's
okay to use LONG_TIMEOUT for the body read since the server is ready to
wait for that read forever.