### PR TITLE
Travis CI: Test on Python 3.9-dev and nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,8 +47,10 @@ jobs:
       env: NOX_SESSION=test-3.7
     - python: 3.8
       env: NOX_SESSION=test-3.8
-    - python: nightly
+    - python: 3.9-dev
       env: NOX_SESSION=test-3.9
+    - python: nightly
+      env: NOX_SESSION=test-3.10
     - python: pypy2.7-6.0
       env: NOX_SESSION=test-pypy
     - python: pypy3.5-6.0

--- a/_travis/run.sh
+++ b/_travis/run.sh
@@ -3,7 +3,7 @@
 set -exo pipefail
 
 if [ -n "${NOX_SESSION}" ]; then
-    nox -s "${NOX_SESSION}"
+    nox -s "${NOX_SESSION}" --error-on-missing-interpreters
 else
     downstream_script="${TRAVIS_BUILD_DIR}/_travis/downstream/${DOWNSTREAM}.sh"
     if [ ! -x "$downstream_script" ]; then

--- a/noxfile.py
+++ b/noxfile.py
@@ -40,7 +40,7 @@ def tests_impl(session, extras="socks,secure,brotli"):
     session.run("coverage", "xml")
 
 
-@nox.session(python=["2.7", "3.5", "3.6", "3.7", "3.8", "3.9", "pypy"])
+@nox.session(python=["2.7", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10", "pypy"])
 def test(session):
     tests_impl(session)
 


### PR DESCRIPTION
Around the time 3.9 branched from CPython's `master` branch, and `master` became 3.10, `nightly` on Travis CI started pointing to 3.10, and a new `3.9-dev` was added.

And the `nightly` job on the CI hasn't been testing anything because its `NOX_SESSION=test-3.9`:

```console
$ python --version
Python 3.10.0a0
...
$ ./_travis/run.sh
+'[' -n test-3.9 ']'
+nox -s test-3.9
Running session test-3.9
Session test-3.9 skipped: Python interpreter 3.9 not found.
The command "./_travis/run.sh" exited with 0.
```

https://travis-ci.org/github/urllib3/urllib3/jobs/711787637

---

This PR switches the config so:

* `3.9-dev` tests with `NOX_SESSION=test-3.9`
* `nightly` tests with `NOX_SESSION=test-3.10`
* adds 3.10 to `noxfile.py`
* and adds `--error-on-missing-interpreters` to nox to prevent silent untests in future ([example](https://travis-ci.org/github/hugovk/urllib3/jobs/714935163))
