### PR TITLE
Skip TLS versions if disabled by OpenSSL config

### DIFF
--- a/test/__init__.py
+++ b/test/__init__.py
@@ -14,7 +14,6 @@ try:
 except ImportError:
     brotli = None
 
-from dummyserver.testcase import HTTPSDummyServerTestCase
 from urllib3 import util
 from urllib3.exceptions import HTTPWarning
 from urllib3.packages import six
@@ -52,31 +51,6 @@ SHORT_TIMEOUT = 0.001
 LONG_TIMEOUT = 0.01
 if os.environ.get("CI") or os.environ.get("GITHUB_ACTIONS") == "true":
     LONG_TIMEOUT = 0.5
-
-
-# We have to create an actual TLS connection
-# to test if the TLS version is not disabled by
-# OpenSSL config. Ubuntu 20.04 specifically
-# disables TLSv1 and TLSv1.1.
-SUPPORTED_TLS_PROTOCOLS = set()
-
-_server = HTTPSDummyServerTestCase()
-_server._start_server()
-for _ssl_version_name in ("PROTOCOL_TLSv1", "PROTOCOL_TLSv1_1", "PROTOCOL_TLSv1_2"):
-    _ssl_version = getattr(ssl, _ssl_version_name, 0)
-    if _ssl_version == 0:
-        continue
-    _sock = socket.create_connection((_server.host, _server.port))
-    try:
-        _sock = ssl_.ssl_wrap_socket(
-            _sock, cert_reqs=ssl.CERT_NONE, ssl_version=_ssl_version
-        )
-    except ssl.SSLError:
-        pass
-    else:
-        SUPPORTED_TLS_PROTOCOLS.add(_ssl_version)
-    _sock.close()
-_server._stop_server()
 
 
 def _can_resolve(host):
@@ -292,40 +266,6 @@ def requires_ssl_context_keyfile_password(test):
         return test(*args, **kwargs)
 
     return wrapper
-
-
-def requiresTLSv1():
-    """Test requires TLSv1 available"""
-    return pytest.mark.skipif(
-        not hasattr(ssl, "PROTOCOL_TLSv1")
-        or ssl.PROTOCOL_TLSv1 not in SUPPORTED_TLS_PROTOCOLS,
-        reason="Test requires TLSv1",
-    )
-
-
-def requiresTLSv1_1():
-    """Test requires TLSv1.1 available"""
-    return pytest.mark.skipif(
-        not hasattr(ssl, "PROTOCOL_TLSv1_1")
-        or ssl.PROTOCOL_TLSv1_1 not in SUPPORTED_TLS_PROTOCOLS,
-        reason="Test requires TLSv1.1",
-    )
-
-
-def requiresTLSv1_2():
-    """Test requires TLSv1.2 available"""
-    return pytest.mark.skipif(
-        not hasattr(ssl, "PROTOCOL_TLSv1_2")
-        or ssl.PROTOCOL_TLSv1_2 not in SUPPORTED_TLS_PROTOCOLS,
-        reason="Test requires TLSv1.2",
-    )
-
-
-def requiresTLSv1_3():
-    """Test requires TLSv1.3 available"""
-    return pytest.mark.skipif(
-        not getattr(ssl, "HAS_TLSv1_3", False), reason="Test requires TLSv1.3"
-    )
 
 
 def resolvesLocalhostFQDN(test):

--- a/test/with_dummyserver/test_https.py
+++ b/test/with_dummyserver/test_https.py
@@ -16,10 +16,6 @@ from test import (
     onlyPy279OrNewer,
     requires_network,
     requires_ssl_context_keyfile_password,
-    requiresTLSv1,
-    requiresTLSv1_1,
-    requiresTLSv1_2,
-    requiresTLSv1_3,
     resolvesLocalhostFQDN,
 )
 
@@ -729,25 +725,25 @@ class TestHTTPS(HTTPSDummyServerTestCase):
             assert r.data.decode("utf-8") == util.ALPN_PROTOCOLS[0]
 
 
-@requiresTLSv1()
+@pytest.mark.usefixtures("requires_tlsv1")
 class TestHTTPS_TLSv1(TestHTTPS):
     tls_protocol_name = "TLSv1"
     certs = TLSv1_CERTS
 
 
-@requiresTLSv1_1()
+@pytest.mark.usefixtures("requires_tlsv1_1")
 class TestHTTPS_TLSv1_1(TestHTTPS):
     tls_protocol_name = "TLSv1.1"
     certs = TLSv1_1_CERTS
 
 
-@requiresTLSv1_2()
+@pytest.mark.usefixtures("requires_tlsv1_2")
 class TestHTTPS_TLSv1_2(TestHTTPS):
     tls_protocol_name = "TLSv1.2"
     certs = TLSv1_2_CERTS
 
 
-@requiresTLSv1_3()
+@pytest.mark.usefixtures("requires_tlsv1_3")
 class TestHTTPS_TLSv1_3(TestHTTPS):
     tls_protocol_name = "TLSv1.3"
     certs = TLSv1_3_CERTS


### PR DESCRIPTION
Tested this on Ubuntu 20.04 and appears to work properly.
Unblocks another part of https://github.com/urllib3/urllib3/issues/2033, onwards to GHA!