### PR TITLE
Fixes errors thrown when the variable line is an empty string

### DIFF
--- a/src/urllib3/response.py
+++ b/src/urllib3/response.py
@@ -692,6 +692,9 @@ class HTTPResponse(io.IOBase):
             return
         line = self._fp.fp.readline()
         line = line.split(b";", 1)[0]
+        if not line:
+            self.chunk_left = 0
+            return
         try:
             self.chunk_left = int(line, 16)
         except ValueError:


### PR DESCRIPTION
I ran into an error when using requests and ended up locating in response.py
```
Traceback (most recent call last):
  File "/venv/lib/python3.7/site-packages/urllib3/response.py", line 688, in _update_chunk_length
    self.chunk_left = int(line, 16)
ValueError: invalid literal for int() with base 16: b''

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/venv/lib/python3.7/site-packages/urllib3/response.py", line 425, in _error_catcher
    yield
  File "/venv/lib/python3.7/site-packages/urllib3/response.py", line 755, in read_chunked
    self._update_chunk_length()
  File "/venv/lib/python3.7/site-packages/urllib3/response.py", line 692, in _update_chunk_length
    raise httplib.IncompleteRead(line)
http.client.IncompleteRead: IncompleteRead(0 bytes read)

```
Fixes errors thrown when the variable` line` is an empty string