### PR TITLE
Add SKIP_HEADER for skipping automatically added headers

### DIFF
--- a/src/urllib3/_collections.py
+++ b/src/urllib3/_collections.py
@@ -155,7 +155,7 @@ class HTTPHeaderDict(MutableMapping):
 
     def __getitem__(self, key):
         val = self._container[key.lower()]
-        return ", ".join([six.ensure_str(v, "ascii") for v in val[1:]])
+        return ", ".join(val[1:])
 
     def __delitem__(self, key):
         del self._container[key.lower()]

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -52,7 +52,7 @@ from .exceptions import (
     SystemTimeWarning,
 )
 from .packages.ssl_match_hostname import CertificateError, match_hostname
-from .util import SUPPRESS_USER_AGENT, connection
+from .util import SKIP_USER_AGENT, connection
 from .util.ssl_ import (
     assert_fingerprint,
     create_urllib3_context,
@@ -217,7 +217,7 @@ class HTTPConnection(_HTTPConnection, object):
         headers = HTTPHeaderDict(headers if headers is not None else {})
         if "user-agent" not in headers:
             headers["User-Agent"] = _get_default_user_agent()
-        elif headers["user-agent"] == SUPPRESS_USER_AGENT:
+        elif SKIP_USER_AGENT in headers.get_all("user-agent"):
             del headers["user-agent"]
         super(HTTPConnection, self).request(method, url, body=body, headers=headers)
 
@@ -234,7 +234,7 @@ class HTTPConnection(_HTTPConnection, object):
         )
         if "user-agent" not in headers:
             headers["User-Agent"] = _get_default_user_agent()
-        elif headers["user-agent"] == SUPPRESS_USER_AGENT:
+        elif SKIP_USER_AGENT in headers.get_all("user-agent"):
             del headers["user-agent"]
         for header, value in headers.items():
             self.putheader(header, value)

--- a/src/urllib3/util/__init__.py
+++ b/src/urllib3/util/__init__.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 # For backwards compatibility, provide imports that used to be here.
 from .connection import is_connection_dropped
-from .request import SKIP_USER_AGENT, make_headers
+from .request import SKIP_HEADER, SKIPPABLE_HEADERS, make_headers
 from .response import is_fp_closed
 from .retry import Retry
 from .ssl_ import (
@@ -44,5 +44,6 @@ __all__ = (
     "ssl_wrap_socket",
     "wait_for_read",
     "wait_for_write",
-    "SKIP_USER_AGENT",
+    "SKIP_HEADER",
+    "SKIPPABLE_HEADERS",
 )

--- a/src/urllib3/util/__init__.py
+++ b/src/urllib3/util/__init__.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 # For backwards compatibility, provide imports that used to be here.
 from .connection import is_connection_dropped
-from .request import SUPPRESS_USER_AGENT, make_headers
+from .request import SKIP_USER_AGENT, make_headers
 from .response import is_fp_closed
 from .retry import Retry
 from .ssl_ import (
@@ -44,5 +44,5 @@ __all__ = (
     "ssl_wrap_socket",
     "wait_for_read",
     "wait_for_write",
-    "SUPPRESS_USER_AGENT",
+    "SKIP_USER_AGENT",
 )

--- a/src/urllib3/util/request.py
+++ b/src/urllib3/util/request.py
@@ -5,10 +5,13 @@ from base64 import b64encode
 from ..exceptions import UnrewindableBodyError
 from ..packages.six import b, integer_types
 
-# Use an invalid User-Agent to represent suppressing of default user agent.
-# See https://tools.ietf.org/html/rfc7231#section-5.5.3 and
-# https://tools.ietf.org/html/rfc7230#section-3.2.6
-SKIP_USER_AGENT = "@@@SKIP_USER_AGENT@@@"
+# Pass as a value within ``headers`` to skip
+# emitting some HTTP headers that are added automatically.
+# The only headers that are supported are ``Accept-Encoding``,
+# ``Host``, and ``User-Agent``.
+SKIP_HEADER = "@@@SKIP_HEADER@@@"
+SKIPPABLE_HEADERS = frozenset(["accept-encoding", "host", "user-agent"])
+
 ACCEPT_ENCODING = "gzip,deflate"
 try:
     import brotli as _unused_module_brotli  # noqa: F401

--- a/src/urllib3/util/request.py
+++ b/src/urllib3/util/request.py
@@ -8,7 +8,7 @@ from ..packages.six import b, integer_types
 # Use an invalid User-Agent to represent suppressing of default user agent.
 # See https://tools.ietf.org/html/rfc7231#section-5.5.3 and
 # https://tools.ietf.org/html/rfc7230#section-3.2.6
-SUPPRESS_USER_AGENT = "@@@INVALID_USER_AGENT@@@"
+SKIP_USER_AGENT = "@@@SKIP_USER_AGENT@@@"
 ACCEPT_ENCODING = "gzip,deflate"
 try:
     import brotli as _unused_module_brotli  # noqa: F401

--- a/test/with_dummyserver/test_chunked_transfer.py
+++ b/test/with_dummyserver/test_chunked_transfer.py
@@ -8,7 +8,7 @@ from dummyserver.testcase import (
     consume_socket,
 )
 from urllib3 import HTTPConnectionPool
-from urllib3.util import SKIP_USER_AGENT
+from urllib3.util import SKIP_HEADER
 from urllib3.util.retry import Retry
 
 # Retry failed tests
@@ -123,30 +123,12 @@ class TestChunkedTransfer(SocketDummyServerTestCase):
                 "GET",
                 "/",
                 chunks,
-                headers={"User-Agent": SKIP_USER_AGENT},
+                headers={"User-Agent": SKIP_HEADER},
                 chunked=True,
             )
 
             ua_headers = self._get_header_lines(b"user-agent")
             assert len(ua_headers) == 0
-
-    @pytest.mark.parametrize(
-        "user_agent", [u"Schönefeld/1.18.0", u"Schönefeld/1.18.0".encode("iso-8859-1")]
-    )
-    def test_user_agent_non_ascii_user_agent(self, user_agent):
-        self.start_chunked_handler()
-        chunks = ["foo", "bar", "", "bazzzzzzzzzzzzzzzzzzzzzz"]
-        with HTTPConnectionPool(self.host, self.port, retries=False) as pool:
-            pool.urlopen(
-                "GET",
-                "/",
-                chunks,
-                headers={"User-Agent": user_agent},
-                chunked=True,
-            )
-
-            ua_headers = self._get_header_lines(b"user-agent")
-            assert ua_headers == [b"user-agent: sch\xf6nefeld/1.18.0"]
 
     def test_preserve_chunked_on_retry_after(self):
         self.chunked_requests = 0


### PR DESCRIPTION
Closes #2014, Closes #2021

Changed the sentinel from `SUPPRESS_USER_AGENT` to `SKIP_HEADER` for skipping 3 of the automatically added headers `Accept-Encoding`, `Host`, and `User-Agent`.

cc @nateprewitt could you test this to ensure it works as you're expecting?