### PR TITLE
Ensure load_verify_locations raises SSLError for all backends

### DIFF
--- a/src/urllib3/contrib/pyopenssl.py
+++ b/src/urllib3/contrib/pyopenssl.py
@@ -450,9 +450,12 @@ class PyOpenSSLContext(object):
             cafile = cafile.encode("utf-8")
         if capath is not None:
             capath = capath.encode("utf-8")
-        self._ctx.load_verify_locations(cafile, capath)
-        if cadata is not None:
-            self._ctx.load_verify_locations(BytesIO(cadata))
+        try:
+            self._ctx.load_verify_locations(cafile, capath)
+            if cadata is not None:
+                self._ctx.load_verify_locations(BytesIO(cadata))
+        except OpenSSL.SSL.Error as e:
+            raise ssl.SSLError("unable to load trusted certificates: %r" % e)
 
     def load_cert_chain(self, certfile, keyfile=None, password=None):
         self._ctx.use_certificate_chain_file(certfile)

--- a/test/contrib/test_pyopenssl.py
+++ b/test/contrib/test_pyopenssl.py
@@ -45,6 +45,7 @@ from ..with_dummyserver.test_socketlevel import (  # noqa: F401
     TestSNI,
     TestSocketClosing,
     TestClientCerts,
+    TestSSL,
 )
 
 

--- a/test/contrib/test_securetransport.py
+++ b/test/contrib/test_securetransport.py
@@ -43,6 +43,7 @@ from ..with_dummyserver.test_socketlevel import (  # noqa: F401
     TestSNI,
     TestSocketClosing,
     TestClientCerts,
+    TestSSL,
 )
 
 

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -1395,7 +1395,6 @@ class TestSSL(SocketDummyServerTestCase):
         """
         with pytest.raises(SSLError) as exc:
             ssl_wrap_socket(None, ca_certs=os.devnull)
-        assert exc.type == SSLError
 
 
 class TestErrorWrapping(SocketDummyServerTestCase):

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -1393,7 +1393,7 @@ class TestSSL(SocketDummyServerTestCase):
         """
         Ensure that load_verify_locations raises SSLError for all backends
         """
-        with pytest.raises(SSLError) as exc:
+        with pytest.raises(SSLError):
             ssl_wrap_socket(None, ca_certs=os.devnull)
 
 

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -10,6 +10,7 @@ from urllib3.exceptions import (
     ProtocolError,
 )
 from urllib3.response import httplib
+from urllib3.util import ssl_wrap_socket
 from urllib3.util.ssl_ import HAS_SNI
 from urllib3.util import ssl_
 from urllib3.util.timeout import Timeout
@@ -37,6 +38,7 @@ except ImportError:
 from collections import OrderedDict
 import os.path
 from threading import Event
+import os
 import select
 import socket
 import shutil
@@ -1386,6 +1388,14 @@ class TestSSL(SocketDummyServerTestCase):
                     with pytest.raises(MaxRetryError):
                         pool.request("GET", "/", timeout=SHORT_TIMEOUT)
                     context.load_default_certs.assert_not_called()
+
+    def test_load_verify_locations_exception(self):
+        """
+        Ensure that load_verify_locations raises SSLError for all backends
+        """
+        with pytest.raises(SSLError) as exc:
+            ssl_wrap_socket(None, ca_certs=os.devnull)
+        assert exc.type == SSLError
 
 
 class TestErrorWrapping(SocketDummyServerTestCase):


### PR DESCRIPTION
This also adds TestSSL to the classes tested in SecureTransport and PyOpenSSL, since:

1. TestSSL was the most natural place for this test.
2. The test only makes sense when run against all SSL backends.

This is my take on #1517 from @pilou-: I've backported it to master, and made a few tweaks. In particular, we can't test the exact message, it's different with every backend.

Closes #1517 