### PR TITLE
Refresh ConnectionPool.urlopen docs

### DIFF
--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -555,8 +555,8 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
             The URL to perform the request on.
 
         :param body:
-            Data to send in the request body, either `str` or `bytes` (useful
-            for creating POST requests).
+            Data to send in the request body, either :class:`str`, :class:`bytes`,
+            an iterable of :class:`str`/:class:`bytes`, or a file-like object.
 
         :param headers:
             Dictionary of custom headers to send, such as User-Agent,

--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -551,10 +551,12 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         :param method:
             HTTP request method (such as GET, POST, PUT, etc.)
 
+        :param url:
+            The URL to perform the request on.
+
         :param body:
-            Data to send in the request body (useful for creating
-            POST requests, see HTTPConnectionPool.post_url for
-            more convenience).
+            Data to send in the request body, either `str` or `bytes` (useful
+            for creating POST requests).
 
         :param headers:
             Dictionary of custom headers to send, such as User-Agent,


### PR DESCRIPTION
- Document the 'url' parameter
- In 'body' param docs: Remove reference to non-existing 'post_url' ,
    and note the support types for this param

Closes #2003

<!---
Thanks for your contribution! ♥️

If this is your first PR to urllib3 please review the Contributing Guide:
https://urllib3.readthedocs.io/en/latest/contributing.html

Adhering to the Contributing Guide means we can review, merge, and release your change faster! :)
--->
