### PR TITLE
Add Discord shield, reorder shields

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,11 +6,12 @@
       </a>
    </p>
    <p align="center">
-      <a href="https://travis-ci.org/urllib3/urllib3"><img alt="Build status on Travis" src="https://travis-ci.org/urllib3/urllib3.svg?branch=master" /></a>
-      <a href="https://github.com/urllib3/urllib3/actions?query=workflow%3ACI"><img alt="Build status on GitHub" src="https://github.com/urllib3/urllib3/workflows/CI/badge.svg" /></a>
-      <a href="https://urllib3.readthedocs.io/en/latest/"><img alt="Documentation Status" src="https://readthedocs.org/projects/urllib3/badge/?version=latest" /></a>
+      <a href="https://pypi.org/project/urllib3"><img alt="PyPI Version" src="https://img.shields.io/pypi/v/urllib3.svg?maxAge=86400" /></a>
+      <a href="https://discord.gg/qGMUA2p"><img alt="Join our Discord" src="https://img.shields.io/discord/756342717725933608?color=%237289da&label=discord" /></a>
       <a href="https://codecov.io/gh/urllib3/urllib3"><img alt="Coverage Status" src="https://img.shields.io/codecov/c/github/urllib3/urllib3.svg" /></a>
-      <a href="https://pypi.org/project/urllib3/"><img alt="PyPI Version" src="https://img.shields.io/pypi/v/urllib3.svg?maxAge=86400" /></a>
+      <a href="https://github.com/urllib3/urllib3/actions?query=workflow%3ACI"><img alt="Build Status on GitHub" src="https://github.com/urllib3/urllib3/workflows/CI/badge.svg" /></a>
+      <a href="https://travis-ci.org/urllib3/urllib3"><img alt="Build Status on Travis" src="https://travis-ci.org/urllib3/urllib3.svg?branch=master" /></a>
+      <a href="https://urllib3.readthedocs.io"><img alt="Documentation Status" src="https://readthedocs.org/projects/urllib3/badge/?version=latest" /></a>
    </p>
 
 urllib3 is a powerful, *user-friendly* HTTP client for Python. Much of the


### PR DESCRIPTION
IMO it makes sense to have things relevant to users on the leftmost side of the screen.
Users likely don't care if our documentation or CI are passing/failing, they do want to see what the latest version that's released is and potentially where to get help.

Also since we're trying to get rid of Travis eventually I favored GitHub Actions.

Also normalized some of the URLs and Alt Text.

Reordered Shields from:
- Travis, GitHub Actions, Doc Status, Coverage, Version

to:
- Version, Discord, Coverage, GitHub Actions, Travis, Doc Status
