### PR TITLE
Do not put a None in a connection pool if it was empty

### DIFF
--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -698,9 +698,6 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
             # Everything went great!
             clean_exit = True
 
-        except queue.Empty:
-            # Timed out by queue.
-            raise EmptyPoolError(self, "No pool connections are available.")
 
         except (
             TimeoutError,

--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -698,6 +698,11 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
             # Everything went great!
             clean_exit = True
 
+        except EmptyPoolError:
+            # Didn't get a connection from the pool, no need to clean up
+            clean_exit = True
+            release_this_conn = False
+            raise
 
         except (
             TimeoutError,

--- a/test/test_connectionpool.py
+++ b/test/test_connectionpool.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 import ssl
 import pytest
+from mock import Mock
 
 from urllib3.connectionpool import (
     connection_from_url,
@@ -279,7 +280,6 @@ class TestConnectionPool(object):
 
             # Make sure that all of the exceptions return the connection
             # to the pool
-            _test(Empty, EmptyPoolError)
             _test(BaseSSLError, MaxRetryError, SSLError)
             _test(CertificateError, MaxRetryError, SSLError)
 
@@ -291,6 +291,15 @@ class TestConnectionPool(object):
             with pytest.raises(MaxRetryError):
                 pool.request("GET", "/", retries=1, pool_timeout=SHORT_TIMEOUT)
             assert pool.pool.qsize() == POOL_SIZE
+
+    def test_empty_does_not_put_conn(self):
+        """Do not put None back in the pool if the pool was empty"""
+
+        with HTTPConnectionPool(host="localhost", maxsize=1, block=True) as pool:
+            pool._get_conn = Mock(side_effect=EmptyPoolError(pool, "Pool is empty"))
+            pool._put_conn = Mock(side_effect=AssertionError("Unexpected _put_conn"))
+            with pytest.raises(EmptyPoolError):
+                pool.request("GET", "/")
 
     def test_assert_same_host(self):
         with connection_from_url("http://google.com:80") as c:


### PR DESCRIPTION
Trying to resolve #1758 in a different approach from #1759 .
I think that there are two different issues.

First, ```HTTPConnection.urlopen``` should not except a ```queue.Empty``` error since these might only be raised in tests:
https://github.com/urllib3/urllib3/blob/898a16d09e4a6d9dbe10134a49b89eedfe8dae7f/test/test_connectionpool.py#L282
In an unpatched flow, ```HTTPConnection.urlopen``` might only raise an ```EmptyPoolError``` inside ```HTTPConnection._get_conn```:
https://github.com/urllib3/urllib3/blob/898a16d09e4a6d9dbe10134a49b89eedfe8dae7f/src/urllib3/connectionpool.py#L261-L267

Secondly, ```HTTPConnection.urlopen``` should not put back a ```None``` in the pool in case of an ```EmptyPoolError```. If it does, then the situation @jaimefrites described might occur.

AFAICT the test I removed in ```test_pool_size``` is not relevant since in real-life scenario the pool is never changed.