### PR TITLE
Properly proxy EOF on the SSLTransport test suite.

### DIFF
--- a/test/test_ssltransport.py
+++ b/test/test_ssltransport.py
@@ -246,6 +246,7 @@ class SocketProxyDummyServer(SocketDummyServerTestCase):
                 )
                 self._read_write_loop(client_sock, upstream_sock)
                 upstream_sock.close()
+                client_sock.close()
 
         self._start_server(proxy_handler)
 
@@ -274,6 +275,10 @@ class SocketProxyDummyServer(SocketDummyServerTestCase):
                 if write_socket in writable:
                     try:
                         b = read_socket.recv(chunks)
+                        if len(b) == 0:
+                            # One of the sockets has EOFed, we return to close
+                            # both.
+                            return
                         write_socket.send(b)
                     except ssl.SSLEOFError:
                         # It's possible, depending on shutdown order, that we'll
@@ -322,6 +327,7 @@ class TlsInTlsTestCase(SocketDummyServerTestCase):
                 request = consume_socket(ssock)
                 validate_request(request)
                 ssock.send(sample_response())
+            sock.close()
 
         cls._start_server(socket_handler)
 


### PR DESCRIPTION
Found by @sethmlarson over in [urllib3/#2209](https://github.com/urllib3/urllib3/pull/2209) the SSLTransport makefile tests were failing with timeouts.

The timeouts are caused by makefile's BufferedReader attempting to read more than what we asked. That's expected and documented.  The bug in the test though is that our test is not really propagating EOFs between client and servers. The test suite is complex as it requires a "proxy server" and a destination server to simulate the TLS in TLS. The problem is the proxy server is not really propagating the EOF when the upstream server closes. 

This commit fixes that. The ``socket.close()`` additions are not really necessary but they're good for readability anyway. 
