### PR TITLE
Add defensive test cases for brotlipy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,10 @@ jobs:
             os: ubuntu-latest
             experimental: false
             nox-session: unsupported_python2
+          - python-version: 3.9
+            os: ubuntu-latest
+            experimental: false
+            nox-session: test_brotlipy
           - python-version: 3.10-dev
             os: ubuntu-latest
             experimental: false

--- a/noxfile.py
+++ b/noxfile.py
@@ -83,6 +83,15 @@ def unsupported_python2(session):
     assert "Unsupported Python version" in process.stderr
 
 
+@nox.session(python=["3"])
+def test_brotlipy(session):
+    """Check that if 'brotlipy' is installed instead of 'brotli' or
+    'brotlicffi' that we still don't blow up.
+    """
+    session.install("brotlipy")
+    tests_impl(session, extras="socks,secure")
+
+
 @nox.session()
 def format(session):
     """Run code formatters."""
@@ -98,6 +107,8 @@ def format(session):
     )
     # Ensure that pre-commit itself ran successfully
     assert process.returncode in (0, 1)
+
+    lint(session)
 
 
 @nox.session

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -111,13 +111,15 @@ def notWindows(test):
     return wrapper
 
 
-def onlyBrotlipy():
-    return pytest.mark.skipif(brotli is None, reason="only run if brotlipy is present")
-
-
-def notBrotlipy():
+def onlyBrotli():
     return pytest.mark.skipif(
-        brotli is not None, reason="only run if brotlipy is absent"
+        brotli is None, reason="only run if brotli library is present"
+    )
+
+
+def notBrotli():
+    return pytest.mark.skipif(
+        brotli is not None, reason="only run if a brotli library is absent"
     )
 
 

--- a/test/test_response.py
+++ b/test/test_response.py
@@ -5,7 +5,7 @@ import ssl
 import zlib
 from base64 import b64decode
 from io import BufferedReader, BytesIO, TextIOWrapper
-from test import onlyBrotlipy
+from test import onlyBrotli
 from unittest import mock
 
 import pytest
@@ -222,7 +222,7 @@ class TestResponse:
 
         assert r.data == b"foofoofoo"
 
-    @onlyBrotlipy()
+    @onlyBrotli()
     def test_decode_brotli(self):
         data = brotli.compress(b"foo")
 
@@ -230,7 +230,7 @@ class TestResponse:
         r = HTTPResponse(fp, headers={"content-encoding": "br"})
         assert r.data == b"foo"
 
-    @onlyBrotlipy()
+    @onlyBrotli()
     def test_chunked_decoding_brotli(self):
         data = brotli.compress(b"foobarbaz")
 
@@ -244,7 +244,7 @@ class TestResponse:
                 break
         assert ret == b"foobarbaz"
 
-    @onlyBrotlipy()
+    @onlyBrotli()
     def test_decode_brotli_error(self):
         fp = BytesIO(b"foo")
         with pytest.raises(DecodeError):

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -4,7 +4,7 @@ import socket
 import ssl
 import warnings
 from itertools import chain
-from test import notBrotlipy, onlyBrotlipy
+from test import notBrotli, onlyBrotli
 from unittest.mock import Mock, patch
 
 import pytest
@@ -442,24 +442,24 @@ class TestUtil:
             pytest.param(
                 {"accept_encoding": True},
                 {"accept-encoding": "gzip,deflate,br"},
-                marks=onlyBrotlipy(),
+                marks=onlyBrotli(),
             ),
             pytest.param(
                 {"accept_encoding": True},
                 {"accept-encoding": "gzip,deflate"},
-                marks=notBrotlipy(),
+                marks=notBrotli(),
             ),
             ({"accept_encoding": "foo,bar"}, {"accept-encoding": "foo,bar"}),
             ({"accept_encoding": ["foo", "bar"]}, {"accept-encoding": "foo,bar"}),
             pytest.param(
                 {"accept_encoding": True, "user_agent": "banana"},
                 {"accept-encoding": "gzip,deflate,br", "user-agent": "banana"},
-                marks=onlyBrotlipy(),
+                marks=onlyBrotli(),
             ),
             pytest.param(
                 {"accept_encoding": True, "user_agent": "banana"},
                 {"accept-encoding": "gzip,deflate", "user-agent": "banana"},
-                marks=notBrotlipy(),
+                marks=notBrotli(),
             ),
             ({"user_agent": "banana"}, {"user-agent": "banana"}),
             ({"keep_alive": True}, {"connection": "keep-alive"}),


### PR DESCRIPTION
brotlipy shadows the 'brotli' module namespace and we previously used brotlipy so to be defensive we should continue to test that 'brotlipy' works.