### PR TITLE
update python dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ setup(
     ],
     package_dir={"": "src"},
     requires=[],
-    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4",
+    python_requires=">=3.6<4",
     extras_require={
         "brotli": ["brotlipy>=0.6.0"],
         "secure": [


### PR DESCRIPTION
Starting this PR to start a question about version compatibility.

I recently tried to add urllib3 to a poetry managed project.

```
poetry add urllib3
Using version ^1.26.3 for urllib3

Updating dependencies
Resolving dependencies... (0.0s)

[SolverProblemError]
The current project's Python requirement (>=3.6<4) is not compatible with some of the required packages Python requirement:
  - urllib3 requires Python >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4

Because no versions of urllib3 match >1.26.3,<2.0.0
 and urllib3 (1.26.3) requires Python >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4, urllib3 is forbidden.
So, because tycho-station depends on urllib3 (^1.26.3), version solving failed.
```

The project has a requirement of Python >= 3.6. Some how that can not get resolved with urllib3 which seems to be compatible. I updated the version string and was able to fix the issue, but don't know if there is a better way to fix this for the project? I essentially dropped python 2 support which is happening in pip anyways this month. What's the best way to resolve this? Right now poetry projects on Python 3 can not use urllib3.