### PR TITLE
Fix flaky test by setting longer connect timeout

### DIFF
--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -496,7 +496,7 @@ class TestSocketClosing(SocketDummyServerTestCase):
 
         try:
             self._start_server(socket_handler)
-            t = Timeout(connect=SHORT_TIMEOUT, read=LONG_TIMEOUT)
+            t = Timeout(connect=LONG_TIMEOUT, read=LONG_TIMEOUT)
             with HTTPConnectionPool(self.host, self.port, timeout=t) as pool:
                 response = pool.request("GET", "/", retries=1)
                 assert response.status == 200


### PR DESCRIPTION
In https://github.com/urllib3/urllib3/pull/1844 we got the following failure:

```2020-04-08T06:27:51.9611850Z _____________ TestSocketClosing.test_timeout_errors_cause_retries ______________
2020-04-08T06:27:51.9612320Z Traceback (most recent call last):
2020-04-08T06:27:51.9615460Z   File "/Users/runner/runners/2.168.0/work/urllib3/urllib3/test/with_dummyserver/test_socketlevel.py", line 501, in test_timeout_errors_cause_retries
2020-04-08T06:27:51.9616040Z     response = pool.request("GET", "/", retries=1)
2020-04-08T06:27:51.9617580Z   File "/Users/runner/runners/2.168.0/work/urllib3/urllib3/.nox/test-2-7/lib/python2.7/site-packages/urllib3/request.py", line 76, in request
2020-04-08T06:27:51.9618460Z     method, url, fields=fields, headers=headers, **urlopen_kw
2020-04-08T06:27:51.9619410Z   File "/Users/runner/runners/2.168.0/work/urllib3/urllib3/.nox/test-2-7/lib/python2.7/site-packages/urllib3/request.py", line 97, in request_encode_url
2020-04-08T06:27:51.9619820Z     return self.urlopen(method, url, **extra_kw)
2020-04-08T06:27:51.9620680Z   File "/Users/runner/runners/2.168.0/work/urllib3/urllib3/.nox/test-2-7/lib/python2.7/site-packages/urllib3/connectionpool.py", line 765, in urlopen
2020-04-08T06:27:51.9621040Z     **response_kw
2020-04-08T06:27:51.9621880Z   File "/Users/runner/runners/2.168.0/work/urllib3/urllib3/.nox/test-2-7/lib/python2.7/site-packages/urllib3/connectionpool.py", line 725, in urlopen
2020-04-08T06:27:51.9622300Z     method, url, error=e, _pool=self, _stacktrace=sys.exc_info()[2]
2020-04-08T06:27:51.9623160Z   File "/Users/runner/runners/2.168.0/work/urllib3/urllib3/.nox/test-2-7/lib/python2.7/site-packages/urllib3/util/retry.py", line 439, in increment
2020-04-08T06:27:51.9623630Z     raise MaxRetryError(_pool, url, error or ResponseError(cause))
2020-04-08T06:27:51.9624410Z MaxRetryError: HTTPConnectionPool(host='localhost', port=49798): Max retries exceeded with url: / (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x10baba590>: Failed to establish a new connection: [Errno 61] Connection refused',))
2020-04-08T06:27:51.9625190Z ----------------------------- Captured stdout call -----------------------------
2020-04-08T06:27:51.9626130Z Retrying (Retry(total=0, connect=None, read=None, redirect=None, status=None)) after connection broken by 'NewConnectionError('<urllib3.connection.HTTPConnection object at 0x10baba450>: Failed to establish a new connection: [Errno 61] Connection refused',)': /
2020-04-08T06:27:51.9627080Z Retrying (Retry(total=0, connect=None, read=None, redirect=None, status=None)) after connection broken by 'NewConnectionError('<urllib3.connection.HTTPConnection object at 0x10baba450>: Failed to establish a new connection: [Errno 61] Connection refused',)': /
2020-04-08T06:27:51.9627890Z ------------------------------ Captured log call -------------------------------
2020-04-08T06:27:51.9628860Z WARNING  urllib3.connectionpool:connectionpool.py:750 Retrying (Retry(total=0, connect=None, read=None, redirect=None, status=None)) after connection broken by 'NewConnectionError('<urllib3.connection.HTTPConnection object at 0x10baba450>: Failed to establish a new connection: [Errno 61] Connection refused',)': /
```

(It's awesome that GitHub Actions includes timestamps with microsecond precision in the raw logs.)

After staring at this for a bit, I realized that this is the only test in the test suite that is setting `connect=SHORT_TIMEOUT` even though it's not testing a connection timeout. When setting `connect=LONG_TIMEOUT`, I did not get a single macOS failure after 750 runs (https://github.com/pquentin/urllib3/actions/runs/73478174). With the existing short timeout, I got 11 failures (https://github.com/pquentin/urllib3/runs/570468264).

(Travis will fail, since this does not include the Sphinx fix.)