### PR TITLE
Fix PyPI long description

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,21 @@ name: CI
 on: [push, pull_request]
 
 jobs:
+  package:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v1
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+      - name: Check packages
+        run: |
+          python3.7 -m pip install wheel twine;
+          python3.7 setup.py sdist bdist_wheel;
+          python3.7 -m twine check dist/*
   macOS:
     runs-on: macos-latest
     

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,4 @@
 .. raw:: html
-
    <p align="center">
       <a href="https://github.com/urllib3/urllib3">
          <img src="./docs/images/banner.svg" width="60%" alt="urllib3" />
@@ -11,7 +10,7 @@
       <a href="https://urllib3.readthedocs.io/en/latest/"><img alt="Documentation Status" src="https://readthedocs.org/projects/urllib3/badge/?version=latest" /></a>
       <a href="https://codecov.io/gh/urllib3/urllib3"><img alt="Coverage Status" src="https://img.shields.io/codecov/c/github/urllib3/urllib3.svg" /></a>
       <a href="https://pypi.org/project/urllib3/"><img alt="PyPI Version" src="https://img.shields.io/pypi/v/urllib3.svg?maxAge=86400" /></a>
-  </p>
+   </p>
 
 urllib3 is a powerful, *sanity-friendly* HTTP client for Python. Much of the
 Python ecosystem already uses urllib3 and you should too.

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,18 @@ with open(os.path.join(base_path, "src", "urllib3", "__init__.py")) as fp:
 
 
 with codecs.open("README.rst", encoding="utf-8") as fp:
-    readme = fp.read()
+    # remove reST raw directive from README
+    mode = None
+    lines = []
+    for line in fp:
+        if line.startswith(".. raw"):
+            mode = "ignore_raw"
+        elif line == "\n":
+            mode = None
+
+        if mode != "ignore_raw":
+            lines.append(line)
+    readme = "".join(lines)
 
 with codecs.open("CHANGES.rst", encoding="utf-8") as fp:
     changes = fp.read()
@@ -28,6 +39,7 @@ setup(
     version=version,
     description="HTTP library with thread-safe connection pooling, file post, and more.",
     long_description=u"\n\n".join([readme, changes]),
+    long_description_content_type="text/x-rst",
     classifiers=[
         "Environment :: Web Environment",
         "Intended Audience :: Developers",


### PR DESCRIPTION
The first commit runs "twine check". I reused @sethmlarson's code from hip, but simplified it since `twine check` returns a non-zero error code on failure. You can see the check working as expected here: https://github.com/pquentin/urllib3/runs/593112721?check_suite_focus=true

The second commits fixes the twine warnings by:

 1. removing the raw directive from the long description, and
 2. specifying the content type.

Parsing README.rst is quite brittle, what do you think? It works now (see the resulting PKG-INFO), but who knows how it could break in the future.

Closes #1854 