### PR TITLE
Complete src/urllib3/util/util.py type hint.

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -22,6 +22,7 @@ TYPED_FILES = {
     "src/urllib3/util/ssl_match_hostname.py",
     "src/urllib3/util/ssltransport.py",
     "src/urllib3/util/url.py",
+    "src/urllib3/util/util.py",
     "src/urllib3/util/wait.py",
 }
 SOURCE_FILES = [

--- a/src/urllib3/util/util.py
+++ b/src/urllib3/util/util.py
@@ -28,7 +28,7 @@ def to_str(
 
 def reraise(
     tp: Optional[Type[BaseException]],
-    value: Optional[BaseException],
+    value: BaseException,
     tb: Optional[TracebackType] = None,
 ) -> NoReturn:
     try:
@@ -36,5 +36,5 @@ def reraise(
             raise value.with_traceback(tb)
         raise value
     finally:
-        value = None
+        value = None  # type: ignore
         tb = None


### PR DESCRIPTION
After https://github.com/urllib3/urllib3/commit/e9171e8d77b457e2c96fca37c89d68c518bec5f7, there are some mypy errors:
```
src/urllib3/util/util.py:35: error: Item "None" of "Optional[BaseException]" has no attribute "__traceback__"
src/urllib3/util/util.py:36: error: Item "None" of "Optional[BaseException]" has no attribute "with_traceback"
src/urllib3/util/util.py:37: error: Exception must be derived from BaseException
```
This patch fixes these errors.