### PR TITLE
Collapse request chunked data and framing into one send() call

### DIFF
--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -240,10 +240,11 @@ class HTTPConnection(_HTTPConnection, object):
                 if not isinstance(chunk, bytes):
                     chunk = chunk.encode("utf8")
                 len_str = hex(len(chunk))[2:]
-                self.send(len_str.encode("utf-8"))
-                self.send(b"\r\n")
-                self.send(chunk)
-                self.send(b"\r\n")
+                to_send = bytearray(len_str.encode())
+                to_send += b"\r\n"
+                to_send += chunk
+                to_send += b"\r\n"
+                self.send(to_send)
 
         # After the if clause, to always have a closed body
         self.send(b"0\r\n\r\n")


### PR DESCRIPTION
Looking at how urllib3 behaves with Wireshark I saw chunks and chunk framing being sent in separate TCP packets even when only a few bytes. Collapsing data and framing into one `send()` call alleviated this issue. Should reduce the number of TCP packets sent when using `request_chunked` by ~2-4x.

I'd like to backport this to 1.25-series and potentially make a release there with other bug fixes that have landed.