### PR TITLE
Upgrade Travis Ubuntu and PyPy versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 os: linux
-dist: bionic
+dist: focal
 
 before_install:
   - env

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 os: linux
-dist: xenial
+dist: bionic
 
 before_install:
   - env
@@ -43,13 +43,13 @@ jobs:
       env: NOX_SESSION=test-3.7
     - python: 3.8
       env: NOX_SESSION=test-3.8
-    - python: 3.9-dev
+    - python: 3.9
       env: NOX_SESSION=test-3.9
     - python: nightly
       env: NOX_SESSION=test-3.10
-    - python: pypy2.7-6.0
+    - python: pypy2.7-7.3.1
       env: NOX_SESSION=test-pypy
-    - python: pypy3.5-6.0
+    - python: pypy3.6-7.3.1
       env: NOX_SESSION=test-pypy
 
     # Extras

--- a/src/urllib3/util/ssl_.py
+++ b/src/urllib3/util/ssl_.py
@@ -393,7 +393,7 @@ def ssl_wrap_socket(
     try:
         if hasattr(context, "set_alpn_protocols"):
             context.set_alpn_protocols(ALPN_PROTOCOLS)
-    except NotImplementedError:
+    except NotImplementedError:  # Defensive: in CI, we always have set_alpn_protocols
         pass
 
     # If we detect server_hostname is an IP address then the SNI

--- a/test/contrib/test_socks.py
+++ b/test/contrib/test_socks.py
@@ -108,7 +108,6 @@ def _set_up_fake_getaddrinfo(monkeypatch):
     monkeypatch.setattr(py_socks.socket, "getaddrinfo", fake_getaddrinfo)
 
 
-
 def handle_socks5_negotiation(sock, negotiate, username=None, password=None):
     """
     Handle the SOCKS5 handshake.

--- a/test/contrib/test_socks.py
+++ b/test/contrib/test_socks.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 import socket
 import threading
+from socket import getaddrinfo as real_getaddrinfo
 from test import SHORT_TIMEOUT
 
 import pytest
@@ -103,7 +104,9 @@ def _set_up_fake_getaddrinfo(monkeypatch):
     # can't affect PySocks retries via its API. Instead, we monkeypatch PySocks so that
     # it only sees a single address, which effectively disables retries.
     def fake_getaddrinfo(addr, port, family, socket_type):
-        return [(socket.AF_INET, socket_type, family, "", (addr, port))]
+        gai_list = real_getaddrinfo(addr, port, family, socket_type)
+        gai_list = [gai for gai in gai_list if gai[0] == socket.AF_INET]
+        return gai_list[:1]
 
     monkeypatch.setattr(py_socks.socket, "getaddrinfo", fake_getaddrinfo)
 


### PR DESCRIPTION
This works around the hanging test that puzzled me in #2034, unblocks #2012 (cc @hramezani), and paves the way for GitHub Actions (#2033), where the same test was an issue too for a slighly different reason.

I haven't upgraded to Ubuntu 20.04 because while Python has `ssl.PROTOCOL_TLSv1` and `PROTOCOL_TLSv1_1`, Ubuntu 20.04 configured OpenSSL to only support TLS v1.2+ and I'm not sure how we want to figure that out from the tests.