### PR TITLE
Add support for Python 3.10 to 1.26.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,10 @@ jobs:
         include:
           - python-version: 3.9-dev
             os: macos-latest
-            experimental: true
+            experimental: false
+          - python-version: 3.10-dev
+            os: ubuntu-latest
+            experimental: false
 
     runs-on: ${{ matrix.os }}
     name: ${{ fromJson('{"macos-latest":"macOS","windows-latest":"Windows"}')[matrix.os] }} (${{ matrix.python-version }})

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,7 +5,8 @@ tornado==6.0.3;python_version>="3.5"
 PySocks==1.7.1
 # https://github.com/Anorov/PySocks/issues/131
 win-inet-pton==1.1.0
-pytest==4.6.9
+pytest==4.6.9; python_version<"3.10"
+pytest==6.2.4; python_version>="3.10"
 pytest-timeout==1.3.4
 pytest-freezegun==0.4.2
 flaky==3.6.1

--- a/dummyserver/handlers.py
+++ b/dummyserver/handlers.py
@@ -62,27 +62,27 @@ class TestingApp(RequestHandler):
     """
 
     def get(self):
-        """ Handle GET requests """
+        """Handle GET requests"""
         self._call_method()
 
     def post(self):
-        """ Handle POST requests """
+        """Handle POST requests"""
         self._call_method()
 
     def put(self):
-        """ Handle PUT requests """
+        """Handle PUT requests"""
         self._call_method()
 
     def options(self):
-        """ Handle OPTIONS requests """
+        """Handle OPTIONS requests"""
         self._call_method()
 
     def head(self):
-        """ Handle HEAD requests """
+        """Handle HEAD requests"""
         self._call_method()
 
     def _call_method(self):
-        """ Call the correct method in this class based on the incoming URI """
+        """Call the correct method in this class based on the incoming URI"""
         req = self.request
         req.params = {}
         for k, v in req.arguments.items():

--- a/dummyserver/server.py
+++ b/dummyserver/server.py
@@ -40,7 +40,7 @@ DEFAULT_CA_KEY = os.path.join(CERTS_PATH, "cacert.key")
 
 
 def _resolves_to_ipv6(host):
-    """ Returns True if the system resolves host to an IPv6 address by default. """
+    """Returns True if the system resolves host to an IPv6 address by default."""
     resolves_to_ipv6 = False
     try:
         for res in socket.getaddrinfo(host, None, socket.AF_UNSPEC):
@@ -54,7 +54,7 @@ def _resolves_to_ipv6(host):
 
 
 def _has_ipv6(host):
-    """ Returns True if the system can bind an IPv6 address. """
+    """Returns True if the system can bind an IPv6 address."""
     sock = None
     has_ipv6 = False
 

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -201,7 +201,7 @@ class HTTPConnection(_HTTPConnection, object):
         self._prepare_conn(conn)
 
     def putrequest(self, method, url, *args, **kwargs):
-        """"""
+        """ """
         # Empty docstring because the indentation of CPython's implementation
         # is broken but we don't want this method in our documentation.
         match = _CONTAINS_CONTROL_CHAR_RE.search(method)
@@ -214,7 +214,7 @@ class HTTPConnection(_HTTPConnection, object):
         return _HTTPConnection.putrequest(self, method, url, *args, **kwargs)
 
     def putheader(self, header, *values):
-        """"""
+        """ """
         if not any(isinstance(v, str) and v == SKIP_HEADER for v in values):
             _HTTPConnection.putheader(self, header, *values)
         elif six.ensure_str(header.lower()) not in SKIPPABLE_HEADERS:

--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -318,7 +318,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         pass
 
     def _get_timeout(self, timeout):
-        """ Helper that always returns a :class:`urllib3.util.Timeout` """
+        """Helper that always returns a :class:`urllib3.util.Timeout`"""
         if timeout is _Default:
             return self.timeout.clone()
 

--- a/src/urllib3/contrib/pyopenssl.py
+++ b/src/urllib3/contrib/pyopenssl.py
@@ -76,6 +76,7 @@ import sys
 
 from .. import util
 from ..packages import six
+from ..util.ssl_ import PROTOCOL_TLS_CLIENT
 
 __all__ = ["inject_into_urllib3", "extract_from_urllib3"]
 
@@ -85,6 +86,7 @@ HAS_SNI = True
 # Map from urllib3 to PyOpenSSL compatible parameter-values.
 _openssl_versions = {
     util.PROTOCOL_TLS: OpenSSL.SSL.SSLv23_METHOD,
+    PROTOCOL_TLS_CLIENT: OpenSSL.SSL.SSLv23_METHOD,
     ssl.PROTOCOL_TLSv1: OpenSSL.SSL.TLSv1_METHOD,
 }
 

--- a/src/urllib3/contrib/securetransport.py
+++ b/src/urllib3/contrib/securetransport.py
@@ -67,6 +67,7 @@ import weakref
 import six
 
 from .. import util
+from ..util.ssl_ import PROTOCOL_TLS_CLIENT
 from ._securetransport.bindings import CoreFoundation, Security, SecurityConst
 from ._securetransport.low_level import (
     _assert_no_error,
@@ -154,7 +155,8 @@ CIPHER_SUITES = [
 # TLSv1 and a high of TLSv1.2. For everything else, we pin to that version.
 # TLSv1 to 1.2 are supported on macOS 10.8+
 _protocol_to_min_max = {
-    util.PROTOCOL_TLS: (SecurityConst.kTLSProtocol1, SecurityConst.kTLSProtocol12)
+    util.PROTOCOL_TLS: (SecurityConst.kTLSProtocol1, SecurityConst.kTLSProtocol12),
+    PROTOCOL_TLS_CLIENT: (SecurityConst.kTLSProtocol1, SecurityConst.kTLSProtocol12),
 }
 
 if hasattr(ssl, "PROTOCOL_SSLv2"):

--- a/src/urllib3/packages/six.py
+++ b/src/urllib3/packages/six.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2019 Benjamin Peterson
+# Copyright (c) 2010-2020 Benjamin Peterson
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -29,7 +29,7 @@ import sys
 import types
 
 __author__ = "Benjamin Peterson <benjamin@python.org>"
-__version__ = "1.12.0"
+__version__ = "1.16.0"
 
 
 # Useful for very coarse version differentiation.
@@ -70,6 +70,11 @@ else:
             # 64-bit
             MAXSIZE = int((1 << 63) - 1)
         del X
+
+if PY34:
+    from importlib.util import spec_from_loader
+else:
+    spec_from_loader = None
 
 
 def _add_doc(func, doc):
@@ -182,6 +187,11 @@ class _SixMetaPathImporter(object):
             return self
         return None
 
+    def find_spec(self, fullname, path, target=None):
+        if fullname in self.known_modules:
+            return spec_from_loader(fullname, self)
+        return None
+
     def __get_module(self, fullname):
         try:
             return self.known_modules[fullname]
@@ -219,6 +229,12 @@ class _SixMetaPathImporter(object):
         return None
 
     get_source = get_code  # same as get_code
+
+    def create_module(self, spec):
+        return self.load_module(spec.name)
+
+    def exec_module(self, module):
+        pass
 
 
 _importer = _SixMetaPathImporter(__name__)
@@ -260,9 +276,19 @@ _moved_attributes = [
     ),
     MovedModule("builtins", "__builtin__"),
     MovedModule("configparser", "ConfigParser"),
+    MovedModule(
+        "collections_abc",
+        "collections",
+        "collections.abc" if sys.version_info >= (3, 3) else "collections",
+    ),
     MovedModule("copyreg", "copy_reg"),
     MovedModule("dbm_gnu", "gdbm", "dbm.gnu"),
-    MovedModule("_dummy_thread", "dummy_thread", "_dummy_thread"),
+    MovedModule("dbm_ndbm", "dbm", "dbm.ndbm"),
+    MovedModule(
+        "_dummy_thread",
+        "dummy_thread",
+        "_dummy_thread" if sys.version_info < (3, 9) else "_thread",
+    ),
     MovedModule("http_cookiejar", "cookielib", "http.cookiejar"),
     MovedModule("http_cookies", "Cookie", "http.cookies"),
     MovedModule("html_entities", "htmlentitydefs", "html.entities"),
@@ -307,7 +333,9 @@ _moved_attributes = [
 ]
 # Add windows specific modules.
 if sys.platform == "win32":
-    _moved_attributes += [MovedModule("winreg", "_winreg")]
+    _moved_attributes += [
+        MovedModule("winreg", "_winreg"),
+    ]
 
 for attr in _moved_attributes:
     setattr(_MovedItems, attr.name, attr)
@@ -476,7 +504,7 @@ class Module_six_moves_urllib_robotparser(_LazyModule):
 
 
 _urllib_robotparser_moved_attributes = [
-    MovedAttribute("RobotFileParser", "robotparser", "urllib.robotparser")
+    MovedAttribute("RobotFileParser", "robotparser", "urllib.robotparser"),
 ]
 for attr in _urllib_robotparser_moved_attributes:
     setattr(Module_six_moves_urllib_robotparser, attr.name, attr)
@@ -678,9 +706,11 @@ if PY3:
     if sys.version_info[1] <= 1:
         _assertRaisesRegex = "assertRaisesRegexp"
         _assertRegex = "assertRegexpMatches"
+        _assertNotRegex = "assertNotRegexpMatches"
     else:
         _assertRaisesRegex = "assertRaisesRegex"
         _assertRegex = "assertRegex"
+        _assertNotRegex = "assertNotRegex"
 else:
 
     def b(s):
@@ -707,6 +737,7 @@ else:
     _assertCountEqual = "assertItemsEqual"
     _assertRaisesRegex = "assertRaisesRegexp"
     _assertRegex = "assertRegexpMatches"
+    _assertNotRegex = "assertNotRegexpMatches"
 _add_doc(b, """Byte literal""")
 _add_doc(u, """Text literal""")
 
@@ -721,6 +752,10 @@ def assertRaisesRegex(self, *args, **kwargs):
 
 def assertRegex(self, *args, **kwargs):
     return getattr(self, _assertRegex)(*args, **kwargs)
+
+
+def assertNotRegex(self, *args, **kwargs):
+    return getattr(self, _assertNotRegex)(*args, **kwargs)
 
 
 if PY3:
@@ -762,18 +797,7 @@ else:
     )
 
 
-if sys.version_info[:2] == (3, 2):
-    exec_(
-        """def raise_from(value, from_value):
-    try:
-        if from_value is None:
-            raise value
-        raise value from from_value
-    finally:
-        value = None
-"""
-    )
-elif sys.version_info[:2] > (3, 2):
+if sys.version_info[:2] > (3,):
     exec_(
         """def raise_from(value, from_value):
     try:
@@ -863,19 +887,41 @@ if sys.version_info[:2] < (3, 3):
 _add_doc(reraise, """Reraise an exception.""")
 
 if sys.version_info[0:2] < (3, 4):
+    # This does exactly the same what the :func:`py3:functools.update_wrapper`
+    # function does on Python versions after 3.2. It sets the ``__wrapped__``
+    # attribute on ``wrapper`` object and it doesn't raise an error if any of
+    # the attributes mentioned in ``assigned`` and ``updated`` are missing on
+    # ``wrapped`` object.
+    def _update_wrapper(
+        wrapper,
+        wrapped,
+        assigned=functools.WRAPPER_ASSIGNMENTS,
+        updated=functools.WRAPPER_UPDATES,
+    ):
+        for attr in assigned:
+            try:
+                value = getattr(wrapped, attr)
+            except AttributeError:
+                continue
+            else:
+                setattr(wrapper, attr, value)
+        for attr in updated:
+            getattr(wrapper, attr).update(getattr(wrapped, attr, {}))
+        wrapper.__wrapped__ = wrapped
+        return wrapper
+
+    _update_wrapper.__doc__ = functools.update_wrapper.__doc__
 
     def wraps(
         wrapped,
         assigned=functools.WRAPPER_ASSIGNMENTS,
         updated=functools.WRAPPER_UPDATES,
     ):
-        def wrapper(f):
-            f = functools.wraps(wrapped, assigned, updated)(f)
-            f.__wrapped__ = wrapped
-            return f
+        return functools.partial(
+            _update_wrapper, wrapped=wrapped, assigned=assigned, updated=updated
+        )
 
-        return wrapper
-
+    wraps.__doc__ = functools.wraps.__doc__
 
 else:
     wraps = functools.wraps
@@ -888,7 +934,15 @@ def with_metaclass(meta, *bases):
     # the actual metaclass.
     class metaclass(type):
         def __new__(cls, name, this_bases, d):
-            return meta(name, bases, d)
+            if sys.version_info[:2] >= (3, 7):
+                # This version introduced PEP 560 that requires a bit
+                # of extra care (we mimic what is done by __build_class__).
+                resolved_bases = types.resolve_bases(bases)
+                if resolved_bases is not bases:
+                    d["__orig_bases__"] = bases
+            else:
+                resolved_bases = bases
+            return meta(name, resolved_bases, d)
 
         @classmethod
         def __prepare__(cls, name, this_bases):
@@ -928,12 +982,11 @@ def ensure_binary(s, encoding="utf-8", errors="strict"):
       - `str` -> encoded to `bytes`
       - `bytes` -> `bytes`
     """
+    if isinstance(s, binary_type):
+        return s
     if isinstance(s, text_type):
         return s.encode(encoding, errors)
-    elif isinstance(s, binary_type):
-        return s
-    else:
-        raise TypeError("not expecting type '%s'" % type(s))
+    raise TypeError("not expecting type '%s'" % type(s))
 
 
 def ensure_str(s, encoding="utf-8", errors="strict"):
@@ -947,12 +1000,15 @@ def ensure_str(s, encoding="utf-8", errors="strict"):
       - `str` -> `str`
       - `bytes` -> decoded to `str`
     """
-    if not isinstance(s, (text_type, binary_type)):
-        raise TypeError("not expecting type '%s'" % type(s))
+    # Optimization: Fast return for the common case.
+    if type(s) is str:
+        return s
     if PY2 and isinstance(s, text_type):
-        s = s.encode(encoding, errors)
+        return s.encode(encoding, errors)
     elif PY3 and isinstance(s, binary_type):
-        s = s.decode(encoding, errors)
+        return s.decode(encoding, errors)
+    elif not isinstance(s, (text_type, binary_type)):
+        raise TypeError("not expecting type '%s'" % type(s))
     return s
 
 
@@ -977,7 +1033,7 @@ def ensure_text(s, encoding="utf-8", errors="strict"):
 
 def python_2_unicode_compatible(klass):
     """
-    A decorator that defines __unicode__ and __str__ methods under Python 2.
+    A class decorator that defines __unicode__ and __str__ methods under Python 2.
     Under Python 3 it does nothing.
 
     To support Python 2 and 3 with a single code base, define a __str__ method

--- a/src/urllib3/packages/ssl_match_hostname/__init__.py
+++ b/src/urllib3/packages/ssl_match_hostname/__init__.py
@@ -1,9 +1,11 @@
 import sys
 
 try:
-    # Our match_hostname function is the same as 3.5's, so we only want to
+    # Our match_hostname function is the same as 3.10's, so we only want to
     # import the match_hostname function if it's at least that good.
-    if sys.version_info < (3, 5):
+    # We also fallback on Python 3.10+ because our code doesn't emit
+    # deprecation warnings and is the same as Python 3.10 otherwise.
+    if sys.version_info < (3, 5) or sys.version_info >= (3, 10):
         raise ImportError("Fallback to vendored code")
 
     from ssl import CertificateError, match_hostname

--- a/src/urllib3/util/connection.py
+++ b/src/urllib3/util/connection.py
@@ -118,7 +118,7 @@ def allowed_gai_family():
 
 
 def _has_ipv6(host):
-    """ Returns True if the system can bind an IPv6 address. """
+    """Returns True if the system can bind an IPv6 address."""
     sock = None
     has_ipv6 = False
 

--- a/src/urllib3/util/retry.py
+++ b/src/urllib3/util/retry.py
@@ -321,7 +321,7 @@ class Retry(object):
 
     @classmethod
     def from_int(cls, retries, redirect=True, default=None):
-        """ Backwards-compatibility for the old retries format."""
+        """Backwards-compatibility for the old retries format."""
         if retries is None:
             retries = default if default is not None else cls.DEFAULT
 
@@ -374,7 +374,7 @@ class Retry(object):
         return seconds
 
     def get_retry_after(self, response):
-        """ Get the value of Retry-After in seconds. """
+        """Get the value of Retry-After in seconds."""
 
         retry_after = response.getheader("Retry-After")
 
@@ -468,7 +468,7 @@ class Retry(object):
         )
 
     def is_exhausted(self):
-        """ Are we out of retries? """
+        """Are we out of retries?"""
         retry_counts = (
             self.total,
             self.connect,

--- a/src/urllib3/util/ssltransport.py
+++ b/src/urllib3/util/ssltransport.py
@@ -193,7 +193,7 @@ class SSLTransport:
                 raise
 
     def _ssl_io_loop(self, func, *args):
-        """ Performs an I/O loop between incoming/outgoing and the socket."""
+        """Performs an I/O loop between incoming/outgoing and the socket."""
         should_loop = True
         ret = None
 

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -54,7 +54,7 @@ if os.environ.get("CI") or os.environ.get("GITHUB_ACTIONS") == "true":
 
 
 def _can_resolve(host):
-    """ Returns True if the system can resolve host to an address. """
+    """Returns True if the system can resolve host to an address."""
     try:
         socket.getaddrinfo(host, None, socket.AF_UNSPEC)
         return True
@@ -63,7 +63,7 @@ def _can_resolve(host):
 
 
 def has_alpn(ctx_cls=None):
-    """ Detect if ALPN support is enabled. """
+    """Detect if ALPN support is enabled."""
     ctx_cls = ctx_cls or util.SSLContext
     ctx = ctx_cls(protocol=ssl_.PROTOCOL_TLS)
     try:

--- a/test/appengine/test_gae_manager.py
+++ b/test/appengine/test_gae_manager.py
@@ -129,7 +129,7 @@ class TestGAERetry(test_connectionpool.TestRetry):
         self.pool = MockPool(self.host, self.port, self.manager)
 
     def test_default_method_whitelist_retried(self):
-        """ urllib3 should retry methods in the default method whitelist """
+        """urllib3 should retry methods in the default method whitelist"""
         retry = urllib3.util.retry.Retry(total=1, status_forcelist=[418])
         # Use HEAD instead of OPTIONS, as URLFetch doesn't support OPTIONS
         resp = self.pool.request(

--- a/test/test_retry.py
+++ b/test/test_retry.py
@@ -26,7 +26,7 @@ def no_retry_deprecations():
 
 class TestRetry(object):
     def test_string(self):
-        """ Retry string representation looks the way we expect """
+        """Retry string representation looks the way we expect"""
         retry = Retry()
         assert (
             str(retry)
@@ -50,7 +50,7 @@ class TestRetry(object):
         assert e.value.reason == error
 
     def test_retry_higher_total_loses(self):
-        """ A lower connect timeout than the total is honored """
+        """A lower connect timeout than the total is honored"""
         error = ConnectTimeoutError()
         retry = Retry(connect=2, total=3)
         retry = retry.increment(error=error)
@@ -59,7 +59,7 @@ class TestRetry(object):
             retry.increment(error=error)
 
     def test_retry_higher_total_loses_vs_read(self):
-        """ A lower read timeout than the total is honored """
+        """A lower read timeout than the total is honored"""
         error = ReadTimeoutError(None, "/", "read timed out")
         retry = Retry(read=2, total=3)
         retry = retry.increment(method="GET", error=error)
@@ -68,7 +68,7 @@ class TestRetry(object):
             retry.increment(method="GET", error=error)
 
     def test_retry_total_none(self):
-        """ if Total is none, connect error should take precedence """
+        """if Total is none, connect error should take precedence"""
         error = ConnectTimeoutError()
         retry = Retry(connect=2, total=None)
         retry = retry.increment(error=error)
@@ -85,7 +85,7 @@ class TestRetry(object):
         assert not retry.is_exhausted()
 
     def test_retry_default(self):
-        """ If no value is specified, should retry connects 3 times """
+        """If no value is specified, should retry connects 3 times"""
         retry = Retry()
         assert retry.total == 10
         assert retry.connect is None
@@ -107,7 +107,7 @@ class TestRetry(object):
         assert not Retry(False).raise_on_redirect
 
     def test_retry_other(self):
-        """ If an unexpected error is raised, should retry other times """
+        """If an unexpected error is raised, should retry other times"""
         other_error = SSLError()
         retry = Retry(connect=1)
         retry = retry.increment(error=other_error)
@@ -121,7 +121,7 @@ class TestRetry(object):
         assert e.value.reason == other_error
 
     def test_retry_read_zero(self):
-        """ No second chances on read timeouts, by default """
+        """No second chances on read timeouts, by default"""
         error = ReadTimeoutError(None, "/", "read timed out")
         retry = Retry(read=0)
         with pytest.raises(MaxRetryError) as e:
@@ -140,7 +140,7 @@ class TestRetry(object):
         )
 
     def test_backoff(self):
-        """ Backoff is computed correctly """
+        """Backoff is computed correctly"""
         max_backoff = Retry.BACKOFF_MAX
 
         retry = Retry(total=100, backoff_factor=0.2)

--- a/test/test_retry_deprecated.py
+++ b/test/test_retry_deprecated.py
@@ -28,7 +28,7 @@ def expect_retry_deprecation():
 
 class TestRetry(object):
     def test_string(self):
-        """ Retry string representation looks the way we expect """
+        """Retry string representation looks the way we expect"""
         retry = Retry()
         assert (
             str(retry)
@@ -52,7 +52,7 @@ class TestRetry(object):
         assert e.value.reason == error
 
     def test_retry_higher_total_loses(self):
-        """ A lower connect timeout than the total is honored """
+        """A lower connect timeout than the total is honored"""
         error = ConnectTimeoutError()
         retry = Retry(connect=2, total=3)
         retry = retry.increment(error=error)
@@ -61,7 +61,7 @@ class TestRetry(object):
             retry.increment(error=error)
 
     def test_retry_higher_total_loses_vs_read(self):
-        """ A lower read timeout than the total is honored """
+        """A lower read timeout than the total is honored"""
         error = ReadTimeoutError(None, "/", "read timed out")
         retry = Retry(read=2, total=3)
         retry = retry.increment(method="GET", error=error)
@@ -70,7 +70,7 @@ class TestRetry(object):
             retry.increment(method="GET", error=error)
 
     def test_retry_total_none(self):
-        """ if Total is none, connect error should take precedence """
+        """if Total is none, connect error should take precedence"""
         error = ConnectTimeoutError()
         retry = Retry(connect=2, total=None)
         retry = retry.increment(error=error)
@@ -87,7 +87,7 @@ class TestRetry(object):
         assert not retry.is_exhausted()
 
     def test_retry_default(self):
-        """ If no value is specified, should retry connects 3 times """
+        """If no value is specified, should retry connects 3 times"""
         retry = Retry()
         assert retry.total == 10
         assert retry.connect is None
@@ -109,7 +109,7 @@ class TestRetry(object):
         assert not Retry(False).raise_on_redirect
 
     def test_retry_other(self):
-        """ If an unexpected error is raised, should retry other times """
+        """If an unexpected error is raised, should retry other times"""
         other_error = SSLError()
         retry = Retry(connect=1)
         retry = retry.increment(error=other_error)
@@ -123,7 +123,7 @@ class TestRetry(object):
         assert e.value.reason == other_error
 
     def test_retry_read_zero(self):
-        """ No second chances on read timeouts, by default """
+        """No second chances on read timeouts, by default"""
         error = ReadTimeoutError(None, "/", "read timed out")
         retry = Retry(read=0)
         with pytest.raises(MaxRetryError) as e:
@@ -142,7 +142,7 @@ class TestRetry(object):
         )
 
     def test_backoff(self):
-        """ Backoff is computed correctly """
+        """Backoff is computed correctly"""
         max_backoff = Retry.BACKOFF_MAX
 
         retry = Retry(total=100, backoff_factor=0.2)

--- a/test/test_ssltransport.py
+++ b/test/test_ssltransport.py
@@ -101,7 +101,7 @@ class SingleTLSLayerTestCase(SocketDummyServerTestCase):
 
     @pytest.mark.timeout(PER_TEST_TIMEOUT)
     def test_start_closed_socket(self):
-        """ Errors generated from an unconnected socket should bubble up."""
+        """Errors generated from an unconnected socket should bubble up."""
         sock = socket.socket(socket.AF_INET)
         context = ssl.create_default_context()
         sock.close()
@@ -110,7 +110,7 @@ class SingleTLSLayerTestCase(SocketDummyServerTestCase):
 
     @pytest.mark.timeout(PER_TEST_TIMEOUT)
     def test_close_after_handshake(self):
-        """ Socket errors should be bubbled up """
+        """Socket errors should be bubbled up"""
         self.start_dummy_server()
 
         sock = socket.create_connection((self.host, self.port))
@@ -123,7 +123,7 @@ class SingleTLSLayerTestCase(SocketDummyServerTestCase):
 
     @pytest.mark.timeout(PER_TEST_TIMEOUT)
     def test_wrap_existing_socket(self):
-        """ Validates a single TLS layer can be established.  """
+        """Validates a single TLS layer can be established."""
         self.start_dummy_server()
 
         sock = socket.create_connection((self.host, self.port))
@@ -187,7 +187,7 @@ class SingleTLSLayerTestCase(SocketDummyServerTestCase):
 
     @pytest.mark.timeout(PER_TEST_TIMEOUT)
     def test_ssl_object_attributes(self):
-        """ Ensures common ssl attributes are exposed """
+        """Ensures common ssl attributes are exposed"""
         self.start_dummy_server()
 
         sock = socket.create_connection((self.host, self.port))
@@ -215,7 +215,7 @@ class SingleTLSLayerTestCase(SocketDummyServerTestCase):
 
     @pytest.mark.timeout(PER_TEST_TIMEOUT)
     def test_socket_object_attributes(self):
-        """ Ensures common socket attributes are exposed """
+        """Ensures common socket attributes are exposed"""
         self.start_dummy_server()
 
         sock = socket.create_connection((self.host, self.port))

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -580,7 +580,7 @@ class TestUtil(object):
             assert len(w) == 1
 
     def _make_time_pass(self, seconds, timeout, time_mock):
-        """ Make some time pass for the timeout object """
+        """Make some time pass for the timeout object"""
         time_mock.return_value = TIMEOUT_EPOCH
         timeout.start_connect()
         time_mock.return_value = TIMEOUT_EPOCH + seconds

--- a/test/with_dummyserver/test_connectionpool.py
+++ b/test/with_dummyserver/test_connectionpool.py
@@ -284,7 +284,7 @@ class TestConnectionPool(HTTPDummyServerTestCase):
             assert r.status == 200, r.data
 
     def test_nagle(self):
-        """ Test that connections have TCP_NODELAY turned on """
+        """Test that connections have TCP_NODELAY turned on"""
         # This test needs to be here in order to be run. socket.create_connection actually tries
         # to connect to the host provided so we need a dummyserver to be running.
         with HTTPConnectionPool(self.host, self.port) as pool:
@@ -354,7 +354,7 @@ class TestConnectionPool(HTTPDummyServerTestCase):
                 s.close()
 
     def test_connection_error_retries(self):
-        """ ECONNREFUSED error should raise a connection error, with retries """
+        """ECONNREFUSED error should raise a connection error, with retries"""
         port = find_unused_port()
         with HTTPConnectionPool(self.host, port) as pool:
             with pytest.raises(MaxRetryError) as e:
@@ -794,13 +794,13 @@ class TestConnectionPool(HTTPDummyServerTestCase):
             assert response.status == 200
 
     def test_preserves_path_dot_segments(self):
-        """ ConnectionPool preserves dot segments in the URI """
+        """ConnectionPool preserves dot segments in the URI"""
         with HTTPConnectionPool(self.host, self.port) as pool:
             response = pool.request("GET", "/echo_uri/seg0/../seg2")
             assert response.data == b"/echo_uri/seg0/../seg2"
 
     def test_default_user_agent_header(self):
-        """ ConnectionPool has a default user agent """
+        """ConnectionPool has a default user agent"""
         default_ua = _get_default_user_agent()
         custom_ua = "I'm not a web scraper, what are you talking about?"
         custom_ua2 = "Yet Another User Agent"
@@ -853,7 +853,7 @@ class TestConnectionPool(HTTPDummyServerTestCase):
                 assert request_headers["User-Agent"] == "key"
 
     def test_no_user_agent_header(self):
-        """ ConnectionPool can suppress sending a user agent header """
+        """ConnectionPool can suppress sending a user agent header"""
         custom_ua = "I'm not a web scraper, what are you talking about?"
         with HTTPConnectionPool(self.host, self.port) as pool:
             # Suppress user agent in the request headers.
@@ -1025,7 +1025,7 @@ class TestRetry(HTTPDummyServerTestCase):
                 pool.request("GET", "/redirect", fields={"target": "/"}, retries=0)
 
     def test_disabled_retry(self):
-        """ Disabled retries should disable redirect handling. """
+        """Disabled retries should disable redirect handling."""
         with HTTPConnectionPool(self.host, self.port) as pool:
             r = pool.request("GET", "/redirect", fields={"target": "/"}, retries=False)
             assert r.status == 303
@@ -1045,7 +1045,7 @@ class TestRetry(HTTPDummyServerTestCase):
                 pool.request("GET", "/test", retries=False)
 
     def test_read_retries(self):
-        """ Should retry for status codes in the whitelist """
+        """Should retry for status codes in the whitelist"""
         with HTTPConnectionPool(self.host, self.port) as pool:
             retry = Retry(read=1, status_forcelist=[418])
             resp = pool.request(
@@ -1057,7 +1057,7 @@ class TestRetry(HTTPDummyServerTestCase):
             assert resp.status == 200
 
     def test_read_total_retries(self):
-        """ HTTP response w/ status code in the whitelist should be retried """
+        """HTTP response w/ status code in the whitelist should be retried"""
         with HTTPConnectionPool(self.host, self.port) as pool:
             headers = {"test-name": "test_read_total_retries"}
             retry = Retry(total=1, status_forcelist=[418])
@@ -1079,7 +1079,7 @@ class TestRetry(HTTPDummyServerTestCase):
             assert resp.status == 418
 
     def test_default_method_whitelist_retried(self):
-        """ urllib3 should retry methods in the default method whitelist """
+        """urllib3 should retry methods in the default method whitelist"""
         with HTTPConnectionPool(self.host, self.port) as pool:
             retry = Retry(total=1, status_forcelist=[418])
             resp = pool.request(
@@ -1107,7 +1107,7 @@ class TestRetry(HTTPDummyServerTestCase):
             assert resp.status == 418
 
     def test_retry_reuse_safe(self):
-        """ It should be possible to reuse a Retry object across requests """
+        """It should be possible to reuse a Retry object across requests"""
         with HTTPConnectionPool(self.host, self.port) as pool:
             headers = {"test-name": "test_retry_safe"}
             retry = Retry(total=1, status_forcelist=[418])

--- a/test/with_dummyserver/test_https.py
+++ b/test/with_dummyserver/test_https.py
@@ -368,7 +368,7 @@ class TestHTTPS(HTTPSDummyServerTestCase):
             assert isinstance(cm.value.reason, SSLError)
 
     def test_unverified_ssl(self):
-        """ Test that bare HTTPSConnection can connect, make requests """
+        """Test that bare HTTPSConnection can connect, make requests"""
         with HTTPSConnectionPool(self.host, self.port, cert_reqs=ssl.CERT_NONE) as pool:
             with mock.patch("warnings.warn") as warn:
                 r = pool.request("GET", "/")
@@ -567,7 +567,7 @@ class TestHTTPS(HTTPSDummyServerTestCase):
             https_pool.request("GET", "/")
 
     def test_tunnel(self):
-        """ test the _tunnel behavior """
+        """test the _tunnel behavior"""
         timeout = Timeout(total=None)
         with HTTPSConnectionPool(
             self.host, self.port, timeout=timeout, cert_reqs="CERT_NONE"

--- a/test/with_dummyserver/test_proxy_poolmanager.py
+++ b/test/with_dummyserver/test_proxy_poolmanager.py
@@ -142,7 +142,7 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
             assert r.status == 200
 
     def test_nagle_proxy(self):
-        """ Test that proxy connections do not have TCP_NODELAY turned on """
+        """Test that proxy connections do not have TCP_NODELAY turned on"""
         with ProxyManager(self.proxy_url) as http:
             hc2 = http.connection_from_host(self.http_host, self.http_port)
             conn = hc2._get_conn()

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -467,7 +467,7 @@ class TestSocketClosing(SocketDummyServerTestCase):
                 timed_out.set()
 
     def test_https_connection_read_timeout(self):
-        """ Handshake timeouts should fail with a Timeout"""
+        """Handshake timeouts should fail with a Timeout"""
         timed_out = Event()
 
         def socket_handler(listener):
@@ -630,7 +630,7 @@ class TestSocketClosing(SocketDummyServerTestCase):
                 response.read()
 
     def test_retry_weird_http_version(self):
-        """ Retry class should handle httplib.BadStatusLine errors properly """
+        """Retry class should handle httplib.BadStatusLine errors properly"""
 
         def socket_handler(listener):
             sock = listener.accept()[0]


### PR DESCRIPTION
Also need to fix the deprecation warnings for `PROTOCOL_TLS`, will have that fix after I see Python 3.10 working on CI.

Closes https://github.com/urllib3/urllib3/issues/2238