### PR TITLE
Stricter RTD builds, move sponsors all to docs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -2,13 +2,13 @@ version: 2
 
 python:
   install:
-    - requirements: docs/requirements.txt
     - method: pip
       path: .
       extra_requirements:
         - brotli
         - secure
         - socks
+    - requirements: docs/requirements.txt
 
 sphinx:
   fail_on_warning: true

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,14 @@
+version: 2
+
+python:
+  install:
+    - requirements: docs/requirements.txt
+    - method: pip
+      path: .
+      extra_requirements:
+        - brotli
+        - secure
+        - socks
+
+sphinx:
+  fail_on_warning: true

--- a/README.rst
+++ b/README.rst
@@ -41,9 +41,9 @@ urllib3 is powerful and easy to use::
 Installing
 ----------
 
-urllib3 can be installed with `pip <https://pip.pypa.io>`_::
+urllib3 can be installed with `Pip <https://pip.pypa.io>`_::
 
-    $ pip install urllib3
+    $ python -m pip install urllib3
 
 Alternatively, you can grab the latest source code from `GitHub <https://github.com/urllib3/urllib3>`_::
 
@@ -61,7 +61,7 @@ Contributing
 ------------
 
 urllib3 happily accepts contributions. Please see our
-`contributing documentation <https://urllib3.readthedocs.io/en/latest/contributing.html>`_
+`contributing documentation <https://urllib3.readthedocs.io/contributing.html>`_
 for some tips on getting started.
 
 
@@ -71,6 +71,7 @@ Security Disclosures
 To report a security vulnerability, please use the
 `Tidelift security contact <https://tidelift.com/security>`_.
 Tidelift will coordinate the fix and disclosure with maintainers.
+
 
 Maintainers
 -----------
@@ -89,6 +90,13 @@ Maintainers
 Sponsorship
 -----------
 
+If your company benefits from this library, please consider `sponsoring its
+development <https://urllib3.readthedocs.io/sponsors.html>`_.
+
+
+For Enterprise
+--------------
+
 .. |tideliftlogo| image:: https://nedbatchelder.com/pix/Tidelift_Logos_RGB_Tidelift_Shorthand_On-White_small.png
    :width: 75
    :alt: Tidelift
@@ -104,13 +112,3 @@ Sponsorship
        tools.
 
 .. _Tidelift Subscription: https://tidelift.com/subscription/pkg/pypi-urllib3?utm_source=pypi-urllib3&utm_medium=referral&utm_campaign=readme
-
-If your company benefits from this library, please consider `sponsoring its
-development <https://urllib3.readthedocs.io/en/latest/contributing.html#sponsorship-project-grants>`_.
-
-Sponsors include:
-
-- Abbott (2018-2019), sponsored `@sethmlarson <https://github.com/sethmlarson>`_'s work on urllib3.
-- Google Cloud Platform (2018-2019), sponsored `@theacodes <https://github.com/theacodes>`_'s work on urllib3.
-- Akamai (2017-2018), sponsored `@haikuginger <https://github.com/haikuginger>`_'s work on urllib3
-- Hewlett Packard Enterprise (2016-2017), sponsored `@Lukasa’s <https://github.com/Lukasa>`_ work on urllib3.

--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,9 @@ standard libraries:
 - Proxy support for HTTP and SOCKS.
 - 100% test coverage.
 
-urllib3 is powerful and easy to use::
+urllib3 is powerful and easy to use:
+
+.. code-block:: python
 
     >>> import urllib3
     >>> http = urllib3.PoolManager()
@@ -41,7 +43,7 @@ urllib3 is powerful and easy to use::
 Installing
 ----------
 
-urllib3 can be installed with `Pip <https://pip.pypa.io>`_::
+urllib3 can be installed with `pip <https://pip.pypa.io>`_::
 
     $ python -m pip install urllib3
 
@@ -61,7 +63,7 @@ Contributing
 ------------
 
 urllib3 happily accepts contributions. Please see our
-`contributing documentation <https://urllib3.readthedocs.io/contributing.html>`_
+`contributing documentation <https://urllib3.readthedocs.io/en/latest/contributing.html>`_
 for some tips on getting started.
 
 
@@ -91,7 +93,7 @@ Sponsorship
 -----------
 
 If your company benefits from this library, please consider `sponsoring its
-development <https://urllib3.readthedocs.io/sponsors.html>`_.
+development <https://urllib3.readthedocs.io/en/latest/sponsors.html>`_.
 
 
 For Enterprise

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -74,7 +74,7 @@ For Enterprise
 Installing
 ----------
 
-urllib3 can be installed with `Pip <https://pip.pypa.io>`_
+urllib3 can be installed with `pip <https://pip.pypa.io>`_
 
 .. code-block:: bash
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
 -r ../dev-requirements.txt
 sphinx!=3.0.0
 requests>=2,<2.16
-furo
+furo==2020.9.8b4

--- a/docs/sponsors.rst
+++ b/docs/sponsors.rst
@@ -1,18 +1,14 @@
 Sponsors
 ========
 
-Grants
-------
-
 Please consider sponsoring urllib3 development, especially if your company
 benefits from this library.
 
 Your contribution will go towards adding new features to urllib3 and making
 sure all functionality continues to meet our high quality standards.
 
-We also welcome sponsorship in the form of time. We greatly appreciate companies
-who encourage employees to contribute on an ongoing basis during their work hours.
-Please let us know and we'll be glad to add you to our sponsors list!
+Sponsors and Grants
+-------------------
 
 A grant for contiguous full-time development has the biggest impact for
 progress. Periods of 3 to 10 days allow a contributor to tackle substantial
@@ -22,12 +18,19 @@ to not fix them.
 Contact `@sethmlarson <https://github.com/sethmlarson>`_ or `@shazow <https://github.com/shazow>`_
 to arrange a grant for a core contributor.
 
-Huge thanks to all the companies and individuals who financially contributed to
-the development of urllib3. Please send a PR if you've donated and would like
-to be listed.
+We also welcome sponsorship in the form of time. We greatly appreciate companies
+who encourage employees to contribute on an ongoing basis during their work hours.
+Let us know and we'll be glad to add you to our sponsors list.
 
-* `GOVCERT.LU <https://govcert.lu/>`_ (October 23, 2018)
+* `Abbott <https://abbott.com>`_ (2018-2019), sponsored `@sethmlarson <https://github.com/sethmlarson>`_
 
-* `Stripe <https://stripe.com/>`_ (June 23, 2014)
+* `Google Cloud Platform <https://cloud.google.com>`_ (2018-2019), sponsored `@theacodes <https://github.com/theacodes>`_
 
-.. * [Company] ([date])
+* `GOVCERT.LU <https://govcert.lu>`_ (October 23, 2018), sponsored `@sethmlarson <https://github.com/sethmlarson>`_
+
+* `Akamai <https://akamai.com>`_ (2017-2018) sponsored `@haikuginger <https://github.com/haikuginger>`_
+
+* `Hewlett Packard Enterprise <https://hpe.com>`_ (2016-2017) sponsored
+  `@Lukasa’s <https://github.com/Lukasa>`_
+
+* `Stripe <https://stripe.com>`_ (June 23, 2014)

--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -6,7 +6,7 @@ User Guide
 Installing
 ----------
 
-urllib3 can be installed with `Pip <https://pip.pypa.io>`_
+urllib3 can be installed with `pip <https://pip.pypa.io>`_
 
 .. code-block:: bash
 


### PR DESCRIPTION
Currently our pyOpenSSL and Brotli docs are failing but RTD isn't failing on warnings.

- Added `.readthedocs.yml` and made Sphinx fail on warnings for RTD
- Merged the sponsors section in the README with the one in the Sponsors docs section
- Fixed minor things in the README