### PR TITLE
Revert "Add context to find_unused_port (#1837)"

### DIFF
--- a/test/test_proxymanager.py
+++ b/test/test_proxymanager.py
@@ -67,11 +67,11 @@ class TestProxyManager(object):
 
     def test_proxy_connect_retry(self):
         retry = Retry(total=None, connect=False)
-        with find_unused_port() as port:
-            with ProxyManager("http://localhost:{}".format(port)) as p:
-                with pytest.raises(ProxyError) as ei:
-                    p.urlopen("HEAD", url="http://localhost/", retries=retry)
-                assert isinstance(ei.value.original_error, NewConnectionError)
+        port = find_unused_port()
+        with ProxyManager("http://localhost:{}".format(port)) as p:
+            with pytest.raises(ProxyError) as ei:
+                p.urlopen("HEAD", url="http://localhost/", retries=retry)
+            assert isinstance(ei.value.original_error, NewConnectionError)
 
         retry = Retry(total=None, connect=2)
         with ProxyManager("http://localhost:{}".format(port)) as p:

--- a/test/with_dummyserver/test_connectionpool.py
+++ b/test/with_dummyserver/test_connectionpool.py
@@ -349,11 +349,11 @@ class TestConnectionPool(HTTPDummyServerTestCase):
 
     def test_connection_error_retries(self):
         """ ECONNREFUSED error should raise a connection error, with retries """
-        with find_unused_port() as port:
-            with HTTPConnectionPool(self.host, port) as pool:
-                with pytest.raises(MaxRetryError) as e:
-                    pool.request("GET", "/", retries=Retry(connect=3))
-                assert type(e.value.reason) == NewConnectionError
+        port = find_unused_port()
+        with HTTPConnectionPool(self.host, port) as pool:
+            with pytest.raises(MaxRetryError) as e:
+                pool.request("GET", "/", retries=Retry(connect=3))
+            assert type(e.value.reason) == NewConnectionError
 
     def test_timeout_success(self):
         timeout = Timeout(connect=3, read=5, total=None)


### PR DESCRIPTION
This reverts commit a9508d8d8ac58ed95bf06d8970382664af4e91e3.

For some reason, this commit was making the tests really, really slow on macOS. For example, `test_proxy_connect_retry` went from nearly instant to 25 seconds on my computer. As a result, macOS tests in CI went from ~3 minutes to ~8 minutes. I thought this was because of GitHub Actions, but in fact the above commit was the last where tests ran on macOS. GitHub Actions is fine.

Sorry about that, @hodbn, but practicality beats purity here.