### PR TITLE
Bring coverage back to 100%

### DIFF
--- a/src/urllib3/util/util.py
+++ b/src/urllib3/util/util.py
@@ -32,8 +32,6 @@ def reraise(
     tb: Optional[TracebackType] = None,
 ) -> NoReturn:
     try:
-        if value is None:
-            value = tp()
         if value.__traceback__ is not tb:
             raise value.with_traceback(tb)
         raise value


### PR DESCRIPTION
All calls to reraise() are in branches where value is truthy, so we can't reach that code. (I don't explain why this only showed up in coverage when we... added types to reraise, though.)

It seemed better than testing a case that we never hit in real code. (I guess that not using reraise at all would be better, but that seems difficult to achieve.)