### PR TITLE
Fix default socket_options value for HTTPSConnection

### DIFF
--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -356,7 +356,9 @@ class HTTPSConnection(HTTPConnection):
         server_hostname: Optional[str] = None,
         source_address: Optional[Tuple[str, int]] = None,
         blocksize: int = 8192,
-        socket_options: Optional[connection.SocketOptions] = None,
+        socket_options: Optional[
+            connection.SocketOptions
+        ] = HTTPConnection.default_socket_options,
         proxy: Optional[str] = None,
         proxy_config: Optional[ProxyConfig] = None,
     ) -> None:


### PR DESCRIPTION
The default value for `socket_options` should not be `None` in `HTTPSConnection`, but should reflect defaults from parent class.
<!---
Thanks for your contribution! ♥️

If this is your first PR to urllib3 please review the Contributing Guide:
https://urllib3.readthedocs.io/en/latest/contributing.html

Adhering to the Contributing Guide means we can review, merge, and release your change faster! :)
--->
