### PR TITLE
Deprecate Retry.is_retry() in favor of Retry.should_retry()

### DIFF
--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -828,8 +828,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
             )
 
         # Check if we should retry the HTTP response.
-        has_retry_after = bool(response.getheader("Retry-After"))
-        if retries.is_retry(method, response.status, has_retry_after):
+        if retries.should_retry(response):
             try:
                 retries = retries.increment(method, url, response=response, _pool=self)
             except MaxRetryError:

--- a/src/urllib3/response.py
+++ b/src/urllib3/response.py
@@ -154,6 +154,20 @@ def _get_decoder(mode):
     return DeflateDecoder()
 
 
+class _HTTPResponseRequest(object):
+    # This class is only used by Retry.should_retry() API
+    # and will be expanded in urllib3 v2.0. For now it is read-only.
+
+    __slots__ = ("_response",)
+
+    def __init__(self, response):
+        self._response = response
+
+    @property
+    def method(self):
+        return self._response._request_method
+
+
 class HTTPResponse(io.IOBase):
     """
     HTTP Response container.
@@ -233,6 +247,7 @@ class HTTPResponse(io.IOBase):
         self._fp_bytes_read = 0
         self.msg = msg
         self._request_url = request_url
+        self._request_method = request_method
 
         if body and isinstance(body, (six.string_types, bytes)):
             self._body = body
@@ -313,6 +328,10 @@ class HTTPResponse(io.IOBase):
         if bytes are encoded on the wire (e.g, compressed).
         """
         return self._fp_bytes_read
+
+    @property
+    def request(self):
+        return _HTTPResponseRequest(self)
 
     def _init_length(self, request_method):
         """


### PR DESCRIPTION
Closes #1994 

For v2.0 we're adding an API that let's you return `True` or `False`, **or a modified Request** from "is_retry()" which is passed the entire `HTTPResponse` object. This API will have access to request info via `HTTPResponse.request.method`, `.url`, `.headers`, etc. For v1.x we're simply making `HTTPResponse.request.method` available as a read-only value to support existing v1.x functionality.

We need to add that API so we can deprecate `Retry.is_retry()` on v1.x and make the migration path easier for users moving to v2.0 that implement custom `Retry.is_retry()` behavior. Most users won't see any difference here, the only users that will see a difference are ones that subclass `Retry` with their own `is_retry()` method implemented. Hopefully because of how inflexible the previous implementation was will prove to be useful to us here :)

Maybe for v2 we can also think about a `Retry.should_redirect()` method as well that contains the `method="GET"` modification for 303 status codes? :)

TODO:
- [ ] Do we really like the name `should_retry()`? I'm not super in love with it.
- [ ] Add a test case using custom `Retry.is_retry()` implementations

cc @sigmavirus24 @nateprewitt since this has implementations in authentication would love your input on this PR!