### PR TITLE
Don't send 'User-Agent' twice if header is binary

### DIFF
--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -228,7 +228,7 @@ class HTTPConnection(_HTTPConnection, object):
         else:
             # Avoid modifying the headers passed into .request()
             headers = headers.copy()
-        if "user-agent" not in (k.lower() for k in headers):
+        if "user-agent" not in (six.ensure_str(k.lower()) for k in headers):
             headers["User-Agent"] = _get_default_user_agent()
         super(HTTPConnection, self).request(method, url, body=body, headers=headers)
 


### PR DESCRIPTION
Previously if `b"user-agent"` was sent for a non-chunked request then we'd emit multiple `User-Agent` headers, this closes that gap. This commit will need to be backported to 1.26