### PR TITLE
Fix LGTM alerts

### DIFF
--- a/src/urllib3/_collections.py
+++ b/src/urllib3/_collections.py
@@ -58,7 +58,6 @@ class RecentlyUsedContainer(MutableMapping):
             return item
 
     def __setitem__(self, key, value):
-        evicted_value = _Null
         with self.lock:
             # Possibly evict the existing value of 'key'
             evicted_value = self._container.get(key, _Null)

--- a/src/urllib3/_collections.py
+++ b/src/urllib3/_collections.py
@@ -58,6 +58,7 @@ class RecentlyUsedContainer(MutableMapping):
             return item
 
     def __setitem__(self, key, value):
+        evicted_value = _Null
         with self.lock:
             # Possibly evict the existing value of 'key'
             evicted_value = self._container.get(key, _Null)

--- a/src/urllib3/fields.py
+++ b/src/urllib3/fields.py
@@ -65,7 +65,6 @@ _HTML5_REPLACEMENTS = {
     u"\u0022": u"%22",
     # Replace "\" with "\\".
     u"\u005C": u"\u005C\u005C",
-    u"\u005C": u"\u005C\u005C",
 }
 
 # All control characters from 0x00 to 0x1F *except* 0x1B.

--- a/src/urllib3/util/ssl_.py
+++ b/src/urllib3/util/ssl_.py
@@ -348,8 +348,7 @@ def ssl_wrap_socket(
     if ca_certs or ca_cert_dir or ca_cert_data:
         try:
             context.load_verify_locations(ca_certs, ca_cert_dir, ca_cert_data)
-        except IOError as e:
-            # TODO: Can be more strict in Python3
+        except (IOError, OSError) as e:
             raise SSLError(e)
 
     elif ssl_context is None and hasattr(context, "load_default_certs"):

--- a/src/urllib3/util/ssl_.py
+++ b/src/urllib3/util/ssl_.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import
-import errno
 import warnings
 import hmac
 import os

--- a/src/urllib3/util/ssl_.py
+++ b/src/urllib3/util/ssl_.py
@@ -349,14 +349,9 @@ def ssl_wrap_socket(
     if ca_certs or ca_cert_dir or ca_cert_data:
         try:
             context.load_verify_locations(ca_certs, ca_cert_dir, ca_cert_data)
-        except IOError as e:  # Platform-specific: Python 2.7
+        except IOError as e:
+            # TODO: Can be more strict in Python3
             raise SSLError(e)
-        # Py33 raises FileNotFoundError which subclasses OSError
-        # These are not equivalent unless we check the errno attribute
-        except OSError as e:  # Platform-specific: Python 3.3 and beyond
-            if e.errno == errno.ENOENT:
-                raise SSLError(e)
-            raise
 
     elif ssl_context is None and hasattr(context, "load_default_certs"):
         # try to load OS default certs; works well on Windows (require Python3.4+)


### PR DESCRIPTION
1. Remove [unused except block](https://lgtm.com/projects/g/urllib3/urllib3/snapshot/f0c417aa08617b25541b23de0391d97adb92d2cf/files/src/urllib3/util/ssl_.py#x5bf6644a21af1868:1). The except block was added to account for `FileNotFoundError` in Python3 but it does not hit.
2. Remove [unnecessary assignment](https://lgtm.com/projects/g/urllib3/urllib3/snapshot/f0c417aa08617b25541b23de0391d97adb92d2cf/files/src/urllib3/_collections.py#xd6dec001decbd3d4:1). The value is never used.
3. Remove [redundant dictionary item](https://lgtm.com/projects/g/urllib3/urllib3/snapshot/f0c417aa08617b25541b23de0391d97adb92d2cf/files/src/urllib3/fields.py#xb8b9b767f000eb07:1). The item is declared twice.