### PR TITLE
Create v2.0 Roadmap and Open Collective Sponsors Section

### DIFF
--- a/docs/_static/tweaks.css
+++ b/docs/_static/tweaks.css
@@ -1,5 +1,0 @@
-.announcement {
-  filter: drop-shadow(0 0.1em 0.1rem #333333);
-  background: linear-gradient(to right, #e32400, #000000, #4f7a28);
-  margin-bottom: 0.3em;
-}

--- a/docs/_static/tweaks.css
+++ b/docs/_static/tweaks.css
@@ -1,3 +1,5 @@
-.sidebar-brand-text {
-  display: none;
+.announcement {
+  filter: drop-shadow(0 0.1em 0.1rem #333333);
+  background: linear-gradient(to right, #e32400, #000000, #4f7a28);
+  margin-bottom: 0.3em;
 }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -76,14 +76,12 @@ html_theme = "furo"
 html_favicon = "images/favicon.png"
 html_logo = "images/banner.svg"
 
-html_static_path = ["_static"]
-html_css_files = ["tweaks.css"]
 html_theme_options = {
     "announcement": """
-        <a style=\"font-size: 1.25em; color: white; text-decoration: none;\" 
-           class=\"announcement-sponsor-link\"
+        <a style=\"text-decoration: none; color: white;\" 
            href=\"https://opencollective.com/urllib3\">
-           <img src=\"_static/favicon.png\"/> Sponsor urllib3 v2.0 on Open Collective</a>
+           <img src=\"_static/favicon.png\"/> Sponsor urllib3 v2.0 on Open Collective
+        </a>
     """,
     "sidebar_hide_name": True,
 }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -78,5 +78,14 @@ html_logo = "images/banner.svg"
 
 html_static_path = ["_static"]
 html_css_files = ["tweaks.css"]
+html_theme_options = {
+    "announcement": """
+        <a style=\"font-size: 1.25em; color: white; text-decoration: none;\" 
+           class=\"announcement-sponsor-link\"
+           href=\"https://opencollective.com/urllib3\">
+           <img src=\"_static/favicon.png\"/> Sponsor urllib3 v2.0 on Open Collective</a>
+    """,
+    "sidebar_hide_name": True,
+}
 
 intersphinx_mapping = {"python": ("https://docs.python.org/3", None)}

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,6 +6,7 @@ urllib3
    :maxdepth: 3
 
    For Enterprise <https://tidelift.com/subscription/pkg/pypi-urllib3?utm_source=pypi-urllib3&utm_medium=referral&utm_campaign=docs>
+   v2-roadmap
    sponsors
    user-guide
    advanced-usage

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
 -r ../dev-requirements.txt
 sphinx!=3.0.0
 requests>=2,<2.16
-furo==2020.9.8b4
+furo

--- a/docs/sponsors.rst
+++ b/docs/sponsors.rst
@@ -1,11 +1,48 @@
-Sponsors
-========
+Sponsors and Supporters
+=======================
 
 Please consider sponsoring urllib3 development, especially if your company
 benefits from this library.
 
 Your contribution will go towards adding new features to urllib3 and making
 sure all functionality continues to meet our high quality standards.
+
+
+v2.0 Sponsor Perks
+------------------
+
+.. important::
+
+   `Get in contact <mailto:sethmichaellarson@gmail.com>`_ for additional
+   details on sponsorship and perks before making a contribution
+   through `Open Collective <https://opencollective.com/urllib3>`_ if you have questions.
+
+
+Gold v2.0 Sponsors Perks
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+These are the perks for `Gold v2.0 Sponsors on Open Collective <https://opencollective.com/urllib3/contribute/gold-v2-sponsor-20443/checkout>`_:
+
+- Organization logo and URL listed on top of the v2.0 Roadmap
+- Call with one or more urllib3 maintainer(s) to discuss
+  the v2.0 release and how it impacts your organization
+- Your organization will be thanked within the v2.0 release
+  announcement, within all blog posts and public updates related to v2.0
+  development, and multiple thank-you's on Twitter from
+  urllib3 maintainers throughout v2.0 development.
+- All perks from the **Silver v2.0 Sponsors Perks** below
+
+
+Silver v2.0 Sponsor Perks
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+These are the perks for `Silver v2.0 Sponsors on Open Collective <https://opencollective.com/urllib3/contribute/silver-v2-sponsor-20442/checkout>`_:
+
+- Your organization name and URL permanently added
+  to the **Sponsors and Grants** section below
+- Thank you within the v2.0 release announcement
+  and on Twitter from urllib3 maintainers
+
 
 Sponsors and Grants
 -------------------
@@ -22,6 +59,9 @@ We also welcome sponsorship in the form of time. We greatly appreciate companies
 who encourage employees to contribute on an ongoing basis during their work hours.
 Let us know and we'll be glad to add you to our sponsors list.
 
+* `GitCoin Grants <https://gitcoin.co/grants>`_ (2019-2020), sponsored `@sethmlarson <https://github.com/sethmlarson>`_
+  and `@pquentin <https://github.com/pquentin>`_
+
 * `Abbott <https://abbott.com>`_ (2018-2019), sponsored `@sethmlarson <https://github.com/sethmlarson>`_
 
 * `Google Cloud Platform <https://cloud.google.com>`_ (2018-2019), sponsored `@theacodes <https://github.com/theacodes>`_
@@ -31,6 +71,15 @@ Let us know and we'll be glad to add you to our sponsors list.
 * `Akamai <https://akamai.com>`_ (2017-2018) sponsored `@haikuginger <https://github.com/haikuginger>`_
 
 * `Hewlett Packard Enterprise <https://hpe.com>`_ (2016-2017) sponsored
-  `@Lukasa’s <https://github.com/Lukasa>`_
+  `@Lukasa <https://github.com/Lukasa>`_
 
 * `Stripe <https://stripe.com>`_ (June 23, 2014)
+
+
+Open Collective Supporters
+--------------------------
+
+All donations are currently going towards the development of new features for urllib3 v2.0.
+Donate $5 or more as an individual or $50 or more as an organization to be added to the list of supporters.
+
+Thanks to all our supporters on `Open Collective <https://opencollective.com/urllib3>`_:

--- a/docs/sponsors.rst
+++ b/docs/sponsors.rst
@@ -18,10 +18,20 @@ v2.0 Sponsor Perks
    through `Open Collective <https://opencollective.com/urllib3>`_ if you have questions.
 
 
-Gold v2.0 Sponsors Perks
-~~~~~~~~~~~~~~~~~~~~~~~~
+Silver v2.0 Sponsor Perks
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
-These are the perks for `Gold v2.0 Sponsors on Open Collective <https://opencollective.com/urllib3/contribute/gold-v2-sponsor-20443/checkout>`_:
+- Your organization name and URL permanently added
+  to the **Sponsors and Grants** section below
+- Thank you within the v2.0 release announcement
+  and on Twitter from urllib3 maintainers
+
+➤ `Contribute to the "Silver v2.0 Sponsor" tier <https://opencollective.com/urllib3/contribute/silver-v2-sponsor-20442/checkout>`_
+on Open Collective.
+
+
+Gold v2.0 Sponsor Perks
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 - Organization logo and URL listed on top of the v2.0 Roadmap
 - Call with one or more urllib3 maintainer(s) to discuss
@@ -29,19 +39,11 @@ These are the perks for `Gold v2.0 Sponsors on Open Collective <https://opencoll
 - Your organization will be thanked within the v2.0 release
   announcement, within all blog posts and public updates related to v2.0
   development, and multiple thank-you's on Twitter from
-  urllib3 maintainers throughout v2.0 development.
-- All perks from the **Silver v2.0 Sponsors Perks** below
+  urllib3 maintainers throughout v2.0 development
+- All perks from the **Silver v2.0 Sponsors Perks** above
 
-
-Silver v2.0 Sponsor Perks
-~~~~~~~~~~~~~~~~~~~~~~~~~
-
-These are the perks for `Silver v2.0 Sponsors on Open Collective <https://opencollective.com/urllib3/contribute/silver-v2-sponsor-20442/checkout>`_:
-
-- Your organization name and URL permanently added
-  to the **Sponsors and Grants** section below
-- Thank you within the v2.0 release announcement
-  and on Twitter from urllib3 maintainers
+➤ `Contribute to the "Gold v2.0 Sponsor" tier <https://opencollective.com/urllib3/contribute/gold-v2-sponsor-20443/checkout>`_
+on Open Collective.
 
 
 Sponsors and Grants
@@ -80,6 +82,6 @@ Open Collective Supporters
 --------------------------
 
 All donations are currently going towards the development of new features for urllib3 v2.0.
-Donate $5 or more as an individual or $50 or more as an organization to be added to the list of supporters.
+Donate $5 or more as an individual or $50 or more as an organization to be added to the list of supporters below (coming soon).
 
-Thanks to all our supporters on `Open Collective <https://opencollective.com/urllib3>`_:
+`Thanks to all our supporters on Open Collective <https://opencollective.com/urllib3#section-contributors>`_!

--- a/docs/v2-roadmap.rst
+++ b/docs/v2-roadmap.rst
@@ -1,0 +1,179 @@
+v2.0 Roadmap
+============
+
+
+**📅 Release and Migration Schedule**
+-------------------------------------
+
+.. important::
+
+   We're seeking `sponsors and supporters for urllib3 v2.0 on Open Collective <https://opencollective.com/urllib3>`_.
+   There's a lot of work to be done for our small team and we want to make sure
+   development can get completed on-time while also fairly compensating contributors
+   for the additional effort required for a large release like ``v2.0``.
+
+   Additional information available within the :doc:`sponsors` section of our documentation.
+
+
+We're aiming for all ``v2.x`` features to be released in **mid-to-late 2021**.
+
+Here's what the release and migration schedule will look like leading up
+to v2.0 being released:
+
+- Development of ``v2.x`` breaking changes starts.
+- Release ``v1.26.0`` with deprecation warnings for ``v2.0.0`` breaking changes.
+  This will be the last non-patch release within the ``v1.x`` stream.
+- Release ``v2.0.0-alpha1`` once all breaking changes have been completed.
+  We'll wait for users to report issues, bugs, and unexpected
+  breakages at this stage to ensure the release ``v2.0.0`` goes smoothly.
+- Development of remaining ``v2.x`` features starts.
+- Release ``v2.0.0`` which will be identical to ``v2.0.0-alpha1``.
+- Release ``v2.1.0`` with remaining ``v2.x`` features.
+
+Deprecation warnings within ``v1.26.x`` will be opt-in by default.
+
+Package and Application Developers
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Since this is the first major release in almost 9 years some users may
+be caught off-guard by a new major release of urllib3. We're mitigating this by
+trying to make ``v2.x`` API-compatible with ``v1.x``.
+
+If your application or library uses urllib3 and you'd like to be extra
+cautious about not breaking your users, you can pin urllib3 like so
+until you ensure compatibility with ``v2.x``:
+
+.. code-block:: python
+
+   # requirements.txt or 'install_requires'
+   "urllib3>=1.25,<2"
+
+We'd really appreciate testing compatibility
+and providing feedback on ``v2.0.0-alpha1`` once released.
+
+
+**🚀 Functional API Compatibility**
+-----------------------------------
+
+We're maintaining **99% functional API compatibility** to make the
+migration an easy choice for most users. Migration from v1.x to v2.x
+should be the simplest major version upgrade you've ever completed.
+
+Most changes are either to default configurations, supported Python versions,
+and internal implementation details. So unless you're in a specific situation
+you should notice no changes! 🎉
+
+
+v1.26.x Security and Bug Fixes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Thanks to support from `Tidelift <https://tidelift.com/subscription/pkg/pypi-urllib3>`_
+we're able to continue supporting v1.26.x releases with
+both security and bug fixes for the forseeable future 💖
+
+If your organization relies on urllib3 and is interested in continuing support you can learn
+more about the `Tidelift Subscription for Enterprise <https://tidelift.com/subscription/pkg/pypi-urllib3?utm_source=pypi-urllib3&utm_medium=referral&utm_campaign=docs>`_.
+
+
+**🔐 Modern Security by Default**
+---------------------------------
+
+HTTPS requires TLS 1.2+
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Greater than 95% of websites support TLS 1.2 or above.
+At this point we're comfortable switching the default
+minimum TLS version to be 1.2 to ensure high security
+for users without breaking services.
+
+Dropping TLS 1.0 and 1.1 by default means you
+won't be vulnerable to TLS downgrade attacks
+if a vulnerability in TLS 1.0 or 1.1 were discovered in
+the future. Extra security for free! By dropping TLS 1.0
+and TLS 1.1 we also tighten the list of ciphers we need
+to support to ensure high security for data traveling
+over the wire.
+
+If you still need to use TLS 1.0 or 1.1 in your application
+you can still upgrade to v2.0, you'll only need to set
+``ssl_version`` to the proper values to continue using
+legacy TLS versions.
+
+
+Stop Verifying CommonName in Certificates
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Dropping support the long deprecated ``commonName``
+field on certificates in favor of only verifying
+``subjectAltName`` to put us in line with browsers and
+other HTTP client libraries and to improve security for our users.
+
+
+Certificate Verification via SSLContext
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+By default certificate verification is handled by urllib3
+to support legacy Python versions, but now we can
+rely on Python's certificate verification instead! This
+should result in a speedup for verifying certificates
+and means that any improvements made to certificate
+verification in Python or OpenSSL will be immediately
+available.
+
+
+**✨ Optimized for Python 3.6+**
+--------------------------------
+
+In v2.0 we'll be specifically be targeting
+CPython 3.6+ and PyPy 7.0+ (compatible with CPython 3.6)
+and dropping support Python versions 2.7 and 3.5.
+
+By dropping end-of-life Python versions we're able to optimize
+the codebase for Python 3.6+ by using new features to improve
+performance and reduce the amount of code that needs to be executed
+in order to support legacy versions.
+
+
+**📡 Telemetry and Tracing**
+----------------------------
+
+Currently with urllib3 it's tough to get low-level insights into what
+how your HTTP client is performing and what your connection information
+looks like. In v2.0 we'll be adding telemetry and tracing information
+to HTTP response objects including:
+
+- Connection ID
+- IP Address resolved by DNS
+- Request Method, Target, and Headers
+- TLS Version and Cipher
+- Certificate Fingerprint, subjectAltName, and Validity Information
+- Timings for DNS, Request Data, First Byte in Response
+
+
+**📜 Type-Hinted APIs**
+-----------------------
+
+You'll finally be able to run Mypy or other type-checkers
+on code using urllib3. This also means that for IDEs
+that support type hints you'll receive better suggestions
+from auto-complete. No more ``**kwargs`` problem!
+
+We'll also add API interfaces to ensure that when
+you're sub-classing an interface you're only using
+supported public APIs to ensure compatibility and
+minimize breakages down the road.
+
+
+**🎁 ...and many more features!**
+---------------------------------
+
+- Top-level ``urllib3.request()`` API
+- Open Possibility to Alternate HTTP Implementations
+- Translated Documentation
+- Support Zstandard Compression
+- Streaming ``multipart/form-encoded`` Request Data
+- More Powerful and Configurable Retry Logic
+
+If there's a feature you don't see here but would like to see
+in urllib3 v2.0, there's an open GitHub issue for making
+feature suggestions.

--- a/docs/v2-roadmap.rst
+++ b/docs/v2-roadmap.rst
@@ -1,10 +1,6 @@
 v2.0 Roadmap
 ============
 
-
-**📅 Release and Migration Schedule**
--------------------------------------
-
 .. important::
 
    We're seeking `sponsors and supporters for urllib3 v2.0 on Open Collective <https://opencollective.com/urllib3>`_.
@@ -13,43 +9,6 @@ v2.0 Roadmap
    for the additional effort required for a large release like ``v2.0``.
 
    Additional information available within the :doc:`sponsors` section of our documentation.
-
-
-We're aiming for all ``v2.x`` features to be released in **mid-to-late 2021**.
-
-Here's what the release and migration schedule will look like leading up
-to v2.0 being released:
-
-- Development of ``v2.x`` breaking changes starts.
-- Release ``v1.26.0`` with deprecation warnings for ``v2.0.0`` breaking changes.
-  This will be the last non-patch release within the ``v1.x`` stream.
-- Release ``v2.0.0-alpha1`` once all breaking changes have been completed.
-  We'll wait for users to report issues, bugs, and unexpected
-  breakages at this stage to ensure the release ``v2.0.0`` goes smoothly.
-- Development of remaining ``v2.x`` features starts.
-- Release ``v2.0.0`` which will be identical to ``v2.0.0-alpha1``.
-- Release ``v2.1.0`` with remaining ``v2.x`` features.
-
-Deprecation warnings within ``v1.26.x`` will be opt-in by default.
-
-Package and Application Developers
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Since this is the first major release in almost 9 years some users may
-be caught off-guard by a new major release of urllib3. We're mitigating this by
-trying to make ``v2.x`` API-compatible with ``v1.x``.
-
-If your application or library uses urllib3 and you'd like to be extra
-cautious about not breaking your users, you can pin urllib3 like so
-until you ensure compatibility with ``v2.x``:
-
-.. code-block:: python
-
-   # requirements.txt or 'install_requires'
-   "urllib3>=1.25,<2"
-
-We'd really appreciate testing compatibility
-and providing feedback on ``v2.0.0-alpha1`` once released.
 
 
 **🚀 Functional API Compatibility**
@@ -134,12 +93,12 @@ performance and reduce the amount of code that needs to be executed
 in order to support legacy versions.
 
 
-**📡 Telemetry and Tracing**
-----------------------------
+**🔮 Tracing**
+--------------
 
 Currently with urllib3 it's tough to get low-level insights into what
 how your HTTP client is performing and what your connection information
-looks like. In v2.0 we'll be adding telemetry and tracing information
+looks like. In v2.0 we'll be adding tracing and telemetry information
 to HTTP response objects including:
 
 - Connection ID
@@ -156,7 +115,7 @@ to HTTP response objects including:
 You'll finally be able to run Mypy or other type-checkers
 on code using urllib3. This also means that for IDEs
 that support type hints you'll receive better suggestions
-from auto-complete. No more ``**kwargs`` problem!
+from auto-complete. No more confusing with ``**kwargs``!
 
 We'll also add API interfaces to ensure that when
 you're sub-classing an interface you're only using
@@ -169,7 +128,7 @@ minimize breakages down the road.
 
 - Top-level ``urllib3.request()`` API
 - Open Possibility to Alternate HTTP Implementations
-- Translated Documentation
+- Translated Guides
 - Support Zstandard Compression
 - Streaming ``multipart/form-encoded`` Request Data
 - More Powerful and Configurable Retry Logic
@@ -177,3 +136,45 @@ minimize breakages down the road.
 If there's a feature you don't see here but would like to see
 in urllib3 v2.0, there's an open GitHub issue for making
 feature suggestions.
+
+
+**📅 Release and Migration Schedule**
+-------------------------------------
+
+We're aiming for all ``v2.x`` features to be released in **mid-to-late 2021**.
+
+Here's what the release and migration schedule will look like leading up
+to v2.0 being released:
+
+- Development of ``v2.x`` breaking changes starts.
+- Release ``v1.26.0`` with deprecation warnings for ``v2.0.0`` breaking changes.
+  This will be the last non-patch release within the ``v1.x`` stream.
+- Release ``v2.0.0-alpha1`` once all breaking changes have been completed.
+  We'll wait for users to report issues, bugs, and unexpected
+  breakages at this stage to ensure the release ``v2.0.0`` goes smoothly.
+- Development of remaining ``v2.x`` features starts.
+- Release ``v2.0.0`` which will be identical to ``v2.0.0-alpha1``.
+- Release ``v2.1.0`` with remaining ``v2.x`` features.
+
+Deprecation warnings within ``v1.26.x`` will be opt-in by default.
+
+**More detailed Application Migration Guide coming soon.**
+
+For Package Maintainers
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Since this is the first major release in almost 9 years some users may
+be caught off-guard by a new major release of urllib3. We're mitigating this by
+trying to make ``v2.x`` API-compatible with ``v1.x``.
+
+If your application or library uses urllib3 and you'd like to be extra
+cautious about not breaking your users, you can pin urllib3 like so
+until you ensure compatibility with ``v2.x``:
+
+.. code-block:: python
+
+   # 'install_requires' or 'requirements.txt'
+   "urllib3>=1.25,<2"
+
+We'd really appreciate testing compatibility
+and providing feedback on ``v2.0.0-alpha1`` once released.


### PR DESCRIPTION
Live URL thanks to RTD: https://urllib3--1971.org.readthedocs.build/en/1971/

Since the v2.0 feature request issue is starting to solidify and I'd like to get the ball rolling I put this together.

Not looking to merge this fast, want to get everything right and then make announcements when everything is ready :)

First of all, I'm very proud of the top bar. CSS is basically magic to me :sparkles:
Thanks @pradyunsg for the "announcement" option making this **way too easy** to implement.

The "splash" page for the v2.0 Roadmap could use some customized HTML+CSS to make it look extra pretty, but this seemed like a good starting point. I've been recommended one potential person who might be good to do this but I'm open to other designer suggestions!

Please be picky on wording of things and ordering of sections, etc.

This is also a good place to discuss the OpenCollective sponsor perks. I added some that I could think of, let me know your thoughts on existing/new perks.

TODOs for me:
- [ ] Make the OpenCollective Section automatically update with JavaScript
  - I've got some work to do here externally but my basic idea is to make a Cloud Function that calculates
  the list using an API call to OpenCollective and then just returns it with a `Cache-Control: immutable` and decent cache validity. Might actually have a second repository under the `@urllib3` org
  - With the results from the cloud function I can use a tiny amount of JavaScript to render the list of supporters in a nice compact grid

