### PR TITLE
Forbid use of cadata arg in pyOpenSSL backend.

### DIFF
--- a/src/urllib3/contrib/pyopenssl.py
+++ b/src/urllib3/contrib/pyopenssl.py
@@ -57,7 +57,6 @@ except ImportError:
 
 
 from socket import timeout, error as SocketError
-from io import BytesIO
 
 try:  # Platform-specific: Python 2
     from socket import _fileobject
@@ -446,14 +445,14 @@ class PyOpenSSLContext(object):
         self._ctx.set_cipher_list(ciphers)
 
     def load_verify_locations(self, cafile=None, capath=None, cadata=None):
+        if cadata is not None:
+            raise ssl.SSLError("CA data not supported in PyOpenSSL")
         if cafile is not None:
             cafile = cafile.encode("utf-8")
         if capath is not None:
             capath = capath.encode("utf-8")
         try:
             self._ctx.load_verify_locations(cafile, capath)
-            if cadata is not None:
-                self._ctx.load_verify_locations(BytesIO(cadata))
         except OpenSSL.SSL.Error as e:
             raise ssl.SSLError("unable to load trusted certificates: %r" % e)
 

--- a/test/contrib/test_pyopenssl.py
+++ b/test/contrib/test_pyopenssl.py
@@ -3,9 +3,14 @@ import os
 
 import mock
 import pytest
+import ssl
 
 try:
-    from urllib3.contrib.pyopenssl import _dnsname_to_stdlib, get_subj_alt_name
+    from urllib3.contrib.pyopenssl import (
+        _dnsname_to_stdlib,
+        get_subj_alt_name,
+        PyOpenSSLContext,
+    )
     from cryptography import x509
     from OpenSSL.crypto import FILETYPE_PEM, load_certificate
 except ImportError:
@@ -97,3 +102,9 @@ class TestPyOpenSSLHelpers(object):
 
         assert mock_warning.call_count == 1
         assert isinstance(mock_warning.call_args[0][1], x509.DuplicateExtension)
+
+
+def test_load_verify_locations_with_cadata():
+    context = PyOpenSSLContext(2)
+    with pytest.raises(ssl.SSLError):
+        context.load_verify_locations(None, None, "Test CA Data")


### PR DESCRIPTION
Fixes https://github.com/urllib3/urllib3/issues/1885