### PR TITLE
Add back the HTTPHeaderDict import from 1.25.x

### DIFF
--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -43,6 +43,7 @@ except NameError:  # Python 2:
         pass
 
 
+from ._collections import HTTPHeaderDict  # noqa (historical, removed in v2)
 from ._version import __version__
 from .exceptions import (
     ConnectTimeoutError,


### PR DESCRIPTION
Closes #2045 

These imports will only be here in the v1 series, starting in v2 we'll be much more strict about what our public APIs are.