### PR TITLE
Fix test_connection_cleanup_on_read_timeout flakiness

### DIFF
--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -708,10 +708,12 @@ class TestSocketClosing(SocketDummyServerTestCase):
             poolsize = pool.pool.qsize()
             timeout = Timeout(connect=LONG_TIMEOUT, read=SHORT_TIMEOUT)
             try:
-                with pytest.raises(ReadTimeoutError):
-                    pool.urlopen(
-                        "GET", "/", retries=Retry(total=False), timeout=timeout,
-                    )
+                with pytest.raises((ReadTimeoutError, MaxRetryError)) as e:
+                    pool.urlopen("GET", "/", retries=0, timeout=timeout)
+                # Reading the status line can fail with a ReadTimeoutError inside a
+                # MaxRetryError
+                if isinstance(e, MaxRetryError):
+                    assert isinstance(e.value.reason.original_error, ReadTimeoutError)
                 assert poolsize == pool.pool.qsize()
             finally:
                 timed_out.set()

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -709,7 +709,7 @@ class TestSocketClosing(SocketDummyServerTestCase):
             timeout = Timeout(connect=LONG_TIMEOUT, read=SHORT_TIMEOUT)
             try:
                 with pytest.raises(ReadTimeoutError):
-                    response = pool.urlopen(
+                    pool.urlopen(
                         "GET", "/", retries=Retry(total=False), timeout=timeout,
                     )
                 assert poolsize == pool.pool.qsize()

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -709,7 +709,7 @@ class TestSocketClosing(SocketDummyServerTestCase):
             timeout = Timeout(connect=LONG_TIMEOUT, read=SHORT_TIMEOUT)
             try:
                 with pytest.raises(MaxRetryError) as e:
-                    pool.urlopen("GET", "/", retries=0, timeout=timeout)
+                    pool.urlopen("GET", "/", retries=Retry(read=False), timeout=timeout)
                 assert isinstance(e.value.reason, ReadTimeoutError)
                 assert poolsize == pool.pool.qsize()
             finally:

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -708,12 +708,9 @@ class TestSocketClosing(SocketDummyServerTestCase):
             poolsize = pool.pool.qsize()
             timeout = Timeout(connect=LONG_TIMEOUT, read=SHORT_TIMEOUT)
             try:
-                with pytest.raises((ReadTimeoutError, MaxRetryError)) as e:
+                with pytest.raises(MaxRetryError) as e:
                     pool.urlopen("GET", "/", retries=0, timeout=timeout)
-                # Reading the status line can fail with a ReadTimeoutError inside a
-                # MaxRetryError
-                if isinstance(e, MaxRetryError):
-                    assert isinstance(e.value.reason.original_error, ReadTimeoutError)
+                assert isinstance(e.value.reason, ReadTimeoutError)
                 assert poolsize == pool.pool.qsize()
             finally:
                 timed_out.set()

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -707,12 +707,11 @@ class TestSocketClosing(SocketDummyServerTestCase):
         with HTTPConnectionPool(self.host, self.port) as pool:
             poolsize = pool.pool.qsize()
             timeout = Timeout(connect=LONG_TIMEOUT, read=SHORT_TIMEOUT)
-            response = pool.urlopen(
-                "GET", "/", retries=0, preload_content=False, timeout=timeout
-            )
             try:
                 with pytest.raises(ReadTimeoutError):
-                    response.read()
+                    response = pool.urlopen(
+                        "GET", "/", retries=Retry(total=False), timeout=timeout,
+                    )
                 assert poolsize == pool.pool.qsize()
             finally:
                 timed_out.set()


### PR DESCRIPTION
When calling `urlopen()`, even with `preload_content=False`, we read the
status line and headers, which can result in a read timeout. It happened
multiple times in CI since the read timeout is set to `SHORT_TIMEOUT`.

The fix is to simply allow those timeouts in the `urlopen()` call by
moving it inside the `pytest.raises()` context manager (and dropping
`preload_content=False`). This won't affect the test results as they're
about the connection pool: as long as we are able to connect, we're
good.

However, unlike `read()`, `urlopen()` can be retried on read timeouts,
which leads to the timeout exception being wrapped in `MaxRetryError` so
I had to take that into account.