### PR TITLE
Fix improper argument order in SSLTransport. 

### DIFF
--- a/src/urllib3/util/ssltransport.py
+++ b/src/urllib3/util/ssltransport.py
@@ -184,19 +184,18 @@ class SSLTransport:
         self.socket._decref_socketios()
 
     def _wrap_ssl_read(self, len, buffer=None):
-        response = None
         try:
-            response = self._ssl_io_loop(self.sslobj.read, len, buffer)
+            return self._ssl_io_loop(self.sslobj.read, len, buffer)
         except ssl.SSLError as e:
             if e.errno == ssl.SSL_ERROR_EOF and self.suppress_ragged_eofs:
-                response = 0  # eof, return 0.
+                return 0  # eof, return 0.
             else:
                 raise
-        return response
 
     def _ssl_io_loop(self, func, *args):
         """ Performs an I/O loop between incoming/outgoing and the socket."""
         should_loop = True
+        ret = None
 
         while should_loop:
             errno = None

--- a/src/urllib3/util/ssltransport.py
+++ b/src/urllib3/util/ssltransport.py
@@ -42,7 +42,7 @@ class SSLTransport:
                 )
 
     def __init__(
-        self, socket, ssl_context, suppress_ragged_eofs=True, server_hostname=None
+        self, socket, ssl_context, server_hostname=None, suppress_ragged_eofs=True
     ):
         """
         Create an SSLTransport around socket using the provided ssl_context.


### PR DESCRIPTION
There are two commits on this PR.

The first commit fixes a bug that was caused by an incorrect order of constructor arguments. The ``server_hostname`` parameter was not properly being passed through to the ``wrap_bio`` method call. This caused issues with SNI hints not properly working and it affected some servers. It was detected in production by a team and I have verified the fix works as expected.

The second commit addresses some comments @sethmlarson had made over Discord. We can chat more about them if needed. 