### PR TITLE
Rename VerifiedHTTPSConnection

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@ master (dev)
 * Raise ``ValueError`` if control characters are given in
   the ``method`` parameter of ``HTTPConnection.request()`` (Pull #1800)
 
+* Rename ``VerifiedHTTPSConnection`` to ``HTTPSConnection`` (Pull #1805)
+
 
 1.25.8 (2020-01-20)
 -------------------

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -285,5 +285,8 @@ In chronological order:
 * Benno Rice <benno@jeamland.net>
   * Allow cadata parameter to be passed to underlying ``SSLContext.load_verify_locations()``.
 
+* Keiichi Kobayashi <abok.1k@gmail.com>
+  * Rename VerifiedHTTPSConnection to HTTPSConnection
+
 * [Your name or handle] <[email or website]>
   * [Brief summary of your changes]

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -237,7 +237,12 @@ class HTTPConnection(_HTTPConnection, object):
 class HTTPSConnection(HTTPConnection):
     default_port = port_by_scheme["https"]
 
+    cert_reqs = None
+    ca_certs = None
+    ca_cert_dir = None
+    ca_cert_data = None
     ssl_version = None
+    assert_fingerprint = None
 
     def __init__(
         self,
@@ -264,20 +269,6 @@ class HTTPSConnection(HTTPConnection):
         # Required property for Google AppEngine 1.9.0 which otherwise causes
         # HTTPS requests to go out as HTTP. (See Issue #356)
         self._protocol = "https"
-
-
-class VerifiedHTTPSConnection(HTTPSConnection):
-    """
-    Based on httplib.HTTPSConnection but wraps the socket with
-    SSL certification.
-    """
-
-    cert_reqs = None
-    ca_certs = None
-    ca_cert_dir = None
-    ca_cert_data = None
-    ssl_version = None
-    assert_fingerprint = None
 
     def set_cert(
         self,
@@ -425,9 +416,8 @@ def _match_hostname(cert, asserted_hostname):
         raise
 
 
-if ssl:
-    # Make a copy for testing.
-    UnverifiedHTTPSConnection = HTTPSConnection
-    HTTPSConnection = VerifiedHTTPSConnection
-else:
+if not ssl:
     HTTPSConnection = DummyConnection
+
+
+VerifiedHTTPSConnection = HTTPSConnection

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -417,7 +417,7 @@ def _match_hostname(cert, asserted_hostname):
 
 
 if not ssl:
-    HTTPSConnection = DummyConnection
+    HTTPSConnection = DummyConnection  # noqa: F811
 
 
 VerifiedHTTPSConnection = HTTPSConnection


### PR DESCRIPTION
Fix: #1799 
Renamed `VerifiedHTTPSConnection` to `HTTPSConnection`.  `VerifiedHTTPSConnection` is backported.