### PR TITLE
Import features from ssl module with more granularity

### DIFF
--- a/src/urllib3/util/ssl_.py
+++ b/src/urllib3/util/ssl_.py
@@ -44,12 +44,20 @@ _const_compare_digest = getattr(hmac, "compare_digest", _const_compare_digest_ba
 
 try:  # Test for SSL features
     import ssl
-    from ssl import HAS_SNI  # Has SNI?
     from ssl import CERT_REQUIRED, wrap_socket
+except ImportError:
+    pass
 
+try:
+    from ssl import HAS_SNI  # Has SNI?
+except ImportError:
+    pass
+
+try:
     from .ssltransport import SSLTransport
 except ImportError:
     pass
+
 
 try:  # Platform-specific: Python 3.6
     from ssl import PROTOCOL_TLS


### PR DESCRIPTION
Very subtle bug here that was caused by isort reordering the imports within `try-except`. Here's the diff of `urllib3.util.ssl_` between 1.25.11 and 1.26.1 that caused the bug:

```diff
 try:  # Test for SSL features
     import ssl
-    from ssl import wrap_socket, CERT_REQUIRED
     from ssl import HAS_SNI  # Has SNI?
+    from ssl import CERT_REQUIRED, wrap_socket
+
+    from .ssltransport import SSLTransport
 except ImportError:
     pass
```

Notice how `HAS_SNI` is now being imported before `wrap_socket` and `CERT_REQUIRED` and `HAS_SNI` is a Python 2.7.9 feature. This meant that imports on Python 2.7.8 and earlier weren't getting `wrap_socket` imported in time before `HAS_SNI` was causing an `ImportError`.

Verified this locally with the `python:2.7.8` Docker container, we currently don't have CI for this Python version.

Closes #2051