### PR TITLE
Use LONG_TIMEOUT on test with disabled retries

### DIFF
--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -485,7 +485,7 @@ class TestSocketClosing(SocketDummyServerTestCase):
 
         self._start_server(socket_handler)
         with HTTPSConnectionPool(
-            self.host, self.port, timeout=SHORT_TIMEOUT, retries=False
+            self.host, self.port, timeout=LONG_TIMEOUT, retries=False
         ) as pool:
             try:
                 with pytest.raises(ReadTimeoutError):


### PR DESCRIPTION
As seen in https://github.com/urllib3/urllib3/pull/1966/checks?check_run_id=1131651057. This fix is in the same vein of https://github.com/urllib3/urllib3/pull/1956 and https://github.com/urllib3/urllib3/pull/1953. While I could try something like `Retry(total=10, read=0)`, this seems risky as it could introduce other issues. Increasing `LONG_TIMEOUT` is more likely to Just Work™️.