### PR TITLE
Add cadata support for PyOpenSSL and SecureTransport backend

### DIFF
--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -871,7 +871,7 @@ class HTTPSConnectionPool(HTTPConnectionPool):
     If ``assert_hostname`` is False, no verification is done.
 
     The ``key_file``, ``cert_file``, ``cert_reqs``, ``ca_certs``,
-    ``ca_cert_dir``, ``ssl_version``, ``key_password`` are only used if :mod:`ssl`
+    ``ca_cert_dir``, ``ca_cert_data``, ``ssl_version``, ``key_password`` are only used if :mod:`ssl`
     is available and are fed into :meth:`urllib3.util.ssl_wrap_socket` to upgrade
     the connection socket into an SSL socket.
     """
@@ -900,6 +900,7 @@ class HTTPSConnectionPool(HTTPConnectionPool):
         assert_hostname=None,
         assert_fingerprint=None,
         ca_cert_dir=None,
+        ca_cert_data=None,
         **conn_kw
     ):
 
@@ -927,6 +928,7 @@ class HTTPSConnectionPool(HTTPConnectionPool):
         self.ssl_version = ssl_version
         self.assert_hostname = assert_hostname
         self.assert_fingerprint = assert_fingerprint
+        self.ca_cert_data = ca_cert_data
 
     def _prepare_conn(self, conn):
         """
@@ -944,6 +946,7 @@ class HTTPSConnectionPool(HTTPConnectionPool):
                 ca_cert_dir=self.ca_cert_dir,
                 assert_hostname=self.assert_hostname,
                 assert_fingerprint=self.assert_fingerprint,
+                ca_cert_data=self.ca_cert_data,
             )
             conn.ssl_version = self.ssl_version
         return conn

--- a/src/urllib3/util/ssl_.py
+++ b/src/urllib3/util/ssl_.py
@@ -378,6 +378,10 @@ def ssl_wrap_socket(
 
     if ca_certs or ca_cert_dir or ca_cert_data:
         try:
+            if ca_cert_data:
+                # This feature was backported from Python 3
+                # See https://bugs.python.org/issue37079
+                ca_cert_data = six.ensure_text(ca_cert_data)
             context.load_verify_locations(ca_certs, ca_cert_dir, ca_cert_data)
         except (IOError, OSError) as e:
             raise SSLError(e)

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -861,32 +861,32 @@ class TestUtilSSL(object):
             None, "CERT_REQUIRED", ciphers=None
         )
 
-    def test_ssl_wrap_socket_loads_verify_locations(self):
-        socket = object()
-        mock_context = Mock()
-        ssl_wrap_socket(ssl_context=mock_context, ca_certs="/path/to/pem", sock=socket)
-        mock_context.load_verify_locations.assert_called_once_with(
-            "/path/to/pem", None, None
-        )
-
-    def test_ssl_wrap_socket_loads_certificate_directories(self):
-        socket = object()
-        mock_context = Mock()
-        ssl_wrap_socket(
-            ssl_context=mock_context, ca_cert_dir="/path/to/pems", sock=socket
-        )
-        mock_context.load_verify_locations.assert_called_once_with(
-            None, "/path/to/pems", None
-        )
-
-    def test_ssl_wrap_socket_loads_certificate_data(self):
+    @pytest.mark.parametrize(
+        "ca_certs,ca_cert_dir,ca_cert_data",
+        [
+            ("/path/to/pem", None, None),
+            (None, "/path/to/pems", None),
+            (None, None, "TOTALLY PEM DATA"),
+            ("/path/to/pem", "/path/to/pems", None),
+            ("/path/to/pem", None, "TOTALLY PEM DATA"),
+            (None, "/path/to/pems", "TOTALLY PEM DATA"),
+            ("/path/to/pem", "/path/to/pems", "TOTALLY PEM DATA"),
+        ],
+    )
+    def test_ssl_wrap_socket_loads_verify_locations(
+        self, ca_certs, ca_cert_dir, ca_cert_data
+    ):
         socket = object()
         mock_context = Mock()
         ssl_wrap_socket(
-            ssl_context=mock_context, ca_cert_data="TOTALLY PEM DATA", sock=socket
+            ssl_context=mock_context,
+            ca_certs=ca_certs,
+            ca_cert_dir=ca_cert_dir,
+            ca_cert_data=ca_cert_data,
+            sock=socket,
         )
         mock_context.load_verify_locations.assert_called_once_with(
-            None, None, "TOTALLY PEM DATA"
+            ca_certs, ca_cert_dir, ca_cert_data
         )
 
     def _wrap_socket_and_mock_warn(self, sock, server_hostname):


### PR DESCRIPTION
Closes #1885.

PyOpenSSL does not support ```ca_cert_data``` for ```load_verify_locations``` but the raw certificate can be added directly to ```SSLContext```'s store.