### PR TITLE
Added body parameter to top-level request() and RequestMethods.request()

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -315,5 +315,8 @@ In chronological order:
 * Ubdussamad <ubdussamad@gmail.com>
   * Added HTTPHeaderDict to top level objects and added relevant usage documentation for the same.
 
+* Bastian Venthur <https://venthur.de>
+  * Added body-parameter to top-level request() and RequestMethods.request
+
 * [Your name or handle] <[email or website]>
   * [Brief summary of your changes]

--- a/src/urllib3/__init__.py
+++ b/src/urllib3/__init__.py
@@ -86,7 +86,7 @@ def disable_warnings(category=exceptions.HTTPWarning):
 _DEFAULT_POOL = PoolManager()
 
 
-def request(method, url, fields=None, headers=None):
+def request(method, url, body=None, fields=None, headers=None):
     """
     A convenience, top-level request method. It uses a module-global ``PoolManager`` instance.
     Therefore, its side effects could be shared across dependencies relying on it.
@@ -94,4 +94,4 @@ def request(method, url, fields=None, headers=None):
     The method does not accept low-level ``**urlopen_kw`` keyword arguments.
     """
 
-    return _DEFAULT_POOL.request(method, url, fields=fields, headers=headers)
+    return _DEFAULT_POOL.request(method, url, body=body, fields=fields, headers=headers)

--- a/src/urllib3/request.py
+++ b/src/urllib3/request.py
@@ -65,6 +65,7 @@ class RequestMethods:
         self,
         method: str,
         url: str,
+        body: Optional[HTTPBody] = None,
         fields: Optional[_TYPE_FIELDS] = None,
         headers: Optional[Mapping[str, str]] = None,
         **urlopen_kw: Any,
@@ -82,6 +83,9 @@ class RequestMethods:
         method = method.upper()
 
         urlopen_kw["request_url"] = url
+
+        if body is not None:
+            urlopen_kw["body"] = body
 
         if method in self._encode_url_methods:
             return self.request_encode_url(

--- a/test/with_dummyserver/test_poolmanager.py
+++ b/test/with_dummyserver/test_poolmanager.py
@@ -334,6 +334,11 @@ class TestPoolManager(HTTPDummyServerTestCase):
             assert returned_headers.get("Foo") is None
             assert returned_headers.get("Baz") == "quux"
 
+    def test_body(self):
+        with PoolManager() as http:
+            r = http.request("POST", f"{self.base_url}/echo", body=b"test")
+            assert r.data == b"test"
+
     def test_http_with_ssl_keywords(self):
         with PoolManager(ca_certs="REQUIRED") as http:
             r = http.request("GET", f"http://{self.host}:{self.port}/")
@@ -367,6 +372,11 @@ class TestPoolManager(HTTPDummyServerTestCase):
         r = request("GET", f"{self.base_url}/")
         assert r.status == 200
         assert r.data == b"Dummy server!"
+
+    def test_top_level_request_with_body(self):
+        r = request("POST", f"{self.base_url}/echo", body=b"test")
+        assert r.status == 200
+        assert r.data == b"test"
 
 
 @pytest.mark.skipif(not HAS_IPV6, reason="IPv6 is not supported on this system")


### PR DESCRIPTION
This adds the `body` parameter to the top-level request() and RequestMethods.request(). For both cases there is a simple echo-test that validates that this feature works.

For ReqestsMethos.requests() the `body` parameter was always implicitly available via the `urlopen_kw` -- so even if you remove the `body` parameter and that tiny piece of code that then adds it to `urlopen_kw` the test will not fail.

Closes: #2222