### PR TITLE
Add CODEOWNERS restricting access to files related to deployment

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# Restrict all files related to deploying to
+# require lead maintainer approval.
+
+.github/CODEOWNERS          @sethmlarson @shazow
+src/urllib3/_version.py     @sethmlarson @shazow
+setup.py                    @sethmlarson @shazow
+_travis/                    @sethmlarson @shazow
+.travis.yml                 @sethmlarson @shazow

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# This file is protected via CODEOWNERS
 
 from setuptools import setup
 
@@ -9,7 +10,7 @@ import codecs
 base_path = os.path.dirname(__file__)
 
 # Get the version (borrowed from SQLAlchemy)
-with open(os.path.join(base_path, "src", "urllib3", "__init__.py")) as fp:
+with open(os.path.join(base_path, "src", "urllib3", "_version.py")) as fp:
     VERSION = (
         re.compile(r""".*__version__ = ["'](.*?)['"]""", re.S).match(fp.read()).group(1)
     )

--- a/src/urllib3/__init__.py
+++ b/src/urllib3/__init__.py
@@ -14,7 +14,7 @@ from .util.request import make_headers
 from .util.url import get_host
 from .util.timeout import Timeout
 from .util.retry import Retry
-from ._version import __version__ as __version__
+from ._version import __version__
 
 
 # Set default logging handler to avoid "No handler found" warnings.
@@ -23,6 +23,7 @@ from logging import NullHandler
 
 __author__ = "Andrey Petrov (andrey.petrov@shazow.net)"
 __license__ = "MIT"
+__version__ = __version__
 
 __all__ = (
     "HTTPConnectionPool",

--- a/src/urllib3/__init__.py
+++ b/src/urllib3/__init__.py
@@ -14,6 +14,7 @@ from .util.request import make_headers
 from .util.url import get_host
 from .util.timeout import Timeout
 from .util.retry import Retry
+from ._version import __version__ as __version__
 
 
 # Set default logging handler to avoid "No handler found" warnings.
@@ -22,7 +23,6 @@ from logging import NullHandler
 
 __author__ = "Andrey Petrov (andrey.petrov@shazow.net)"
 __license__ = "MIT"
-__version__ = "1.25.8"
 
 __all__ = (
     "HTTPConnectionPool",

--- a/src/urllib3/_version.py
+++ b/src/urllib3/_version.py
@@ -1,0 +1,2 @@
+# This file is protected via CODEOWNERS
+__version__ = "1.25.9"


### PR DESCRIPTION
Basically want to reduce the current surface of accounts that'd be required to either:
- Make a malicious release via our automated deploy
- Dump the `PYPI_PASSWORD` from Travis by merging into master

The first is thwarted by making `setup.py` and `_version.py` protected files. That way even if an attacker commits changes and tags a commit on `master` the upload would fail due to there being a duplicate version.

The second is thwarted by disallowing changes to scripts that have access to `PYPI_PASSWORD` on Travis to require admin approval.

In total this reduces our attack surface from requiring access to 2 committer accounts or 1 admin account to only the 1 admin account scenario, and in that case we're pretty hosed anyways. :)