### PR TITLE
Actually reject common names

### DIFF
--- a/src/urllib3/packages/ssl_match_hostname/__init__.py
+++ b/src/urllib3/packages/ssl_match_hostname/__init__.py
@@ -1,19 +1,3 @@
-import sys
+from ._implementation import CertificateError, match_hostname
 
-try:
-    # Our match_hostname function is the same as 3.5's, so we only want to
-    # import the match_hostname function if it's at least that good.
-    from ssl import CertificateError, match_hostname
-except ImportError:
-    try:
-        # Backport of the function from a pypi module
-        from backports.ssl_match_hostname import (  # type: ignore
-            CertificateError,
-            match_hostname,
-        )
-    except ImportError:
-        # Our vendored copy
-        from ._implementation import CertificateError, match_hostname  # type: ignore
-
-# Not needed, but documenting what we provide.
 __all__ = ("CertificateError", "match_hostname")

--- a/src/urllib3/packages/ssl_match_hostname/__init__.pyi
+++ b/src/urllib3/packages/ssl_match_hostname/__init__.pyi
@@ -1,4 +1,0 @@
-import ssl
-
-CertificateError = ssl.CertificateError
-match_hostname = ssl.match_hostname

--- a/test/with_dummyserver/test_https.py
+++ b/test/with_dummyserver/test_https.py
@@ -779,6 +779,20 @@ class TestHTTPS_TLSv1_3(TestHTTPS):
     certs = TLSv1_3_CERTS
 
 
+class TestHTTPS_NoSAN:
+    def test_common_name_without_san_fails(self, no_san_server):
+        """Ensure that a warning is raised when the cert from the server has
+        no Subject Alternative Name."""
+        with HTTPSConnectionPool(
+            no_san_server.host,
+            no_san_server.port,
+            cert_reqs="CERT_REQUIRED",
+            ca_certs=no_san_server.ca_certs,
+        ) as https_pool:
+            with pytest.raises(MaxRetryError, match="no appropriate subjectAltName"):
+                https_pool.request("GET", "/")
+
+
 class TestHTTPS_IPSAN:
     def test_can_validate_ip_san(self, ip_san_server):
         """Ensure that urllib3 can validate SANs with IP addresses in them."""

--- a/test/with_dummyserver/test_https.py
+++ b/test/with_dummyserver/test_https.py
@@ -781,8 +781,6 @@ class TestHTTPS_TLSv1_3(TestHTTPS):
 
 class TestHTTPS_NoSAN:
     def test_common_name_without_san_fails(self, no_san_server):
-        """Ensure that a warning is raised when the cert from the server has
-        no Subject Alternative Name."""
         with HTTPSConnectionPool(
             no_san_server.host,
             no_san_server.port,


### PR DESCRIPTION
We were using Python's match_hostname by default, who accepts them.

The next step is to move ssl_match_hostname from packages to util, but that would make a nice first issue so I left it out.