### PR TITLE
Get SSLTransport tests to 100% coverage.

### DIFF
--- a/test/contrib/test_ssltransport.py
+++ b/test/contrib/test_ssltransport.py
@@ -164,26 +164,26 @@ class SingleTLSLayerTestCase(SocketDummyServerTestCase):
 
             request = consume_socket(ssl_sock)
             validate_request(request)
-            ssl_sock.send(sample_response())
+            ssl_sock.sendall(sample_response())
 
             unwrapped_sock = ssl_sock.unwrap()
 
             request = consume_socket(unwrapped_sock)
             validate_request(request)
-            unwrapped_sock.send(sample_response())
+            unwrapped_sock.sendall(sample_response())
 
         self.start_dummy_server(shutdown_handler)
         sock = socket.create_connection((self.host, self.port))
         ssock = SSLTransport(sock, self.client_context, server_hostname="localhost")
 
         # request/response over TLS.
-        ssock.send(sample_request())
+        ssock.sendall(sample_request())
         response = consume_socket(ssock)
         validate_response(response)
 
         # request/response over plaintext after unwrap.
         ssock.unwrap()
-        sock.send(sample_request())
+        sock.sendall(sample_request())
         response = consume_socket(sock)
         validate_response(response)
 

--- a/test/contrib/test_ssltransport.py
+++ b/test/contrib/test_ssltransport.py
@@ -166,20 +166,19 @@ class SingleTLSLayerTestCase(SocketDummyServerTestCase):
             request = bytearray(65536)
             ssl_sock.recv_into(request)
             validate_request(request.strip(b"\x00"))
-            unwrap_event.set()
             sock = ssl_sock.unwrap()
+            unwrap_event.set()
             sock.send(sample_response())
 
         self.start_dummy_server(shutdown_handler)
         sock = socket.create_connection((self.host, self.port))
         ssock = SSLTransport(sock, self.client_context, server_hostname="localhost")
         ssock.send(sample_request())
+        ssock.unwrap()
 
         unwrap_event.wait(5)
         if not unwrap_event.is_set():
             raise RuntimeError("Unable to validate unwrapping.")
-
-        ssock.unwrap()
         response = sock.recv(4096)
         validate_response(response)
 


### PR DESCRIPTION
The PR has a single commit which adds two additional tests (one for recv_into without a buffer, and one for unbuffered binary access through makefile), and it also enables the shutdown test. For the shutdown test I mitigated the flakiness by adding synchronization between the client and server threads.

With the three tests, we should be at 100% coverage. 