### PR TITLE
Doc: fix resolve_cert_reqs default value in docstring

### DIFF
--- a/src/urllib3/util/ssl_.py
+++ b/src/urllib3/util/ssl_.py
@@ -182,7 +182,7 @@ def resolve_cert_reqs(candidate):
     """
     Resolves the argument to a numeric constant, which can be passed to
     the wrap_socket function/method from the ssl module.
-    Defaults to :data:`ssl.CERT_NONE`.
+    Defaults to :data:`ssl.CERT_REQUIRED`.
     If given a string it is assumed to be the name of the constant in the
     :mod:`ssl` module or its abbreviation.
     (So you can specify `REQUIRED` instead of `CERT_REQUIRED`.


### PR DESCRIPTION
resolve_cert_reqs was changed in pull #1507 but the docstring was left
with its old default: update to new CERT_REQUIRED default.

----------

I was tempted to also update `self.verify_mode` in the python2 SSLContext implementation, as that should be unused and is a bit confusing as to where the default stands, but it's an actual code change even if I think it should not be used and I didn't run tests so I'll pass there.

Also feel free to close this PR and merge something similar otherwise, I consider this kind of trivial PRs faster to do than opening an actual issue so please just treat it as an issue with benefits.

Thanks!