### PR TITLE
Avoid hasattr in hot loop in brotli decoder

### DIFF
--- a/src/urllib3/response.py
+++ b/src/urllib3/response.py
@@ -107,11 +107,10 @@ if brotli is not None:
         # are for 'brotlipy' and bottom branches for 'Brotli'
         def __init__(self):
             self._obj = brotli.Decompressor()
-
-        def decompress(self, data):
             if hasattr(self._obj, "decompress"):
-                return self._obj.decompress(data)
-            return self._obj.process(data)
+                self.decompress = self._obj.decompress
+            else:
+                self.decompress = self._obj.process
 
         def flush(self):
             if hasattr(self._obj, "flush"):


### PR DESCRIPTION
`hasattr` has a nasty performance penalty when it returns false: in the background it is actually a try/except AttributeError.  Since we know the method we want won't change, by instead caching the bound method object we can amortise the cost across an entire encoded body.

This removes the intermediate `decompress` method altogether, instead giving the underlying method the `decompress` name.