### PR TITLE
Restore coverage measurements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /dist
 /build
 /docs/_build
+coverage.xml

--- a/_travis/upload_coverage.sh
+++ b/_travis/upload_coverage.sh
@@ -4,5 +4,5 @@ set -exo pipefail
 
 if [[ -e .coverage ]]; then
     python -m pip install codecov
-    python -m codecov --env TRAVIS_OS_NAME,NOX_SESSION
+    python -m codecov --env TRAVIS_OS_NAME,NOX_SESSION --file coverage.xml
 fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -55,4 +55,4 @@ test_script:
 
 on_success:
   - pip install codecov
-  - codecov --env PLATFORM,TOXENV
+  - codecov --env NOX_SESSION

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -55,4 +55,4 @@ test_script:
 
 on_success:
   - pip install codecov
-  - codecov --env NOX_SESSION
+  - codecov --env NOX_SESSION --file coverage.xml

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,12 +1,12 @@
 mock==3.0.5
-coverage~=4.5
+coverage~=5.0
 tornado==5.1.1;python_version<="2.7"
 tornado==6.0.3;python_version>="3.5"
 PySocks==1.7.1
 # https://github.com/Anorov/PySocks/issues/131
 win-inet-pton==1.1.0
-pytest==4.6.6
-pytest-timeout==1.3.3
+pytest==4.6.9
+pytest-timeout==1.3.4
 flaky==3.6.1
 trustme==0.5.3
 cryptography==2.8

--- a/noxfile.py
+++ b/noxfile.py
@@ -37,6 +37,7 @@ def tests_impl(session, extras="socks,secure,brotli"):
     )
     session.run("coverage", "combine")
     session.run("coverage", "report", "-m")
+    session.run("coverage", "xml")
 
 
 @nox.session(python=["2.7", "3.5", "3.6", "3.7", "3.8", "3.9", "pypy"])
@@ -70,6 +71,7 @@ def app_engine(session):
     )
     session.run("coverage", "combine")
     session.run("coverage", "report", "-m")
+    session.run("coverage", "xml")
 
 
 @nox.session()


### PR DESCRIPTION
The idea is to generate coverage.xml explicitly, and ask codecov to upload this file. This reduces possible errors significantly. For example, it avoids a case where codecov uploaded a coverage.py binary!