### PR TITLE
Add type hints to urllib3.poolmanager

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -14,6 +14,7 @@ TYPED_FILES = {
     "src/urllib3/_collections.py",
     "src/urllib3/fields.py",
     "src/urllib3/filepost.py",
+    "src/urllib3/poolmanager.py",
     "src/urllib3/request.py",
     "src/urllib3/util/connection.py",
     "src/urllib3/util/proxy.py",

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -78,7 +78,7 @@ HTTPBody = Union[bytes, IO[Any], Iterable[bytes], str]
 
 
 class ProxyConfig(NamedTuple):
-    ssl_context: "ssl.SSLContext"
+    ssl_context: Optional["ssl.SSLContext"]
     use_forwarding_for_https: bool
 
 

--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -459,7 +459,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         except queue.Empty:
             pass  # Done.
 
-    def is_same_host(self, url):
+    def is_same_host(self, url: str) -> bool:
         """
         Check if the given ``url`` is a member of the same host as this
         connection pool.

--- a/src/urllib3/poolmanager.py
+++ b/src/urllib3/poolmanager.py
@@ -5,7 +5,7 @@ from typing import (
     Any,
     Callable,
     Dict,
-    List,
+    FrozenSet,
     Mapping,
     NamedTuple,
     Optional,
@@ -30,6 +30,7 @@ from .exceptions import (
 )
 from .request import RequestMethods
 from .response import BaseHTTPResponse
+from .util.connection import SocketOptions
 from .util.proxy import connection_requires_http_tunnel
 from .util.retry import Retry
 from .util.timeout import Timeout
@@ -64,29 +65,29 @@ SSL_KEYWORDS = (
 class PoolKey(NamedTuple):
     key_scheme: str
     key_host: str
-    key_port: int
-    key_timeout: Union[Timeout, float, int]
-    key_retries: Union[Retry, int]
-    key_block: bool
-    key_source_address: str
-    key_key_file: str
-    key_key_password: str
-    key_cert_file: str
-    key_cert_reqs: str
-    key_ca_certs: str
-    key_ssl_version: str
-    key_ca_cert_dir: str
+    key_port: Optional[int]
+    key_timeout: Optional[Union[Timeout, float, int]]
+    key_retries: Optional[Union[Retry, int]]
+    key_block: Optional[bool]
+    key_source_address: Optional[Tuple[str, int]]
+    key_key_file: Optional[str]
+    key_key_password: Optional[str]
+    key_cert_file: Optional[str]
+    key_cert_reqs: Optional[str]
+    key_ca_certs: Optional[str]
+    key_ssl_version: Optional[str]
+    key_ca_cert_dir: Optional[str]
     key_ssl_context: Optional["ssl.SSLContext"]
-    key_maxsize: int
-    key_headers: Mapping[str, str]
-    key__proxy: Url
-    key__proxy_headers: Mapping[str, str]
-    key__proxy_config: Type[ProxyConfig]
-    key_socket_options: List[Tuple[int, int, Union[int, str]]]
-    key__socks_options: Dict[str, Any]
-    key_assert_hostname: Union[bool, str]
-    key_assert_fingerprint: str
-    key_server_hostname: str
+    key_maxsize: Optional[int]
+    key_headers: Optional[FrozenSet[Tuple[str, str]]]
+    key__proxy: Optional[Url]
+    key__proxy_headers: Optional[FrozenSet[Tuple[str, str]]]
+    key__proxy_config: Optional[ProxyConfig]
+    key_socket_options: Optional[SocketOptions]
+    key__socks_options: Optional[FrozenSet[Tuple[str, str]]]
+    key_assert_hostname: Optional[Union[bool, str]]
+    key_assert_fingerprint: Optional[str]
+    key_server_hostname: Optional[str]
 
 
 def _default_key_normalizer(

--- a/src/urllib3/poolmanager.py
+++ b/src/urllib3/poolmanager.py
@@ -57,11 +57,14 @@ SSL_KEYWORDS = (
 )
 
 
-# All known keyword arguments that could be provided to the pool manager, its
-# pools, or the underlying connections. This is used to construct a pool key.
-#: The namedtuple class used to construct keys for the connection pool.
-#: All custom key schemes should include the fields in this key at a minimum.
 class PoolKey(NamedTuple):
+    """
+    All known keyword arguments that could be provided to the pool manager, its
+    pools, or the underlying connections.
+
+    All custom key schemes should include the fields in this key at a minimum.
+    """
+
     key_scheme: str
     key_host: str
     key_port: Optional[int]
@@ -299,7 +302,7 @@ class PoolManager(RequestMethods):
         ``request_context`` must at least contain the ``scheme`` key and its
         value must be a key in ``key_fn_by_scheme`` instance variable.
         """
-        scheme = str(request_context["scheme"]).lower()
+        scheme = request_context["scheme"].lower()
         pool_key_constructor = self.key_fn_by_scheme.get(scheme)
         if not pool_key_constructor:
             raise URLSchemeUnknown(scheme)
@@ -403,7 +406,7 @@ class PoolManager(RequestMethods):
         kw["redirect"] = False
 
         if "headers" not in kw:
-            kw["headers"] = dict(self.headers).copy()
+            kw["headers"] = self.headers.copy()  # type: ignore
 
         if self._proxy_requires_url_absolute_form(u):
             response = conn.urlopen(method, url, **kw)
@@ -415,7 +418,7 @@ class PoolManager(RequestMethods):
             return response
 
         # Support relative URLs for redirecting.
-        redirect_location = urljoin(url, str(redirect_location))
+        redirect_location = urljoin(url, redirect_location)
 
         # RFC 7231, Section 6.4.4
         if response.status == 303:
@@ -428,7 +431,7 @@ class PoolManager(RequestMethods):
         # Strip headers marked as unsafe to forward to the redirected location.
         # Check remove_headers_on_redirect to avoid a potential network call within
         # conn.is_same_host() which may use socket.gethostbyname() in the future.
-        if retries.remove_headers_on_redirect and not conn.is_same_host(  # type: ignore
+        if retries.remove_headers_on_redirect and not conn.is_same_host(
             redirect_location
         ):
             headers = list(kw["headers"].keys())

--- a/src/urllib3/response.py
+++ b/src/urllib3/response.py
@@ -29,6 +29,9 @@ from .exceptions import (
 )
 from .util.response import is_fp_closed, is_response_to_head
 
+if typing.TYPE_CHECKING:
+    from typing_extensions import Literal
+
 log = logging.getLogger(__name__)
 
 
@@ -199,7 +202,7 @@ class BaseHTTPResponse(io.IOBase):
 
         self._decoder: typing.Optional[ContentDecoder] = None
 
-    def get_redirect_location(self) -> typing.Optional[typing.Union[bool, str]]:
+    def get_redirect_location(self) -> typing.Union[str, "Literal[False]"]:
         """
         Should we redirect and where to?
 

--- a/src/urllib3/util/connection.py
+++ b/src/urllib3/util/connection.py
@@ -1,12 +1,12 @@
 import socket
-from typing import List, Optional, Tuple, Union
+from typing import Optional, Sequence, Tuple, Union
 
 from urllib3.exceptions import LocationParseError
 
 from .wait import wait_for_read
 
 SOCKET_GLOBAL_DEFAULT_TIMEOUT = socket._GLOBAL_DEFAULT_TIMEOUT  # type: ignore
-SocketOptions = List[Tuple[int, int, Union[int, bytes]]]
+SocketOptions = Sequence[Tuple[int, int, Union[int, bytes]]]
 
 
 def is_connection_dropped(conn: socket.socket) -> bool:  # Platform-specific

--- a/test/with_dummyserver/test_connectionpool.py
+++ b/test/with_dummyserver/test_connectionpool.py
@@ -294,14 +294,21 @@ class TestConnectionPool(HTTPDummyServerTestCase):
             finally:
                 conn.close()
 
-    def test_socket_options(self):
+    @pytest.mark.parametrize(
+        "socket_options",
+        [
+            [(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)],
+            ((socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1),),
+        ],
+    )
+    def test_socket_options(self, socket_options):
         """Test that connections accept socket options."""
         # This test needs to be here in order to be run. socket.create_connection actually tries to
         # connect to the host provided so we need a dummyserver to be running.
         with HTTPConnectionPool(
             self.host,
             self.port,
-            socket_options=[(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)],
+            socket_options=socket_options,
         ) as pool:
             s = pool._new_conn()._new_conn()  # Get the socket
             try:


### PR DESCRIPTION
This is a draft PR to add type hint for `urllib3.poolmanager`. There are some mypy errors that we can ignore.
Here is the list of errors:

```
src/urllib3/poolmanager.py:9: error: Module 'urllib3.connectionpool' does not explicitly export attribute 'port_by_scheme'; implicit reexport disabled
src/urllib3/poolmanager.py:73: error: List or tuple literal expected as the second argument to namedtuple()
src/urllib3/poolmanager.py:125: error: Returning Any from function declared to return "PoolKey"
src/urllib3/poolmanager.py:125: error: "PoolKey" not callable
src/urllib3/poolmanager.py:305: error: No overload variant of "get" of "Mapping" matches argument type "PoolKey"
src/urllib3/poolmanager.py:305: note: Possible overload variant:
src/urllib3/poolmanager.py:305: note:     def get(self, key: int) -> Optional[Callable[[_VT], None]]
src/urllib3/poolmanager.py:305: note:     <1 more non-matching overload not shown>
src/urllib3/poolmanager.py:307: error: Returning Any from function declared to return "Union[HTTPConnectionPool, HTTPSConnectionPool]"
src/urllib3/poolmanager.py:310: error: Value of type "Optional[Dict[str, Any]]" is not indexable
src/urllib3/poolmanager.py:311: error: Value of type "Optional[Dict[str, Any]]" is not indexable
src/urllib3/poolmanager.py:312: error: Value of type "Optional[Dict[str, Any]]" is not indexable
src/urllib3/poolmanager.py:314: error: Invalid index type "PoolKey" for "RecentlyUsedContainer[int, Optional[Callable[[_VT], None]]]"; expected type "int"
src/urllib3/poolmanager.py:316: error: Returning Any from function declared to return "Union[HTTPConnectionPool, HTTPSConnectionPool]"
src/urllib3/poolmanager.py:369: error: Signature of "urlopen" incompatible with supertype "RequestMethods"
src/urllib3/poolmanager.py:388: error: "Mapping[str, str]" has no attribute "copy"
src/urllib3/poolmanager.py:400: error: Value of type variable "AnyStr" of "urljoin" cannot be "object"
src/urllib3/poolmanager.py:422: error: Argument "response" to "increment" of "Retry" has incompatible type "BaseHTTPResponse"; expected "Optional[HTTPResponse]"
src/urllib3/poolmanager.py:487: error: Function is missing a type annotation for one or more arguments
src/urllib3/poolmanager.py:509: error: Incompatible types in assignment (expression has type "Url", variable has type "None")
src/urllib3/poolmanager.py:512: error: Incompatible types in assignment (expression has type "ProxyConfig", variable has type "None")
src/urllib3/poolmanager.py:533: error: "None" has no attribute "host"
src/urllib3/poolmanager.py:533: error: "None" has no attribute "port"
src/urllib3/poolmanager.py:533: error: "None" has no attribute "scheme"
src/urllib3/poolmanager.py:553: error: Signature of "urlopen" incompatible with supertype "RequestMethods"
```