### PR TITLE
Detect GitHub Actions as continuous integration

### DIFF
--- a/test/__init__.py
+++ b/test/__init__.py
@@ -36,7 +36,9 @@ INVALID_SOURCE_ADDRESSES = [("192.0.2.255", 0), ("2001:db8::1", 0)]
 # 3. To test our timeout logic by using two different values, eg. by using different
 #    values at the pool level and at the request level.
 SHORT_TIMEOUT = 0.001
-LONG_TIMEOUT = 0.5 if os.environ.get("CI") else 0.01
+LONG_TIMEOUT = 0.01
+if os.environ.get("CI") or os.environ.get("GITHUB_ACTIONS") == "true":
+    LONG_TIMEOUT = 0.5
 
 
 def _can_resolve(host):


### PR DESCRIPTION
When setting up longer timeouts on continuous integration, I noticed that the "CI" environment variable was not available on GitHub Actions, and realized that it would be easy to forget when switching to GitHub Actions. And indeed, I forgot about it! And then https://github.com/urllib3/urllib3/runs/553809349 failed because `LONG_TIMEOUT` was too small. This pull request fixes that.

(By the way, the macOS builds are currently really slow, 2x to 3x slower than on Travis, even if they start faster. But it's still worth it, thanks to the parallelism.)