### PR TITLE
Restore 3.10-dev CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,10 @@ jobs:
             os: ubuntu-latest
             experimental: false
             nox-session: unsupported_python2
+          - python-version: 3.10-dev
+            os: ubuntu-latest
+            experimental: false
+            nox-session: test-3.10
 
     runs-on: ${{ matrix.os }}
     name: ${{ fromJson('{"macos-latest":"macOS","windows-latest":"Windows","ubuntu-latest":"Ubuntu"}')[matrix.os] }} ${{ matrix.python-version }} ${{ matrix.nox-session}}
@@ -68,11 +72,23 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Set Up Python 3.7 to run nox
-        if: matrix.python-version != '3.7'
+      - name: Set Up Python - ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        if: "!endsWith(matrix.python-version, '-dev')"
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Set Up Python - ${{ matrix.python-version }}
+        uses: deadsnakes/action@v2.0.2
+        if: endsWith(matrix.python-version, '-dev')
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Set Up Python 3 to run nox on Python 2
+        if: matrix.python-version == '2.7'
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3
 
       - name: Install Dependencies
         run: python -m pip install --upgrade nox


### PR DESCRIPTION
See https://github.com/urllib3/urllib3/pull/1922. CPython finally decided that there was nothing to fix for Python 3.10, and that the fix should be in packaging/wheel. Maybe there will be something to fix in Python 31.0! Anyway, we can install cryptography again on 3.10.

Since then urllib3 switched from Travis CI to GitHub Actions, so restoring the 3.10 build on Ubuntu implies using the deadsnakes workaround. It actually works really well.

I also sneaked in a change to only install Python 3 for the `unsupported_python2` test and decided to let GitHub Actions choose the specific Python version it wants to install.