### PR TITLE
Parse UTC for 'Retry-After' redirect handler

### DIFF
--- a/dummyserver/handlers.py
+++ b/dummyserver/handlers.py
@@ -321,7 +321,7 @@ class TestingApp(RequestHandler):
         date = request.params.get("date")
         if date:
             retry_after = str(
-                httputil.format_timestamp(datetime.fromtimestamp(float(date)))
+                httputil.format_timestamp(datetime.utcfromtimestamp(float(date)))
             )
         else:
             retry_after = "1"


### PR DESCRIPTION
This value is sent in with `time.time()` so is UTC but then was getting converted to local time which was giving errors for folks behind UTC (in my case UTC-5) with the new parsing of the `Retry-After` header.