### PR TITLE
Fix lint after flake8 3.8 upgrade

### DIFF
--- a/src/urllib3/util/ssl_.py
+++ b/src/urllib3/util/ssl_.py
@@ -29,8 +29,8 @@ def _const_compare_digest_backport(a, b):
     Returns True if the digests match, and False otherwise.
     """
     result = abs(len(a) - len(b))
-    for l, r in zip(bytearray(a), bytearray(b)):
-        result |= l ^ r
+    for left, right in zip(bytearray(a), bytearray(b)):
+        result |= left ^ right
     return result == 0
 
 

--- a/test/contrib/test_pyopenssl.py
+++ b/test/contrib/test_pyopenssl.py
@@ -30,7 +30,7 @@ def teardown_module():
         pass
 
 
-from ..with_dummyserver.test_https import (  # noqa: F401
+from ..with_dummyserver.test_https import (  # noqa: E402, F401
     TestHTTPS,
     TestHTTPS_TLSv1,
     TestHTTPS_TLSv1_1,
@@ -41,7 +41,7 @@ from ..with_dummyserver.test_https import (  # noqa: F401
     TestHTTPS_NoSAN,
     TestHTTPS_IPV6SAN,
 )
-from ..with_dummyserver.test_socketlevel import (  # noqa: F401
+from ..with_dummyserver.test_socketlevel import (  # noqa: E402, F401
     TestSNI,
     TestSocketClosing,
     TestClientCerts,

--- a/test/contrib/test_securetransport.py
+++ b/test/contrib/test_securetransport.py
@@ -31,13 +31,13 @@ def teardown_module():
 
 # SecureTransport does not support TLSv1.3
 # https://github.com/urllib3/urllib3/issues/1674
-from ..with_dummyserver.test_https import (  # noqa: F401
+from ..with_dummyserver.test_https import (  # noqa: E402, F401
     TestHTTPS,
     TestHTTPS_TLSv1,
     TestHTTPS_TLSv1_1,
     TestHTTPS_TLSv1_2,
 )
-from ..with_dummyserver.test_socketlevel import (  # noqa: F401
+from ..with_dummyserver.test_socketlevel import (  # noqa: E402, F401
     TestSNI,
     TestSocketClosing,
     TestClientCerts,


### PR DESCRIPTION
The 3.9 build fails because of https://github.com/nedbat/coveragepy/issues/988, it is fixed in Python master, but Travis hasn't picked that up yet.

Here's a failing lint job by the way: https://travis-ci.org/github/urllib3/urllib3/jobs/685968468