### PR TITLE
Fix - Issue with Parsing URIs - Breaks Security Tools when testing for Path Traversal  

### DIFF
--- a/src/urllib3/util/url.py
+++ b/src/urllib3/util/url.py
@@ -241,36 +241,6 @@ def _encode_invalid_chars(component, allowed_chars, encoding="utf-8"):
     return encoded_component.decode(encoding)
 
 
-def _remove_path_dot_segments(path):
-    # See http://tools.ietf.org/html/rfc3986#section-5.2.4 for pseudo-code
-    segments = path.split("/")  # Turn the path into a list of segments
-    output = []  # Initialize the variable to use to store output
-
-    for segment in segments:
-        # '.' is the current directory, so ignore it, it is superfluous
-        if segment == ".":
-            continue
-        # Anything other than '..', should be appended to the output
-        elif segment != "..":
-            output.append(segment)
-        # In this case segment == '..', if we can, we should pop the last
-        # element
-        elif output:
-            output.pop()
-
-    # If the path starts with '/' and the output is empty or the first string
-    # is non-empty
-    if path.startswith("/") and (not output or output[0]):
-        output.insert(0, "")
-
-    # If the path starts with '/.' or '/..' ensure we add one more empty
-    # string to add a trailing '/'
-    if path.endswith(("/.", "/..")):
-        output.append("")
-
-    return "/".join(output)
-
-
 def _normalize_host(host, scheme):
     if host:
         if isinstance(host, six.binary_type):
@@ -381,7 +351,6 @@ def parse_url(url):
         host = _normalize_host(host, scheme)
 
         if normalize_uri and path:
-            path = _remove_path_dot_segments(path)
             path = _encode_invalid_chars(path, PATH_CHARS)
         if normalize_uri and query:
             query = _encode_invalid_chars(query, QUERY_CHARS)

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -312,9 +312,6 @@ class TestUtil(object):
     def test_unparse_url(self, url, expected_url):
         assert url == expected_url.url
 
-    @pytest.mark.parametrize(
-        ["url", "expected_url"]
-    )
     def test_parse_and_normalize_url_paths(self, url, expected_url):
         actual_url = parse_url(url)
         assert actual_url == expected_url

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -271,8 +271,6 @@ class TestUtil(object):
         # Path/query/fragment
         ("?", Url(path="", query="")),
         ("#", Url(path="", fragment="")),
-        # Path normalization
-        ("/abc/../def", Url(path="/def")),
         # Empty Port
         ("http://google.com:", Url("http", host="google.com")),
         ("http://google.com:/", Url("http", host="google.com", path="/")),
@@ -315,16 +313,7 @@ class TestUtil(object):
         assert url == expected_url.url
 
     @pytest.mark.parametrize(
-        ["url", "expected_url"],
-        [
-            # RFC 3986 5.2.4
-            ("/abc/../def", Url(path="/def")),
-            ("/..", Url(path="/")),
-            ("/./abc/./def/", Url(path="/abc/def/")),
-            ("/.", Url(path="/")),
-            ("/./", Url(path="/")),
-            ("/abc/./.././d/././e/.././f/./../../ghi", Url(path="/ghi")),
-        ],
+        ["url", "expected_url"]
     )
     def test_parse_and_normalize_url_paths(self, url, expected_url):
         actual_url = parse_url(url)


### PR DESCRIPTION
This PR fixes https://github.com/urllib3/urllib3/issues/1790

The code introduced in https://github.com/urllib3/urllib3/commit/5b047b645f5f93900d5e2fc31230848c25eb1f5f#diff-c289049c6f3c9d7397378a8be7e700c6 brought this unexpected functionality. The PR removes the responsible function and its uses.

