### PR TITLE
Fix test URLs containing whitespaces

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -306,5 +306,8 @@ In chronological order:
 * [Ezzeri Esa] <https://github.com/savarin>
   * Ports and extends on types from typeshed
 
+* Jacek Tomasiak <jacek.tomasiak@gmail.com>
+  * Test improvements
+
 * [Your name or handle] <[email or website]>
   * [Brief summary of your changes]

--- a/test/with_dummyserver/test_connectionpool.py
+++ b/test/with_dummyserver/test_connectionpool.py
@@ -707,7 +707,7 @@ class TestConnectionPool(HTTPDummyServerTestCase):
                 self.host, self.port, source_address=addr, retries=False
             ) as pool:
                 with pytest.raises(NewConnectionError):
-                    pool.request("GET", "/source_address?{0}".format(addr))
+                    pool.request("GET", "/source_address")
 
     def test_stream_keepalive(self):
         x = 2


### PR DESCRIPTION
They triggered CVE-2019-9740 checks added in python here [0].
The problematic test should fail because of invalid source address but it
failed earlier because of invalid request URL. Request URLs contained string
representation of the tested source address which can contain whitespaces.
E.g. "/source_address?(\'192.0.2.255\', 0)"
The source addresses seem to be there only for information and were added as
part of [1]. Removing them from the request URL makes the tests pass again.

[0] https://github.com/python/cpython/pull/12755
[1] https://github.com/urllib3/urllib3/pull/703

<!---
Thanks for your contribution! ♥️

If this is your first PR to urllib3 please review the Contributing Guide:
https://urllib3.readthedocs.io/en/latest/contributing.html

Adhering to the Contributing Guide means we can review, merge, and release your change faster! :)
--->
