### PR TITLE
Use default `dict` instead of OrderedDict on Python 3.7 and above

### DIFF
--- a/src/urllib3/_collections.py
+++ b/src/urllib3/_collections.py
@@ -16,7 +16,15 @@ except ImportError:  # Platform-specific: No threads available
             pass
 
 
-from collections import OrderedDict
+from sys import version_info
+
+# Since Python 3.7, `dict` must be ordered (language-level requirement)
+# so it is ok to use it instead of OrderedDict, and it is faster in CPython.
+if version_info >= (3, 7):
+    OrderedDictCls = dict
+else:
+    from collections import OrderedDict as OrderedDictCls
+
 from .exceptions import InvalidHeader
 from .packages.six import ensure_str, iterkeys, itervalues, PY3
 
@@ -41,7 +49,7 @@ class RecentlyUsedContainer(MutableMapping):
         ``dispose_func(value)`` is called.  Callback which will get called
     """
 
-    ContainerCls = OrderedDict
+    ContainerCls = OrderedDictCls
 
     def __init__(self, maxsize=10, dispose_func=None):
         self._maxsize = maxsize
@@ -139,7 +147,7 @@ class HTTPHeaderDict(MutableMapping):
 
     def __init__(self, headers=None, **kwargs):
         super(HTTPHeaderDict, self).__init__()
-        self._container = OrderedDict()
+        self._container = OrderedDictCls()
         if headers is not None:
             if isinstance(headers, HTTPHeaderDict):
                 self._copy_from(headers)


### PR DESCRIPTION
This should be free performance on python 3.7 and above, as OrderedDict is slow.
Any python interpreter is required to provide insertion ordered default dict if they implement 3.7 or above.

See:
- https://stackoverflow.com/questions/39980323/are-dictionaries-ordered-in-python-3-6
- https://mail.python.org/pipermail/python-dev/2017-December/151283.html


Also planning to use these collection classes in another change.