### PR TITLE
[1.25.x] Don't set keylog_filename for empty values

### DIFF
--- a/src/urllib3/util/ssl_.py
+++ b/src/urllib3/util/ssl_.py
@@ -296,9 +296,11 @@ def create_urllib3_context(
         context.check_hostname = False
 
     # Enable logging of TLS session keys via defacto standard environment variable
-    # 'SSLKEYLOGFILE', if the feature is available (Python 3.8+).
+    # 'SSLKEYLOGFILE', if the feature is available (Python 3.8+). Skip empty values.
     if hasattr(context, "keylog_filename"):
-        context.keylog_filename = os.environ.get("SSLKEYLOGFILE")
+        sslkeylogfile = os.environ.get("SSLKEYLOGFILE")
+        if sslkeylogfile:
+            context.keylog_filename = sslkeylogfile
 
     return context
 

--- a/test/with_dummyserver/test_https.py
+++ b/test/with_dummyserver/test_https.py
@@ -718,6 +718,18 @@ class TestHTTPS(HTTPSDummyServerTestCase):
                 keylog_file
             )
 
+    @pytest.mark.parametrize("sslkeylogfile", [None, ""])
+    def test_sslkeylogfile_empty(self, monkeypatch, sslkeylogfile):
+        # Assert that an HTTPS connection doesn't error out when given
+        # no SSLKEYLOGFILE or an empty value (ie 'SSLKEYLOGFILE=')
+        if sslkeylogfile is not None:
+            monkeypatch.setenv("SSLKEYLOGFILE", sslkeylogfile)
+        else:
+            monkeypatch.delenv("SSLKEYLOGFILE", raising=False)
+        with HTTPSConnectionPool(self.host, self.port, ca_certs=DEFAULT_CA) as pool:
+            r = pool.request("GET", "/")
+            assert r.status == 200, r.data
+
 
 @requiresTLSv1()
 class TestHTTPS_TLSv1(TestHTTPS):


### PR DESCRIPTION
Backport of #2016