### PR TITLE
Skip two flaky Windows tests

### DIFF
--- a/test/__init__.py
+++ b/test/__init__.py
@@ -143,6 +143,19 @@ def notPyPy2(test):
     return wrapper
 
 
+def notWindows(test):
+    """Skips this test on Windows"""
+
+    @six.wraps(test)
+    def wrapper(*args, **kwargs):
+        msg = "{} is flaky on Windows".format(test.__name__)
+        if platform.system() == "Windows":
+            pytest.skip(msg)
+        return test(*args, **kwargs)
+
+    return wrapper
+
+
 def onlyBrotlipy():
     return pytest.mark.skipif(brotli is None, reason="only run if brotlipy is present")
 

--- a/test/with_dummyserver/test_chunked_transfer.py
+++ b/test/with_dummyserver/test_chunked_transfer.py
@@ -1,13 +1,12 @@
 # -*- coding: utf-8 -*-
 
-import os
-
 import pytest
 
 from urllib3 import HTTPConnectionPool
 from urllib3.util.retry import Retry
 from urllib3.util import SUPPRESS_USER_AGENT
 from dummyserver.testcase import SocketDummyServerTestCase, consume_socket
+from test import notWindows
 
 # Retry failed tests
 pytestmark = pytest.mark.flaky
@@ -157,7 +156,7 @@ class TestChunkedTransfer(SocketDummyServerTestCase):
                 sock.close()
         assert self.chunked_requests == 2
 
-    @pytest.mark.skipif(os.name == "nt", reason="flaky on Windows")
+    @notWindows
     def test_preserve_chunked_on_redirect(self):
         self.chunked_requests = 0
 
@@ -185,7 +184,7 @@ class TestChunkedTransfer(SocketDummyServerTestCase):
             )
         assert self.chunked_requests == 2
 
-    @pytest.mark.skipif(os.name == "nt", reason="flaky on Windows")
+    @notWindows
     def test_preserve_chunked_on_broken_connection(self):
         self.chunked_requests = 0
 

--- a/test/with_dummyserver/test_chunked_transfer.py
+++ b/test/with_dummyserver/test_chunked_transfer.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+import os
+
 import pytest
 
 from urllib3 import HTTPConnectionPool
@@ -155,6 +157,7 @@ class TestChunkedTransfer(SocketDummyServerTestCase):
                 sock.close()
         assert self.chunked_requests == 2
 
+    @pytest.mark.skipif(os.name == "nt", reason="flaky on Windows")
     def test_preserve_chunked_on_redirect(self):
         self.chunked_requests = 0
 
@@ -182,6 +185,7 @@ class TestChunkedTransfer(SocketDummyServerTestCase):
             )
         assert self.chunked_requests == 2
 
+    @pytest.mark.skipif(os.name == "nt", reason="flaky on Windows")
     def test_preserve_chunked_on_broken_connection(self):
         self.chunked_requests = 0
 


### PR DESCRIPTION
These tests tend to throw WinError 10053, 10054 and 10061 on Windows,
which breaks the continuous integration most of the time. Since we're
not testing anything Windows-specific here, it's okay to not run those
tests on Windows.

(It would have been better to fix the actual errors, but I don't know how to do that.)