### PR TITLE
Use coverage version with PyPy workaround

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,4 @@
-coverage==5.3
+coverage==5.3.1
 tornado==6.1
 PySocks==1.7.1
 pytest==6.1.2


### PR DESCRIPTION
I thought we were using this already, but no. This should make PyPy builds much more reliable.
