### PR TITLE
Stop testing docs in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,10 +32,6 @@ jobs:
   allow_failures:
     - python: nightly
   include:
-    # Lint & documentation.
-    - python: 3.8
-      env: NOX_SESSION=docs
-
     # Unit tests
     - python: 2.7
       env: NOX_SESSION=test-2.7


### PR DESCRIPTION
Let's rely on the ReadTheDocs pull request check instead. This does mean that `nox -rs docs` won't get exercised by continuous integration, which is an acceptable compromise.