### PR TITLE
raise FullPoolError if we try to _put_conn an extra connection in blocking mode

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -309,5 +309,8 @@ In chronological order:
 * [Franciszek Magiera] <https://github.com/franekmagiera>
   * Add top-level request method.
 
+* Dmitry Mazin <https://archvile.net>
+  * _put_conn changes and unit tests
+
 * [Your name or handle] <[email or website]>
   * [Brief summary of your changes]

--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -247,7 +247,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
             if self.block:
                 raise EmptyPoolError(
                     self,
-                    "Pool reached maximum size and no more connections are allowed.",
+                    "No connection is available, and new connection cannot be created due to blocking mode.",
                 )
             pass  # Oh well, we'll create a new connection then
 

--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -284,15 +284,17 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
             # Connection never got put back into the pool, close it.
             conn and conn.close()
         except queue.Full:
+            # This should never happen if self.block == True and you got the conn from self._get_conn
+
             # Connection never got put back into the pool, close it.
             conn and conn.close()
 
-            # This should never happen if self.block == True and you got the conn from self._get_conn
             if self.block:
                 raise FullPoolError(
                     self,
                     "Pool reached maximum size and no more connections are allowed.",
                 )
+
             log.warning("Connection pool is full, discarding connection: %s", self.host)
 
     def _validate_conn(self, conn):

--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -247,7 +247,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
             if self.block:
                 raise EmptyPoolError(
                     self,
-                    "No connection is available, and new connection cannot be created due to blocking mode.",
+                    "Pool is empty and a new connection can't be opened due to blocking mode.",
                 )
             pass  # Oh well, we'll create a new connection then
 

--- a/src/urllib3/exceptions.py
+++ b/src/urllib3/exceptions.py
@@ -169,6 +169,12 @@ class EmptyPoolError(PoolError):
     pass
 
 
+class FullPoolError(PoolError):
+    """Raised when we try to add a connection to a full pool in blocking mode."""
+
+    pass
+
+
 class ClosedPoolError(PoolError):
     """Raised when a request enters a pool after the pool has been closed."""
 

--- a/test/test_connectionpool.py
+++ b/test/test_connectionpool.py
@@ -270,6 +270,20 @@ class TestConnectionPool:
 
             assert conn1 == pool._get_conn()
 
+    def test_put_conn_closed_pool(self):
+        with HTTPConnectionPool(host="localhost", maxsize=1, block=True) as pool:
+            conn1 = pool._get_conn()
+            conn1.close = Mock()
+
+            pool.close()
+            assert pool.pool is None
+
+            # Accessing pool.pool will raise AttributeError, which will get
+            # caught and will close conn1
+            pool._put_conn(conn1)
+
+            assert conn1.close.called is True
+
     def test_exception_str(self):
         assert (
             str(EmptyPoolError(HTTPConnectionPool(host="localhost"), "Test."))

--- a/test/test_connectionpool.py
+++ b/test/test_connectionpool.py
@@ -224,7 +224,7 @@ class TestConnectionPool:
 
             assert pool.num_connections == 1
 
-    def test_put_conn_when_pool_is_full(self):
+    def test_put_conn_when_pool_is_full_nonblocking(self):
         """
         If maxsize = n and we _put_conn n + 1 conns, the n + 1th conn will
         get closed and will not get added to the pool.


### PR DESCRIPTION
I have been looking at ConnectionPool's behavior in blocking mode and was confused by EmptyPoolError's message (it said the pool was full, which is sort of true, but needs a bit of explanation, which I added.

I was also confused by the absence of a FullPoolError if you try to _put_conn a conn in blocking mode. I added a FullPoolError.

I also added a couple of tests for blocking mode and one test for non-blocking mode.