### PR TITLE
Remove unneeded test timeout

### DIFF
--- a/test/contrib/test_securetransport.py
+++ b/test/contrib/test_securetransport.py
@@ -10,6 +10,8 @@ try:
 except ImportError:
     pass
 
+pytestmark = pytest.mark.skip()
+
 
 def setup_module():
     try:

--- a/test/contrib/test_securetransport.py
+++ b/test/contrib/test_securetransport.py
@@ -10,8 +10,6 @@ try:
 except ImportError:
     pass
 
-pytestmark = pytest.mark.skip()
-
 
 def setup_module():
     try:

--- a/test/with_dummyserver/test_proxy_poolmanager.py
+++ b/test/with_dummyserver/test_proxy_poolmanager.py
@@ -136,7 +136,6 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
                     "GET",
                     "%s/redirect" % self.http_url,
                     fields={"target": cross_host_location},
-                    timeout=LONG_TIMEOUT,
                     retries=0,
                 )
 
@@ -144,7 +143,6 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
                 "GET",
                 "%s/redirect" % self.http_url,
                 fields={"target": "%s/echo?a=b" % self.http_url_alt},
-                timeout=LONG_TIMEOUT,
                 retries=1,
             )
             assert r._pool.host != self.http_host_alt
@@ -157,7 +155,6 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
                     "GET",
                     "%s/redirect" % self.http_url,
                     fields={"target": cross_protocol_location},
-                    timeout=LONG_TIMEOUT,
                     retries=0,
                 )
 
@@ -165,7 +162,6 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
                 "GET",
                 "%s/redirect" % self.http_url,
                 fields={"target": "%s/echo?a=b" % self.https_url},
-                timeout=LONG_TIMEOUT,
                 retries=1,
             )
             assert r._pool.host == self.https_host


### PR DESCRIPTION
Should hopefully fix the last two failures mentioned in #1755 by @mgorny.

It's not fun when a test suite hangs, but it never happened to me when working on urllib3, while having false positives due to timeouts happened to me a *lot*. So I think we should optimize the latter case, and revisit later if we start to see hanged tests.