### PR TITLE
Remove deprecated and unused test arguments from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,14 +69,6 @@ setup(
     package_dir={"": "src"},
     requires=[],
     python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4",
-    tests_require=[
-        # These are a less-specific subset of dev-requirements.txt, for the
-        # convenience of distro package maintainers.
-        "pytest",
-        "mock",
-        "tornado",
-    ],
-    test_suite="test",
     extras_require={
         "brotli": ["brotlipy>=0.6.0"],
         "secure": [


### PR DESCRIPTION
Since setuptools v41.5.0 (27 Oct 2019), the 'test' command and its
arguments are formally deprecated and should not be used. Tests are
still easy to run using nox, as before.