### PR TITLE
Use absolute path for docs Banner image

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -8,7 +8,8 @@ from datetime import date
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 
-root_path = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+docs_path = os.path.abspath(os.path.dirname(__file__))
+root_path = os.path.join(docs_path, "..")
 sys.path.insert(0, root_path)
 
 # Mock some expensive/platform-specific modules so build will work.
@@ -77,11 +78,13 @@ html_logo = "images/banner.svg"
 
 html_theme_options = {
     "announcement": """
-        <a style=\"text-decoration: none; color: white;\" 
+        <a style=\"text-decoration: none; color: white;\"
            href=\"https://opencollective.com/urllib3\">
-           <img src=\"_static/favicon.png\"/> Sponsor urllib3 v2.0 on Open Collective
+           <img src=\"{docs_root}/{image_path}\"/> Sponsor urllib3 v2.0 on Open Collective
         </a>
-    """,
+    """.format(
+        docs_root=docs_path, image_path=html_favicon
+    ),
     "sidebar_hide_name": True,
 }
 


### PR DESCRIPTION
Also fix some (seemingly) errant whitespace.

I noticed this while working with the docs recently, and thought I'd have a go at fixing it (i.e. I have no idea if my solution is reasonable)

<!---
Thanks for your contribution! ♥️

If this is your first PR to urllib3 please review the Contributing Guide:
https://urllib3.readthedocs.io/en/latest/contributing.html

Adhering to the Contributing Guide means we can review, merge, and release your change faster! :)
--->
