### PR TITLE
Raise ValueError if method contains control characters

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,13 @@
 Changes
 =======
 
+master (dev)
+------------
+
+* Raise ``ValueError`` if control characters are given in
+  the ``method`` parameter of ``HTTPConnection.request()`` (Pull #1800)
+
+
 1.25.8 (2020-01-20)
 -------------------
 

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -59,7 +59,7 @@ port_by_scheme = {"http": 80, "https": 443}
 # (ie test_recent_date is failing) update it to ~6 months before the current date.
 RECENT_DATE = datetime.date(2019, 1, 1)
 
-_CONTAINS_CONTROL_CHAR_RE = re.compile("[\x00-\x20\x7f]")
+_CONTAINS_CONTROL_CHAR_RE = re.compile(r"[^-!#$%&'*+.^_`|~0-9a-zA-Z]")
 
 
 class DummyConnection(object):
@@ -191,7 +191,7 @@ class HTTPConnection(_HTTPConnection, object):
         match = _CONTAINS_CONTROL_CHAR_RE.search(method)
         if match:
             raise ValueError(
-                "Method cannot contain control characters. %r (found at least %r)"
+                "Method cannot contain non-token characters %r (found at least %r)"
                 % (method, match.group())
             )
 

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+import re
 import datetime
 import logging
 import os
@@ -57,6 +58,8 @@ port_by_scheme = {"http": 80, "https": 443}
 # When it comes time to update this value as a part of regular maintenance
 # (ie test_recent_date is failing) update it to ~6 months before the current date.
 RECENT_DATE = datetime.date(2019, 1, 1)
+
+_CONTAINS_CONTROL_CHAR_RE = re.compile("[\x00-\x20\x7f]")
 
 
 class DummyConnection(object):
@@ -183,6 +186,16 @@ class HTTPConnection(_HTTPConnection, object):
     def connect(self):
         conn = self._new_conn()
         self._prepare_conn(conn)
+
+    def putrequest(self, method, url, *args, **kwargs):
+        match = _CONTAINS_CONTROL_CHAR_RE.search(method)
+        if match:
+            raise ValueError(
+                "Method cannot contain control characters. %r (found at least %r)"
+                % (method, match.group())
+            )
+
+        return _HTTPConnection.putrequest(self, method, url, *args, **kwargs)
 
     def request_chunked(self, method, url, body=None, headers=None):
         """

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -188,6 +188,7 @@ class HTTPConnection(_HTTPConnection, object):
         self._prepare_conn(conn)
 
     def putrequest(self, method, url, *args, **kwargs):
+        """Send a request to the server"""
         match = _CONTAINS_CONTROL_CHAR_RE.search(method)
         if match:
             raise ValueError(

--- a/test/with_dummyserver/test_connectionpool.py
+++ b/test/with_dummyserver/test_connectionpool.py
@@ -677,6 +677,12 @@ class TestConnectionPool(HTTPDummyServerTestCase):
             with pytest.raises(MaxRetryError):
                 pool.request("GET", "/test", retries=2)
 
+    @pytest.mark.parametrize("char", [" ", "\r", "\n", "\x00"])
+    def test_invalid_method_not_allowed(self, char):
+        with pytest.raises(ValueError):
+            with HTTPConnectionPool(self.host, self.port) as pool:
+                pool.request("GET" + char, "/")
+
     def test_percent_encode_invalid_target_chars(self):
         with HTTPConnectionPool(self.host, self.port) as pool:
             r = pool.request("GET", "/echo_params?q=\r&k=\n \n")

--- a/test/with_dummyserver/test_poolmanager.py
+++ b/test/with_dummyserver/test_poolmanager.py
@@ -312,12 +312,6 @@ class TestPoolManager(HTTPDummyServerTestCase):
             r = http.request("GET", "http://%s:%s/" % (self.host, self.port))
             assert r.status == 200
 
-    @pytest.mark.parametrize("char", [" ", "\r", "\n", "\x00"])
-    def test_invalid_method_not_allowed(self, char):
-        with pytest.raises(ValueError):
-            with PoolManager() as http:
-                http.request("GET" + char, "/")
-
     @pytest.mark.parametrize(
         ["target", "expected_target"],
         [

--- a/test/with_dummyserver/test_poolmanager.py
+++ b/test/with_dummyserver/test_poolmanager.py
@@ -312,6 +312,12 @@ class TestPoolManager(HTTPDummyServerTestCase):
             r = http.request("GET", "http://%s:%s/" % (self.host, self.port))
             assert r.status == 200
 
+    @pytest.mark.parametrize("char", [" ", "\r", "\n", "\x00"])
+    def test_invalid_method_not_allowed(self, char):
+        with pytest.raises(ValueError):
+            with PoolManager() as http:
+                http.request("GET" + char, "/")
+
     @pytest.mark.parametrize(
         ["target", "expected_target"],
         [


### PR DESCRIPTION
Protects against [BPO-39603](https://bugs.python.org/issue39603) which was reported to CPython and Requests. The risk of this being exploited is minimal as attackers will rarely have direct control of the request method, but in that case header injection is possible in `http.client`, `urllib3` and `requests`.

This change makes that not possible, unfortunately there's not really an exception that fits the bill for this error, but hopefully this situation is rare enough that we don't have to care.