### PR TITLE
Empty responses should have no lines.

### DIFF
--- a/src/urllib3/response.py
+++ b/src/urllib3/response.py
@@ -792,7 +792,7 @@ class HTTPResponse(io.IOBase):
             return self._request_url
 
     def __iter__(self):
-        buffer = [b""]
+        buffer = []
         for chunk in self.stream(decode_content=True):
             if b"\n" in chunk:
                 chunk = chunk.split(b"\n")

--- a/test/test_response.py
+++ b/test/test_response.py
@@ -859,8 +859,9 @@ class TestResponse(object):
     @pytest.mark.parametrize(
         ["payload", "expected_stream"],
         [
-            (b"", [b""]),
+            (b"", []),
             (b"\n", [b"\n"]),
+            (b"\n\n\n", [b"\n", b"\n", b"\n"]),
             (b"abc\ndef", [b"abc\n", b"def"]),
             (b"Hello\nworld\n\n\n!", [b"Hello\n", b"world\n", b"\n", b"\n", b"!"]),
         ],


### PR DESCRIPTION
Previously, iterating the lines of an empty response would yield the empty string once. However, the iterator should instead never yield anything. This is consistent with file io; `open('/dev/null', 'rb').readlines()` is `[]`.

Closes #1780