### PR TITLE
Fix Python 3.10 tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
             os: ubuntu-latest
             experimental: false
             nox-session: test_brotlipy
-          - python-version: 3.10-dev
+          - python-version: 3.10.0-alpha.7
             os: ubuntu-latest
             experimental: false
             nox-session: test-3.10

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,11 +1,11 @@
-coverage==5.3.1
+coverage==5.5
 tornado==6.1
 PySocks==1.7.1
-pytest==6.1.2
+pytest==6.2.3
 pytest-timeout==1.4.2
 pytest-freezegun==0.4.2
 flaky==3.7.0
-trustme==0.6.0
-cryptography==3.3.2
+trustme==0.7.0
+cryptography==3.4.7
 python-dateutil==2.8.1
 typing-extensions==3.7.4.3


### PR DESCRIPTION
There was a change in CPython that broke pytest. https://github.com/pytest-dev/pytest/pull/8540 fixed it, which is why I bumped it but pytest was not relased, so that did not help. But it does not hurt either, so I left the version bumps.

The issue appeared since GitHub Actions released a "beta 1" CPython 3.10, which is weird since the actual beta 1 is not out yet, but this is what 3.10-dev now refers to. See https://github.com/pytest-dev/pytest/pull/8540#issuecomment-822330273.

So the fix is to pin to alpha 7, and when pytest gets relased we'll unpin Python 3.10 and bump pytest.