### PR TITLE
Improve `assert_hostname` and `server_hostname` documentation

### DIFF
--- a/docs/advanced-usage.rst
+++ b/docs/advanced-usage.rst
@@ -232,14 +232,13 @@ you could connect to a server by IP using HTTPS like so::
 
     >>> import urllib3
     >>> pool = urllib3.HTTPSConnectionPool(
-    ...     "10.0.0.10",
-    ...     assert_hostname="example.org",
-    ...     server_hostname="example.org"
+    ...     "104.154.89.105",
+    ...     server_hostname="badssl.com"
     ... )
     >>> pool.urlopen(
     ...     "GET",
     ...     "/",
-    ...     headers={"Host": "example.org"},
+    ...     headers={"Host": "badssl.com"},
     ...     assert_same_host=False
     ... )
 

--- a/docs/advanced-usage.rst
+++ b/docs/advanced-usage.rst
@@ -251,6 +251,22 @@ address that you would like to use. The IP may be for a private interface, or
 you may want to use a specific host under round-robin DNS.
 
 
+.. _assert_hostname:
+
+Verifying TLS against a different host
+--------------------------------------
+
+If the server you're connecting to presents a different certificate than the
+hostname or the SNI hostname, you can use ``assert_hostname``::
+
+    >>> import urllib3
+    >>> pool = urllib3.HTTPSConnectionPool(
+    ...     "wrong.host.badssl.com",
+    ...     assert_hostname="badssl.com",
+    ... )
+    >>> pool.urlopen("GET", "/")
+
+
 .. _ssl_client:
 
 Client Certificates


### PR DESCRIPTION
The default value of `assert_hostname` is `server_hostname`, so specifying `assert_hostname` for SNI isn't needed. Also, even if the IP of badssl.com probably isn't that stable, being able to actually run the example seems nicer than using a private IP.

Having a separate example for `assert_hostname` clarifies that it's not only about SNI. Again, I've used badssl.com since that allows to actually run the example.

Fixes https://github.com/urllib3/urllib3/issues/2126 (the type documentation will be handled by https://github.com/urllib3/urllib3/pull/2162)