### PR TITLE
Remove unneeded requirement

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -10,9 +10,7 @@ pytest-timeout==1.3.4
 flaky==3.6.1
 trustme==0.5.3
 cryptography==2.8
+gcp-devrel-py-tools==0.0.15
 
 # https://github.com/GoogleCloudPlatform/python-repo-tools/issues/23
 pylint<2.0;python_version<="2.7"
-
-# Because typed-ast doesn't provide Python 3.4+Windows wheels
-gcp-devrel-py-tools;python_version>='3.5' or sys_platform != 'win32'


### PR DESCRIPTION
It was only needed for Python 3.4.