### PR TITLE
Remove outdated workaround for missing ipaddress

### DIFF
--- a/src/urllib3/packages/ssl_match_hostname/_implementation.py
+++ b/src/urllib3/packages/ssl_match_hostname/_implementation.py
@@ -3,17 +3,9 @@
 # Note: This file is under the PSF license as the code comes from the python
 # stdlib.   http://docs.python.org/3/license.html
 
+import ipaddress
 import re
 import sys
-
-# ipaddress has been backported to 2.6+ in pypi.  If it is installed on the
-# system, use it to handle IPAddress ServerAltnames (this was added in
-# python-3.5) otherwise only do DNS matching.  This allows
-# backports.ssl_match_hostname to continue to be used in Python 2.7.
-try:
-    import ipaddress
-except ImportError:
-    ipaddress = None
 
 __version__ = "3.5.0.1"
 
@@ -108,12 +100,6 @@ def match_hostname(cert, hostname):
     except ValueError:
         # Not an IP address (common case)
         host_ip = None
-    except AttributeError:
-        # Divergence from upstream: Make ipaddress library optional
-        if ipaddress is None:
-            host_ip = None
-        else:
-            raise
     dnsnames = []
     san = cert.get("subjectAltName", ())
     for key, value in san:

--- a/test/with_dummyserver/test_https.py
+++ b/test/with_dummyserver/test_https.py
@@ -785,11 +785,6 @@ class TestHTTPS_TLSv1_3(TestHTTPS):
 class TestHTTPS_IPSAN:
     def test_can_validate_ip_san(self, ip_san_server):
         """Ensure that urllib3 can validate SANs with IP addresses in them."""
-        try:
-            import ipaddress  # noqa: F401
-        except ImportError:
-            pytest.skip("Only runs on systems with an ipaddress module")
-
         with HTTPSConnectionPool(
             ip_san_server.host,
             ip_san_server.port,
@@ -803,11 +798,6 @@ class TestHTTPS_IPSAN:
 class TestHTTPS_IPV6SAN:
     def test_can_validate_ipv6_san(self, ipv6_san_server):
         """Ensure that urllib3 can validate SANs with IPv6 addresses in them."""
-        try:
-            import ipaddress  # noqa: F401
-        except ImportError:
-            pytest.skip("Only runs on systems with an ipaddress module")
-
         with HTTPSConnectionPool(
             "[::1]",
             ipv6_san_server.port,


### PR DESCRIPTION
Outdated since urllib3 dropped Python 2 support. The ipaddress module
has been available in the stdlib since Python 3.3 and all used functions
are available.
