### PR TITLE
Added management for unknown pool kwargs

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -309,5 +309,8 @@ In chronological order:
 * [Franciszek Magiera] <https://github.com/franekmagiera>
   * Add top-level request method.
 
+* [Tanya] <https://github.com/TanyaEleventhGoddess>
+  * Add check for pool arguments in order to avoid errors with versions change
+
 * [Your name or handle] <[email or website]>
   * [Brief summary of your changes]

--- a/src/urllib3/poolmanager.py
+++ b/src/urllib3/poolmanager.py
@@ -164,7 +164,12 @@ class PoolManager(RequestMethods):
 
     def __init__(self, num_pools=10, headers=None, **connection_pool_kw):
         super().__init__(headers)
-        self.connection_pool_kw = connection_pool_kw
+        # Discards unknown pool kwargs
+        self.connection_pool_kw = {
+            k: connection_pool_kw[k]
+            for k in connection_pool_kw
+            if "key_" + k in _key_fields
+        }
         self.pools = RecentlyUsedContainer(num_pools, dispose_func=lambda p: p.close())
 
         # Locally set the pool classes and keys so other PoolManagers can
@@ -310,7 +315,7 @@ class PoolManager(RequestMethods):
                         del base_pool_kwargs[key]
                     except KeyError:
                         pass
-                else:
+                elif "key_" + key in _key_fields:
                     base_pool_kwargs[key] = value
         return base_pool_kwargs
 


### PR DESCRIPTION
As the title says, this change prevents errors resulting from changes in supported pool arguments.
If another script or library which depends on urllib3 supplies a deprecated or removed argument, it'll be simply ignored and removed
