### PR TITLE
URI parsing: disallow backslash in the authority part

### DIFF
--- a/src/urllib3/util/url.py
+++ b/src/urllib3/util/url.py
@@ -18,7 +18,7 @@ PERCENT_RE = re.compile(r"%[a-fA-F0-9]{2}")
 SCHEME_RE = re.compile(r"^(?:[a-zA-Z][a-zA-Z0-9+-]*:|/)")
 URI_RE = re.compile(
     r"^(?:([a-zA-Z][a-zA-Z0-9+.-]*):)?"
-    r"(?://([^/?#]*))?"
+    r"(?://([^\\/?#]*))?"
     r"([^?#]*)"
     r"(?:\?([^#]*))?"
     r"(?:#(.*))?$",

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -425,6 +425,18 @@ class TestUtil(object):
                 query="%0D%0ASET%20test%20failure12%0D%0A:8080/test/?test=a",
             ),
         ),
+        # See https://bugs.xdavidhu.me/google/2020/03/08/the-unexpected-google-wide-domain-check-bypass/
+        (
+            "https://user:pass@xdavidhu.me\\test.corp.google.com:8080/path/to/something?param=value#hash",
+            Url(
+                scheme="https",
+                auth="user:pass",
+                host="xdavidhu.me",
+                path="/%5Ctest.corp.google.com:8080/path/to/something",
+                query="param=value",
+                fragment="hash",
+            ),
+        ),
     ]
 
     @pytest.mark.parametrize("url, expected_url", url_vulnerabilities)


### PR DESCRIPTION
The backslash character is not allowed in the authority part of a URI by [rfc3986](https://tools.ietf.org/html/rfc3986#appendix-A). Including it might even lead to [dangerous cases](https://bugs.xdavidhu.me/google/2020/03/08/the-unexpected-google-wide-domain-check-bypass/).

As far as I can understand, the [example regex in rfc3986](https://tools.ietf.org/html/rfc3986#appendix-B) allows the character, but we probably still want to disallow it.

Pretty much the same as https://github.com/python-hyper/rfc3986/pull/64.