### PR TITLE
Fix banner URL in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 
    <p align="center">
       <a href="https://github.com/urllib3/urllib3">
-         <img src="./docs/images/banner.svg" width="60%" alt="urllib3" />
+         <img src="./docs/_static/banner.svg" width="60%" alt="urllib3" />
       </a>
    </p>
    <p align="center">


### PR DESCRIPTION
Recent changes moved the banner away from the images directory and the README doesn't render it anymore.