### PR TITLE
FUNDING.yml: Add Gitcoin

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,3 @@
 tidelift: pypi/urllib3
 open_collective: urllib3
+custom: https://gitcoin.co/grants/65/urllib3


### PR DESCRIPTION
AFAIK Github does not support Gitcoin natively so we'd have to add it as a Custom URL.