### PR TITLE
Switch macOS CI to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  macOS:
+    runs-on: macos-latest
+    
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [2.7, 3.5, 3.6, 3.7, 3.8]
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v1
+      - name: Set Up Python 3.7 to run nox
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+      - name: Set Up Python - ${{ matrix.python-version }}
+        if: matrix.python_version != '3.7'
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install Dependencies
+        run: |
+          python3.7 -m pip install --upgrade nox
+      - name: Run Tests
+        run: |
+          nox -s test-${{ matrix.python-version }}
+      - name: Upload Coverage
+        uses: codecov/codecov-action@v1
+        with:
+          file: ./coverage.xml
+          flags: unittests
+          name: codecov-umbrella
+          yml: ./codecov.yml
+          fail_ci_if_error: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,23 +62,6 @@ jobs:
     - python: 3.7
       env: NOX_SESSION=google_brotli-3
 
-    # OS X unit tests.
-    - language: generic
-      os: osx
-      env: NOX_SESSION=test-2.7
-    - language: generic
-      os: osx
-      env: NOX_SESSION=test-3.5
-    - language: generic
-      os: osx
-      env: NOX_SESSION=test-3.6
-    - language: generic
-      os: osx
-      env: NOX_SESSION=test-3.7
-    - language: generic
-      os: osx
-      env: NOX_SESSION=test-3.8
-
     # Downstream integration tests.
     - python: 2.7
       env: DOWNSTREAM=requests

--- a/_travis/install.sh
+++ b/_travis/install.sh
@@ -3,54 +3,17 @@
 set -exo pipefail
 
 
-install_mac_python() {
-    local FULL=$1
-    local MINOR=$(echo $FULL | cut -d. -f1,2)
-    local PYTHON_EXE=/Library/Frameworks/Python.framework/Versions/${MINOR}/bin/python${MINOR}
-    if [[ "$MINOR" == "3.5" ]]; then
-        # The 3.5 python.org macOS build is only compiled with macOS 10.6
-        local COMPILER=10.6
-    else
-        local COMPILER=10.9
-    fi
-
-    curl -Lo macpython.pkg https://www.python.org/ftp/python/${FULL}/python-${FULL}-macosx${COMPILER}.pkg
-    sudo installer -pkg macpython.pkg -target /
-
-    # The pip in older MacPython releases doesn't support a new enough TLS
-    curl https://bootstrap.pypa.io/get-pip.py | sudo $PYTHON_EXE
-    $PYTHON_EXE -m pip install virtualenv
-}
-
-
-if [[ "$(uname -s)" == 'Darwin' ]]; then
-    # Mac OS setup.
-    case "${NOX_SESSION}" in
-        test-2.7) MACPYTHON=2.7.17 ;;
-        test-3.5) MACPYTHON=3.5.4 ;;  # last binary release
-        test-3.6) MACPYTHON=3.6.8 ;;  # last binary release
-        test-3.7) MACPYTHON=3.7.6 ;;
-        test-3.8) MACPYTHON=3.8.1 ;;
-    esac
-
-    install_mac_python $MACPYTHON
-
-    # Install Nox
-    python3 -m pip install nox
-
+# Linux Setup
+# Even when testing on Python 2, we need Python 3 for Nox. This detects if
+# we're in one of the Travis Python 2 sessions and sets up the Python 3 install
+# for Nox.
+if ! python3 -m pip --version; then
+    curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+    sudo python3 get-pip.py
+    sudo python3 -m pip install nox
 else
-    # Linux Setup
-    # Even when testing on Python 2, we need Python 3 for Nox. This detects if
-    # we're in one of the Travis Python 2 sessions and sets up the Python 3 install
-    # for Nox.
-    if ! python3 -m pip --version; then
-        curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-        sudo python3 get-pip.py
-        sudo python3 -m pip install nox
-    else
-        # We're not in "dual Python" mode, so we can just install Nox normally.
-        python3 -m pip install nox
-    fi
+    # We're not in "dual Python" mode, so we can just install Nox normally.
+    python3 -m pip install nox
 fi
 
 if [[ "${NOX_SESSION}" == "app_engine" ]]; then

--- a/_travis/run.sh
+++ b/_travis/run.sh
@@ -3,12 +3,7 @@
 set -exo pipefail
 
 if [ -n "${NOX_SESSION}" ]; then
-    if [[ "$(uname -s)" == 'Darwin' ]]; then
-        # Explicitly use python3 on macOS as `nox` is not in the PATH
-        python3 -m nox -s "${NOX_SESSION}"
-    else
-        nox -s "${NOX_SESSION}"
-    fi
+    nox -s "${NOX_SESSION}"
 else
     downstream_script="${TRAVIS_BUILD_DIR}/_travis/downstream/${DOWNSTREAM}.sh"
     if [ ! -x "$downstream_script" ]; then


### PR DESCRIPTION
The macOS tests are the current bottleneck, which is why I'm moving them first. I've simply copy-pasted my work from https://github.com/python-trio/hip/blob/master/.github/workflows/ci.yml. GitHub Actions is nice because it gives up to 20x parallelism and is better integrated with GitHub, however the UI is barely usable when the tests are still running. Good news: a codecov token is no longer required.