### PR TITLE
Bring coverage back to 100%

### DIFF
--- a/src/urllib3/_collections.py
+++ b/src/urllib3/_collections.py
@@ -38,7 +38,7 @@ if TYPE_CHECKING:
 else:
     try:
         from threading import RLock
-    except ImportError:  # Platform-specific: No threads available
+    except ImportError:  # Python 3.6
         from ._compat import RLock
 
 

--- a/src/urllib3/_compat.py
+++ b/src/urllib3/_compat.py
@@ -1,4 +1,4 @@
-class RLock:
+class RLock:  # Python 3.6
     # We shim out a context manager to be used as a compatibility layer
     # if the system `threading` module doesn't have a real `RLock` available.
     def __enter__(self) -> None:


### PR DESCRIPTION
The real reason for this pull request is that we forgot to mark our `Rlock` as not covered, but I also used this opportunity to switch to a different `.coveragerc` string.

Indeed, it's true that `threading` support is "platform-specific" since it's optional in Python 3.6, but since it's always available in Python 3.7 (https://docs.python.org/3/library/threading.html), using "Python 3.6" will remind us to remove the shim when we drop support for Python 3.6 next year.