### PR TITLE
Add explicit support for Python 3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,8 +46,10 @@ matrix:
       env: NOX_SESSION=test-3.6
     - python: 3.7
       env: NOX_SESSION=test-3.7
-    - python: 3.8-dev
+    - python: 3.8
       env: NOX_SESSION=test-3.8
+    - python: 3.9-dev
+      env: NOX_SESSION=test-3.9
     - python: pypy2.7-6.0
       env: NOX_SESSION=test-pypy
     - python: pypy3.5-6.0
@@ -74,6 +76,9 @@ matrix:
     - language: generic
       os: osx
       env: NOX_SESSION=test-3.7
+    - language: generic
+      os: osx
+      env: NOX_SESSION=test-3.8
 
     # Downstream integration tests.
     - python: 2.7

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,6 +27,11 @@ environment:
       PYTHON_ARCH: "64"
       NOX_SESSION: "test-3.7"
 
+    - PYTHON: "C:\\Python38-x64"
+      PYTHON_VERSION: "3.8.x"
+      PYTHON_ARCH: "64"
+      NOX_SESSION: "test-3.8"
+
 cache:
   - C:\Users\appveyor\AppData\Local\pip\Cache
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -39,7 +39,7 @@ def tests_impl(session, extras="socks,secure,brotli"):
     session.run("coverage", "report", "-m")
 
 
-@nox.session(python=["2.7", "3.5", "3.6", "3.7", "3.8", "pypy"])
+@nox.session(python=["2.7", "3.5", "3.6", "3.7", "3.8", "3.9", "pypy"])
 def test(session):
     tests_impl(session)
 

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
         "Topic :: Internet :: WWW/HTTP",


### PR DESCRIPTION
Start testing on 3.9, add testing on Python 3.8 where there is finally support.