### PR TITLE
Configure isort for editors too

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -104,7 +104,7 @@ def format(session):
     """Run code formatters."""
     session.install("black", "isort")
     session.run("black", *SOURCE_FILES)
-    session.run("isort", "--profile", "black", *SOURCE_FILES)
+    session.run("isort", *SOURCE_FILES)
 
     lint(session)
 
@@ -117,7 +117,7 @@ def lint(session):
     session.run("isort", "--version")
     session.run("mypy", "--version")
     session.run("black", "--check", *SOURCE_FILES)
-    session.run("isort", "--profile", "black", "--check", *SOURCE_FILES)
+    session.run("isort", "--check", *SOURCE_FILES)
     session.run("flake8", *SOURCE_FILES)
 
     session.log("mypy --strict src/urllib3")

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,3 +24,6 @@ requires-dist =
 [tool:pytest]
 xfail_strict = true
 python_classes = Test *TestCase
+
+[isort]
+profile=black


### PR DESCRIPTION
This way, editors can pick up the profile to use (black).

This is actually quite important, as without that some noqa comment can get messed up and break lint, with no easy way to fix that.
