### PR TITLE
extend LifoQueue from python

### DIFF
--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -37,7 +37,6 @@ from .request import RequestMethods
 from .response import BaseHTTPResponse, HTTPResponse
 from .util.connection import is_connection_dropped
 from .util.proxy import connection_requires_http_tunnel
-from .util.queue import LifoQueue
 from .util.request import set_file_position
 from .util.response import assert_header_parsing
 from .util.retry import Retry
@@ -65,7 +64,7 @@ class ConnectionPool:
     """
 
     scheme = None
-    QueueCls = LifoQueue
+    QueueCls = queue.LifoQueue
 
     def __init__(self, host, port=None):
         if not host:

--- a/src/urllib3/util/queue.py
+++ b/src/urllib3/util/queue.py
@@ -1,3 +1,0 @@
-from queue import LifoQueue as LifoQueue
-
-__all__ = ["LifoQueue"]

--- a/src/urllib3/util/queue.py
+++ b/src/urllib3/util/queue.py
@@ -2,15 +2,6 @@ import collections
 import queue
 
 
-class LifoQueue(queue.Queue):
+class LifoQueue(queue.LifoQueue):
     def _init(self, _):
         self.queue = collections.deque()
-
-    def _qsize(self, len=len):
-        return len(self.queue)
-
-    def _put(self, item):
-        self.queue.append(item)
-
-    def _get(self):
-        return self.queue.pop()

--- a/src/urllib3/util/queue.py
+++ b/src/urllib3/util/queue.py
@@ -1,7 +1,3 @@
-import collections
-import queue
+from queue import LifoQueue as LifoQueue
 
-
-class LifoQueue(queue.LifoQueue):
-    def _init(self, _):
-        self.queue = collections.deque()
+__all__ = ["LifoQueue"]


### PR DESCRIPTION
This PR changes LifoQueue to extend from [queue.LifoQueue](https://github.com/python/cpython/blob/35d5068928ab5485e5f28b60b1e33062bc2c46cc/Lib/queue.py#L242), which uses list as queue internally. LifoQueue was introduced in 2.7 with https://github.com/python/cpython/commit/35641461db7c692877ffa4bbbfe31a525c81770e.

