### PR TITLE
Simplify get_unreachable_address

### DIFF
--- a/dummyserver/server.py
+++ b/dummyserver/server.py
@@ -7,8 +7,6 @@ from __future__ import print_function
 
 import logging
 import os
-import random
-import string
 import sys
 import threading
 import socket
@@ -160,17 +158,8 @@ def run_loop_in_thread(io_loop):
 
 
 def get_unreachable_address():
-    while True:
-        host = "".join(random.choice(string.ascii_lowercase) for _ in range(60))
-        sockaddr = (host, 54321)
-
-        # check if we are really "lucky" and hit an actual server
-        try:
-            s = socket.create_connection(sockaddr)
-        except socket.error:
-            return sockaddr
-        else:
-            s.close()
+    # reserved as per rfc2606
+    return ("something.invalid", 54321)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`get_unreachable_address` returns an invalid IP endpoint.
It does that by looping through random long domain names and returning the first one that fails to resolve.
A faster and deterministic approach to accomplish that, is to use the `.invalid` TLD specified in [rfc2606](https://tools.ietf.org/html/rfc2606).