### PR TITLE
Sort imports

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 
-from datetime import date
 import os
 import sys
+from datetime import date
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -29,7 +29,6 @@ sys.modules.update((mod_name, MockModule()) for mod_name in MOCK_MODULES)
 
 
 import urllib3
-
 
 # -- General configuration -----------------------------------------------------
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -13,7 +13,7 @@ If you wish to add a new feature or fix a bug:
    to start making your changes.
 #. Write a test which shows that the bug was fixed or that the feature works
    as expected.
-#. Format your changes with black using command `$ nox -rs blacken` and lint your
+#. Format your changes with black using command `$ nox -rs format` and lint your
    changes using command `nox -rs lint`.
 #. Send a pull request and bug the maintainer until it gets merged and published.
    :) Make sure to add yourself to ``CONTRIBUTORS.txt``.

--- a/dummyserver/handlers.py
+++ b/dummyserver/handlers.py
@@ -8,16 +8,15 @@ import logging
 import sys
 import time
 import zlib
-
+from datetime import datetime, timedelta
 from io import BytesIO
-from tornado.web import RequestHandler
-from tornado import httputil
-from datetime import datetime
-from datetime import timedelta
 
+from tornado import httputil
+from tornado.web import RequestHandler
+
+from urllib3.packages.six import binary_type, ensure_str
 from urllib3.packages.six.moves.http_client import responses
 from urllib3.packages.six.moves.urllib.parse import urlsplit
-from urllib3.packages.six import binary_type, ensure_str
 
 log = logging.getLogger(__name__)
 

--- a/dummyserver/proxy.py
+++ b/dummyserver/proxy.py
@@ -25,16 +25,16 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-import sys
 import socket
+import ssl
+import sys
 
 import tornado.gen
+import tornado.httpclient
 import tornado.httpserver
 import tornado.ioloop
 import tornado.iostream
 import tornado.web
-import tornado.httpclient
-import ssl
 
 __all__ = ["ProxyHandler", "run_proxy"]
 

--- a/dummyserver/server.py
+++ b/dummyserver/server.py
@@ -7,24 +7,23 @@ from __future__ import print_function
 
 import logging
 import os
+import socket
+import ssl
 import sys
 import threading
-import socket
 import warnings
-import ssl
 from datetime import datetime
 
-from urllib3.exceptions import HTTPWarning
-from urllib3.util import resolve_cert_reqs, resolve_ssl_version, ALPN_PROTOCOLS
-
-from cryptography.hazmat.backends import default_backend
-from cryptography.hazmat.primitives import serialization
 import tornado.httpserver
 import tornado.ioloop
 import tornado.netutil
 import tornado.web
 import trustme
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import serialization
 
+from urllib3.exceptions import HTTPWarning
+from urllib3.util import ALPN_PROTOCOLS, resolve_cert_reqs, resolve_ssl_version
 
 log = logging.getLogger(__name__)
 

--- a/dummyserver/testcase.py
+++ b/dummyserver/testcase.py
@@ -4,17 +4,16 @@ from contextlib import contextmanager
 import pytest
 from tornado import ioloop, web
 
-from urllib3.connection import HTTPConnection
-
-from dummyserver.server import (
-    SocketServerThread,
-    run_tornado_app,
-    run_loop_in_thread,
-    DEFAULT_CERTS,
-    HAS_IPV6,
-)
 from dummyserver.handlers import TestingApp
 from dummyserver.proxy import ProxyHandler
+from dummyserver.server import (
+    DEFAULT_CERTS,
+    HAS_IPV6,
+    SocketServerThread,
+    run_loop_in_thread,
+    run_tornado_app,
+)
+from urllib3.connection import HTTPConnection
 
 
 def consume_socket(sock, chunks=65536):

--- a/noxfile.py
+++ b/noxfile.py
@@ -101,21 +101,24 @@ def app_engine(session):
 
 
 @nox.session()
-def blacken(session):
-    """Run black code formatter."""
-    session.install("black")
+def format(session):
+    """Run code formatters."""
+    session.install("black", "isort")
     session.run("black", *SOURCE_FILES)
+    session.run("isort", "--profile", "black", *SOURCE_FILES)
 
     lint(session)
 
 
 @nox.session
 def lint(session):
-    session.install("flake8", "flake8-2020", "black", "mypy")
+    session.install("flake8", "flake8-2020", "black", "isort", "mypy")
     session.run("flake8", "--version")
     session.run("black", "--version")
+    session.run("isort", "--version")
     session.run("mypy", "--version")
     session.run("black", "--check", *SOURCE_FILES)
+    session.run("isort", "--profile", "black", "--check", *SOURCE_FILES)
     session.run("flake8", *SOURCE_FILES)
 
     session.log("mypy --strict src/urllib3")

--- a/noxfile.py
+++ b/noxfile.py
@@ -4,7 +4,6 @@ import subprocess
 
 import nox
 
-
 # Whenever type-hints are completed on a file it should be added here so that
 # this file will continue to be checked by mypy. Errors from other files are
 # ignored.

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python
 # This file is protected via CODEOWNERS
 
-from setuptools import setup
-
+import codecs
 import os
 import re
-import codecs
+
+from setuptools import setup
 
 base_path = os.path.dirname(__file__)
 

--- a/src/urllib3/__init__.py
+++ b/src/urllib3/__init__.py
@@ -2,24 +2,22 @@
 Python HTTP library with thread-safe connection pooling, file post support, user friendly, and more
 """
 from __future__ import absolute_import
-import warnings
 
-from .connectionpool import HTTPConnectionPool, HTTPSConnectionPool, connection_from_url
+# Set default logging handler to avoid "No handler found" warnings.
+import logging
+import warnings
+from logging import NullHandler
 
 from . import exceptions
+from ._version import __version__
+from .connectionpool import HTTPConnectionPool, HTTPSConnectionPool, connection_from_url
 from .filepost import encode_multipart_formdata
 from .poolmanager import PoolManager, ProxyManager, proxy_from_url
 from .response import HTTPResponse
 from .util.request import make_headers
-from .util.url import get_host
-from .util.timeout import Timeout
 from .util.retry import Retry
-from ._version import __version__
-
-
-# Set default logging handler to avoid "No handler found" warnings.
-import logging
-from logging import NullHandler
+from .util.timeout import Timeout
+from .util.url import get_host
 
 __author__ = "Andrey Petrov (andrey.petrov@shazow.net)"
 __license__ = "MIT"

--- a/src/urllib3/_collections.py
+++ b/src/urllib3/_collections.py
@@ -17,10 +17,10 @@ except ImportError:  # Platform-specific: No threads available
 
 
 from collections import OrderedDict
+
 from .exceptions import InvalidHeader
 from .packages import six
 from .packages.six import iterkeys, itervalues
-
 
 __all__ = ["RecentlyUsedContainer", "HTTPHeaderDict"]
 

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -1,11 +1,14 @@
 from __future__ import absolute_import
-import re
+
 import datetime
 import logging
 import os
+import re
 import socket
-from socket import error as SocketError, timeout as SocketTimeout
 import warnings
+from socket import error as SocketError
+from socket import timeout as SocketTimeout
+
 from .packages import six
 from .packages.six.moves.http_client import HTTPConnection as _HTTPConnection
 from .packages.six.moves.http_client import HTTPException  # noqa: F401
@@ -40,27 +43,23 @@ except NameError:  # Python 2:
         pass
 
 
+from ._collections import HTTPHeaderDict
+from ._version import __version__
 from .exceptions import (
-    NewConnectionError,
     ConnectTimeoutError,
+    NewConnectionError,
     SubjectAltNameWarning,
     SystemTimeWarning,
 )
-from .packages.ssl_match_hostname import match_hostname, CertificateError
-
+from .packages.ssl_match_hostname import CertificateError, match_hostname
+from .util import SUPPRESS_USER_AGENT, connection
 from .util.ssl_ import (
-    resolve_cert_reqs,
-    resolve_ssl_version,
     assert_fingerprint,
     create_urllib3_context,
+    resolve_cert_reqs,
+    resolve_ssl_version,
     ssl_wrap_socket,
 )
-
-
-from .util import connection, SUPPRESS_USER_AGENT
-
-from ._collections import HTTPHeaderDict
-from ._version import __version__
 
 log = logging.getLogger(__name__)
 

--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -1,59 +1,53 @@
 from __future__ import absolute_import
+
 import errno
 import logging
+import socket
 import sys
 import warnings
+from socket import error as SocketError
+from socket import timeout as SocketTimeout
 
-from socket import error as SocketError, timeout as SocketTimeout
-import socket
-
-
+from .connection import (
+    BaseSSLError,
+    BrokenPipeError,
+    DummyConnection,
+    HTTPConnection,
+    HTTPException,
+    HTTPSConnection,
+    VerifiedHTTPSConnection,
+    port_by_scheme,
+)
 from .exceptions import (
     ClosedPoolError,
-    ProtocolError,
     EmptyPoolError,
     HeaderParsingError,
     HostChangedError,
+    InsecureRequestWarning,
     LocationValueError,
     MaxRetryError,
+    NewConnectionError,
+    ProtocolError,
     ProxyError,
     ReadTimeoutError,
     SSLError,
     TimeoutError,
-    InsecureRequestWarning,
-    NewConnectionError,
 )
-from .packages.ssl_match_hostname import CertificateError
 from .packages import six
 from .packages.six.moves import queue
-from .connection import (
-    port_by_scheme,
-    DummyConnection,
-    HTTPConnection,
-    HTTPSConnection,
-    VerifiedHTTPSConnection,
-    HTTPException,
-    BaseSSLError,
-    BrokenPipeError,
-)
+from .packages.ssl_match_hostname import CertificateError
 from .request import RequestMethods
 from .response import HTTPResponse
-
 from .util.connection import is_connection_dropped
 from .util.proxy import connection_requires_http_tunnel
+from .util.queue import LifoQueue
 from .util.request import set_file_position
 from .util.response import assert_header_parsing
 from .util.retry import Retry
 from .util.timeout import Timeout
-from .util.url import (
-    get_host,
-    parse_url,
-    Url,
-    _normalize_host as normalize_host,
-    _encode_target,
-)
-from .util.queue import LifoQueue
-
+from .util.url import Url, _encode_target
+from .util.url import _normalize_host as normalize_host
+from .util.url import get_host, parse_url
 
 xrange = six.moves.xrange
 

--- a/src/urllib3/contrib/_securetransport/bindings.py
+++ b/src/urllib3/contrib/_securetransport/bindings.py
@@ -32,21 +32,23 @@ license and by oscrypto's:
 from __future__ import absolute_import
 
 import platform
-from ctypes.util import find_library
 from ctypes import (
-    c_void_p,
-    c_int32,
-    c_char_p,
-    c_size_t,
+    CDLL,
+    CFUNCTYPE,
+    POINTER,
+    c_bool,
     c_byte,
+    c_char_p,
+    c_int32,
+    c_long,
+    c_size_t,
     c_uint32,
     c_ulong,
-    c_long,
-    c_bool,
+    c_void_p,
 )
-from ctypes import CDLL, POINTER, CFUNCTYPE
-from urllib3.packages.six import raise_from
+from ctypes.util import find_library
 
+from urllib3.packages.six import raise_from
 
 if platform.system() != "Darwin":
     raise ImportError("Only macOS is supported")

--- a/src/urllib3/contrib/_securetransport/low_level.py
+++ b/src/urllib3/contrib/_securetransport/low_level.py
@@ -10,13 +10,12 @@ appropriate and useful assistance to the higher-level code.
 import base64
 import ctypes
 import itertools
-import re
 import os
+import re
 import ssl
 import tempfile
 
-from .bindings import Security, CoreFoundation, CFConst
-
+from .bindings import CFConst, CoreFoundation, Security
 
 # This regular expression is used to grab PEM data out of a PEM bundle.
 _PEM_CERTS_RE = re.compile(

--- a/src/urllib3/contrib/appengine.py
+++ b/src/urllib3/contrib/appengine.py
@@ -39,24 +39,24 @@ urllib3 on Google App Engine:
 """
 
 from __future__ import absolute_import
+
 import io
 import logging
 import warnings
-from ..packages.six.moves.urllib.parse import urljoin
 
 from ..exceptions import (
     HTTPError,
     HTTPWarning,
     MaxRetryError,
     ProtocolError,
-    TimeoutError,
     SSLError,
+    TimeoutError,
 )
-
+from ..packages.six.moves.urllib.parse import urljoin
 from ..request import RequestMethods
 from ..response import HTTPResponse
-from ..util.timeout import Timeout
 from ..util.retry import Retry
+from ..util.timeout import Timeout
 from . import _appengine_environ
 
 try:

--- a/src/urllib3/contrib/ntlmpool.py
+++ b/src/urllib3/contrib/ntlmpool.py
@@ -6,11 +6,11 @@ Issue #10, see: http://code.google.com/p/urllib3/issues/detail?id=10
 from __future__ import absolute_import
 
 from logging import getLogger
+
 from ntlm import ntlm
 
 from .. import HTTPSConnectionPool
 from ..packages.six.moves.http_client import HTTPSConnection
-
 
 log = getLogger(__name__)
 

--- a/src/urllib3/contrib/pyopenssl.py
+++ b/src/urllib3/contrib/pyopenssl.py
@@ -60,8 +60,9 @@ except ImportError:
         pass
 
 
-from socket import timeout, error as SocketError
 from io import BytesIO
+from socket import error as SocketError
+from socket import timeout
 
 try:  # Platform-specific: Python 2
     from socket import _fileobject
@@ -71,11 +72,10 @@ except ImportError:  # Platform-specific: Python 3
 
 import logging
 import ssl
-from ..packages import six
 import sys
 
 from .. import util
-
+from ..packages import six
 
 __all__ = ["inject_into_urllib3", "extract_from_urllib3"]
 

--- a/src/urllib3/contrib/securetransport.py
+++ b/src/urllib3/contrib/securetransport.py
@@ -58,20 +58,21 @@ import ctypes
 import errno
 import os.path
 import shutil
-import six
 import socket
 import ssl
 import threading
 import weakref
 
+import six
+
 from .. import util
-from ._securetransport.bindings import Security, SecurityConst, CoreFoundation
+from ._securetransport.bindings import CoreFoundation, Security, SecurityConst
 from ._securetransport.low_level import (
     _assert_no_error,
     _cert_array_from_pem,
-    _temporary_keychain,
-    _load_client_cert_chain,
     _create_cfstring_array,
+    _load_client_cert_chain,
+    _temporary_keychain,
 )
 
 try:  # Platform-specific: Python 2

--- a/src/urllib3/contrib/socks.py
+++ b/src/urllib3/contrib/socks.py
@@ -44,6 +44,7 @@ try:
     import socks
 except ImportError:
     import warnings
+
     from ..exceptions import DependencyWarning
 
     warnings.warn(
@@ -56,7 +57,8 @@ except ImportError:
     )
     raise
 
-from socket import error as SocketError, timeout as SocketTimeout
+from socket import error as SocketError
+from socket import timeout as SocketTimeout
 
 from ..connection import HTTPConnection, HTTPSConnection
 from ..connectionpool import HTTPConnectionPool, HTTPSConnectionPool

--- a/src/urllib3/exceptions.py
+++ b/src/urllib3/exceptions.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+
 from .packages.six.moves.http_client import IncompleteRead as httplib_IncompleteRead
 
 # Base Exceptions

--- a/src/urllib3/exceptions.pyi
+++ b/src/urllib3/exceptions.pyi
@@ -1,4 +1,4 @@
-from typing import Any, Optional, Union, Tuple, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Optional, Tuple, Union
 
 if TYPE_CHECKING:
     from urllib3.connectionpool import ConnectionPool

--- a/src/urllib3/fields.py
+++ b/src/urllib3/fields.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+
 import email.utils
 import mimetypes
 import re

--- a/src/urllib3/filepost.py
+++ b/src/urllib3/filepost.py
@@ -1,13 +1,13 @@
 from __future__ import absolute_import
+
 import binascii
 import codecs
 import os
-
 from io import BytesIO
 
+from .fields import RequestField
 from .packages import six
 from .packages.six import b
-from .fields import RequestField
 
 writer = codecs.lookup("utf-8")[3]
 

--- a/src/urllib3/packages/backports/makefile.py
+++ b/src/urllib3/packages/backports/makefile.py
@@ -7,7 +7,6 @@ Backports the Python 3 ``socket.makefile`` method for use with anything that
 wants to create a "fake" socket object.
 """
 import io
-
 from socket import SocketIO
 
 

--- a/src/urllib3/packages/ssl_match_hostname/__init__.py
+++ b/src/urllib3/packages/ssl_match_hostname/__init__.py
@@ -10,7 +10,10 @@ try:
 except ImportError:
     try:
         # Backport of the function from a pypi module
-        from backports.ssl_match_hostname import CertificateError, match_hostname  # type: ignore
+        from backports.ssl_match_hostname import (  # type: ignore
+            CertificateError,
+            match_hostname,
+        )
     except ImportError:
         # Our vendored copy
         from ._implementation import CertificateError, match_hostname  # type: ignore

--- a/src/urllib3/poolmanager.py
+++ b/src/urllib3/poolmanager.py
@@ -1,12 +1,11 @@
 from __future__ import absolute_import
+
 import collections
 import functools
 import logging
 
 from ._collections import RecentlyUsedContainer
-from .connectionpool import HTTPConnectionPool, HTTPSConnectionPool
-from .connectionpool import port_by_scheme
-
+from .connectionpool import HTTPConnectionPool, HTTPSConnectionPool, port_by_scheme
 from .exceptions import (
     LocationValueError,
     MaxRetryError,
@@ -17,10 +16,9 @@ from .exceptions import (
 from .packages import six
 from .packages.six.moves.urllib.parse import urljoin
 from .request import RequestMethods
-from .util.url import parse_url
-from .util.retry import Retry
 from .util.proxy import connection_requires_http_tunnel
-
+from .util.retry import Retry
+from .util.url import parse_url
 
 __all__ = ["PoolManager", "ProxyManager", "proxy_from_url"]
 

--- a/src/urllib3/request.py
+++ b/src/urllib3/request.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import
 from .filepost import encode_multipart_formdata
 from .packages.six.moves.urllib.parse import urlencode
 
-
 __all__ = ["RequestMethods"]
 
 

--- a/src/urllib3/response.py
+++ b/src/urllib3/response.py
@@ -1,10 +1,11 @@
 from __future__ import absolute_import
-from contextlib import contextmanager
-import zlib
+
 import io
 import logging
-from socket import timeout as SocketTimeout
+import zlib
+from contextlib import contextmanager
 from socket import error as SocketError
+from socket import timeout as SocketTimeout
 
 try:
     import brotli
@@ -12,20 +13,20 @@ except ImportError:
     brotli = None
 
 from ._collections import HTTPHeaderDict
+from .connection import BaseSSLError, HTTPException
 from .exceptions import (
     BodyNotHttplibCompatible,
-    ProtocolError,
     DecodeError,
-    ReadTimeoutError,
-    ResponseNotChunked,
+    HTTPError,
     IncompleteRead,
     InvalidChunkLength,
     InvalidHeader,
-    HTTPError,
+    ProtocolError,
+    ReadTimeoutError,
+    ResponseNotChunked,
     SSLError,
 )
 from .packages import six
-from .connection import HTTPException, BaseSSLError
 from .util.response import is_fp_closed, is_response_to_head
 
 log = logging.getLogger(__name__)

--- a/src/urllib3/util/__init__.py
+++ b/src/urllib3/util/__init__.py
@@ -2,24 +2,23 @@ from __future__ import absolute_import
 
 # For backwards compatibility, provide imports that used to be here.
 from .connection import is_connection_dropped
-from .request import make_headers, SUPPRESS_USER_AGENT
+from .request import SUPPRESS_USER_AGENT, make_headers
 from .response import is_fp_closed
+from .retry import Retry
 from .ssl_ import (
-    SSLContext,
+    ALPN_PROTOCOLS,
     HAS_SNI,
     IS_PYOPENSSL,
     IS_SECURETRANSPORT,
+    PROTOCOL_TLS,
+    SSLContext,
     assert_fingerprint,
     resolve_cert_reqs,
     resolve_ssl_version,
     ssl_wrap_socket,
-    PROTOCOL_TLS,
-    ALPN_PROTOCOLS,
 )
-from .timeout import current_time, Timeout
-
-from .retry import Retry
-from .url import get_host, parse_url, split_first, Url
+from .timeout import Timeout, current_time
+from .url import Url, get_host, parse_url, split_first
 from .wait import wait_for_read, wait_for_write
 
 __all__ = (

--- a/src/urllib3/util/connection.py
+++ b/src/urllib3/util/connection.py
@@ -1,11 +1,12 @@
 from __future__ import absolute_import
+
 import socket
 
 from urllib3.exceptions import LocationParseError
 
-from .wait import NoWayToWaitForSocketError, wait_for_read
 from ..contrib import _appengine_environ
 from ..packages import six
+from .wait import NoWayToWaitForSocketError, wait_for_read
 
 
 def is_connection_dropped(conn):  # Platform-specific

--- a/src/urllib3/util/proxy.py
+++ b/src/urllib3/util/proxy.py
@@ -1,8 +1,4 @@
-from .ssl_ import (
-    resolve_cert_reqs,
-    resolve_ssl_version,
-    create_urllib3_context,
-)
+from .ssl_ import create_urllib3_context, resolve_cert_reqs, resolve_ssl_version
 
 
 def connection_requires_http_tunnel(

--- a/src/urllib3/util/queue.py
+++ b/src/urllib3/util/queue.py
@@ -1,4 +1,5 @@
 import collections
+
 from ..packages import six
 from ..packages.six.moves import queue
 

--- a/src/urllib3/util/request.py
+++ b/src/urllib3/util/request.py
@@ -1,8 +1,9 @@
 from __future__ import absolute_import
+
 from base64 import b64encode
 
-from ..packages.six import b, integer_types
 from ..exceptions import UnrewindableBodyError
+from ..packages.six import b, integer_types
 
 # Use an invalid User-Agent to represent suppressing of default user agent.
 # See https://tools.ietf.org/html/rfc7231#section-5.5.3 and

--- a/src/urllib3/util/response.py
+++ b/src/urllib3/util/response.py
@@ -1,8 +1,9 @@
 from __future__ import absolute_import
-from email.errors import StartBoundaryNotFoundDefect, MultipartInvariantViolationDefect
-from ..packages.six.moves import http_client as httplib
+
+from email.errors import MultipartInvariantViolationDefect, StartBoundaryNotFoundDefect
 
 from ..exceptions import HeaderParsingError
+from ..packages.six.moves import http_client as httplib
 
 
 def is_fp_closed(obj):

--- a/src/urllib3/util/retry.py
+++ b/src/urllib3/util/retry.py
@@ -1,23 +1,23 @@
 from __future__ import absolute_import
-import time
+
+import email
 import logging
+import re
+import time
+import warnings
 from collections import namedtuple
 from itertools import takewhile
-import email
-import re
-import warnings
 
 from ..exceptions import (
     ConnectTimeoutError,
+    InvalidHeader,
     MaxRetryError,
     ProtocolError,
+    ProxyError,
     ReadTimeoutError,
     ResponseError,
-    InvalidHeader,
-    ProxyError,
 )
 from ..packages import six
-
 
 log = logging.getLogger(__name__)
 

--- a/src/urllib3/util/ssl_.py
+++ b/src/urllib3/util/ssl_.py
@@ -1,21 +1,20 @@
 from __future__ import absolute_import
-import warnings
+
 import hmac
 import os
 import sys
-
+import warnings
 from binascii import hexlify, unhexlify
 from hashlib import md5, sha1, sha256
 
-from .url import IPV4_RE, BRACELESS_IPV6_ADDRZ_RE
 from ..exceptions import (
-    SSLError,
     InsecurePlatformWarning,
-    SNIMissingWarning,
     ProxySchemeUnsupported,
+    SNIMissingWarning,
+    SSLError,
 )
 from ..packages import six
-
+from .url import BRACELESS_IPV6_ADDRZ_RE, IPV4_RE
 
 SSLContext = None
 SSLTransport = None
@@ -45,8 +44,9 @@ _const_compare_digest = getattr(hmac, "compare_digest", _const_compare_digest_ba
 
 try:  # Test for SSL features
     import ssl
-    from ssl import wrap_socket, CERT_REQUIRED
     from ssl import HAS_SNI  # Has SNI?
+    from ssl import CERT_REQUIRED, wrap_socket
+
     from .ssltransport import SSLTransport
 except ImportError:
     pass
@@ -65,7 +65,7 @@ except ImportError:
 
 
 try:
-    from ssl import OP_NO_SSLv2, OP_NO_SSLv3, OP_NO_COMPRESSION
+    from ssl import OP_NO_COMPRESSION, OP_NO_SSLv2, OP_NO_SSLv3
 except ImportError:
     OP_NO_SSLv2, OP_NO_SSLv3 = 0x1000000, 0x2000000
     OP_NO_COMPRESSION = 0x20000

--- a/src/urllib3/util/ssltransport.py
+++ b/src/urllib3/util/ssltransport.py
@@ -1,6 +1,6 @@
-import ssl
-import socket
 import io
+import socket
+import ssl
 
 from urllib3.exceptions import ProxySchemeUnsupported
 from urllib3.packages import six

--- a/src/urllib3/util/timeout.py
+++ b/src/urllib3/util/timeout.py
@@ -1,9 +1,10 @@
 from __future__ import absolute_import
 
+import time
+
 # The default socket timeout, used by httplib to indicate that no timeout was
 # specified by the user
 from socket import _GLOBAL_DEFAULT_TIMEOUT
-import time
 
 from ..exceptions import TimeoutStateError
 

--- a/src/urllib3/util/url.py
+++ b/src/urllib3/util/url.py
@@ -1,10 +1,10 @@
 from __future__ import absolute_import
+
 import re
 from collections import namedtuple
 
 from ..exceptions import LocationParseError
 from ..packages import six
-
 
 url_attrs = ["scheme", "auth", "host", "port", "path", "query", "fragment"]
 

--- a/src/urllib3/util/wait.py
+++ b/src/urllib3/util/wait.py
@@ -1,7 +1,7 @@
 import errno
-from functools import partial
 import select
 import sys
+from functools import partial
 
 try:
     from time import monotonic

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,11 +1,11 @@
-import warnings
-import sys
 import errno
 import logging
-import socket
-import ssl
 import os
 import platform
+import socket
+import ssl
+import sys
+import warnings
 
 import pytest
 
@@ -14,10 +14,10 @@ try:
 except ImportError:
     brotli = None
 
+from urllib3 import util
 from urllib3.exceptions import HTTPWarning
 from urllib3.packages import six
 from urllib3.util import ssl_
-from urllib3 import util
 
 try:
     import urllib3.contrib.pyopenssl as pyopenssl

--- a/test/appengine/conftest.py
+++ b/test/appengine/conftest.py
@@ -28,7 +28,6 @@ except ImportError:
 import pytest
 import six
 
-
 __all__ = [
     "pytest_configure",
     "pytest_runtest_call",

--- a/test/appengine/test_gae_manager.py
+++ b/test/appengine/test_gae_manager.py
@@ -1,13 +1,13 @@
-import dummyserver.testcase
+from test import SHORT_TIMEOUT
+from test.with_dummyserver import test_connectionpool
+
 import pytest
 
-from urllib3.contrib import appengine
+import dummyserver.testcase
 import urllib3.exceptions
-import urllib3.util.url
 import urllib3.util.retry
-
-from test.with_dummyserver import test_connectionpool
-from test import SHORT_TIMEOUT
+import urllib3.util.url
+from urllib3.contrib import appengine
 
 
 # This class is used so we can re-use the tests from the connection pool.

--- a/test/appengine/test_urlfetch.py
+++ b/test/appengine/test_urlfetch.py
@@ -3,10 +3,9 @@ App Engine sandbox enabled that urllib3 appropriately uses the App
 Engine-patched version of httplib to make requests."""
 
 import httplib
-import StringIO
-
-from mock import patch
 import pytest
+import StringIO
+from mock import patch
 
 from ..test_no_ssl import TestWithoutSSL
 

--- a/test/benchmark.py
+++ b/test/benchmark.py
@@ -13,7 +13,6 @@ import urllib
 sys.path.append("../")
 import urllib3  # noqa: E402
 
-
 # URLs to download. Doesn't matter as long as they're from the same host, so we
 # can take advantage of connection re-using.
 TO_DOWNLOAD = [

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,18 +1,17 @@
 import collections
 import contextlib
-import threading
 import platform
 import sys
+import threading
 
 import pytest
 import trustme
-from tornado import web, ioloop
-
-from .tz_stub import stub_timezone_ctx
+from tornado import ioloop, web
 
 from dummyserver.handlers import TestingApp
-from dummyserver.server import run_tornado_app
-from dummyserver.server import HAS_IPV6
+from dummyserver.server import HAS_IPV6, run_tornado_app
+
+from .tz_stub import stub_timezone_ctx
 
 
 # The Python 3.8+ default loop on Windows breaks Tornado

--- a/test/contrib/test_pyopenssl.py
+++ b/test/contrib/test_pyopenssl.py
@@ -5,9 +5,10 @@ import mock
 import pytest
 
 try:
-    from urllib3.contrib.pyopenssl import _dnsname_to_stdlib, get_subj_alt_name
     from cryptography import x509
     from OpenSSL.crypto import FILETYPE_PEM, load_certificate
+
+    from urllib3.contrib.pyopenssl import _dnsname_to_stdlib, get_subj_alt_name
 except ImportError:
     pass
 
@@ -33,19 +34,19 @@ def teardown_module():
 from ..test_util import TestUtilSSL  # noqa: E402, F401
 from ..with_dummyserver.test_https import (  # noqa: E402, F401
     TestHTTPS,
+    TestHTTPS_IPSAN,
+    TestHTTPS_IPv6Addr,
+    TestHTTPS_IPV6SAN,
+    TestHTTPS_NoSAN,
     TestHTTPS_TLSv1,
     TestHTTPS_TLSv1_1,
     TestHTTPS_TLSv1_2,
     TestHTTPS_TLSv1_3,
-    TestHTTPS_IPSAN,
-    TestHTTPS_IPv6Addr,
-    TestHTTPS_NoSAN,
-    TestHTTPS_IPV6SAN,
 )
 from ..with_dummyserver.test_socketlevel import (  # noqa: E402, F401
+    TestClientCerts,
     TestSNI,
     TestSocketClosing,
-    TestClientCerts,
     TestSSL,
 )
 

--- a/test/contrib/test_pyopenssl_dependencies.py
+++ b/test/contrib/test_pyopenssl_dependencies.py
@@ -1,10 +1,9 @@
 # -*- coding: utf-8 -*-
 import pytest
-
-from mock import patch, Mock
+from mock import Mock, patch
 
 try:
-    from urllib3.contrib.pyopenssl import inject_into_urllib3, extract_from_urllib3
+    from urllib3.contrib.pyopenssl import extract_from_urllib3, inject_into_urllib3
 except ImportError:
     pass
 

--- a/test/contrib/test_securetransport.py
+++ b/test/contrib/test_securetransport.py
@@ -40,9 +40,9 @@ from ..with_dummyserver.test_https import (  # noqa: E402, F401
     TestHTTPS_TLSv1_2,
 )
 from ..with_dummyserver.test_socketlevel import (  # noqa: E402, F401
+    TestClientCerts,
     TestSNI,
     TestSocketClosing,
-    TestClientCerts,
     TestSSL,
 )
 

--- a/test/contrib/test_socks.py
+++ b/test/contrib/test_socks.py
@@ -1,17 +1,17 @@
-import threading
 import socket
+import threading
+from test import SHORT_TIMEOUT
 
+import pytest
+
+from dummyserver.server import DEFAULT_CA, DEFAULT_CERTS
+from dummyserver.testcase import IPV4SocketDummyServerTestCase
 from urllib3.contrib import socks
 from urllib3.exceptions import ConnectTimeoutError, NewConnectionError
 
-from dummyserver.server import DEFAULT_CERTS, DEFAULT_CA
-from dummyserver.testcase import IPV4SocketDummyServerTestCase
-
-import pytest
-from test import SHORT_TIMEOUT
-
 try:
     import ssl
+
     from urllib3.util import ssl_ as better_ssl
 
     HAS_SSL = True

--- a/test/port_helpers.py
+++ b/test/port_helpers.py
@@ -3,7 +3,6 @@
 
 import socket
 
-
 # Don't use "localhost", since resolving it uses the DNS under recent
 # Windows versions (see issue #18792).
 HOST = "127.0.0.1"

--- a/test/test_collections.py
+++ b/test/test_collections.py
@@ -1,6 +1,7 @@
-from urllib3._collections import HTTPHeaderDict, RecentlyUsedContainer as Container
 import pytest
 
+from urllib3._collections import HTTPHeaderDict
+from urllib3._collections import RecentlyUsedContainer as Container
 from urllib3.exceptions import InvalidHeader
 from urllib3.packages import six
 

--- a/test/test_compatibility.py
+++ b/test/test_compatibility.py
@@ -3,8 +3,8 @@ import warnings
 import pytest
 
 from urllib3.connection import HTTPConnection
-from urllib3.response import HTTPResponse
 from urllib3.packages.six.moves import http_cookiejar, urllib
+from urllib3.response import HTTPResponse
 
 
 class TestVersionCompatibility(object):

--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -1,9 +1,9 @@
 import datetime
-import mock
 
+import mock
 import pytest
 
-from urllib3.connection import CertificateError, _match_hostname, RECENT_DATE
+from urllib3.connection import RECENT_DATE, CertificateError, _match_hostname
 
 
 class TestConnection(object):

--- a/test/test_connectionpool.py
+++ b/test/test_connectionpool.py
@@ -1,21 +1,21 @@
 from __future__ import absolute_import
 
 import ssl
+from socket import error as SocketError
+from ssl import SSLError as BaseSSLError
+from test import SHORT_TIMEOUT
+
 import pytest
 from mock import Mock
 
+from dummyserver.server import DEFAULT_CA
+from urllib3._collections import HTTPHeaderDict
 from urllib3.connectionpool import (
-    connection_from_url,
     HTTPConnection,
     HTTPConnectionPool,
     HTTPSConnectionPool,
+    connection_from_url,
 )
-from urllib3.response import HTTPResponse
-from urllib3.util.timeout import Timeout
-from urllib3.packages.six.moves import http_client as httplib
-from urllib3.packages.six.moves.http_client import HTTPException
-from urllib3.packages.six.moves.queue import Empty
-from urllib3.packages.ssl_match_hostname import CertificateError
 from urllib3.exceptions import (
     ClosedPoolError,
     EmptyPoolError,
@@ -26,14 +26,14 @@ from urllib3.exceptions import (
     SSLError,
     TimeoutError,
 )
-from urllib3._collections import HTTPHeaderDict
+from urllib3.packages.six.moves import http_client as httplib
+from urllib3.packages.six.moves.http_client import HTTPException
+from urllib3.packages.six.moves.queue import Empty
+from urllib3.packages.ssl_match_hostname import CertificateError
+from urllib3.response import HTTPResponse
+from urllib3.util.timeout import Timeout
+
 from .test_response import MockChunkedEncodingResponse, MockSock
-
-from socket import error as SocketError
-from ssl import SSLError as BaseSSLError
-
-from dummyserver.server import DEFAULT_CA
-from test import SHORT_TIMEOUT
 
 
 class HTTPUnixConnection(HTTPConnection):

--- a/test/test_exceptions.py
+++ b/test/test_exceptions.py
@@ -2,18 +2,18 @@ import pickle
 
 import pytest
 
-from urllib3.exceptions import (
-    HTTPError,
-    MaxRetryError,
-    LocationParseError,
-    ClosedPoolError,
-    EmptyPoolError,
-    HostChangedError,
-    ReadTimeoutError,
-    ConnectTimeoutError,
-    HeaderParsingError,
-)
 from urllib3.connectionpool import HTTPConnectionPool
+from urllib3.exceptions import (
+    ClosedPoolError,
+    ConnectTimeoutError,
+    EmptyPoolError,
+    HeaderParsingError,
+    HostChangedError,
+    HTTPError,
+    LocationParseError,
+    MaxRetryError,
+    ReadTimeoutError,
+)
 
 
 class TestPickle(object):

--- a/test/test_fields.py
+++ b/test/test_fields.py
@@ -1,6 +1,6 @@
 import pytest
 
-from urllib3.fields import format_header_param_rfc2231, guess_content_type, RequestField
+from urllib3.fields import RequestField, format_header_param_rfc2231, guess_content_type
 from urllib3.packages.six import u
 
 

--- a/test/test_filepost.py
+++ b/test/test_filepost.py
@@ -1,9 +1,8 @@
 import pytest
 
-from urllib3.filepost import encode_multipart_formdata, iter_fields
 from urllib3.fields import RequestField
+from urllib3.filepost import encode_multipart_formdata, iter_fields
 from urllib3.packages.six import b, u
-
 
 BOUNDARY = "!! test boundary !!"
 

--- a/test/test_no_ssl.py
+++ b/test/test_no_ssl.py
@@ -6,6 +6,7 @@ Test what happens if Python was built without SSL
 """
 
 import sys
+
 import pytest
 
 

--- a/test/test_poolmanager.py
+++ b/test/test_poolmanager.py
@@ -1,12 +1,12 @@
 import socket
+from test import resolvesLocalhostFQDN
 
 import pytest
 
-from urllib3.poolmanager import PoolKey, key_fn_by_scheme, PoolManager
 from urllib3 import connection_from_url
 from urllib3.exceptions import ClosedPoolError, LocationValueError
+from urllib3.poolmanager import PoolKey, PoolManager, key_fn_by_scheme
 from urllib3.util import retry, timeout
-from test import resolvesLocalhostFQDN
 
 
 class TestPoolManager(object):

--- a/test/test_proxymanager.py
+++ b/test/test_proxymanager.py
@@ -1,14 +1,11 @@
 import pytest
 
-from .port_helpers import find_unused_port
+from urllib3.exceptions import MaxRetryError, NewConnectionError, ProxyError
 from urllib3.poolmanager import ProxyManager
-from urllib3.util.url import parse_url
 from urllib3.util.retry import Retry
-from urllib3.exceptions import (
-    MaxRetryError,
-    ProxyError,
-    NewConnectionError,
-)
+from urllib3.util.url import parse_url
+
+from .port_helpers import find_unused_port
 
 
 class TestProxyManager(object):

--- a/test/test_queue_monkeypatch.py
+++ b/test/test_queue_monkeypatch.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 
 import mock
-
 import pytest
 
 from urllib3 import HTTPConnectionPool

--- a/test/test_response.py
+++ b/test/test_response.py
@@ -5,31 +5,28 @@ import re
 import socket
 import ssl
 import zlib
-
-from io import BytesIO, BufferedReader, TextIOWrapper
-
-import pytest
-import mock
-import six
-
-from urllib3.response import HTTPResponse, brotli
-from urllib3.exceptions import (
-    DecodeError,
-    ResponseNotChunked,
-    ProtocolError,
-    InvalidHeader,
-    httplib_IncompleteRead,
-    IncompleteRead,
-    InvalidChunkLength,
-    SSLError,
-)
-from urllib3.packages.six.moves import http_client as httplib
-from urllib3.util.retry import Retry, RequestHistory
-from urllib3.util.response import is_fp_closed
-
+from base64 import b64decode
+from io import BufferedReader, BytesIO, TextIOWrapper
 from test import onlyBrotlipy
 
-from base64 import b64decode
+import mock
+import pytest
+import six
+
+from urllib3.exceptions import (
+    DecodeError,
+    IncompleteRead,
+    InvalidChunkLength,
+    InvalidHeader,
+    ProtocolError,
+    ResponseNotChunked,
+    SSLError,
+    httplib_IncompleteRead,
+)
+from urllib3.packages.six.moves import http_client as httplib
+from urllib3.response import HTTPResponse, brotli
+from urllib3.util.response import is_fp_closed
+from urllib3.util.retry import RequestHistory, Retry
 
 # A known random (i.e, not-too-compressible) payload generated with:
 #    "".join(random.choice(string.printable) for i in xrange(512))

--- a/test/test_retry.py
+++ b/test/test_retry.py
@@ -1,11 +1,8 @@
-import mock
-import pytest
 import warnings
 
-from urllib3.response import HTTPResponse
-from urllib3.packages import six
-from urllib3.packages.six.moves import xrange
-from urllib3.util.retry import Retry, RequestHistory
+import mock
+import pytest
+
 from urllib3.exceptions import (
     ConnectTimeoutError,
     InvalidHeader,
@@ -14,6 +11,10 @@ from urllib3.exceptions import (
     ResponseError,
     SSLError,
 )
+from urllib3.packages import six
+from urllib3.packages.six.moves import xrange
+from urllib3.response import HTTPResponse
+from urllib3.util.retry import RequestHistory, Retry
 
 
 @pytest.fixture(scope="function", autouse=True)

--- a/test/test_retry_deprecated.py
+++ b/test/test_retry_deprecated.py
@@ -1,12 +1,9 @@
 # This is a copy-paste of test_retry.py with extra asserts about deprecated options. It will be removed for v2.
-import mock
-import pytest
 import warnings
 
-from urllib3.response import HTTPResponse
-from urllib3.packages import six
-from urllib3.packages.six.moves import xrange
-from urllib3.util.retry import Retry, RequestHistory
+import mock
+import pytest
+
 from urllib3.exceptions import (
     ConnectTimeoutError,
     InvalidHeader,
@@ -15,6 +12,10 @@ from urllib3.exceptions import (
     ResponseError,
     SSLError,
 )
+from urllib3.packages import six
+from urllib3.packages.six.moves import xrange
+from urllib3.response import HTTPResponse
+from urllib3.util.retry import RequestHistory, Retry
 
 
 # TODO: Remove this entire file once deprecated Retry options are removed in v2.

--- a/test/test_ssl.py
+++ b/test/test_ssl.py
@@ -1,9 +1,10 @@
+from test import notPyPy2
+
 import mock
 import pytest
-from urllib3.util import ssl_
-from urllib3.exceptions import SNIMissingWarning
 
-from test import notPyPy2
+from urllib3.exceptions import SNIMissingWarning
+from urllib3.util import ssl_
 
 
 @pytest.mark.parametrize(

--- a/test/test_ssltransport.py
+++ b/test/test_ssltransport.py
@@ -1,18 +1,14 @@
-from dummyserver.testcase import SocketDummyServerTestCase, consume_socket
-from dummyserver.server import (
-    DEFAULT_CERTS,
-    DEFAULT_CA,
-)
-
-from urllib3.util.ssltransport import SSLTransport
-
+import platform
 import select
-import pytest
 import socket
 import ssl
 import sys
-import platform
 
+import pytest
+
+from dummyserver.server import DEFAULT_CA, DEFAULT_CERTS
+from dummyserver.testcase import SocketDummyServerTestCase, consume_socket
+from urllib3.util.ssltransport import SSLTransport
 
 # consume_socket can iterate forever, we add timeouts to prevent halting.
 PER_TEST_TIMEOUT = 60

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -1,47 +1,41 @@
 # coding: utf-8
 import hashlib
-import warnings
-import logging
 import io
-import ssl
+import logging
 import socket
+import ssl
+import warnings
 from itertools import chain
+from test import notBrotlipy, onlyBrotlipy, onlyPy2, onlyPy3
 
-from mock import patch, Mock
 import pytest
+from mock import Mock, patch
 
 from urllib3 import add_stderr_logger, disable_warnings, util
-from urllib3.util.connection import create_connection
-from urllib3.util.request import make_headers, rewind_body, _FAILEDTELL
+from urllib3.exceptions import (
+    InsecureRequestWarning,
+    LocationParseError,
+    SNIMissingWarning,
+    TimeoutStateError,
+    UnrewindableBodyError,
+)
+from urllib3.packages import six
+from urllib3.poolmanager import ProxyConfig
+from urllib3.util import is_fp_closed
+from urllib3.util.connection import _has_ipv6, allowed_gai_family, create_connection
+from urllib3.util.proxy import connection_requires_http_tunnel, create_proxy_ssl_context
+from urllib3.util.request import _FAILEDTELL, make_headers, rewind_body
 from urllib3.util.response import assert_header_parsing
-from urllib3.util.timeout import Timeout
-from urllib3.util.url import get_host, parse_url, split_first, Url
 from urllib3.util.ssl_ import (
+    _const_compare_digest_backport,
     resolve_cert_reqs,
     resolve_ssl_version,
     ssl_wrap_socket,
-    _const_compare_digest_backport,
 )
-from urllib3.exceptions import (
-    LocationParseError,
-    TimeoutStateError,
-    InsecureRequestWarning,
-    SNIMissingWarning,
-    UnrewindableBodyError,
-)
-from urllib3.util.proxy import (
-    connection_requires_http_tunnel,
-    create_proxy_ssl_context,
-)
-from urllib3.util import is_fp_closed
-from urllib3.util.connection import allowed_gai_family, _has_ipv6
-from urllib3.packages import six
-
-from urllib3.poolmanager import ProxyConfig
+from urllib3.util.timeout import Timeout
+from urllib3.util.url import Url, get_host, parse_url, split_first
 
 from . import clear_warnings
-
-from test import onlyPy3, onlyPy2, onlyBrotlipy, notBrotlipy
 
 # This number represents a time in seconds, it doesn't mean anything in
 # isolation. Setting to a high-ish value to avoid conflicts with the smaller

--- a/test/test_wait.py
+++ b/test/test_wait.py
@@ -6,19 +6,21 @@ try:
     from time import monotonic
 except ImportError:
     from time import time as monotonic
+
 import time
 
 import pytest
 
-from .socketpair_helper import socketpair
 from urllib3.util.wait import (
-    wait_for_read,
-    wait_for_write,
-    wait_for_socket,
-    select_wait_for_socket,
-    poll_wait_for_socket,
     _have_working_poll,
+    poll_wait_for_socket,
+    select_wait_for_socket,
+    wait_for_read,
+    wait_for_socket,
+    wait_for_write,
 )
+
+from .socketpair_helper import socketpair
 
 
 @pytest.fixture

--- a/test/tz_stub.py
+++ b/test/tz_stub.py
@@ -1,7 +1,8 @@
-from contextlib import contextmanager
-import time
 import datetime
 import os
+import time
+from contextlib import contextmanager
+
 import pytest
 from dateutil import tz
 

--- a/test/with_dummyserver/test_chunked_transfer.py
+++ b/test/with_dummyserver/test_chunked_transfer.py
@@ -2,14 +2,14 @@
 
 import pytest
 
-from urllib3 import HTTPConnectionPool
-from urllib3.util.retry import Retry
-from urllib3.util import SUPPRESS_USER_AGENT
 from dummyserver.testcase import (
+    ConnectionMarker,
     SocketDummyServerTestCase,
     consume_socket,
-    ConnectionMarker,
 )
+from urllib3 import HTTPConnectionPool
+from urllib3.util import SUPPRESS_USER_AGENT
+from urllib3.util.retry import Retry
 
 # Retry failed tests
 pytestmark = pytest.mark.flaky

--- a/test/with_dummyserver/test_connectionpool.py
+++ b/test/with_dummyserver/test_connectionpool.py
@@ -5,34 +5,33 @@ import socket
 import sys
 import time
 import warnings
-import pytest
+from test import LONG_TIMEOUT, SHORT_TIMEOUT
+from threading import Event
 
 import mock
+import pytest
 
-from .. import TARPIT_HOST, VALID_SOURCE_ADDRESSES, INVALID_SOURCE_ADDRESSES
-from ..port_helpers import find_unused_port
-from urllib3 import encode_multipart_formdata, HTTPConnectionPool
+from dummyserver.server import HAS_IPV6_AND_DNS, NoIPv6Warning
+from dummyserver.testcase import HTTPDummyServerTestCase, SocketDummyServerTestCase
+from urllib3 import HTTPConnectionPool, encode_multipart_formdata
 from urllib3.connection import _get_default_user_agent
 from urllib3.exceptions import (
     ConnectTimeoutError,
-    EmptyPoolError,
     DecodeError,
+    EmptyPoolError,
     MaxRetryError,
-    ReadTimeoutError,
     NewConnectionError,
+    ReadTimeoutError,
     UnrewindableBodyError,
 )
 from urllib3.packages.six import b, u
 from urllib3.packages.six.moves.urllib.parse import urlencode
 from urllib3.util import SUPPRESS_USER_AGENT
-from urllib3.util.retry import Retry, RequestHistory
+from urllib3.util.retry import RequestHistory, Retry
 from urllib3.util.timeout import Timeout
 
-from test import SHORT_TIMEOUT, LONG_TIMEOUT
-from dummyserver.testcase import HTTPDummyServerTestCase, SocketDummyServerTestCase
-from dummyserver.server import NoIPv6Warning, HAS_IPV6_AND_DNS
-
-from threading import Event
+from .. import INVALID_SOURCE_ADDRESSES, TARPIT_HOST, VALID_SOURCE_ADDRESSES
+from ..port_helpers import find_unused_port
 
 pytestmark = pytest.mark.flaky
 

--- a/test/with_dummyserver/test_https.py
+++ b/test/with_dummyserver/test_https.py
@@ -2,53 +2,53 @@ import datetime
 import json
 import logging
 import os.path
+import shutil
 import ssl
 import sys
-import shutil
 import tempfile
 import warnings
-
-import mock
-import pytest
-import trustme
-
-from dummyserver.testcase import HTTPSDummyServerTestCase
-from dummyserver.server import (
-    encrypt_key_pem,
-    DEFAULT_CA,
-    DEFAULT_CA_KEY,
-    DEFAULT_CERTS,
-)
-
 from test import (
-    onlyPy279OrNewer,
-    notSecureTransport,
+    LONG_TIMEOUT,
+    SHORT_TIMEOUT,
+    TARPIT_HOST,
     notOpenSSL098,
+    notSecureTransport,
+    onlyPy279OrNewer,
     requires_network,
     requires_ssl_context_keyfile_password,
     requiresTLSv1,
     requiresTLSv1_1,
     requiresTLSv1_2,
     requiresTLSv1_3,
-    TARPIT_HOST,
-    SHORT_TIMEOUT,
-    LONG_TIMEOUT,
     resolvesLocalhostFQDN,
 )
+
+import mock
+import pytest
+import trustme
+
+import urllib3.util as util
+from dummyserver.server import (
+    DEFAULT_CA,
+    DEFAULT_CA_KEY,
+    DEFAULT_CERTS,
+    encrypt_key_pem,
+)
+from dummyserver.testcase import HTTPSDummyServerTestCase
 from urllib3 import HTTPSConnectionPool
-from urllib3.connection import VerifiedHTTPSConnection, RECENT_DATE
+from urllib3.connection import RECENT_DATE, VerifiedHTTPSConnection
 from urllib3.exceptions import (
-    SSLError,
     ConnectTimeoutError,
-    InsecureRequestWarning,
-    SystemTimeWarning,
     InsecurePlatformWarning,
+    InsecureRequestWarning,
     MaxRetryError,
     ProtocolError,
+    SSLError,
+    SystemTimeWarning,
 )
 from urllib3.packages import six
 from urllib3.util.timeout import Timeout
-import urllib3.util as util
+
 from .. import has_alpn
 
 # Retry failed tests

--- a/test/with_dummyserver/test_no_ssl.py
+++ b/test/with_dummyserver/test_no_ssl.py
@@ -4,11 +4,11 @@ Test connections without the builtin ssl module
 Note: Import urllib3 inside the test functions to get the importblocker to work
 """
 import pytest
-from ..test_no_ssl import TestWithoutSSL
-
-from dummyserver.testcase import HTTPDummyServerTestCase, HTTPSDummyServerTestCase
 
 import urllib3
+from dummyserver.testcase import HTTPDummyServerTestCase, HTTPSDummyServerTestCase
+
+from ..test_no_ssl import TestWithoutSSL
 
 # Retry failed tests
 pytestmark = pytest.mark.flaky

--- a/test/with_dummyserver/test_poolmanager.py
+++ b/test/with_dummyserver/test_poolmanager.py
@@ -1,15 +1,14 @@
 import json
+from test import LONG_TIMEOUT
 
 import pytest
 
 from dummyserver.server import HAS_IPV6
 from dummyserver.testcase import HTTPDummyServerTestCase, IPv6HTTPDummyServerTestCase
-from urllib3.poolmanager import PoolManager
 from urllib3.connectionpool import port_by_scheme
 from urllib3.exceptions import MaxRetryError, URLSchemeUnknown
+from urllib3.poolmanager import PoolManager
 from urllib3.util.retry import Retry
-
-from test import LONG_TIMEOUT
 
 # Retry failed tests
 pytestmark = pytest.mark.flaky

--- a/test/with_dummyserver/test_proxy_poolmanager.py
+++ b/test/with_dummyserver/test_proxy_poolmanager.py
@@ -3,36 +3,33 @@ import os.path
 import shutil
 import socket
 import tempfile
-
+from test import (
+    LONG_TIMEOUT,
+    SHORT_TIMEOUT,
+    onlyPy2,
+    onlyPy3,
+    onlySecureTransport,
+    withPyOpenSSL,
+)
 
 import pytest
 import trustme
 
-from dummyserver.testcase import HTTPDummyProxyTestCase, IPv6HTTPDummyProxyTestCase
 from dummyserver.server import DEFAULT_CA, HAS_IPV6, get_unreachable_address
-from .. import TARPIT_HOST, requires_network
-
+from dummyserver.testcase import HTTPDummyProxyTestCase, IPv6HTTPDummyProxyTestCase
 from urllib3._collections import HTTPHeaderDict
-from urllib3.poolmanager import proxy_from_url, ProxyManager
+from urllib3.connectionpool import VerifiedHTTPSConnection, connection_from_url
 from urllib3.exceptions import (
-    MaxRetryError,
-    SSLError,
-    ProxyError,
     ConnectTimeoutError,
+    MaxRetryError,
+    ProxyError,
     ProxySchemeUnsupported,
+    SSLError,
 )
-from urllib3.connectionpool import connection_from_url, VerifiedHTTPSConnection
+from urllib3.poolmanager import ProxyManager, proxy_from_url
 from urllib3.util.ssl_ import create_urllib3_context
 
-from test import (
-    SHORT_TIMEOUT,
-    LONG_TIMEOUT,
-    onlyPy3,
-    onlyPy2,
-    withPyOpenSSL,
-    onlySecureTransport,
-)
-
+from .. import TARPIT_HOST, requires_network
 
 # Retry failed tests
 pytestmark = pytest.mark.flaky

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -1,33 +1,29 @@
 # TODO: Break this module up into pieces. Maybe group by functionality tested
 # rather than the socket level-ness of it.
-from urllib3 import HTTPConnectionPool, HTTPSConnectionPool
-from urllib3.connection import HTTPConnection
-from urllib3.poolmanager import proxy_from_url
-from urllib3.connection import _get_default_user_agent
+from dummyserver.server import (
+    DEFAULT_CA,
+    DEFAULT_CERTS,
+    encrypt_key_pem,
+    get_unreachable_address,
+)
+from dummyserver.testcase import SocketDummyServerTestCase, consume_socket
+from urllib3 import HTTPConnectionPool, HTTPSConnectionPool, util
+from urllib3._collections import HTTPHeaderDict
+from urllib3.connection import HTTPConnection, _get_default_user_agent
 from urllib3.exceptions import (
     MaxRetryError,
+    ProtocolError,
     ProxyError,
     ReadTimeoutError,
     SSLError,
-    ProtocolError,
 )
 from urllib3.packages.six.moves import http_client as httplib
-from urllib3 import util
-from urllib3.util import ssl_wrap_socket
-from urllib3.util import ssl_
-from urllib3.util.timeout import Timeout
+from urllib3.poolmanager import proxy_from_url
+from urllib3.util import ssl_, ssl_wrap_socket
 from urllib3.util.retry import Retry
-from urllib3._collections import HTTPHeaderDict
+from urllib3.util.timeout import Timeout
 
-from dummyserver.testcase import SocketDummyServerTestCase, consume_socket
-from dummyserver.server import (
-    DEFAULT_CERTS,
-    DEFAULT_CA,
-    get_unreachable_address,
-    encrypt_key_pem,
-)
-
-from .. import onlyPy3, LogRecorder, has_alpn
+from .. import LogRecorder, has_alpn, onlyPy3
 
 try:
     from mimetools import Message as MimeToolMessage
@@ -37,29 +33,28 @@ except ImportError:
         pass
 
 
-from collections import OrderedDict
-import os.path
-from threading import Event
 import os
+import os.path
 import select
-import socket
 import shutil
+import socket
 import ssl
 import tempfile
-import mock
-
-import pytest
-import trustme
-
+from collections import OrderedDict
 from test import (
-    requires_ssl_context_keyfile_password,
-    SHORT_TIMEOUT,
     LONG_TIMEOUT,
+    SHORT_TIMEOUT,
     notPyPy2,
     notSecureTransport,
     notWindows,
+    requires_ssl_context_keyfile_password,
     resolvesLocalhostFQDN,
 )
+from threading import Event
+
+import mock
+import pytest
+import trustme
 
 # Retry failed tests
 pytestmark = pytest.mark.flaky


### PR DESCRIPTION
isort 5.x came out in July and plays well with black, so that sounded like a nice opportunity to sort the urllib3 imports that are, honestly, quite a mess, especially in tests. I think black wants to sort imports at some point, but until then, that would be one less thing to worry about when working on urllib3.

We don't have many pull requests open thank to the hard work of @sethmlarson and @hodbn, but I'll be happy to fix the conflicts for the active ones.

What do you think?