### PR TITLE
Expose peer certificate

### DIFF
--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -294,6 +294,7 @@ class VerifiedHTTPSConnection(HTTPSConnection):
         self.assert_fingerprint = assert_fingerprint
         self.ca_certs = ca_certs and os.path.expanduser(ca_certs)
         self.ca_cert_dir = ca_cert_dir and os.path.expanduser(ca_cert_dir)
+        self.peer_cert = None
 
     def connect(self):
         # Add certificate verification
@@ -360,10 +361,10 @@ class VerifiedHTTPSConnection(HTTPSConnection):
             ssl_context=context,
         )
 
+        self.peer_cert = self.sock.getpeercert(binary_form=True)
+
         if self.assert_fingerprint:
-            assert_fingerprint(
-                self.sock.getpeercert(binary_form=True), self.assert_fingerprint
-            )
+            assert_fingerprint(self.peer_cert, self.assert_fingerprint)
         elif (
             context.verify_mode != ssl.CERT_NONE
             and not getattr(context, "check_hostname", False)

--- a/src/urllib3/response.py
+++ b/src/urllib3/response.py
@@ -238,6 +238,9 @@ class HTTPResponse(io.IOBase):
         self._pool = pool
         self._connection = connection
 
+        if hasattr(connection, 'peer_cert'):
+            self.peer_cert = connection.peer_cert
+
         if hasattr(body, "read"):
             self._fp = body
 

--- a/src/urllib3/response.py
+++ b/src/urllib3/response.py
@@ -238,7 +238,7 @@ class HTTPResponse(io.IOBase):
         self._pool = pool
         self._connection = connection
 
-        if hasattr(connection, 'peer_cert'):
+        if hasattr(connection, "peer_cert"):
             self.peer_cert = connection.peer_cert
 
         if hasattr(body, "read"):


### PR DESCRIPTION
In order to do more advanced fingerprinting on certificates, it would be most useful if the peer certificate could be exposed in the connection and in responses.

If possible, I'd like to expose the entire peer certificate chain for things like DANE/TLSA validation, but I'm not sure where do find this information.