### PR TITLE
Replace codecs.open() with builtin open()

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # This file is protected via CODEOWNERS
 
-import codecs
 import os
 import re
 import sys
@@ -45,7 +44,7 @@ with open(os.path.join(base_path, "src", "urllib3", "_version.py")) as fp:
     )
 
 
-with codecs.open("README.rst", encoding="utf-8") as fp:
+with open("README.rst", encoding="utf-8") as fp:
     # Remove reST raw directive from README as they're not allowed on PyPI
     # Those blocks start with a newline and continue until the next newline
     mode = None
@@ -60,7 +59,7 @@ with codecs.open("README.rst", encoding="utf-8") as fp:
             lines.append(line)
     readme = "".join(lines)
 
-with codecs.open("CHANGES.rst", encoding="utf-8") as fp:
+with open("CHANGES.rst", encoding="utf-8") as fp:
     changes = fp.read()
 
 version = VERSION


### PR DESCRIPTION
Since commit 494213c96915c6e420d6cce9c59fa99a6b621f33, this code will no
longer be executed by Python 2.

This follows the work from commit
fbe9620784b130dcdccf43cd3105940152c4d762.

In Python 3, the feature set between these two functions is the same,
might as well use the builtin version.
