### PR TITLE
Stop skipping SecureTransport tests

### DIFF
--- a/src/urllib3/contrib/securetransport.py
+++ b/src/urllib3/contrib/securetransport.py
@@ -819,6 +819,11 @@ class SecureTransportContext(object):
         if capath is not None:
             raise ValueError("SecureTransport does not support cert directories")
 
+        # Raise if cafile does not exist.
+        if cafile is not None:
+            with open(cafile):
+                pass
+
         self._trust_bundle = cafile or cadata
 
     def load_cert_chain(self, certfile, keyfile=None, password=None):

--- a/test/contrib/test_securetransport.py
+++ b/test/contrib/test_securetransport.py
@@ -10,8 +10,6 @@ try:
 except ImportError:
     pass
 
-pytestmark = pytest.mark.skip()
-
 
 def setup_module():
     try:

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -1394,7 +1394,7 @@ class TestSSL(SocketDummyServerTestCase):
         Ensure that load_verify_locations raises SSLError for all backends
         """
         with pytest.raises(SSLError):
-            ssl_wrap_socket(None, ca_certs=os.devnull)
+            ssl_wrap_socket(None, ca_certs="/tmp/fake-file")
 
 
 class TestErrorWrapping(SocketDummyServerTestCase):

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -55,6 +55,7 @@ from test import (
     SHORT_TIMEOUT,
     LONG_TIMEOUT,
     notPyPy2,
+    notSecureTransport,
 )
 
 # Retry failed tests
@@ -1167,6 +1168,7 @@ class TestSSL(SocketDummyServerTestCase):
                 pool.request("GET", "/", retries=0)
             assert isinstance(cm.value.reason, SSLError)
 
+    @notSecureTransport
     def test_ssl_read_timeout(self):
         timed_out = Event()
 


### PR DESCRIPTION
They're failing on macOS 10.15, which means I can't run them locally,
which is why I skip them. Sorry about that.