### PR TITLE
Draft: Upgrade Travis PyPy versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,7 @@ jobs:
       env: NOX_SESSION=test-pypy
     - python: pypy3.6-7.3.1
       env: NOX_SESSION=test-pypy
+      dist: bionic
 
     # Extras
     - python: 2.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,9 +47,9 @@ jobs:
       env: NOX_SESSION=test-3.9
     - python: nightly
       env: NOX_SESSION=test-3.10
-    - python: pypy2.7-6.0
+    - python: pypy2.7-7.3.1
       env: NOX_SESSION=test-pypy
-    - python: pypy3.5-6.0
+    - python: pypy3.6-7.3.1
       env: NOX_SESSION=test-pypy
 
     # Extras

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ jobs:
       env: NOX_SESSION=test-pypy
     - python: pypy3.6-7.3.1
       env: NOX_SESSION=test-pypy
-      dist: bionic
+      dist: focal
 
     # Extras
     - python: 2.7

--- a/noxfile.py
+++ b/noxfile.py
@@ -55,6 +55,8 @@ def tests_impl(session, extras="socks,secure,brotli"):
         "pytest",
         "-r",
         "a",
+        "-k",
+        "test_tls_protocol_name_of_socket",
         "--tb=native",
         "--no-success-flaky-report",
         *(session.posargs or ("test/",)),


### PR DESCRIPTION
This will avoid dropping PyPy 3 when dropping Python 3.5 in https://github.com/urllib3/urllib3/pull/2012.

I got the versions numbers by running `gsutil ls gs://travis-ci-language-archives/python/binaries/ubuntu/16.04/x86_64 | grep pypy`. (We should upgrade to 18.04 or even 20.04, but that's another issue entirely, and those PyPy versions exist on the 18.04 and 20.04 Travis environments anyway.)

There's a weird `TestHTTPS_TLSv1_3.test_tls_protocol_name_of_socket` that we need to understand and fix, though.