### PR TITLE
Backport fixes to 1.25

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -300,5 +300,8 @@ In chronological order:
 * Chris Olufson <tycarac@gmail.com>
   * Fix for connection not being released on HTTP redirect and response not preloaded
 
+* [Bastiaan Bakker] <https://github.com/bastiaanb>
+  * Support for logging session keys via environment variable ``SSLKEYLOGFILE`` (Python 3.8+)
+
 * [Your name or handle] <[email or website]>
   * [Brief summary of your changes]

--- a/_travis/install.sh
+++ b/_travis/install.sh
@@ -10,7 +10,8 @@ set -exo pipefail
 if ! python3 -m pip --version; then
     curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
     sudo python3 get-pip.py
-    sudo python3 -m pip install nox
+    # https://github.com/theacodes/nox/issues/328
+    sudo python3 -m pip install nox==2019.11.9
 else
     # We're not in "dual Python" mode, so we can just install Nox normally.
     python3 -m pip install nox

--- a/docs/advanced-usage.rst
+++ b/docs/advanced-usage.rst
@@ -72,7 +72,7 @@ Setting ``preload_content`` to ``False`` means that urllib3 will stream the
 response content. :meth:`~response.HTTPResponse.stream` lets you iterate over
 chunks of the response content.
 
-.. note:: When using ``preload_content=False``, you should call 
+.. note:: When using ``preload_content=False``, you should call
     :meth:`~response.HTTPResponse.release_conn` to release the http connection
     back to the connection pool so that it can be re-used.
 
@@ -87,7 +87,7 @@ a file-like object. This allows you to do buffering::
     b'\x88\x1f\x8b\xe5'
 
 Calls to :meth:`~response.HTTPResponse.read()` will block until more response
-data is available. 
+data is available.
 
     >>> import io
     >>> reader = io.BufferedReader(r, 8)
@@ -289,3 +289,16 @@ Here's an example using brotli encoding via the ``Accept-Encoding`` header::
     >>> from urllib3 import PoolManager
     >>> http = PoolManager()
     >>> http.request('GET', 'https://www.google.com/', headers={'Accept-Encoding': 'br'})
+
+Decrypting captured TLS sessions with Wireshark
+-----------------------------------------------
+Python 3.8 and higher support logging of TLS pre-master secrets.
+With these secrets tools like `Wireshark <https://wireshark.org>`_ can decrypt captured
+network traffic.
+
+To enable this simply define environment variable `SSLKEYLOGFILE`:
+
+    export SSLKEYLOGFILE=/path/to/keylogfile.txt
+
+Then configure the key logfile in `Wireshark <https://wireshark.org>`_, see
+`Wireshark TLS Decryption <https://wiki.wireshark.org/TLS#TLS_Decryption>`_ for instructions.

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -225,10 +225,11 @@ class HTTPConnection(_HTTPConnection, object):
                 if not isinstance(chunk, bytes):
                     chunk = chunk.encode("utf8")
                 len_str = hex(len(chunk))[2:]
-                self.send(len_str.encode("utf-8"))
-                self.send(b"\r\n")
-                self.send(chunk)
-                self.send(b"\r\n")
+                to_send = bytearray(len_str.encode())
+                to_send += b"\r\n"
+                to_send += chunk
+                to_send += b"\r\n"
+                self.send(to_send)
 
         # After the if clause, to always have a closed body
         self.send(b"0\r\n\r\n")

--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -698,9 +698,11 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
             # Everything went great!
             clean_exit = True
 
-        except queue.Empty:
-            # Timed out by queue.
-            raise EmptyPoolError(self, "No pool connections are available.")
+        except EmptyPoolError:
+            # Didn't get a connection from the pool, no need to clean up
+            clean_exit = True
+            release_this_conn = False
+            raise
 
         except (
             TimeoutError,

--- a/src/urllib3/contrib/_securetransport/bindings.py
+++ b/src/urllib3/contrib/_securetransport/bindings.py
@@ -45,17 +45,11 @@ from ctypes import (
     c_bool,
 )
 from ctypes import CDLL, POINTER, CFUNCTYPE
+from urllib3.packages.six import raise_from
 
 
-security_path = find_library("Security")
-if not security_path:
-    raise ImportError("The library Security could not be found")
-
-
-core_foundation_path = find_library("CoreFoundation")
-if not core_foundation_path:
-    raise ImportError("The library CoreFoundation could not be found")
-
+if platform.system() != "Darwin":
+    raise ImportError("Only macOS is supported")
 
 version = platform.mac_ver()[0]
 version_info = tuple(map(int, version.split(".")))
@@ -65,8 +59,31 @@ if version_info < (10, 8):
         % (version_info[0], version_info[1])
     )
 
-Security = CDLL(security_path, use_errno=True)
-CoreFoundation = CDLL(core_foundation_path, use_errno=True)
+
+def load_cdll(name, macos10_16_path):
+    """Loads a CDLL by name, falling back to known path on 10.16+"""
+    try:
+        # Big Sur is technically 11 but we use 10.16 due to the Big Sur
+        # beta being labeled as 10.16.
+        if version_info >= (10, 16):
+            path = macos10_16_path
+        else:
+            path = find_library(name)
+        if not path:
+            raise OSError  # Caught and reraised as 'ImportError'
+        return CDLL(path, use_errno=True)
+    except OSError:
+        raise_from(ImportError("The library %s failed to load" % name), None)
+
+
+Security = load_cdll(
+    "Security", "/System/Library/Frameworks/Security.framework/Security"
+)
+CoreFoundation = load_cdll(
+    "CoreFoundation",
+    "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation",
+)
+
 
 Boolean = c_bool
 CFIndex = c_long

--- a/src/urllib3/response.py
+++ b/src/urllib3/response.py
@@ -107,11 +107,10 @@ if brotli is not None:
         # are for 'brotlipy' and bottom branches for 'Brotli'
         def __init__(self):
             self._obj = brotli.Decompressor()
-
-        def decompress(self, data):
             if hasattr(self._obj, "decompress"):
-                return self._obj.decompress(data)
-            return self._obj.process(data)
+                self.decompress = self._obj.decompress
+            else:
+                self.decompress = self._obj.process
 
         def flush(self):
             if hasattr(self._obj, "flush"):

--- a/src/urllib3/util/ssl_.py
+++ b/src/urllib3/util/ssl_.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 import errno
 import warnings
 import hmac
+import os
 import sys
 
 from binascii import hexlify, unhexlify
@@ -293,6 +294,12 @@ def create_urllib3_context(
         # We do our own verification, including fingerprints and alternative
         # hostnames. So disable it here
         context.check_hostname = False
+
+    # Enable logging of TLS session keys via defacto standard environment variable
+    # 'SSLKEYLOGFILE', if the feature is available (Python 3.8+).
+    if hasattr(context, "keylog_filename"):
+        context.keylog_filename = os.environ.get("SSLKEYLOGFILE")
+
     return context
 
 

--- a/src/urllib3/util/ssl_.py
+++ b/src/urllib3/util/ssl_.py
@@ -29,8 +29,8 @@ def _const_compare_digest_backport(a, b):
     Returns True if the digests match, and False otherwise.
     """
     result = abs(len(a) - len(b))
-    for l, r in zip(bytearray(a), bytearray(b)):
-        result |= l ^ r
+    for left, right in zip(bytearray(a), bytearray(b)):
+        result |= left ^ right
     return result == 0
 
 

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -19,8 +19,14 @@ from urllib3.packages import six
 from urllib3.util import ssl_
 
 # We need a host that will not immediately close the connection with a TCP
-# Reset. SO suggests this hostname
-TARPIT_HOST = "10.255.255.1"
+# Reset.
+if platform.system() == "Windows":
+    # Reserved loopback subnet address
+    TARPIT_HOST = "127.0.0.0"
+else:
+    # Reserved internet scoped address
+    # https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml
+    TARPIT_HOST = "240.0.0.0"
 
 # (Arguments for socket, is it IPv6 address?)
 VALID_SOURCE_ADDRESSES = [(("::1", 0), True), (("127.0.0.1", 0), False)]

--- a/test/contrib/test_pyopenssl.py
+++ b/test/contrib/test_pyopenssl.py
@@ -30,7 +30,7 @@ def teardown_module():
         pass
 
 
-from ..with_dummyserver.test_https import (  # noqa: F401
+from ..with_dummyserver.test_https import (  # noqa: E402, F401
     TestHTTPS,
     TestHTTPS_TLSv1,
     TestHTTPS_TLSv1_1,
@@ -41,7 +41,7 @@ from ..with_dummyserver.test_https import (  # noqa: F401
     TestHTTPS_NoSAN,
     TestHTTPS_IPV6SAN,
 )
-from ..with_dummyserver.test_socketlevel import (  # noqa: F401
+from ..with_dummyserver.test_socketlevel import (  # noqa: E402, F401
     TestSNI,
     TestSocketClosing,
     TestClientCerts,

--- a/test/contrib/test_securetransport.py
+++ b/test/contrib/test_securetransport.py
@@ -31,13 +31,13 @@ def teardown_module():
 
 # SecureTransport does not support TLSv1.3
 # https://github.com/urllib3/urllib3/issues/1674
-from ..with_dummyserver.test_https import (  # noqa: F401
+from ..with_dummyserver.test_https import (  # noqa: E402, F401
     TestHTTPS,
     TestHTTPS_TLSv1,
     TestHTTPS_TLSv1_1,
     TestHTTPS_TLSv1_2,
 )
-from ..with_dummyserver.test_socketlevel import (  # noqa: F401
+from ..with_dummyserver.test_socketlevel import (  # noqa: E402, F401
     TestSNI,
     TestSocketClosing,
     TestClientCerts,

--- a/test/test_connectionpool.py
+++ b/test/test_connectionpool.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 import ssl
 import pytest
+from mock import Mock
 
 from urllib3.connectionpool import (
     connection_from_url,
@@ -279,7 +280,6 @@ class TestConnectionPool(object):
 
             # Make sure that all of the exceptions return the connection
             # to the pool
-            _test(Empty, EmptyPoolError)
             _test(BaseSSLError, MaxRetryError, SSLError)
             _test(CertificateError, MaxRetryError, SSLError)
 
@@ -291,6 +291,15 @@ class TestConnectionPool(object):
             with pytest.raises(MaxRetryError):
                 pool.request("GET", "/", retries=1, pool_timeout=SHORT_TIMEOUT)
             assert pool.pool.qsize() == POOL_SIZE
+
+    def test_empty_does_not_put_conn(self):
+        """Do not put None back in the pool if the pool was empty"""
+
+        with HTTPConnectionPool(host="localhost", maxsize=1, block=True) as pool:
+            pool._get_conn = Mock(side_effect=EmptyPoolError(pool, "Pool is empty"))
+            pool._put_conn = Mock(side_effect=AssertionError("Unexpected _put_conn"))
+            with pytest.raises(EmptyPoolError):
+                pool.request("GET", "/")
 
     def test_assert_same_host(self):
         with connection_from_url("http://google.com:80") as c:

--- a/test/with_dummyserver/test_https.py
+++ b/test/with_dummyserver/test_https.py
@@ -698,6 +698,31 @@ class TestHTTPS(HTTPSDummyServerTestCase):
             finally:
                 conn.close()
 
+    @pytest.mark.skipif(
+        not hasattr(ssl.SSLContext, "keylog_filename"),
+        reason="requires OpenSSL 1.1.1+",
+    )
+    @pytest.mark.skipif(sys.version_info < (3, 8), reason="requires python 3.8+")
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="does not work reliably in Appveyor test enviroment for not yet known reasons",
+    )
+    def test_sslkeylogfile(self, tmpdir, monkeypatch):
+        keylog_file = tmpdir.join("keylogfile.txt")
+        monkeypatch.setenv("SSLKEYLOGFILE", str(keylog_file))
+        with HTTPSConnectionPool(
+            self.host, self.port, ca_certs=DEFAULT_CA
+        ) as https_pool:
+            r = https_pool.request("GET", "/")
+            assert r.status == 200, r.data
+            assert keylog_file.check(file=1), "keylogfile '%s' should exist" % str(
+                keylog_file
+            )
+            assert keylog_file.read().startswith("# TLS secrets log file"), (
+                "keylogfile '%s' should start with '# TLS secrets log file'"
+                % str(keylog_file)
+            )
+
 
 @requiresTLSv1()
 class TestHTTPS_TLSv1(TestHTTPS):

--- a/test/with_dummyserver/test_https.py
+++ b/test/with_dummyserver/test_https.py
@@ -698,16 +698,10 @@ class TestHTTPS(HTTPSDummyServerTestCase):
             finally:
                 conn.close()
 
-    @pytest.mark.skipif(
-        not hasattr(ssl.SSLContext, "keylog_filename"),
-        reason="requires OpenSSL 1.1.1+",
-    )
     @pytest.mark.skipif(sys.version_info < (3, 8), reason="requires python 3.8+")
-    @pytest.mark.skipif(
-        sys.platform == "win32",
-        reason="does not work reliably in Appveyor test enviroment for not yet known reasons",
-    )
     def test_sslkeylogfile(self, tmpdir, monkeypatch):
+        if not hasattr(util.SSLContext, "keylog_filename"):
+            pytest.skip("requires OpenSSL 1.1.1+")
         keylog_file = tmpdir.join("keylogfile.txt")
         monkeypatch.setenv("SSLKEYLOGFILE", str(keylog_file))
         with HTTPSConnectionPool(

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -10,8 +10,8 @@ from urllib3.exceptions import (
     ProtocolError,
 )
 from urllib3.response import httplib
+from urllib3 import util
 from urllib3.util import ssl_wrap_socket
-from urllib3.util.ssl_ import HAS_SNI
 from urllib3.util import ssl_
 from urllib3.util.timeout import Timeout
 from urllib3.util.retry import Retry
@@ -87,8 +87,9 @@ class TestCookies(SocketDummyServerTestCase):
 
 
 class TestSNI(SocketDummyServerTestCase):
-    @pytest.mark.skipif(not HAS_SNI, reason="SNI-support not available")
     def test_hostname_in_first_request_packet(self):
+        if not util.HAS_SNI:
+            pytest.skip("SNI-support not available")
         done_receiving = Event()
         self.buf = b""
 


### PR DESCRIPTION
Backported the following commits:
- (Add hardcoded paths for macOS Big Sur) https://github.com/urllib3/urllib3/commit/6bd33f64fb1c3107c56b23d479561322406ecfc9
- (Collapse Chunked Framing) https://github.com/urllib3/urllib3/commit/42ec81df905713045e69e2add4bb5787d89eab2f
- (SSLKEYLOGFILE) https://github.com/urllib3/urllib3/commit/fd1ad730bae89992e9591e84494713fc1cde3ad4
- (SSLKEYLOGFILE) https://github.com/urllib3/urllib3/commit/b8733538ef3a258ee76329c3900acb9456fae98e
- (Don't insert None into ConnectionPool) https://github.com/urllib3/urllib3/commit/46fc29d5108553a58cc14d28e73443e864be76c2
- (Change TARPIT_HOST) https://github.com/urllib3/urllib3/commit/898a16d09e4a6d9dbe10134a49b89eedfe8dae7f
- (Remove hasattr call in BrotliDecoder) https://github.com/urllib3/urllib3/commit/8fadde1f8a2add75b1de135a9374b5fa24a7c0d9

Commits that I didn't backport (because IMO they're features)
- (ALPN HTTP/1.1) https://github.com/urllib3/urllib3/commit/688584d692f3d77f5d6beca6bb97faef15f0977b
- (Default User-Agent) https://github.com/urllib3/urllib3/commit/a5a45dc36f3821e97bb9d6f2b4cd438a3f518af3
- (Unknown Scheme Error) https://github.com/urllib3/urllib3/commit/3ba4755960f54a21a6a1e492aa0d1df8b88aaba6
- (Invalid Chunk Length Error) https://github.com/urllib3/urllib3/commit/13953e8b2f5b85ff6a9c9b198cb0cde0c02ada28
- (Retry.other counter) https://github.com/urllib3/urllib3/commit/caad948e02b24c9516da453b7411df13af357449

I backported the `SSLKEYLOGFILE` environment variable commit because it doesn't change any functionality, it's just a change that's been long overdue and I'd like to get out there. Let me know if one of the commits I left out you think should also be backported.

Should be rebase merged once complete.