### PR TITLE
Add coverage for all raise branches

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -21,6 +21,7 @@ exclude_lines =
     except ImportError:
     pass
     import
+    raise NotImplementedError
     .* # Platform-specific.*
     .*:.* # Python \d.*
     .* # Abstract

--- a/.coveragerc
+++ b/.coveragerc
@@ -21,7 +21,6 @@ exclude_lines =
     except ImportError:
     pass
     import
-    raise
     .* # Platform-specific.*
     .*:.* # Python \d.*
     .* # Abstract

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -315,5 +315,8 @@ In chronological order:
 * Ubdussamad <ubdussamad@gmail.com>
   * Added HTTPHeaderDict to top level objects and added relevant usage documentation for the same.
 
+* Bastian Venthur <https://venthur.de>
+  * fixed all remaining coverage checks for raise statements
+
 * [Your name or handle] <[email or website]>
   * [Brief summary of your changes]

--- a/src/urllib3/util/timeout.py
+++ b/src/urllib3/util/timeout.py
@@ -146,11 +146,18 @@ class Timeout:
                 "int, float or None." % (name, value)
             )
 
-        if value <= 0:  # type: ignore
+        try:
+            if value <= 0:  # type: ignore
+                raise ValueError(
+                    "Attempted to set %s timeout to %s, but the "
+                    "timeout cannot be set to a value less "
+                    "than or equal to 0." % (name, value)
+                )
+        except TypeError:
+            # Python 3
             raise ValueError(
-                "Attempted to set %s timeout to %s, but the "
-                "timeout cannot be set to a value less "
-                "than or equal to 0." % (name, value)
+                "Timeout value %s was %s, but it must be an "
+                "int, float or None." % (name, value)
             )
 
         return value

--- a/src/urllib3/util/timeout.py
+++ b/src/urllib3/util/timeout.py
@@ -146,18 +146,11 @@ class Timeout:
                 "int, float or None." % (name, value)
             )
 
-        try:
-            if value <= 0:  # type: ignore
-                raise ValueError(
-                    "Attempted to set %s timeout to %s, but the "
-                    "timeout cannot be set to a value less "
-                    "than or equal to 0." % (name, value)
-                )
-        except TypeError:
-            # Python 3
+        if value <= 0:  # type: ignore
             raise ValueError(
-                "Timeout value %s was %s, but it must be an "
-                "int, float or None." % (name, value)
+                "Attempted to set %s timeout to %s, but the "
+                "timeout cannot be set to a value less "
+                "than or equal to 0." % (name, value)
             )
 
         return value

--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -86,11 +86,11 @@ class TestConnection:
     def test_match_hostname_more_than_one_dnsname_error(self):
         cert = {"subjectAltName": [("DNS", "foo*"), ("DNS", "fo*")]}
         asserted_hostname = "bar"
-        with pytest.raises(CertificateError):
+        with pytest.raises(CertificateError, match="doesn't match either of"):
             _match_hostname(cert, asserted_hostname)
 
     def test_dnsname_match_include_more_than_one_wildcard_error(self):
-        with pytest.raises(CertificateError):
+        with pytest.raises(CertificateError, match="too many wildcards in certificate"):
             _dnsname_match("foo**", "foobar")
 
     def test_match_hostname_ignore_common_name(self):

--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -13,7 +13,7 @@ from urllib3.connection import (
 from urllib3.util.ssl_match_hostname import (
     CertificateError as ImplementationCertificateError,
 )
-from urllib3.util.ssl_match_hostname import match_hostname
+from urllib3.util.ssl_match_hostname import _dnsname_match, match_hostname
 
 
 class TestConnection:
@@ -82,6 +82,16 @@ class TestConnection:
         cert = {"subjectAltName": [("DNS", "foo*")]}
         asserted_hostname = "foobar"
         _match_hostname(cert, asserted_hostname)
+
+    def test_match_hostname_more_than_one_dnsname_error(self):
+        cert = {"subjectAltName": [("DNS", "foo*"), ("DNS", "fo*")]}
+        asserted_hostname = "bar"
+        with pytest.raises(CertificateError):
+            _match_hostname(cert, asserted_hostname)
+
+    def test_dnsname_match_include_more_than_one_wildcard_error(self):
+        with pytest.raises(CertificateError):
+            _dnsname_match("foo**", "foobar")
 
     def test_match_hostname_ignore_common_name(self):
         cert = {"subject": [("commonName", "foo")]}

--- a/test/test_connectionpool.py
+++ b/test/test_connectionpool.py
@@ -1,4 +1,3 @@
-import errno
 import http.client as httplib
 import ssl
 from http.client import HTTPException
@@ -534,13 +533,6 @@ class TestConnectionPool:
         _test(HTTPException)
         _test(SocketError)
         _test(ProtocolError)
-
-    def test_raise_timeout_error(self):
-        with HTTPConnectionPool(host="localhost") as pool:
-            err = Mock()
-            err.errno = errno.EAGAIN
-            with pytest.raises(ReadTimeoutError):
-                pool._raise_timeout(err, "", 0)
 
     def test_make_request_error(self):
         with HTTPConnectionPool(host="localhost", maxsize=1) as pool:

--- a/test/test_connectionpool.py
+++ b/test/test_connectionpool.py
@@ -534,7 +534,7 @@ class TestConnectionPool:
         _test(SocketError)
         _test(ProtocolError)
 
-    def test_make_request_error(self):
+    def test_read_timeout_0_does_not_raise_bad_status_line_error(self):
         with HTTPConnectionPool(host="localhost", maxsize=1) as pool:
             conn = Mock()
             with patch.object(Timeout, "read_timeout", 0):

--- a/test/test_response.py
+++ b/test/test_response.py
@@ -21,7 +21,7 @@ from urllib3.exceptions import (
     SSLError,
     httplib_IncompleteRead,
 )
-from urllib3.response import BaseHTTPResponse, ContentDecoder, HTTPResponse, brotli
+from urllib3.response import HTTPResponse, brotli
 from urllib3.util.response import is_fp_closed
 from urllib3.util.retry import RequestHistory, Retry
 
@@ -48,18 +48,6 @@ def sock():
     s = socket.socket()
     yield s
     s.close()
-
-
-class TestContentDecoder:
-    decoder = ContentDecoder()
-
-    def test_decompress_error(self):
-        with pytest.raises(NotImplementedError):
-            self.decoder.decompress(None)
-
-    def test_flush_error(self):
-        with pytest.raises(NotImplementedError):
-            self.decoder.flush()
 
 
 class TestLegacyResponse:
@@ -972,60 +960,6 @@ class TestResponse:
             with pytest.raises(SSLError) as e:
                 resp.read()
             assert e.value.args[0] == mac_error
-
-
-class TestBaseHTTPResponse:
-
-    # test a bunch of NotImplementedErrors
-    def test_data_not_implemented_error(self):
-        r = BaseHTTPResponse(status=0, version=0, reason="foo", decode_content=False)
-        with pytest.raises(NotImplementedError):
-            r.data
-
-    def test_url_not_implemented_error(self):
-        r = BaseHTTPResponse(status=0, version=0, reason="foo", decode_content=False)
-        with pytest.raises(NotImplementedError):
-            r.url
-
-    def test_closed_not_implemented_error(self):
-        r = BaseHTTPResponse(status=0, version=0, reason="foo", decode_content=False)
-        with pytest.raises(NotImplementedError):
-            r.closed
-
-    def test_connection_not_implemented_error(self):
-        r = BaseHTTPResponse(status=0, version=0, reason="foo", decode_content=False)
-        with pytest.raises(NotImplementedError):
-            r.connection
-
-    def test_stream_not_implemented_error(self):
-        r = BaseHTTPResponse(status=0, version=0, reason="foo", decode_content=False)
-        with pytest.raises(NotImplementedError):
-            r.stream()
-
-    def test_read_not_implemented_error(self):
-        r = BaseHTTPResponse(status=0, version=0, reason="foo", decode_content=False)
-        with pytest.raises(NotImplementedError):
-            r.read()
-
-    def test_read_chunked_not_implemented_error(self):
-        r = BaseHTTPResponse(status=0, version=0, reason="foo", decode_content=False)
-        with pytest.raises(NotImplementedError):
-            r.read_chunked()
-
-    def test_release_conn_chunked_not_implemented_error(self):
-        r = BaseHTTPResponse(status=0, version=0, reason="foo", decode_content=False)
-        with pytest.raises(NotImplementedError):
-            r.release_conn()
-
-    def test_drain_conn_chunked_not_implemented_error(self):
-        r = BaseHTTPResponse(status=0, version=0, reason="foo", decode_content=False)
-        with pytest.raises(NotImplementedError):
-            r.drain_conn()
-
-    def test_close_chunked_not_implemented_error(self):
-        r = BaseHTTPResponse(status=0, version=0, reason="foo", decode_content=False)
-        with pytest.raises(NotImplementedError):
-            r.close()
 
 
 class MockChunkedEncodingResponse:

--- a/test/test_response.py
+++ b/test/test_response.py
@@ -21,7 +21,7 @@ from urllib3.exceptions import (
     SSLError,
     httplib_IncompleteRead,
 )
-from urllib3.response import HTTPResponse, brotli, ContentDecoder, BaseHTTPResponse
+from urllib3.response import BaseHTTPResponse, ContentDecoder, HTTPResponse, brotli
 from urllib3.util.response import is_fp_closed
 from urllib3.util.retry import RequestHistory, Retry
 
@@ -766,7 +766,9 @@ class TestResponse:
         resp = HTTPResponse(
             r, preload_content=False, headers={"transfer-encoding": "chunked"}
         )
-        with mock.patch.object(HTTPResponse, "supports_chunked_reads") as supports_chunked_reads:
+        with mock.patch.object(
+            HTTPResponse, "supports_chunked_reads"
+        ) as supports_chunked_reads:
             supports_chunked_reads.return_value = False
             r = resp.read_chunked()
             with pytest.raises(BodyNotHttplibCompatible):

--- a/test/test_response.py
+++ b/test/test_response.py
@@ -21,7 +21,7 @@ from urllib3.exceptions import (
     SSLError,
     httplib_IncompleteRead,
 )
-from urllib3.response import HTTPResponse, brotli, ContentDecoder
+from urllib3.response import HTTPResponse, brotli, ContentDecoder, BaseHTTPResponse
 from urllib3.util.response import is_fp_closed
 from urllib3.util.retry import RequestHistory, Retry
 
@@ -970,6 +970,60 @@ class TestResponse:
             with pytest.raises(SSLError) as e:
                 resp.read()
             assert e.value.args[0] == mac_error
+
+
+class TestBaseHTTPResponse:
+
+    # test a bunch of NotImplementedErrors
+    def test_data_not_implemented_error(self):
+        r = BaseHTTPResponse(status=0, version=0, reason="foo", decode_content=False)
+        with pytest.raises(NotImplementedError):
+            r.data
+
+    def test_url_not_implemented_error(self):
+        r = BaseHTTPResponse(status=0, version=0, reason="foo", decode_content=False)
+        with pytest.raises(NotImplementedError):
+            r.url
+
+    def test_closed_not_implemented_error(self):
+        r = BaseHTTPResponse(status=0, version=0, reason="foo", decode_content=False)
+        with pytest.raises(NotImplementedError):
+            r.closed
+
+    def test_connection_not_implemented_error(self):
+        r = BaseHTTPResponse(status=0, version=0, reason="foo", decode_content=False)
+        with pytest.raises(NotImplementedError):
+            r.connection
+
+    def test_stream_not_implemented_error(self):
+        r = BaseHTTPResponse(status=0, version=0, reason="foo", decode_content=False)
+        with pytest.raises(NotImplementedError):
+            r.stream()
+
+    def test_read_not_implemented_error(self):
+        r = BaseHTTPResponse(status=0, version=0, reason="foo", decode_content=False)
+        with pytest.raises(NotImplementedError):
+            r.read()
+
+    def test_read_chunked_not_implemented_error(self):
+        r = BaseHTTPResponse(status=0, version=0, reason="foo", decode_content=False)
+        with pytest.raises(NotImplementedError):
+            r.read_chunked()
+
+    def test_release_conn_chunked_not_implemented_error(self):
+        r = BaseHTTPResponse(status=0, version=0, reason="foo", decode_content=False)
+        with pytest.raises(NotImplementedError):
+            r.release_conn()
+
+    def test_drain_conn_chunked_not_implemented_error(self):
+        r = BaseHTTPResponse(status=0, version=0, reason="foo", decode_content=False)
+        with pytest.raises(NotImplementedError):
+            r.drain_conn()
+
+    def test_close_chunked_not_implemented_error(self):
+        r = BaseHTTPResponse(status=0, version=0, reason="foo", decode_content=False)
+        with pytest.raises(NotImplementedError):
+            r.close()
 
 
 class MockChunkedEncodingResponse:

--- a/test/test_response.py
+++ b/test/test_response.py
@@ -20,7 +20,7 @@ from urllib3.exceptions import (
     SSLError,
     httplib_IncompleteRead,
 )
-from urllib3.response import HTTPResponse, brotli
+from urllib3.response import HTTPResponse, brotli, ContentDecoder
 from urllib3.util.response import is_fp_closed
 from urllib3.util.retry import RequestHistory, Retry
 
@@ -47,6 +47,18 @@ def sock():
     s = socket.socket()
     yield s
     s.close()
+
+
+class TestContentDecoder:
+    decoder = ContentDecoder()
+
+    def test_decompress_error(self):
+        with pytest.raises(NotImplementedError):
+            self.decoder.decompress(None)
+
+    def test_flush_error(self):
+        with pytest.raises(NotImplementedError):
+            self.decoder.flush()
 
 
 class TestLegacyResponse:

--- a/test/test_response.py
+++ b/test/test_response.py
@@ -747,20 +747,13 @@ class TestResponse:
             next(r)
 
     def test_read_chunked_not_supported(self):
-        stream = [b"fo", b"o", b"bar"]
-        fp = MockChunkedEncodingResponse(stream)
-        r = httplib.HTTPResponse(MockSock)
-        r.fp = fp
+        fp = BytesIO(b"foo")
         resp = HTTPResponse(
-            r, preload_content=False, headers={"transfer-encoding": "chunked"}
+            fp, preload_content=False, headers={"transfer-encoding": "chunked"}
         )
-        with mock.patch.object(
-            HTTPResponse, "supports_chunked_reads"
-        ) as supports_chunked_reads:
-            supports_chunked_reads.return_value = False
-            r = resp.read_chunked()
-            with pytest.raises(BodyNotHttplibCompatible):
-                next(r)
+        r = resp.read_chunked()
+        with pytest.raises(BodyNotHttplibCompatible):
+            next(r)
 
     def test_buggy_incomplete_read(self):
         # Simulate buggy versions of Python (<2.7.4)

--- a/test/test_ssl.py
+++ b/test/test_ssl.py
@@ -2,7 +2,7 @@ from unittest import mock
 
 import pytest
 
-from urllib3.exceptions import SNIMissingWarning, SSLError, ProxySchemeUnsupported
+from urllib3.exceptions import ProxySchemeUnsupported, SNIMissingWarning, SSLError
 from urllib3.util import ssl_
 
 

--- a/test/test_ssl.py
+++ b/test/test_ssl.py
@@ -2,7 +2,7 @@ from unittest import mock
 
 import pytest
 
-from urllib3.exceptions import SNIMissingWarning, SSLError
+from urllib3.exceptions import SNIMissingWarning, SSLError, ProxySchemeUnsupported
 from urllib3.util import ssl_
 
 
@@ -95,6 +95,11 @@ class TestSSL:
             assert context.set_ciphers.call_count == 1
             assert context.set_ciphers.call_args == mock.call(expected_ciphers)
 
+    def test_create_urllib3_no_context(self):
+        with mock.patch("urllib3.util.ssl_.SSLContext", None):
+            with pytest.raises(TypeError):
+                ssl_.create_urllib3_context()
+
     def test_wrap_socket_given_context_no_load_default_certs(self):
         context = mock.create_autospec(ssl_.SSLContext)
         context.load_default_certs = mock.Mock()
@@ -128,6 +133,12 @@ class TestSSL:
         ssl_.ssl_wrap_socket(sock)
 
         context.load_default_certs.assert_called_with()
+
+    def test_wrap_socket_no_ssltransport(self):
+        with mock.patch("urllib3.util.ssl_.SSLTransport", None):
+            with pytest.raises(ProxySchemeUnsupported):
+                sock = mock.Mock()
+                ssl_.ssl_wrap_socket(sock, tls_in_tls=True)
 
     @pytest.mark.parametrize(
         ["pha", "expected_pha"], [(None, None), (False, True), (True, True)]

--- a/test/test_ssltransport.py
+++ b/test/test_ssltransport.py
@@ -504,7 +504,7 @@ class TestSSLTransportWithMock:
         )
         assert not ssl_transport.suppress_ragged_eofs
 
-    def test_recv_no_flags_error(self):
+    def test_various_flags_errors(self):
         server_hostname = "example-domain.com"
         sock = mock.Mock()
         context = mock.create_autospec(ssl_.SSLContext)
@@ -514,33 +514,12 @@ class TestSSLTransportWithMock:
         with pytest.raises(ValueError):
             ssl_transport.recv(flags=1)
 
-    def test_recv_into_no_flags_error(self):
-        server_hostname = "example-domain.com"
-        sock = mock.Mock()
-        context = mock.create_autospec(ssl_.SSLContext)
-        ssl_transport = SSLTransport(
-            sock, context, server_hostname=server_hostname, suppress_ragged_eofs=False
-        )
         with pytest.raises(ValueError):
             ssl_transport.recv_into(None, flags=1)
 
-    def test_sendall_no_flags_error(self):
-        server_hostname = "example-domain.com"
-        sock = mock.Mock()
-        context = mock.create_autospec(ssl_.SSLContext)
-        ssl_transport = SSLTransport(
-            sock, context, server_hostname=server_hostname, suppress_ragged_eofs=False
-        )
         with pytest.raises(ValueError):
             ssl_transport.sendall(None, flags=1)
 
-    def test_send_no_flags_error(self):
-        server_hostname = "example-domain.com"
-        sock = mock.Mock()
-        context = mock.create_autospec(ssl_.SSLContext)
-        ssl_transport = SSLTransport(
-            sock, context, server_hostname=server_hostname, suppress_ragged_eofs=False
-        )
         with pytest.raises(ValueError):
             ssl_transport.send(None, flags=1)
 

--- a/test/test_ssltransport.py
+++ b/test/test_ssltransport.py
@@ -553,3 +553,15 @@ class TestSSLTransportWithMock:
         )
         with pytest.raises(ValueError):
             ssl_transport.makefile(mode="x")
+
+    def test_wrap_ssl_read_error(self):
+        server_hostname = "example-domain.com"
+        sock = mock.Mock()
+        context = mock.create_autospec(ssl_.SSLContext)
+        ssl_transport = SSLTransport(
+            sock, context, server_hostname=server_hostname, suppress_ragged_eofs=False
+        )
+        with mock.patch.object(ssl_transport, "_ssl_io_loop") as _ssl_io_loop:
+            _ssl_io_loop.side_effect = ssl.SSLError()
+            with pytest.raises(ssl.SSLError):
+                ssl_transport._wrap_ssl_read(1)

--- a/test/test_ssltransport.py
+++ b/test/test_ssltransport.py
@@ -503,3 +503,53 @@ class TestSSLTransportWithMock:
             mock.ANY, mock.ANY, server_hostname=server_hostname
         )
         assert not ssl_transport.suppress_ragged_eofs
+
+    def test_recv_no_flags_error(self):
+        server_hostname = "example-domain.com"
+        sock = mock.Mock()
+        context = mock.create_autospec(ssl_.SSLContext)
+        ssl_transport = SSLTransport(
+            sock, context, server_hostname=server_hostname, suppress_ragged_eofs=False
+        )
+        with pytest.raises(ValueError):
+            ssl_transport.recv(flags=1)
+
+    def test_recv_into_no_flags_error(self):
+        server_hostname = "example-domain.com"
+        sock = mock.Mock()
+        context = mock.create_autospec(ssl_.SSLContext)
+        ssl_transport = SSLTransport(
+            sock, context, server_hostname=server_hostname, suppress_ragged_eofs=False
+        )
+        with pytest.raises(ValueError):
+            ssl_transport.recv_into(None, flags=1)
+
+    def test_sendall_no_flags_error(self):
+        server_hostname = "example-domain.com"
+        sock = mock.Mock()
+        context = mock.create_autospec(ssl_.SSLContext)
+        ssl_transport = SSLTransport(
+            sock, context, server_hostname=server_hostname, suppress_ragged_eofs=False
+        )
+        with pytest.raises(ValueError):
+            ssl_transport.sendall(None, flags=1)
+
+    def test_send_no_flags_error(self):
+        server_hostname = "example-domain.com"
+        sock = mock.Mock()
+        context = mock.create_autospec(ssl_.SSLContext)
+        ssl_transport = SSLTransport(
+            sock, context, server_hostname=server_hostname, suppress_ragged_eofs=False
+        )
+        with pytest.raises(ValueError):
+            ssl_transport.send(None, flags=1)
+
+    def test_makefile_wrong_mode_error(self):
+        server_hostname = "example-domain.com"
+        sock = mock.Mock()
+        context = mock.create_autospec(ssl_.SSLContext)
+        ssl_transport = SSLTransport(
+            sock, context, server_hostname=server_hostname, suppress_ragged_eofs=False
+        )
+        with pytest.raises(ValueError):
+            ssl_transport.makefile(mode="x")

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -145,6 +145,7 @@ class TestUtil:
             "http://::1/",
             "http://::1:80/",
             "http://google.com:-80",
+            "http://google.com:65536",
             "http://google.com:\xb2\xb2",  # \xb2 = ^2
             # Invalid IDNA labels
             "http://\uD7FF.com",

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -744,6 +744,12 @@ class TestUtil:
         socket.return_value = Mock()
         create_connection((host, 80))
 
+    @patch("socket.getaddrinfo")
+    def test_create_connection_error(self, getaddrinfo):
+        getaddrinfo.return_value = []
+        with pytest.raises(OSError, match="getaddrinfo returns an empty list"):
+            create_connection(("example.com", 80))
+
     @pytest.mark.parametrize(
         "input,params,expected",
         (

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -547,6 +547,7 @@ class TestUtil:
             ({"read": True}, "cannot be a boolean"),
             ({"connect": 0}, "less than or equal"),
             ({"read": "foo"}, "int, float or None"),
+            ({"read": "1.0"}, "int, float or None"),
         ],
     )
     def test_invalid_timeouts(self, kwargs, message):

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -491,10 +491,11 @@ class TestSocketClosing(SocketDummyServerTestCase):
                 timed_out.set()
 
         # second ReadTimeoutError due to errno
-        err = mock.Mock()
-        err.errno = errno.EAGAIN
-        with pytest.raises(ReadTimeoutError):
-            pool._raise_timeout(err, "", 0)
+        with HTTPSConnectionPool(host=self.host):
+            err = mock.Mock()
+            err.errno = errno.EAGAIN
+            with pytest.raises(ReadTimeoutError):
+                pool._raise_timeout(err, "", 0)
 
     def test_timeout_errors_cause_retries(self):
         def socket_handler(listener):


### PR DESCRIPTION
This PR tackles all of the missing `raise` statements missing from coverage.

Since I'm not super familiar with urllibs internals, you might find stuff you're not very happy with.

I also removed the `exclude_lines = raise` from `.coveragerc`, since the coverage should now be on par with the `main` branch.

Fixes: #1214

<!---
Thanks for your contribution! ♥️

If this is your first PR to urllib3 please review the Contributing Guide:
https://urllib3.readthedocs.io/en/latest/contributing.html

Adhering to the Contributing Guide means we can review, merge, and release your change faster! :)
--->
