### PR TITLE
set minimal six version to fix urllib3.exceptions.LocationParseError

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,7 @@ requires-dist =
     ipaddress; python_version=="2.7" and extra == 'secure'
     PySocks>=1.5.6,<2.0,!=1.5.7; extra == 'socks'
     brotlipy>=0.6.0; extra == 'brotli'
+    six>=1.12.0
 
 [tool:pytest]
 xfail_strict = true


### PR DESCRIPTION
Hello i just installed ubuntu 20.04 and saw this issue, to fix it it requires `six>=1.12.0`

original error
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/dist-packages/requests/models.py", line 380, in prepare_url
    scheme, auth, host, port, path, query, fragment = parse_url(url)
  File "/usr/lib/python3/dist-packages/urllib3/util/url.py", line 392, in parse_url
    return six.raise_from(LocationParseError(source_url), None)
  File "<string>", line 3, in raise_from
urllib3.exceptions.LocationParseError: Failed to parse: http://127.0.0.18000/
```

debugging i found that it caused by
https://github.com/urllib3/urllib3/blob/263da24d4b5c33392772e638b12d02e5b07abf9f/src/urllib3/util/url.py#L217
```
module 'six' has no attribute 'ensure_text' Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/urllib3/util/url.py", line 385, in parse_url
    path = _encode_invalid_chars(path, PATH_CHARS)
  File "/usr/lib/python3/dist-packages/urllib3/util/url.py", line 217, in _encode_invalid_chars
    component = six.ensure_text(component)
AttributeError: module 'six' has no attribute 'ensure_text
```

as you can see https://github.com/benjaminp/six/blob/master/CHANGES
```
1.12.0
------

- Issue #259, pull request #260: `six.add_metaclass` now preserves
  `__qualname__` from the original class.

- Pull request #204: Add `six.ensure_binary`, `six.ensure_text`, and
  `six.ensure_str`.