### PR TITLE
Allow Python nightly build to fail on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,8 @@ env:
     # PYPI_PASSWORD is set in Travis control panel.
 
 jobs:
+  allow_failures:
+    - python: nightly
   include:
     # Lint & documentation.
     - python: 3.6


### PR DESCRIPTION
It's looking like Python 3.10 will be an interesting release for tooling due to the 3 digit major version.