### PR TITLE
Fix macOS and Python 2.7 build

### DIFF
--- a/_travis/run.sh
+++ b/_travis/run.sh
@@ -2,7 +2,8 @@
 
 set -exo pipefail
 
-if [[ "$(uname -s)" == "Darwin" && "$NOX_SESSION" == "tests-2.7" ]]; then
+# Work around https://github.com/pypa/virtualenv/issues/1561
+if [[ "$(uname -s)" == "Darwin" && "$NOX_SESSION" == "test-2.7" ]]; then
     export PATH="/Library/Frameworks/Python.framework/Versions/2.7/bin":$PATH
 fi
 


### PR DESCRIPTION
The macOS + Python 2.7 build currently fails because the "coverage" entry point is installed outside of PATH. I think I got hit by this when working on the macOS tests, and added a workaround in _travis/run.sh.

The workaround stopped being necessary at some point, which is why we did not notice when the switch to Nox broke it. Now there's [a bug in virtualenv's rewrite](https://github.com/pypa/virtualenv/issues/1561), so we need the workaround again. But this time we know where the bug is, and will be able to remove the workaround when virtualenv fixes this issue.

By the way, I found out about https://github.com/MacPython/terryfy today, which could allow us to remove some of the boilerplate. But I think I'd rather migrate to GitHub Actions that to continue investing time in our Travis macOS builds.