### PR TITLE
Show Ubuntu 18.04 SOCKS test failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,14 +43,25 @@ jobs:
       env: NOX_SESSION=test-3.7
     - python: 3.8
       env: NOX_SESSION=test-3.8
+    - python: 3.8
+      env: NOX_SESSION=test-3.8
+      dist: bionic
+    - python: 3.8
+      env: NOX_SESSION=test-3.8
+      dist: focal
     - python: 3.9-dev
       env: NOX_SESSION=test-3.9
     - python: nightly
       env: NOX_SESSION=test-3.10
-    - python: pypy2.7-6.0
+    - python: pypy2.7-7.3.1
       env: NOX_SESSION=test-pypy
-    - python: pypy3.5-6.0
+    - python: pypy3.5-7.0
       env: NOX_SESSION=test-pypy
+    - python: pypy3.6-7.3.1
+      env: NOX_SESSION=test-pypy
+    - python: pypy3.6-7.3.1
+      env: NOX_SESSION=test-pypy
+      dist: bionic
 
     # Extras
     - python: 2.7

--- a/test/contrib/test_socks.py
+++ b/test/contrib/test_socks.py
@@ -351,7 +351,7 @@ class TestSocks5Proxy(IPV4SocketDummyServerTestCase):
         proxy_url = "socks5h://%s:%s" % (self.host, self.port)
         with socks.SOCKSProxyManager(proxy_url) as pm:
             with pytest.raises(NewConnectionError):
-                pm.request("GET", "http://example.com", retries=False)
+                pm.request("GET", "http://example.com", retries=False, timeout=1)
             evt.set()
 
     def test_socks_with_password(self):
@@ -609,7 +609,7 @@ class TestSOCKS4Proxy(IPV4SocketDummyServerTestCase):
         proxy_url = "socks4a://%s:%s" % (self.host, self.port)
         with socks.SOCKSProxyManager(proxy_url) as pm:
             with pytest.raises(NewConnectionError):
-                pm.request("GET", "http://example.com", retries=False)
+                pm.request("GET", "http://example.com", retries=False, timeout=1)
             evt.set()
 
     def test_socks4_with_username(self):


### PR DESCRIPTION
On Ubuntu 16.04 and 18.04 the socket creation times out in PySocks instead of failing as expected.

It was hard enough to get to this point. :) The next step is to figure out why, and how it can be fixed. (Or maybe a timeout is fine too? I don't know anything about SOCKS.)

This issue is blocking the migration to GitHub Actions: they do not include 16.04 at all.