### PR TITLE
Update dev-requirements.txt

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,14 +1,10 @@
-coverage~=5.0
-tornado==6.0.3
+coverage==5.3
+tornado==6.1
 PySocks==1.7.1
-# https://github.com/Anorov/PySocks/issues/131
-win-inet-pton==1.1.0
-pytest==4.6.9
-pytest-timeout==1.3.4
+pytest==6.1.2
+pytest-timeout==1.4.2
 pytest-freezegun==0.4.2
-flaky==3.6.1
-trustme==0.5.3
-cryptography==3.2
-gcp-devrel-py-tools==0.0.15
-
+flaky==3.7.0
+trustme==0.6.0
+cryptography==3.2.1
 python-dateutil==2.8.1


### PR DESCRIPTION
We no longer support Python 2.7, so we can stop worrying about the
PySocks bug and can install latest version of pytest. We also remove
gcp-devrel-py-tool that was installed to test Google App Engine.

@sethmlarson Do you plan to set up dependabot? I was surprised by this pull request: https://github.com/urllib3/urllib3/pull/2032