### PR TITLE
Fix SSLKEYLOGFILE on AppVeyor

### DIFF
--- a/test/with_dummyserver/test_https.py
+++ b/test/with_dummyserver/test_https.py
@@ -698,16 +698,10 @@ class TestHTTPS(HTTPSDummyServerTestCase):
             finally:
                 conn.close()
 
-    @pytest.mark.skipif(
-        not hasattr(ssl.SSLContext, "keylog_filename"),
-        reason="requires OpenSSL 1.1.1+",
-    )
     @pytest.mark.skipif(sys.version_info < (3, 8), reason="requires python 3.8+")
-    @pytest.mark.skipif(
-        sys.platform == "win32",
-        reason="does not work reliably in Appveyor test enviroment for not yet known reasons",
-    )
     def test_sslkeylogfile(self, tmpdir, monkeypatch):
+        if not hasattr(util.SSLContext, "keylog_filename"):
+            pytest.skip("requires OpenSSL 1.1.1+")
         keylog_file = tmpdir.join("keylogfile.txt")
         monkeypatch.setenv("SSLKEYLOGFILE", str(keylog_file))
         with HTTPSConnectionPool(

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -10,8 +10,8 @@ from urllib3.exceptions import (
     ProtocolError,
 )
 from urllib3.packages.six.moves import http_client as httplib
+from urllib3 import util
 from urllib3.util import ssl_wrap_socket
-from urllib3.util.ssl_ import HAS_SNI
 from urllib3.util import ssl_
 from urllib3.util.timeout import Timeout
 from urllib3.util.retry import Retry
@@ -87,8 +87,9 @@ class TestCookies(SocketDummyServerTestCase):
 
 
 class TestSNI(SocketDummyServerTestCase):
-    @pytest.mark.skipif(not HAS_SNI, reason="SNI-support not available")
     def test_hostname_in_first_request_packet(self):
+        if not util.HAS_SNI:
+            pytest.skip("SNI-support not available")
         done_receiving = Event()
         self.buf = b""
 


### PR DESCRIPTION
Closes #1889.

The failures weren't caused by AppVeyor/Windows but PyOpenSSL. The implementation does not support ```SSLContext.keylog_filename```. Our skip condition was that Python's OpenSSL version > 1.1.1.
We didn't we see the failures on Linux/Mac because the tests were skipped:
* Travis-CI's OpenSSL version is [1.0.2g](https://travis-ci.org/github/urllib3/urllib3/jobs/697205369).
* Github's OpenSSL version on the 3.8 machine is [1.0.2t](https://github.com/urllib3/urllib3/pull/1867/checks?check_run_id=761708091).
* In AppVeyor, the OpenSSL version is [1.1.1d](https://ci.appveyor.com/project/urllib3/urllib3/builds/33460611/job/f1toc94t54y6l0io), this is why the test was not skipped and failed.

We need to skip if ```util.SSLContext``` does not have the ```keylog_filename``` attribute (and not ```ssl.SSLContext```). Also, we need to skip in the test itself, since the ```skipif``` mark is evaluated during the collection phase, before the tested implementation was injected.