### PR TITLE
Use nox version that works with Python 3.5.2

### DIFF
--- a/_travis/install.sh
+++ b/_travis/install.sh
@@ -10,7 +10,8 @@ set -exo pipefail
 if ! python3 -m pip --version; then
     curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
     sudo python3 get-pip.py
-    sudo python3 -m pip install nox
+    # https://github.com/theacodes/nox/issues/328
+    sudo python3 -m pip install nox==2019.11.9
 else
     # We're not in "dual Python" mode, so we can just install Nox normally.
     python3 -m pip install nox


### PR DESCRIPTION
This is the default `python3` shipped by Travis.

See https://github.com/theacodes/nox/issues/328 for details