### PR TITLE
Release 1.26.1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,13 @@
 Changes
 =======
 
+1.26.1 (2020-11-11)
+-------------------
+
+* Fixed an issue where two ``User-Agent`` headers would be sent if a
+  ``User-Agent`` header key is passed as ``bytes`` (Pull #2047)
+
+
 1.26.0 (2020-11-10)
 -------------------
 

--- a/src/urllib3/_version.py
+++ b/src/urllib3/_version.py
@@ -1,2 +1,2 @@
 # This file is protected via CODEOWNERS
-__version__ = "1.26.0"
+__version__ = "1.26.1"


### PR DESCRIPTION
Small release to fix reported issues now that Requests has unpinned us in 2.25.0.

One change in this release isn't documented here: the addition of `HTTPHeaderDict` back to `urllib3.connection` isn't technically in our public API, however the change is impacting users of one of our dependents and we're making the fix as a courtesy.