### PR TITLE
Release: 1.26.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 Changes
 =======
 
-1.26.0 (2020-11-??)
+1.26.0 (2020-11-10)
 -------------------
 
 * **NOTE: urllib3 v2.0 will drop support for Python 2**.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,48 @@
 Changes
 =======
 
+1.26.0 (2020-11-??)
+-------------------
+
+* **NOTE: urllib3 v2.0 will drop support for Python 2**.
+  `Read more in the v2.0 Roadmap <https://urllib3.readthedocs.io/en/latest/v2-roadmap.html>`_.
+
+* Added support for HTTPS proxies contacting HTTPS servers (Pull #1923, Pull #1806)
+
+* Deprecated negotiating TLSv1 and TLSv1.1 by default. Users that
+  still wish to use TLS earlier than 1.2 without a deprecation warning
+  should opt-in explicitly by setting ``ssl_version=ssl.PROTOCOL_TLSv1_1`` (Pull #2002)
+  **Starting in urllib3 v2.0: Connections that receive a ``DeprecationWarning`` will fail**
+
+* Deprecated ``Retry`` options ``Retry.DEFAULT_METHOD_WHITELIST``, ``Retry.DEFAULT_REDIRECT_HEADERS_BLACKLIST``
+  and ``Retry(method_whitelist=...)`` in favor of ``Retry.DEFAULT_ALLOWED_METHODS``,
+  ``Retry.DEFAULT_REMOVE_HEADERS_ON_REDIRECT``, and ``Retry(allowed_methods=...)``
+  (Pull #2000) **Starting in urllib3 v2.0: Deprecated options will be removed**
+
+* Added default ``User-Agent`` header to every request (Pull #1750)
+
+* Added ``urllib3.util.SKIP_HEADER`` for skipping ``User-Agent``, ``Accept-Encoding``, 
+  and ``Host`` headers from being automatically emitted with requests (Pull #2018)
+
+* Collapse ``transfer-encoding: chunked`` request data and framing into
+  the same ``socket.send()`` call (Pull #1906)
+
+* Send ``http/1.1`` ALPN identifier with every TLS handshake by default (Pull #1894)
+
+* Properly terminate SecureTransport connections when CA verification fails (Pull #1977)
+
+* Don't emit an ``SNIMissingWarning`` when passing ``server_hostname=None``
+  to SecureTransport (Pull #1903)
+
+* Disabled requesting TLSv1.2 session tickets as they weren't being used by urllib3 (Pull #1970)
+
+* Suppress ``BrokenPipeError`` when writing request body after the server
+  has closed the socket (Pull #1524)
+
+* Wrap ``ssl.SSLError`` that can be raised from reading a socket (e.g. "bad MAC")
+  into an ``urllib3.exceptions.SSLError`` (Pull #1939)
+
+
 1.25.11 (2020-10-19)
 --------------------
 
@@ -153,7 +195,7 @@ Changes
 * Add TLSv1.3 support to CPython, pyOpenSSL, and SecureTransport ``SSLContext``
   implementations. (Pull #1496)
 
-* Switched the default multipart header encoder from RFC 2231 to HTML 5 working draft. (Issue #303, PR #1492)
+* Switched the default multipart header encoder from RFC 2231 to HTML 5 working draft. (Issue #303, Pull #1492)
 
 * Fixed issue where OpenSSL would block if an encrypted client private key was
   given and no password was given. Instead an ``SSLError`` is raised. (Pull #1489)
@@ -384,13 +426,13 @@ Changes
   interprets the presence of any flag as requesting certificate validation.
 
   There is no PR for this patch, as it was prepared for simultaneous disclosure
-  and release. The master branch received the same fix in PR #1010.
+  and release. The master branch received the same fix in Pull #1010.
 
 
 1.18 (2016-09-26)
 -----------------
 
-* Fixed incorrect message for IncompleteRead exception. (PR #973)
+* Fixed incorrect message for IncompleteRead exception. (Pull #973)
 
 * Accept ``iPAddress`` subject alternative name fields in TLS certificates.
   (Issue #258)
@@ -419,32 +461,32 @@ Changes
   contains retries history. (Issue #848)
 
 * Timeout can no longer be set as boolean, and must be greater than zero.
-  (PR #924)
+  (Pull #924)
 
 * Removed pyasn1 and ndg-httpsclient from dependencies used for PyOpenSSL. We
   now use cryptography and idna, both of which are already dependencies of
-  PyOpenSSL. (PR #930)
+  PyOpenSSL. (Pull #930)
 
 * Fixed infinite loop in ``stream`` when amt=None. (Issue #928)
 
 * Try to use the operating system's certificates when we are using an
-  ``SSLContext``. (PR #941)
+  ``SSLContext``. (Pull #941)
 
 * Updated cipher suite list to allow ChaCha20+Poly1305. AES-GCM is preferred to
-  ChaCha20, but ChaCha20 is then preferred to everything else. (PR #947)
+  ChaCha20, but ChaCha20 is then preferred to everything else. (Pull #947)
 
-* Updated cipher suite list to remove 3DES-based cipher suites. (PR #958)
+* Updated cipher suite list to remove 3DES-based cipher suites. (Pull #958)
 
-* Removed the cipher suite fallback to allow HIGH ciphers. (PR #958)
+* Removed the cipher suite fallback to allow HIGH ciphers. (Pull #958)
 
 * Implemented ``length_remaining`` to determine remaining content
-  to be read. (PR #949)
+  to be read. (Pull #949)
 
 * Implemented ``enforce_content_length`` to enable exceptions when
-  incomplete data chunks are received. (PR #949)
+  incomplete data chunks are received. (Pull #949)
 
 * Dropped connection start, dropped connection reset, redirect, forced retry,
-  and new HTTPS connection log levels to DEBUG, from INFO. (PR #967)
+  and new HTTPS connection log levels to DEBUG, from INFO. (Pull #967)
 
 
 1.16 (2016-06-11)

--- a/src/urllib3/_version.py
+++ b/src/urllib3/_version.py
@@ -1,2 +1,2 @@
 # This file is protected via CODEOWNERS
-__version__ = "1.26.0.dev0"
+__version__ = "1.26.0"


### PR DESCRIPTION
Please verify that the changelog entries look good. Specifically was a little unsure how to phrase some of the SecureTransport changes @hodbn.

@nateprewitt would be nice to get some testing from Requests before we release this if possible.