### PR TITLE
Improve `Retry` warning

### DIFF
--- a/src/urllib3/util/retry.py
+++ b/src/urllib3/util/retry.py
@@ -253,6 +253,7 @@ class Retry(object):
                 "Using 'method_whitelist' with Retry is deprecated and "
                 "will be removed in v2.0. Use 'allowed_methods' instead",
                 DeprecationWarning,
+                stacklevel=2,
             )
             allowed_methods = method_whitelist
         if allowed_methods is _Default:


### PR DESCRIPTION
By default, `warnings.warn` will point to the location of the `warnings.warn` call e.g. (with `logging.captureWarnings(True)`)
```
WARNING test py.warnings: /home/odoo/.pyenv/versions/odoo39/lib/python3.9/site-packages/urllib3/util/retry.py:252: DeprecationWarning: Using 'method_whitelist' with Retry is deprecated and will be removed in v2.0. Use 'allowed_methods' instead
  warnings.warn(
```

For this specific warning it's not useful, the issue really is with the whoever *calls* `Retry`, so that's where we want the warning message to point us: for the case above it would have pointed directly into [firebase-admin](https://github.com/firebase/firebase-admin-python/issues/515).

