### PR TITLE
Upgrade pytest-freezegun to 0.4.2

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -7,7 +7,7 @@ PySocks==1.7.1
 win-inet-pton==1.1.0
 pytest==4.6.9
 pytest-timeout==1.3.4
-pytest-freezegun==0.3.0.post1
+pytest-freezegun==0.4.2
 flaky==3.6.1
 trustme==0.5.3
 cryptography==2.8


### PR DESCRIPTION
Upgrade pytest-freezegun to 0.4.2 to prevent a warning during our tests.
See https://github.com/ktosiek/pytest-freezegun/pull/20.

The warning:
```
.nox/test-3-8/lib/python3.8/site-packages/_pytest/mark/structures.py:331
  [snip]/urllib3/.nox/test-3-8/lib/python3.8/site-packages/_pytest/mark/structures.py:331: PytestUnknownMarkWarning: Unknown pytest.mark.freeze_time -
 is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    warnings.warn(

-- Docs: https://docs.pytest.org/en/latest/warnings.html
```