### PR TITLE
Remove notOpenSSL098

### DIFF
--- a/test/__init__.py
+++ b/test/__init__.py
@@ -3,7 +3,6 @@ import logging
 import os
 import platform
 import socket
-import ssl
 import warnings
 
 import pytest

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -149,19 +149,6 @@ def notSecureTransport(test):
     return wrapper
 
 
-def notOpenSSL098(test):
-    """Skips this test for Python 3.5 macOS python.org distribution"""
-
-    @functools.wraps(test)
-    def wrapper(*args, **kwargs):
-        is_stdlib_ssl = not ssl_.IS_SECURETRANSPORT and not ssl_.IS_PYOPENSSL
-        if is_stdlib_ssl and ssl.OPENSSL_VERSION == "OpenSSL 0.9.8zh 14 Jan 2016":
-            pytest.xfail(f"{test.__name__} fails with OpenSSL 0.9.8zh")
-        return test(*args, **kwargs)
-
-    return wrapper
-
-
 _requires_network_has_route = None
 
 

--- a/test/with_dummyserver/test_https.py
+++ b/test/with_dummyserver/test_https.py
@@ -11,7 +11,6 @@ from test import (
     LONG_TIMEOUT,
     SHORT_TIMEOUT,
     TARPIT_HOST,
-    notOpenSSL098,
     notSecureTransport,
     requires_network,
     requires_ssl_context_keyfile_password,
@@ -240,7 +239,6 @@ class TestHTTPS(HTTPSDummyServerTestCase):
                 assert not warn.called, warn.call_args_list
 
     @notSecureTransport  # SecureTransport does not support cert directories
-    @notOpenSSL098  # OpenSSL 0.9.8 does not support cert directories
     def test_ca_dir_verified(self, tmpdir):
         # OpenSSL looks up certificates by the hash for their name, see c_rehash
         # TODO infer the bytes using `cryptography.x509.Name.public_bytes`.


### PR DESCRIPTION
Support for OpenSSL 0.9.8 ended in 2016.