### PR TITLE
Timeout: Add repr

### DIFF
--- a/src/urllib3/util/timeout.py
+++ b/src/urllib3/util/timeout.py
@@ -98,13 +98,16 @@ class Timeout(object):
         self.total = self._validate_timeout(total, "total")
         self._start_connect = None
 
-    def __str__(self):
+    def __repr__(self):
         return "%s(connect=%r, read=%r, total=%r)" % (
             type(self).__name__,
             self._connect,
             self._read,
             self.total,
         )
+
+    # __str__ provided for backwards compatibility
+    __str__ = __repr__
 
     @classmethod
     def _validate_timeout(cls, value, name):


### PR DESCRIPTION
The `__str__` uses %r, and is largely unmodified since ee75ccf
It is a repr, so it is renamed to `__repr__`.
A `__str__` is re-added for backwards compatibility.