### PR TITLE
Fix flaky test by avoiding refused connection with short timeout

### DIFF
--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -458,7 +458,7 @@ class TestSocketClosing(SocketDummyServerTestCase):
 
         self._start_server(socket_handler)
         with HTTPConnectionPool(
-            self.host, self.port, timeout=SHORT_TIMEOUT, retries=True
+            self.host, self.port, timeout=LONG_TIMEOUT, retries=True
         ) as pool:
             try:
                 with pytest.raises(ReadTimeoutError):

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -447,7 +447,7 @@ class TestSocketClosing(SocketDummyServerTestCase):
 
             assert http.pool.qsize() == http.pool.maxsize
 
-    def test_read_timeout_dont_retry_method_not_in_whitelist(self):
+    def test_read_timeout_dont_retry_method_not_in_allowlist(self):
         timed_out = Event()
 
         def socket_handler(listener):


### PR DESCRIPTION
As seen in https://github.com/urllib3/urllib3/runs/1193400148
