### PR TITLE
Fix documentation build by skipping Sphinx 3.0.0

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
 -r ../dev-requirements.txt
-sphinx<3
+sphinx!=3.0.0
 alabaster
 requests>=2,<2.16

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
 -r ../dev-requirements.txt
-sphinx
+sphinx<3
 alabaster
 requests>=2,<2.16


### PR DESCRIPTION
Sphinx 3 currently fails with an mysterious ValueError: `wrapper loop
when unwrapping <MockModule id='139897808864312'>`