### PR TITLE
is_appengine=False in testbed (like it used to)

### DIFF
--- a/src/urllib3/contrib/_appengine_environ.py
+++ b/src/urllib3/contrib/_appengine_environ.py
@@ -6,7 +6,7 @@ import os
 
 
 def is_appengine():
-    return "APPENGINE_RUNTIME" in os.environ
+    return is_local_appengine() or is_prod_appengine()
 
 
 def is_appengine_sandbox():
@@ -20,15 +20,15 @@ def is_appengine_sandbox():
 
 
 def is_local_appengine():
-    return is_appengine() and os.environ.get("SERVER_SOFTWARE", "").startswith(
-        "Development/"
-    )
+    return "APPENGINE_RUNTIME" in os.environ and os.environ.get(
+        "SERVER_SOFTWARE", ""
+    ).startswith("Development/")
 
 
 def is_prod_appengine():
-    return is_appengine() and os.environ.get("SERVER_SOFTWARE", "").startswith(
-        "Google App Engine/"
-    )
+    return "APPENGINE_RUNTIME" in os.environ and os.environ.get(
+        "SERVER_SOFTWARE", ""
+    ).startswith("Google App Engine/")
 
 
 def is_prod_appengine_mvms():


### PR DESCRIPTION
Whether testbed tests "are appengine" is debatable, but historically
this function has returned False in testbed tests. This behavior was
inadvertently (and unnecessarily) changed in PR #1704.  This commit
undoes that regression for testbed tests.