### PR TITLE
Add support for TLS in TLS for HTTPS proxies.

### DIFF
--- a/src/urllib3/contrib/ssl.py
+++ b/src/urllib3/contrib/ssl.py
@@ -1,0 +1,197 @@
+import ssl
+import socket
+import io
+
+SSL_BLOCKSIZE = 16384
+
+
+class SSLTransport:
+    """
+    The SSLTransport wraps an existing socket and establishes an SSL connection.
+
+    Contrary to Python's implementation of SSLSocket, it allows you to chain
+    multiple TLS connections together. It's particularly useful if you need to
+    implement TLS within TLS.
+
+    The class supports most of the socket API operations.
+    """
+
+    def __init__(
+        self, socket, ssl_context, suppress_ragged_eofs=True, server_hostname=None
+    ):
+        """
+        Create an SSLTransport around socket using the provided ssl_context.
+        """
+        self.incoming = ssl.MemoryBIO()
+        self.outgoing = ssl.MemoryBIO()
+
+        self.suppress_ragged_eofs = suppress_ragged_eofs
+        self.socket = socket
+
+        self.sslobj = ssl_context.wrap_bio(
+            self.incoming, self.outgoing, server_hostname=server_hostname
+        )
+
+        # Perform initial handshake.
+        self._ssl_io_loop(self.sslobj.do_handshake)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        self.close()
+
+    def fileno(self):
+        return self.socket.fileno()
+
+    def read(self, len=1024, buffer=None):
+        return self._wrap_ssl_read(len, buffer)
+
+    def recv(self, len=1024, flags=0):
+        if flags != 0:
+            raise ValueError("non-zero flags not allowed in calls to recv")
+        return self._wrap_ssl_read(len)
+
+    def recv_into(self, buffer, nbytes=None, flags=0):
+        if flags != 0:
+            raise ValueError("non-zero flags not allowed in calls to recv_into")
+        if buffer and (nbytes is None):
+            nbytes = len(buffer)
+        elif nbytes is None:
+            nbytes = 1024
+        return self.read(nbytes, buffer)
+
+    def sendall(self, data, flags=0):
+        if flags != 0:
+            raise ValueError("non-zero flags not allowed in calls to sendall")
+        count = 0
+        with memoryview(data) as view, view.cast("B") as byte_view:
+            amount = len(byte_view)
+            while count < amount:
+                v = self.send(byte_view[count:])
+                count += v
+
+    def send(self, data, flags=0):
+        if flags != 0:
+            raise ValueError("non-zero flags not allowed in calls to send")
+        response = self._ssl_io_loop(self.sslobj.write, data)
+        return response
+
+    def makefile(
+        self, mode="r", buffering=None, encoding=None, errors=None, newline=None
+    ):
+        """
+        Python's httpclient uses makefile and buffered io when reading HTTP
+        messages and we need to support it.
+
+        This is unfortunately a copy and paste of socket.py makefile with small
+        changes to point to the socket directly.
+        """
+        if not set(mode) <= {"r", "w", "b"}:
+            raise ValueError("invalid mode %r (only r, w, b allowed)" % (mode,))
+
+        writing = "w" in mode
+        reading = "r" in mode or not writing
+        assert reading or writing
+        binary = "b" in mode
+        rawmode = ""
+        if reading:
+            rawmode += "r"
+        if writing:
+            rawmode += "w"
+        raw = socket.SocketIO(self, rawmode)
+        self.socket._io_refs += 1
+        if buffering is None:
+            buffering = -1
+        if buffering < 0:
+            buffering = io.DEFAULT_BUFFER_SIZE
+        if buffering == 0:
+            if not binary:
+                raise ValueError("unbuffered streams must be binary")
+            return raw
+        if reading and writing:
+            buffer = io.BufferedRWPair(raw, raw, buffering)
+        elif reading:
+            buffer = io.BufferedReader(raw, buffering)
+        else:
+            assert writing
+            buffer = io.BufferedWriter(raw, buffering)
+        if binary:
+            return buffer
+        text = io.TextIOWrapper(buffer, encoding, errors, newline)
+        text.mode = mode
+        return text
+
+    def unwrap(self):
+        self._ssl_io_loop(self.sslobj.unwrap)
+
+    def close(self):
+        self.socket.close()
+
+    def getpeercert(self, binary_form=False):
+        return self.sslobj.getpeercert(binary_form)
+
+    def version(self):
+        return self.sslobj.version()
+
+    def cipher(self):
+        return self.sslobj.cipher()
+
+    def selected_alpn_protocol(self):
+        return self.sslobj.selected_alpn_protocol()
+
+    def selected_npn_protocol(self):
+        return self.sslobj.selected_npn_protocol()
+
+    def shared_ciphers(self):
+        return self.sslobj.shared_ciphers()
+
+    def compression(self):
+        return self.sslobj.compression()
+
+    def settimeout(self, value):
+        self.socket.settimeout(value)
+
+    def gettimeout(self):
+        return self.socket.gettimeout()
+
+    def _decref_socketios(self):
+        self.socket._decref_socketios()
+
+    def _wrap_ssl_read(self, len, buffer=None):
+        response = None
+        try:
+            response = self._ssl_io_loop(self.sslobj.read, len, buffer)
+        except ssl.SSLError as e:
+            if e.errno == ssl.SSL_ERROR_EOF and self.suppress_ragged_eofs:
+                response = 0  # eof, return 0.
+            else:
+                raise
+        return response
+
+    def _ssl_io_loop(self, func, *args):
+        """ Performs an I/O loop between incoming/outgoing and the socket."""
+        should_loop = True
+
+        while should_loop:
+            errno = None
+            try:
+                ret = func(*args)
+            except ssl.SSLError as e:
+                if e.errno not in (ssl.SSL_ERROR_WANT_READ, ssl.SSL_ERROR_WANT_WRITE):
+                    # WANT_READ, and WANT_WRITE are expected, others are not.
+                    raise e
+                errno = e.errno
+
+            buf = self.outgoing.read()
+            self.socket.sendall(buf)
+
+            if errno is None:
+                should_loop = False
+            elif errno == ssl.SSL_ERROR_WANT_READ:
+                buf = self.socket.recv(SSL_BLOCKSIZE)
+                if buf:
+                    self.incoming.write(buf)
+                else:
+                    self.incoming.write_eof()
+        return ret

--- a/test/contrib/test_ssltransport.py
+++ b/test/contrib/test_ssltransport.py
@@ -1,0 +1,470 @@
+from dummyserver.testcase import SocketDummyServerTestCase, consume_socket
+from dummyserver.server import (
+    DEFAULT_CERTS,
+    DEFAULT_CA,
+)
+
+from urllib3.contrib.ssl import SSLTransport
+
+import select
+import pytest
+import socket
+import ssl
+import sys
+import platform
+
+
+# consume_socket can iterate forever, we add timeouts to prevent halting.
+PER_TEST_TIMEOUT = 60
+
+
+def server_client_ssl_contexts():
+    if hasattr(ssl, "PROTOCOL_TLS_SERVER"):
+        server_context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    else:
+        # python 2.7 and 3.5 workaround.
+        # PROTOCOL_TLS_SERVER was added in 3.6
+        server_context = ssl.SSLContext(ssl.PROTOCOL_TLS)
+    server_context.load_cert_chain(DEFAULT_CERTS["certfile"], DEFAULT_CERTS["keyfile"])
+
+    if hasattr(ssl, "PROTOCOL_TLS_CLIENT"):
+        client_context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    else:
+        # python 2.7 and 3.5 workaround.
+        # PROTOCOL_TLS_SERVER was added in 3.6
+        client_context = ssl.SSLContext(ssl.PROTOCOL_TLS)
+        client_context.verify_mode = ssl.CERT_REQUIRED
+        client_context.check_hostname = True
+
+    client_context.load_verify_locations(DEFAULT_CA)
+    return server_context, client_context
+
+
+def sample_request(binary=True):
+    request = (
+        b"GET http://www.testing.com/ HTTP/1.1\r\n"
+        b"Host: www.testing.com\r\n"
+        b"User-Agent: awesome-test\r\n"
+        b"\r\n"
+    )
+    return request if binary else request.decode("utf-8")
+
+
+def validate_request(provided_request, binary=True):
+    assert provided_request is not None
+    expected_request = sample_request(binary)
+    assert provided_request == expected_request
+
+
+def sample_response(binary=True):
+    response = b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n"
+    return response if binary else response.decode("utf-8")
+
+
+def validate_response(provided_response, binary=True):
+    assert provided_response is not None
+    expected_response = sample_response(binary)
+    assert provided_response == expected_response
+
+
+def validate_peercert(ssl_socket):
+
+    binary_cert = ssl_socket.getpeercert(binary_form=True)
+    assert type(binary_cert) == bytes
+    assert len(binary_cert) > 0
+
+    cert = ssl_socket.getpeercert()
+    assert type(cert) == dict
+    assert "serialNumber" in cert
+    assert cert["serialNumber"] != ""
+
+
+@pytest.mark.skipif(sys.version_info < (3, 5), reason="requires python3.5 or higher")
+class SingleTLSLayerTestCase(SocketDummyServerTestCase):
+    """
+    Uses the SocketDummyServer to validate a single TLS layer can be
+    established through the SSLTransport.
+    """
+
+    @classmethod
+    def setup_class(cls):
+        cls.server_context, cls.client_context = server_client_ssl_contexts()
+
+    def start_dummy_server(self, handler=None):
+        def socket_handler(listener):
+            sock = listener.accept()[0]
+            with self.server_context.wrap_socket(sock, server_side=True) as ssock:
+                request = consume_socket(ssock)
+                validate_request(request)
+                ssock.send(sample_response())
+
+        chosen_handler = handler if handler else socket_handler
+        self._start_server(chosen_handler)
+
+    @pytest.mark.timeout(PER_TEST_TIMEOUT)
+    def test_start_closed_socket(self):
+        """ Errors generated from an unconnected socket should bubble up."""
+        sock = socket.socket(socket.AF_INET)
+        context = ssl.create_default_context()
+        sock.close()
+        with pytest.raises(OSError):
+            SSLTransport(sock, context)
+
+    @pytest.mark.timeout(PER_TEST_TIMEOUT)
+    def test_close_after_handshake(self):
+        """ Socket errors should be bubbled up """
+        self.start_dummy_server()
+
+        sock = socket.create_connection((self.host, self.port))
+        with SSLTransport(
+            sock, self.client_context, server_hostname="localhost"
+        ) as ssock:
+            ssock.close()
+            with pytest.raises(OSError):
+                ssock.send(b"blaaargh")
+
+    @pytest.mark.timeout(PER_TEST_TIMEOUT)
+    def test_wrap_existing_socket(self):
+        """ Validates a single TLS layer can be established.  """
+        self.start_dummy_server()
+
+        sock = socket.create_connection((self.host, self.port))
+        with SSLTransport(
+            sock, self.client_context, server_hostname="localhost"
+        ) as ssock:
+            assert ssock.version() is not None
+            ssock.send(sample_request())
+            response = consume_socket(ssock)
+            validate_response(response)
+
+    @pytest.mark.timeout(PER_TEST_TIMEOUT)
+    def test_unbuffered_text_makefile(self):
+        self.start_dummy_server()
+
+        sock = socket.create_connection((self.host, self.port))
+        with SSLTransport(
+            sock, self.client_context, server_hostname="localhost"
+        ) as ssock:
+            with pytest.raises(ValueError):
+                ssock.makefile("r", buffering=0)
+            ssock.send(sample_request())
+            response = consume_socket(ssock)
+            validate_response(response)
+
+    @pytest.mark.skip(reason="Disabled as it's currently flaky.")
+    def test_unwrap_existing_socket(self):
+        """
+        Validates we can break up the TLS layer
+        Request is sent over TLS. response received over regular TCP.
+
+        Currently disabled as its flaky on occassion.
+        """
+
+        def shutdown_handler(listener):
+            sock = listener.accept()[0]
+            ssl_sock = self.server_context.wrap_socket(sock, server_side=True)
+            request = consume_socket(ssl_sock)
+            validate_request(request)
+            sock = ssl_sock.unwrap()
+            sock.send(sample_response())
+
+        self.start_dummy_server(shutdown_handler)
+        sock = socket.create_connection((self.host, self.port))
+        ssock = SSLTransport(sock, self.client_context, server_hostname="localhost")
+        ssock.send(sample_request())
+        ssock.unwrap()
+        response = consume_socket(sock)
+        validate_response(response)
+
+    @pytest.mark.timeout(PER_TEST_TIMEOUT)
+    def test_ssl_object_attributes(self):
+        """ Ensures common ssl attributes are exposed """
+        self.start_dummy_server()
+
+        sock = socket.create_connection((self.host, self.port))
+        with SSLTransport(
+            sock, self.client_context, server_hostname="localhost"
+        ) as ssock:
+            cipher = ssock.cipher()
+            assert type(cipher) == tuple
+
+            # No chosen protocol through ALPN or NPN.
+            assert ssock.selected_alpn_protocol() is None
+            assert ssock.selected_npn_protocol() is None
+
+            shared_ciphers = ssock.shared_ciphers()
+            assert type(shared_ciphers) == list
+            assert len(shared_ciphers) > 0
+
+            assert ssock.compression() is None
+
+            validate_peercert(ssock)
+
+            ssock.send(sample_request())
+            response = consume_socket(ssock)
+            validate_response(response)
+
+    @pytest.mark.timeout(PER_TEST_TIMEOUT)
+    def test_socket_object_attributes(self):
+        """ Ensures common socket attributes are exposed """
+        self.start_dummy_server()
+
+        sock = socket.create_connection((self.host, self.port))
+        with SSLTransport(
+            sock, self.client_context, server_hostname="localhost"
+        ) as ssock:
+            assert ssock.fileno() is not None
+            test_timeout = 10
+            ssock.settimeout(test_timeout)
+            assert ssock.gettimeout() == test_timeout
+            assert ssock.socket.gettimeout() == test_timeout
+
+            ssock.send(sample_request())
+            response = consume_socket(ssock)
+            validate_response(response)
+
+
+class SocketProxyDummyServer(SocketDummyServerTestCase):
+    """
+    Simulates a proxy that performs a simple I/O loop on client/server
+    socket.
+    """
+
+    def __init__(self, destination_server_host, destination_server_port):
+        self.destination_server_host = destination_server_host
+        self.destination_server_port = destination_server_port
+        self.server_context, self.client_context = server_client_ssl_contexts()
+
+    def start_proxy_handler(self):
+        """
+        Socket handler for the proxy. Terminates the first TLS layer and tunnels
+        any bytes needed for client <-> server communicatin.
+        """
+
+        def proxy_handler(listener):
+            sock = listener.accept()[0]
+            with self.server_context.wrap_socket(sock, server_side=True) as client_sock:
+                upstream_sock = socket.create_connection(
+                    (self.destination_server_host, self.destination_server_port)
+                )
+                self._read_write_loop(client_sock, upstream_sock)
+                upstream_sock.close()
+
+        self._start_server(proxy_handler)
+
+    def _read_write_loop(self, client_sock, server_sock, chunks=65536):
+        inputs = [client_sock, server_sock]
+        output = [client_sock, server_sock]
+
+        while inputs:
+            readable, writable, exception = select.select(inputs, output, inputs)
+
+            if exception:
+                # Error ocurred with either of the sockets, time to
+                # wrap up, parent func will close sockets.
+                break
+
+            for s in readable:
+                read_socket, write_socket = None, None
+                if s == client_sock:
+                    read_socket = client_sock
+                    write_socket = server_sock
+                else:
+                    read_socket = server_sock
+                    write_socket = client_sock
+
+                # Ensure buffer is not full before writting
+                if write_socket in writable:
+                    try:
+                        b = read_socket.recv(chunks)
+                        write_socket.send(b)
+                    except ssl.SSLEOFError:
+                        # It's possible, depending on shutdown order, that we'll
+                        # try to use a socket that was closed between select
+                        # calls.
+                        return
+
+
+@pytest.mark.skipif(sys.version_info < (3, 5), reason="requires python3.5 or higher")
+class TlsInTlsTestCase(SocketDummyServerTestCase):
+    """
+    Creates a TLS in TLS tunnel by chaining a 'SocketProxyDummyServer' and a
+    `SocketDummyServerTestCase`.
+
+    Client will first connect to the proxy, who will then proxy any bytes send
+    to the destination server. First TLS layer terminates at the proxy, second
+    TLS layer terminates at the destination server.
+    """
+
+    @classmethod
+    def setup_class(cls):
+        cls.server_context, cls.client_context = server_client_ssl_contexts()
+
+    @classmethod
+    def start_proxy_server(cls):
+        # Proxy server will handle the first TLS connection and create a
+        # connection to the destination server.
+        cls.proxy_server = SocketProxyDummyServer(cls.host, cls.port)
+        cls.proxy_server.start_proxy_handler()
+
+    @classmethod
+    def teardown_class(cls):
+        if hasattr(cls, "proxy_server"):
+            cls.proxy_server.teardown_class()
+        super(TlsInTlsTestCase, cls).teardown_class()
+
+    @classmethod
+    def start_destination_server(cls):
+        """
+        Socket handler for the destination_server. Terminates the second TLS
+        layer and send a basic HTTP response.
+        """
+
+        def socket_handler(listener):
+            sock = listener.accept()[0]
+            with cls.server_context.wrap_socket(sock, server_side=True) as ssock:
+                request = consume_socket(ssock)
+                validate_request(request)
+                ssock.send(sample_response())
+
+        cls._start_server(socket_handler)
+
+    @pytest.mark.timeout(PER_TEST_TIMEOUT)
+    def test_tls_in_tls_tunnel(self):
+        """
+        Basic communication over the TLS in TLS tunnel.
+        """
+        self.start_destination_server()
+        self.start_proxy_server()
+
+        sock = socket.create_connection(
+            (self.proxy_server.host, self.proxy_server.port)
+        )
+        with self.client_context.wrap_socket(
+            sock, server_hostname="localhost"
+        ) as proxy_sock:
+            with SSLTransport(
+                proxy_sock, self.client_context, server_hostname="localhost"
+            ) as destination_sock:
+                assert destination_sock.version() is not None
+                destination_sock.send(sample_request())
+                response = consume_socket(destination_sock)
+                validate_response(response)
+
+    @pytest.mark.timeout(PER_TEST_TIMEOUT)
+    def test_wrong_sni_hint(self):
+        """
+        Provides a wrong sni hint to validate an exception is thrown.
+        """
+        self.start_destination_server()
+        self.start_proxy_server()
+
+        sock = socket.create_connection(
+            (self.proxy_server.host, self.proxy_server.port)
+        )
+        with self.client_context.wrap_socket(
+            sock, server_hostname="localhost"
+        ) as proxy_sock:
+            with pytest.raises(Exception) as e:
+                SSLTransport(
+                    proxy_sock, self.client_context, server_hostname="veryverywrong"
+                )
+            # ssl.CertificateError is a child of ValueError in python3.6 or
+            # before. After python3.7 it's a child of SSLError
+            assert e.type in [ssl.SSLError, ssl.CertificateError]
+
+    @pytest.mark.skipif(
+        platform.system() == "Windows",
+        reason="Skipping windows due to text makefile support",
+    )
+    @pytest.mark.timeout(PER_TEST_TIMEOUT)
+    def test_tls_in_tls_makefile_rw_binary(self):
+        """
+        Uses makefile with read, write and binary modes.
+        """
+        self.start_destination_server()
+        self.start_proxy_server()
+
+        sock = socket.create_connection(
+            (self.proxy_server.host, self.proxy_server.port)
+        )
+        with self.client_context.wrap_socket(
+            sock, server_hostname="localhost"
+        ) as proxy_sock:
+            with SSLTransport(
+                proxy_sock, self.client_context, server_hostname="localhost"
+            ) as destination_sock:
+
+                file = destination_sock.makefile("rwb")
+                file.write(sample_request())
+                file.flush()
+
+                response = bytearray(65536)
+                wrote = file.readinto(response)
+                assert wrote is not None
+                # Allocated response is bigger than the actual response, we
+                # rtrim remaining x00 bytes.
+                str_response = response.decode("utf-8").rstrip("\x00")
+                validate_response(str_response, binary=False)
+                file.close()
+
+    @pytest.mark.skipif(
+        platform.system() == "Windows",
+        reason="Skipping windows due to text makefile support",
+    )
+    @pytest.mark.timeout(PER_TEST_TIMEOUT)
+    def test_tls_in_tls_makefile_rw_text(self):
+        """
+        Creates a separate buffer for reading and writing using text mode and
+        utf-8 encoding.
+        """
+        self.start_destination_server()
+        self.start_proxy_server()
+
+        sock = socket.create_connection(
+            (self.proxy_server.host, self.proxy_server.port)
+        )
+        with self.client_context.wrap_socket(
+            sock, server_hostname="localhost"
+        ) as proxy_sock:
+            with SSLTransport(
+                proxy_sock, self.client_context, server_hostname="localhost"
+            ) as destination_sock:
+
+                read = destination_sock.makefile("r", encoding="utf-8")
+                write = destination_sock.makefile("w", encoding="utf-8")
+
+                write.write(sample_request(binary=False))
+                write.flush()
+
+                response = read.read()
+                if "\r" not in response:
+                    # Carriage return will be removed when reading as a file on
+                    # some platforms.  We add it before the comparison.
+                    response = response.replace("\n", "\r\n")
+                validate_response(response, binary=False)
+
+    @pytest.mark.timeout(PER_TEST_TIMEOUT)
+    def test_tls_in_tls_recv_into_sendall(self):
+        """
+        Valides recv_into and sendall also work as expected. Other tests are
+        using recv/send.
+        """
+        self.start_destination_server()
+        self.start_proxy_server()
+
+        sock = socket.create_connection(
+            (self.proxy_server.host, self.proxy_server.port)
+        )
+        with self.client_context.wrap_socket(
+            sock, server_hostname="localhost"
+        ) as proxy_sock:
+            with SSLTransport(
+                proxy_sock, self.client_context, server_hostname="localhost"
+            ) as destination_sock:
+
+                destination_sock.sendall(sample_request())
+                response = bytearray(65536)
+                destination_sock.recv_into(response)
+                str_response = response.decode("utf-8").rstrip("\x00")
+                validate_response(str_response, binary=False)


### PR DESCRIPTION
This PR aims to add support for HTTPS proxies by adding a class to easily provide TLS in TLS support.  TLS within TLS is not supported easily within the ssl library. The SSLSocket actually takes over the existing socket (https://github.com/python/cpython/blob/master/Lib/ssl.py#L999-L1006)
instead of wrapping it entirely. The only way to support to TLS within TLS is with the ``SSLContext.wrap_bio`` methods.

The first commit introduces a class called SSLTransport which wraps a socket in TLS using the provided SSL context.  I'm currently in the process of adding unit tests and integration tests but it would be useful if we can merge #1679 for that.

Once I can fully integrate this within ``urlib3`` I'll perform some production testing on my own to validate the changes work as expected. 

