### PR TITLE
Support Python 3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,6 +74,9 @@ matrix:
     - language: generic
       os: osx
       env: NOX_SESSION=test-3.7
+    - language: generic
+      os: osx
+      env: NOX_SESSION=test-3.8
 
     # Downstream integration tests.
     - python: 2.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,8 +46,10 @@ matrix:
       env: NOX_SESSION=test-3.6
     - python: 3.7
       env: NOX_SESSION=test-3.7
-    - python: 3.8-dev
+    - python: 3.8
       env: NOX_SESSION=test-3.8
+    - python: nightly
+      env: NOX_SESSION=test-3.9
     - python: pypy2.7-6.0
       env: NOX_SESSION=test-pypy
     - python: pypy3.5-6.0

--- a/_travis/install.sh
+++ b/_travis/install.sh
@@ -7,8 +7,14 @@ install_mac_python() {
     local FULL=$1
     local MINOR=$(echo $FULL | cut -d. -f1,2)
     local PYTHON_EXE=/Library/Frameworks/Python.framework/Versions/${MINOR}/bin/python${MINOR}
+    if [[ "$MINOR" == "3.5" ]]; then
+        # The 3.5 python.org macOS build is only compiled with macOS 10.6
+        local COMPILER=10.6
+    else
+        local COMPILER=10.9
+    fi
 
-    curl -Lo macpython.pkg https://www.python.org/ftp/python/${FULL}/python-${FULL}-macosx10.6.pkg
+    curl -Lo macpython.pkg https://www.python.org/ftp/python/${FULL}/python-${FULL}-macosx${COMPILER}.pkg
     sudo installer -pkg macpython.pkg -target /
 
     # The pip in older MacPython releases doesn't support a new enough TLS
@@ -20,10 +26,11 @@ install_mac_python() {
 if [[ "$(uname -s)" == 'Darwin' ]]; then
     # Mac OS setup.
     case "${NOX_SESSION}" in
-        test-2.7) MACPYTHON=2.7.16 ;;
+        test-2.7) MACPYTHON=2.7.17 ;;
         test-3.5) MACPYTHON=3.5.4 ;;  # last binary release
         test-3.6) MACPYTHON=3.6.8 ;;  # last binary release
-        test-3.7) MACPYTHON=3.7.4 ;;
+        test-3.7) MACPYTHON=3.7.6 ;;
+        test-3.8) MACPYTHON=3.8.1 ;;
     esac
 
     install_mac_python $MACPYTHON

--- a/noxfile.py
+++ b/noxfile.py
@@ -39,7 +39,7 @@ def tests_impl(session, extras="socks,secure,brotli"):
     session.run("coverage", "report", "-m")
 
 
-@nox.session(python=["2.7", "3.5", "3.6", "3.7", "3.8", "pypy"])
+@nox.session(python=["2.7", "3.5", "3.6", "3.7", "3.8", "3.9", "pypy"])
 def test(session):
     tests_impl(session)
 

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
         "Topic :: Internet :: WWW/HTTP",


### PR DESCRIPTION
Closes #1776

3.9 support is only tested on Linux:

 * AppVeyor does not support Python 3.9 yet,
 * and using the python.org Python 3.9 build for macOS fails due to an obscure virtualenv issue.