### PR TITLE
Use tz-aware functions in Retry.parse_retry_after()

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -7,6 +7,7 @@ PySocks==1.7.1
 win-inet-pton==1.1.0
 pytest==4.6.9
 pytest-timeout==1.3.4
+pytest-freezegun==0.3.0.post1
 flaky==3.6.1
 trustme==0.5.3
 cryptography==2.8

--- a/src/urllib3/util/retry.py
+++ b/src/urllib3/util/retry.py
@@ -266,10 +266,10 @@ class Retry(object):
         if re.match(r"^\s*[0-9]+\s*$", retry_after):
             seconds = int(retry_after)
         else:
-            retry_date_tuple = email.utils.parsedate(retry_after)
+            retry_date_tuple = email.utils.parsedate_tz(retry_after)
             if retry_date_tuple is None:
                 raise InvalidHeader("Invalid Retry-After header: %s" % retry_after)
-            retry_date = time.mktime(retry_date_tuple)
+            retry_date = email.utils.mktime_tz(retry_date_tuple)
             seconds = retry_date - time.time()
 
         if seconds < 0:


### PR DESCRIPTION
Switches `parsedate` and `mktime` to the tz-aware equivalents in `email.utils`. Also adds Freezegun as a dev dependency for complete time-mocking.

Closes #1896