### PR TITLE
Remove Python 2 related code and tests and comments.

### DIFF
--- a/src/urllib3/_collections.py
+++ b/src/urllib3/_collections.py
@@ -14,8 +14,6 @@ except ImportError:  # Platform-specific: No threads available
 
 from collections import OrderedDict
 
-from .exceptions import InvalidHeader
-
 __all__ = ["RecentlyUsedContainer", "HTTPHeaderDict"]
 
 
@@ -296,31 +294,3 @@ class HTTPHeaderDict(MutableMapping):
 
     def items(self):
         return list(self.iteritems())
-
-    @classmethod
-    def from_httplib(cls, message):  # Python 2
-        """Read headers from a Python 2 httplib message object."""
-        # python2.7 does not expose a proper API for exporting multiheaders
-        # efficiently. This function re-reads raw lines from the message
-        # object and extracts the multiheaders properly.
-        obs_fold_continued_leaders = (" ", "\t")
-        headers = []
-
-        for line in message.headers:
-            if line.startswith(obs_fold_continued_leaders):
-                if not headers:
-                    # We received a header line that starts with OWS as described
-                    # in RFC-7230 S3.2.4. This indicates a multiline header, but
-                    # there exists no previous header to which we can attach it.
-                    raise InvalidHeader(
-                        f"Header continuation with no previous header: {line}"
-                    )
-                else:
-                    key, value = headers[-1]
-                    headers[-1] = (key, value + " " + line.strip())
-                    continue
-
-            key, value = line.split(":", 1)
-            headers.append((key, value.strip()))
-
-        return cls(headers)

--- a/src/urllib3/contrib/pyopenssl.py
+++ b/src/urllib3/contrib/pyopenssl.py
@@ -59,21 +59,15 @@ except ImportError:
         pass
 
 
+import logging
+import ssl
 from io import BytesIO
 from socket import error as SocketError
 from socket import timeout
 
-try:  # Platform-specific: Python 2
-    from socket import _fileobject
-except ImportError:  # Platform-specific: Python 3
-    _fileobject = None
-    from ..packages.backports.makefile import backport_makefile
-
-import logging
-import ssl
-
 from .. import util
 from ..packages import six
+from ..packages.backports.makefile import backport_makefile
 
 __all__ = ["inject_into_urllib3", "extract_from_urllib3"]
 
@@ -394,17 +388,7 @@ class WrappedSocket:
             self._makefile_refs -= 1
 
 
-if _fileobject:  # Platform-specific: Python 2
-
-    def makefile(self, mode, bufsize=-1):
-        self._makefile_refs += 1
-        return _fileobject(self, mode, bufsize, close=True)
-
-
-else:  # Platform-specific: Python 3
-    makefile = backport_makefile
-
-WrappedSocket.makefile = makefile
+WrappedSocket.makefile = backport_makefile
 
 
 class PyOpenSSLContext:
@@ -479,7 +463,7 @@ class PyOpenSSLContext:
     ):
         cnx = OpenSSL.SSL.Connection(self._ctx, sock)
 
-        if isinstance(server_hostname, str):  # Platform-specific: Python 3
+        if isinstance(server_hostname, str):
             server_hostname = server_hostname.encode("utf-8")
 
         if server_hostname is not None:

--- a/src/urllib3/util/retry.py
+++ b/src/urllib3/util/retry.py
@@ -354,12 +354,6 @@ class Retry(metaclass=_RetryMeta):
             retry_date_tuple = email.utils.parsedate_tz(retry_after)
             if retry_date_tuple is None:
                 raise InvalidHeader(f"Invalid Retry-After header: {retry_after}")
-            if retry_date_tuple[9] is None:  # Python 2
-                # Assume UTC if no timezone was specified
-                # On Python2.7, parsedate_tz returns None for a timezone offset
-                # instead of 0 if no timezone is given, where mktime_tz treats
-                # a None timezone offset as local time.
-                retry_date_tuple = retry_date_tuple[:9] + (0,) + retry_date_tuple[10:]
 
             retry_date = email.utils.mktime_tz(retry_date_tuple)
             seconds = retry_date - time.time()

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -255,15 +255,6 @@ class TestUtil:
             "http://foo:bar@localhost/",
             Url("http", auth="foo:bar", host="localhost", path="/"),
         ),
-        # Unicode type (Python 2.x)
-        (
-            "http://foo:bar@localhost/",
-            Url("http", auth="foo:bar", host="localhost", path="/"),
-        ),
-        (
-            "http://foo:bar@localhost/",
-            Url("http", auth="foo:bar", host="localhost", path="/"),
-        ),
     ]
 
     non_round_tripping_parse_url_host_map = [

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -1414,8 +1414,7 @@ class TestSSL(SocketDummyServerTestCase):
 
         def is_closed_socket(sock):
             try:
-                sock.settimeout(SHORT_TIMEOUT)  # Python 3
-                sock.recv(1)  # Python 2
+                sock.settimeout(SHORT_TIMEOUT)
             except OSError:
                 return True
             return False


### PR DESCRIPTION
<!---
Thanks for your contribution! ♥️

If this is your first PR to urllib3 please review the Contributing Guide:
https://urllib3.readthedocs.io/en/latest/contributing.html

Adhering to the Contributing Guide means we can review, merge, and release your change faster! :)
--->

Here is the other part that can be included in this path. but I wasn't sure about it. So, I decided to put it here and aks your opinion about it.

```diff
diff --git a/src/urllib3/util/ssl_.py b/src/urllib3/util/ssl_.py
index cf54d41d..ef6b10da 100644
--- a/src/urllib3/util/ssl_.py
+++ b/src/urllib3/util/ssl_.py
@@ -232,12 +232,7 @@ def create_urllib3_context(
         context.post_handshake_auth = True
 
     context.verify_mode = cert_reqs
-    if (
-        getattr(context, "check_hostname", None) is not None
-    ):  # Platform-specific: Python 3.2
-        # We do our own verification, including fingerprints and alternative
-        # hostnames. So disable it here
-        context.check_hostname = False
+    context.check_hostname = False
 
     # Enable logging of TLS session keys via defacto standard environment variable
     # 'SSLKEYLOGFILE', if the feature is available (Python 3.8+). Skip empty values.
(END)

```