### PR TITLE
Use LONG_TIMEOUT on another timeout-based test

### DIFF
--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -916,7 +916,7 @@ class TestSocketClosing(SocketDummyServerTestCase):
                 retries=1,
                 release_conn=False,
                 preload_content=False,
-                timeout=Timeout(connect=LONG_TIMEOUT, read=SHORT_TIMEOUT),
+                timeout=LONG_TIMEOUT,
             )
 
             # The connection should still be on the response object, and none


### PR DESCRIPTION
While we do have a retry here, it's needed to make two queries, and cannot be wasted on a timeout due to continuous integration being slow.

Fixes errors like https://travis-ci.org/github/urllib3/urllib3/jobs/725437480.