### PR TITLE
[1.26] Configure lint with pre-commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,21 +7,6 @@ defaults:
     shell: bash
 
 jobs:
-  lint:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v2
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.8
-      - name: Install dependencies
-        run: python3.8 -m pip install nox
-      - name: Lint the code
-        run: nox -s lint
-
   package:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,18 @@
+name: lint
+
+on: [push, pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Lint the code
+        uses: pre-commit/action@v2.0.0
+

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,23 @@
+repos:
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v2.18.3
+    hooks:
+      - id: pyupgrade
+
+  - repo: https://github.com/psf/black
+    rev: 21.5b1
+    hooks:
+      - id: black
+        additional_dependencies: ['.[python2]']
+        args: ["--target-version", "py27"]
+
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.8.0
+    hooks:
+      - id: isort
+
+  - repo: https://github.com/pycqa/flake8
+    rev: 3.9.2
+    hooks:
+      - id: flake8
+        additional_dependencies: [flake8-2020]

--- a/dummyserver/handlers.py
+++ b/dummyserver/handlers.py
@@ -112,7 +112,7 @@ class TestingApp(RequestHandler):
         cert = request.get_ssl_certificate()
         subject = dict()
         if cert is not None:
-            subject = dict((k, v) for (k, v) in [y for z in cert["subject"] for y in z])
+            subject = {k: v for (k, v) in [y for z in cert["subject"] for y in z]}
         return Response(json.dumps(subject))
 
     def alpn_protocol(self, request):
@@ -128,7 +128,7 @@ class TestingApp(RequestHandler):
         test_type = request.params.get("test_type")
         test_id = request.params.get("test_id")
         if test_id:
-            print("\nNew test %s: %s" % (test_type, test_id))
+            print("\nNew test {}: {}".format(test_type, test_id))
         else:
             print("\nNew test %s" % test_type)
         return Response("Dummy server is ready!")
@@ -141,7 +141,7 @@ class TestingApp(RequestHandler):
 
         if request.method != method:
             return Response(
-                "Wrong method: %s != %s" % (method, request.method),
+                "Wrong method: {} != {}".format(method, request.method),
                 status="400 Bad Request",
             )
         return Response()
@@ -174,7 +174,7 @@ class TestingApp(RequestHandler):
         # Tornado can leave the trailing \n in place on the filename.
         if filename != got_filename:
             return Response(
-                u"Wrong filename: %s != %s" % (filename, file_.filename),
+                u"Wrong filename: {} != {}".format(filename, file_.filename),
                 status="400 Bad Request",
             )
 
@@ -197,7 +197,7 @@ class TestingApp(RequestHandler):
         "Performs a redirect chain based on ``redirect_codes``"
         codes = request.params.get("redirect_codes", b"200").decode("utf-8")
         head, tail = codes.split(",", 1) if "," in codes else (codes, None)
-        status = "{0} {1}".format(head, responses[int(head)])
+        status = "{} {}".format(head, responses[int(head)])
         if not tail:
             return Response("Done redirecting", status=status)
 
@@ -214,7 +214,7 @@ class TestingApp(RequestHandler):
 
     def echo_params(self, request):
         params = sorted(
-            [(ensure_str(k), ensure_str(v)) for k, v in request.params.items()]
+            (ensure_str(k), ensure_str(v)) for k, v in request.params.items()
         )
         return Response(repr(params))
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+import subprocess
 
 import nox
 
@@ -86,22 +87,26 @@ def app_engine(session):
 @nox.session()
 def format(session):
     """Run code formatters."""
-    session.install("black", "isort")
-    session.run("black", *SOURCE_FILES)
-    session.run("isort", *SOURCE_FILES)
+    session.install("pre-commit")
+    session.run("pre-commit", "--version")
+
+    process = subprocess.run(
+        ["pre-commit", "run", "--all-files"],
+        env=session.env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+    # Ensure that pre-commit itself ran successfully
+    assert process.returncode in (0, 1)
 
     lint(session)
 
 
 @nox.session
 def lint(session):
-    session.install("flake8", "flake8-2020", "black", "isort")
-    session.run("flake8", "--version")
-    session.run("black", "--version")
-    session.run("isort", "--version")
-    session.run("black", "--check", *SOURCE_FILES)
-    session.run("isort", "--check", *SOURCE_FILES)
-    session.run("flake8", *SOURCE_FILES)
+    session.install("pre-commit")
+    session.run("pre-commit", "run", "--all-files")
 
 
 @nox.session

--- a/src/urllib3/_collections.py
+++ b/src/urllib3/_collections.py
@@ -168,9 +168,9 @@ class HTTPHeaderDict(MutableMapping):
             return False
         if not isinstance(other, type(self)):
             other = type(self)(other)
-        return dict((k.lower(), v) for k, v in self.itermerged()) == dict(
-            (k.lower(), v) for k, v in other.itermerged()
-        )
+        return {k.lower(): v for k, v in self.itermerged()} == {
+            k.lower(): v for k, v in other.itermerged()
+        }
 
     def __ne__(self, other):
         return not self.__eq__(other)
@@ -236,7 +236,7 @@ class HTTPHeaderDict(MutableMapping):
         if len(args) > 1:
             raise TypeError(
                 "extend() takes at most 1 positional "
-                "arguments ({0} given)".format(len(args))
+                "arguments ({} given)".format(len(args))
             )
         other = args[0] if len(args) >= 1 else ()
 
@@ -277,7 +277,7 @@ class HTTPHeaderDict(MutableMapping):
     get_all = getlist
 
     def __repr__(self):
-        return "%s(%s)" % (type(self).__name__, dict(self.itermerged()))
+        return "{}({})".format(type(self).__name__, dict(self.itermerged()))
 
     def _copy_from(self, other):
         for key in other:

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -239,7 +239,7 @@ class HTTPConnection(_HTTPConnection, object):
         body with chunked encoding and not as one block
         """
         headers = headers or {}
-        header_keys = set([six.ensure_str(k.lower()) for k in headers])
+        header_keys = {six.ensure_str(k.lower()) for k in headers}
         skip_accept_encoding = "accept-encoding" in header_keys
         skip_host = "host" in header_keys
         self.putrequest(
@@ -378,7 +378,7 @@ class HTTPSConnection(HTTPConnection):
         if is_time_off:
             warnings.warn(
                 (
-                    "System time is way off (before {0}). This will probably "
+                    "System time is way off (before {}). This will probably "
                     "lead to SSL verification errors"
                 ).format(RECENT_DATE),
                 SystemTimeWarning,
@@ -454,7 +454,7 @@ class HTTPSConnection(HTTPConnection):
             if not cert.get("subjectAltName", ()):
                 warnings.warn(
                     (
-                        "Certificate for {0} has no `subjectAltName`, falling back to check for a "
+                        "Certificate for {} has no `subjectAltName`, falling back to check for a "
                         "`commonName` for now. This feature is being removed by major browsers and "
                         "deprecated by RFC 2818. (See https://github.com/urllib3/urllib3/issues/497 "
                         "for details.)".format(hostname)

--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -80,7 +80,9 @@ class ConnectionPool(object):
         self.port = port
 
     def __str__(self):
-        return "%s(host=%r, port=%r)" % (type(self).__name__, self.host, self.port)
+        return "{}(host={!r}, port={!r})".format(
+            type(self).__name__, self.host, self.port
+        )
 
     def __enter__(self):
         return self

--- a/src/urllib3/contrib/_securetransport/low_level.py
+++ b/src/urllib3/contrib/_securetransport/low_level.py
@@ -97,7 +97,7 @@ def _create_cfstring_array(lst):
     except BaseException as e:
         if cf_arr:
             CoreFoundation.CFRelease(cf_arr)
-        raise ssl.SSLError("Unable to allocate array: %s" % (e,))
+        raise ssl.SSLError("Unable to allocate array: {}".format(e))
     return cf_arr
 
 

--- a/src/urllib3/contrib/ntlmpool.py
+++ b/src/urllib3/contrib/ntlmpool.py
@@ -77,7 +77,9 @@ class NTLMConnectionPool(HTTPSConnectionPool):
                 auth_header_value = s[5:]
         if auth_header_value is None:
             raise Exception(
-                "Unexpected %s response header: %s" % (resp_header, reshdr[resp_header])
+                "Unexpected {} response header: {}".format(
+                    resp_header, reshdr[resp_header]
+                )
             )
 
         # Send authentication message
@@ -97,7 +99,9 @@ class NTLMConnectionPool(HTTPSConnectionPool):
         if res.status != 200:
             if res.status == 401:
                 raise Exception("Server rejected request: wrong username or password")
-            raise Exception("Wrong server response: %s %s" % (res.status, res.reason))
+            raise Exception(
+                "Wrong server response: {} {}".format(res.status, res.reason)
+            )
 
         res.fp = None
         log.debug("Connection established")

--- a/src/urllib3/contrib/pyopenssl.py
+++ b/src/urllib3/contrib/pyopenssl.py
@@ -106,7 +106,7 @@ _stdlib_to_openssl_verify = {
     ssl.CERT_REQUIRED: OpenSSL.SSL.VERIFY_PEER
     + OpenSSL.SSL.VERIFY_FAIL_IF_NO_PEER_CERT,
 }
-_openssl_to_stdlib_verify = dict((v, k) for k, v in _stdlib_to_openssl_verify.items())
+_openssl_to_stdlib_verify = {v: k for k, v in _stdlib_to_openssl_verify.items()}
 
 # OpenSSL will only write 16K at a time
 SSL_WRITE_BLOCKSIZE = 16384

--- a/src/urllib3/contrib/securetransport.py
+++ b/src/urllib3/contrib/securetransport.py
@@ -418,7 +418,7 @@ class WrappedSocket(object):
             reason = "error code: %d" % (trust_result,)
         except Exception as e:
             # Do not trust on error
-            reason = "exception: %r" % (e,)
+            reason = "exception: {!r}".format(e)
 
         # SecureTransport does not send an alert nor shuts down the connection.
         rec = _build_tls_unknown_ca_alert(self.version())

--- a/src/urllib3/exceptions.py
+++ b/src/urllib3/exceptions.py
@@ -22,7 +22,7 @@ class PoolError(HTTPError):
 
     def __init__(self, pool, message):
         self.pool = pool
-        HTTPError.__init__(self, "%s: %s" % (pool, message))
+        HTTPError.__init__(self, "{}: {}".format(pool, message))
 
     def __reduce__(self):
         # For pickling purposes.
@@ -87,7 +87,9 @@ class MaxRetryError(RequestError):
     def __init__(self, pool, url, reason=None):
         self.reason = reason
 
-        message = "Max retries exceeded with url: %s (Caused by %r)" % (url, reason)
+        message = "Max retries exceeded with url: {} (Caused by {!r})".format(
+            url, reason
+        )
 
         RequestError.__init__(self, pool, url, message)
 
@@ -313,7 +315,7 @@ class HeaderParsingError(HTTPError):
     """Raised by assert_header_parsing, but we convert it to a log.warning statement."""
 
     def __init__(self, defects, unparsed_data):
-        message = "%s, unparsed data: %r" % (defects or "Unknown", unparsed_data)
+        message = "{}, unparsed data: {!r}".format(defects or "Unknown", unparsed_data)
         super(HeaderParsingError, self).__init__(message)
 
 

--- a/src/urllib3/fields.py
+++ b/src/urllib3/fields.py
@@ -41,7 +41,7 @@ def format_header_param_rfc2231(name, value):
         value = value.decode("utf-8")
 
     if not any(ch in value for ch in '"\\\r\n'):
-        result = u'%s="%s"' % (name, value)
+        result = u'{}="{}"'.format(name, value)
         try:
             result.encode("ascii")
         except (UnicodeEncodeError, UnicodeDecodeError):
@@ -55,7 +55,7 @@ def format_header_param_rfc2231(name, value):
     # encode_rfc2231 accepts an encoded string and returns an ascii-encoded
     # string in Python 2 but accepts and returns unicode strings in Python 3
     value = email.utils.encode_rfc2231(value, "utf-8")
-    value = "%s*=%s" % (name, value)
+    value = "{}*={}".format(name, value)
 
     if six.PY2:  # Python 2:
         value = value.decode("utf-8")
@@ -84,7 +84,7 @@ def _replace_multiple(value, needles_and_replacements):
         return needles_and_replacements[match.group(0)]
 
     pattern = re.compile(
-        r"|".join([re.escape(needle) for needle in needles_and_replacements.keys()])
+        r"|".join(re.escape(needle) for needle in needles_and_replacements.keys())
     )
 
     result = pattern.sub(replacer, value)
@@ -116,7 +116,7 @@ def format_header_param_html5(name, value):
 
     value = _replace_multiple(value, _HTML5_REPLACEMENTS)
 
-    return u'%s="%s"' % (name, value)
+    return u'{}="{}"'.format(name, value)
 
 
 # For backwards-compatibility.
@@ -236,12 +236,12 @@ class RequestField(object):
         sort_keys = ["Content-Disposition", "Content-Type", "Content-Location"]
         for sort_key in sort_keys:
             if self.headers.get(sort_key, False):
-                lines.append(u"%s: %s" % (sort_key, self.headers[sort_key]))
+                lines.append(u"{}: {}".format(sort_key, self.headers[sort_key]))
 
         for header_name, header_value in self.headers.items():
             if header_name not in sort_keys:
                 if header_value:
-                    lines.append(u"%s: %s" % (header_name, header_value))
+                    lines.append(u"{}: {}".format(header_name, header_value))
 
         lines.append(u"\r\n")
         return u"\r\n".join(lines)

--- a/src/urllib3/packages/backports/makefile.py
+++ b/src/urllib3/packages/backports/makefile.py
@@ -17,7 +17,7 @@ def backport_makefile(
     Backport of ``socket.makefile`` from Python 3.5.
     """
     if not set(mode) <= {"r", "w", "b"}:
-        raise ValueError("invalid mode %r (only r, w, b allowed)" % (mode,))
+        raise ValueError("invalid mode {!r} (only r, w, b allowed)".format(mode))
     writing = "w" in mode
     reading = "r" in mode or not writing
     assert reading or writing

--- a/src/urllib3/packages/six.py
+++ b/src/urllib3/packages/six.py
@@ -554,7 +554,7 @@ def remove_move(name):
         try:
             del moves.__dict__[name]
         except KeyError:
-            raise AttributeError("no such move, %r" % (name,))
+            raise AttributeError("no such move, {!r}".format(name))
 
 
 if PY3:
@@ -785,7 +785,7 @@ else:
             del frame
         elif _locs_ is None:
             _locs_ = _globs_
-        exec("""exec _code_ in _globs_, _locs_""")
+        exec ("""exec _code_ in _globs_, _locs_""")
 
     exec_(
         """def reraise(tp, value, tb=None):

--- a/src/urllib3/packages/ssl_match_hostname/_implementation.py
+++ b/src/urllib3/packages/ssl_match_hostname/_implementation.py
@@ -153,7 +153,9 @@ def match_hostname(cert, hostname):
             "doesn't match either of %s" % (hostname, ", ".join(map(repr, dnsnames)))
         )
     elif len(dnsnames) == 1:
-        raise CertificateError("hostname %r doesn't match %r" % (hostname, dnsnames[0]))
+        raise CertificateError(
+            "hostname {!r} doesn't match {!r}".format(hostname, dnsnames[0])
+        )
     else:
         raise CertificateError(
             "no appropriate commonName or subjectAltName fields were found"

--- a/src/urllib3/response.py
+++ b/src/urllib3/response.py
@@ -340,7 +340,7 @@ class HTTPResponse(io.IOBase):
                 # (e.g. Content-Length: 42, 42). This line ensures the values
                 # are all valid ints and that as long as the `set` length is 1,
                 # all values are the same. Otherwise, the header is invalid.
-                lengths = set([int(val) for val in length.split(",")])
+                lengths = {int(val) for val in length.split(",")}
                 if len(lengths) > 1:
                     raise InvalidHeader(
                         "Content-Length contained multiple "

--- a/src/urllib3/util/response.py
+++ b/src/urllib3/util/response.py
@@ -53,7 +53,7 @@ def assert_header_parsing(headers):
     # This will fail silently if we pass in the wrong kind of parameter.
     # To make debugging easier add an explicit check.
     if not isinstance(headers, httplib.HTTPMessage):
-        raise TypeError("expected httplib.Message, got {0}.".format(type(headers)))
+        raise TypeError("expected httplib.Message, got {}.".format(type(headers)))
 
     defects = getattr(headers, "defects", None)
     get_payload = getattr(headers, "get_payload", None)

--- a/src/urllib3/util/retry.py
+++ b/src/urllib3/util/retry.py
@@ -280,7 +280,7 @@ class Retry(object):
         self.history = history or tuple()
         self.respect_retry_after_header = respect_retry_after_header
         self.remove_headers_on_redirect = frozenset(
-            [h.lower() for h in remove_headers_on_redirect]
+            h.lower() for h in remove_headers_on_redirect
         )
 
     def new(self, **kw):

--- a/src/urllib3/util/ssl_.py
+++ b/src/urllib3/util/ssl_.py
@@ -193,7 +193,7 @@ def assert_fingerprint(cert, fingerprint):
     digest_length = len(fingerprint)
     hashfunc = HASHFUNC_MAP.get(digest_length)
     if not hashfunc:
-        raise SSLError("Fingerprint of invalid length: {0}".format(fingerprint))
+        raise SSLError("Fingerprint of invalid length: {}".format(fingerprint))
 
     # We need encode() here for py32; works on py2 and p33.
     fingerprint_bytes = unhexlify(fingerprint.encode())
@@ -202,7 +202,7 @@ def assert_fingerprint(cert, fingerprint):
 
     if not _const_compare_digest(cert_digest, fingerprint_bytes):
         raise SSLError(
-            'Fingerprints did not match. Expected "{0}", got "{1}".'.format(
+            'Fingerprints did not match. Expected "{}", got "{}".'.format(
                 fingerprint, hexlify(cert_digest)
             )
         )

--- a/src/urllib3/util/ssltransport.py
+++ b/src/urllib3/util/ssltransport.py
@@ -113,7 +113,7 @@ class SSLTransport:
         changes to point to the socket directly.
         """
         if not set(mode) <= {"r", "w", "b"}:
-            raise ValueError("invalid mode %r (only r, w, b allowed)" % (mode,))
+            raise ValueError("invalid mode {!r} (only r, w, b allowed)".format(mode))
 
         writing = "w" in mode
         reading = "r" in mode or not writing

--- a/src/urllib3/util/timeout.py
+++ b/src/urllib3/util/timeout.py
@@ -106,7 +106,7 @@ class Timeout(object):
         self._start_connect = None
 
     def __repr__(self):
-        return "%s(connect=%r, read=%r, total=%r)" % (
+        return "{}(connect={!r}, read={!r}, total={!r})".format(
             type(self).__name__,
             self._connect,
             self._read,

--- a/src/urllib3/util/url.py
+++ b/src/urllib3/util/url.py
@@ -51,7 +51,7 @@ _variations = [
 ]
 
 UNRESERVED_PAT = r"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789._!\-~"
-IPV6_PAT = "(?:" + "|".join([x % _subs for x in _variations]) + ")"
+IPV6_PAT = "(?:" + "|".join(x % _subs for x in _variations) + ")"
 ZONE_ID_PAT = "(?:%25|%)(?:[" + UNRESERVED_PAT + "]|%[a-fA-F0-9]{2})+"
 IPV6_ADDRZ_PAT = r"\[" + IPV6_PAT + r"(?:" + ZONE_ID_PAT + r")?\]"
 REG_NAME_PAT = r"(?:[^\[\]%:/?#]|%[a-fA-F0-9]{2})*"

--- a/test/appengine/test_urlfetch.py
+++ b/test/appengine/test_urlfetch.py
@@ -19,7 +19,9 @@ class MockResponse(object):
         self.final_url = final_url
         self.header_msg = httplib.HTTPMessage(
             StringIO.StringIO(
-                "".join(["%s: %s\n" % (k, v) for k, v in headers.iteritems()] + ["\n"])
+                "".join(
+                    ["{}: {}\n".format(k, v) for k, v in headers.iteritems()] + ["\n"]
+                )
             )
         )
         self.headers = headers

--- a/test/benchmark.py
+++ b/test/benchmark.py
@@ -40,7 +40,7 @@ def urllib_get(url_list):
         now = time.time()
         urllib.urlopen(url)
         elapsed = time.time() - now
-        print("Got in %0.3f: %s" % (elapsed, url))
+        print("Got in {:0.3f}: {}".format(elapsed, url))
 
 
 def pool_get(url_list):
@@ -50,7 +50,7 @@ def pool_get(url_list):
         now = time.time()
         pool.request("GET", url, assert_same_host=False)
         elapsed = time.time() - now
-        print("Got in %0.3fs: %s" % (elapsed, url))
+        print("Got in {:0.3f}s: {}".format(elapsed, url))
 
 
 if __name__ == "__main__":

--- a/test/contrib/test_socks.py
+++ b/test/contrib/test_socks.py
@@ -230,7 +230,7 @@ class TestSocks5Proxy(IPV4SocketDummyServerTestCase):
             sock.close()
 
         self._start_server(request_handler)
-        proxy_url = "socks5://%s:%s" % (self.host, self.port)
+        proxy_url = "socks5://{}:{}".format(self.host, self.port)
         with socks.SOCKSProxyManager(proxy_url) as pm:
             response = pm.request("GET", "http://16.17.18.19")
 
@@ -263,7 +263,7 @@ class TestSocks5Proxy(IPV4SocketDummyServerTestCase):
             sock.close()
 
         self._start_server(request_handler)
-        proxy_url = "socks5://%s:%s" % (self.host, self.port)
+        proxy_url = "socks5://{}:{}".format(self.host, self.port)
         with socks.SOCKSProxyManager(proxy_url) as pm:
             response = pm.request("GET", "http://localhost")
 
@@ -300,7 +300,7 @@ class TestSocks5Proxy(IPV4SocketDummyServerTestCase):
             sock.close()
 
         self._start_server(request_handler)
-        proxy_url = "socks5h://%s:%s" % (self.host, self.port)
+        proxy_url = "socks5h://{}:{}".format(self.host, self.port)
         with socks.SOCKSProxyManager(proxy_url) as pm:
             response = pm.request("GET", "http://example.com")
             assert response.status == 200
@@ -312,7 +312,7 @@ class TestSocks5Proxy(IPV4SocketDummyServerTestCase):
             event.wait()
 
         self._start_server(request_handler)
-        proxy_url = "socks5h://%s:%s" % (self.host, self.port)
+        proxy_url = "socks5h://{}:{}".format(self.host, self.port)
         with socks.SOCKSProxyManager(proxy_url) as pm:
             with pytest.raises(ConnectTimeoutError):
                 pm.request(
@@ -328,7 +328,7 @@ class TestSocks5Proxy(IPV4SocketDummyServerTestCase):
             event.set()
 
         self._start_server(request_handler)
-        proxy_url = "socks5h://%s:%s" % (self.host, self.port)
+        proxy_url = "socks5h://{}:{}".format(self.host, self.port)
         with socks.SOCKSProxyManager(proxy_url) as pm:
             event.wait()
             with pytest.raises(NewConnectionError):
@@ -348,7 +348,7 @@ class TestSocks5Proxy(IPV4SocketDummyServerTestCase):
             sock.close()
 
         self._start_server(request_handler)
-        proxy_url = "socks5h://%s:%s" % (self.host, self.port)
+        proxy_url = "socks5h://{}:{}".format(self.host, self.port)
         with socks.SOCKSProxyManager(proxy_url) as pm:
             with pytest.raises(NewConnectionError):
                 pm.request("GET", "http://example.com", retries=False)
@@ -381,7 +381,7 @@ class TestSocks5Proxy(IPV4SocketDummyServerTestCase):
             sock.close()
 
         self._start_server(request_handler)
-        proxy_url = "socks5://%s:%s" % (self.host, self.port)
+        proxy_url = "socks5://{}:{}".format(self.host, self.port)
         with socks.SOCKSProxyManager(proxy_url, username="user", password="pass") as pm:
             response = pm.request("GET", "http://16.17.18.19")
 
@@ -421,7 +421,7 @@ class TestSocks5Proxy(IPV4SocketDummyServerTestCase):
             sock.close()
 
         self._start_server(request_handler)
-        proxy_url = "socks5://user:pass@%s:%s" % (self.host, self.port)
+        proxy_url = "socks5://user:pass@{}:{}".format(self.host, self.port)
         with socks.SOCKSProxyManager(proxy_url) as pm:
             response = pm.request("GET", "http://16.17.18.19")
 
@@ -439,7 +439,7 @@ class TestSocks5Proxy(IPV4SocketDummyServerTestCase):
             next(handler)
 
         self._start_server(request_handler)
-        proxy_url = "socks5h://%s:%s" % (self.host, self.port)
+        proxy_url = "socks5h://{}:{}".format(self.host, self.port)
         with socks.SOCKSProxyManager(
             proxy_url, username="user", password="badpass"
         ) as pm:
@@ -476,7 +476,7 @@ class TestSocks5Proxy(IPV4SocketDummyServerTestCase):
             sock.close()
 
         self._start_server(request_handler)
-        proxy_url = "socks5://%s:%s" % (self.host, self.port)
+        proxy_url = "socks5://{}:{}".format(self.host, self.port)
         with socks.SOCKSProxyManager(
             proxy_url, source_address=("127.0.0.1", expected_port)
         ) as pm:
@@ -517,7 +517,7 @@ class TestSOCKS4Proxy(IPV4SocketDummyServerTestCase):
             sock.close()
 
         self._start_server(request_handler)
-        proxy_url = "socks4://%s:%s" % (self.host, self.port)
+        proxy_url = "socks4://{}:{}".format(self.host, self.port)
         with socks.SOCKSProxyManager(proxy_url) as pm:
             response = pm.request("GET", "http://16.17.18.19")
 
@@ -550,7 +550,7 @@ class TestSOCKS4Proxy(IPV4SocketDummyServerTestCase):
             sock.close()
 
         self._start_server(request_handler)
-        proxy_url = "socks4://%s:%s" % (self.host, self.port)
+        proxy_url = "socks4://{}:{}".format(self.host, self.port)
         with socks.SOCKSProxyManager(proxy_url) as pm:
             response = pm.request("GET", "http://localhost")
 
@@ -587,7 +587,7 @@ class TestSOCKS4Proxy(IPV4SocketDummyServerTestCase):
             sock.close()
 
         self._start_server(request_handler)
-        proxy_url = "socks4a://%s:%s" % (self.host, self.port)
+        proxy_url = "socks4a://{}:{}".format(self.host, self.port)
         with socks.SOCKSProxyManager(proxy_url) as pm:
             response = pm.request("GET", "http://example.com")
             assert response.status == 200
@@ -606,7 +606,7 @@ class TestSOCKS4Proxy(IPV4SocketDummyServerTestCase):
             sock.close()
 
         self._start_server(request_handler)
-        proxy_url = "socks4a://%s:%s" % (self.host, self.port)
+        proxy_url = "socks4a://{}:{}".format(self.host, self.port)
         with socks.SOCKSProxyManager(proxy_url) as pm:
             with pytest.raises(NewConnectionError):
                 pm.request("GET", "http://example.com", retries=False)
@@ -637,7 +637,7 @@ class TestSOCKS4Proxy(IPV4SocketDummyServerTestCase):
             sock.close()
 
         self._start_server(request_handler)
-        proxy_url = "socks4://%s:%s" % (self.host, self.port)
+        proxy_url = "socks4://{}:{}".format(self.host, self.port)
         with socks.SOCKSProxyManager(proxy_url, username="user") as pm:
             response = pm.request("GET", "http://16.17.18.19")
 
@@ -653,7 +653,7 @@ class TestSOCKS4Proxy(IPV4SocketDummyServerTestCase):
             next(handler)
 
         self._start_server(request_handler)
-        proxy_url = "socks4a://%s:%s" % (self.host, self.port)
+        proxy_url = "socks4a://{}:{}".format(self.host, self.port)
         with socks.SOCKSProxyManager(proxy_url, username="baduser") as pm:
             with pytest.raises(NewConnectionError) as e:
                 pm.request("GET", "http://example.com", retries=False)
@@ -700,7 +700,7 @@ class TestSOCKSWithTLS(IPV4SocketDummyServerTestCase):
             sock.close()
 
         self._start_server(request_handler)
-        proxy_url = "socks5h://%s:%s" % (self.host, self.port)
+        proxy_url = "socks5h://{}:{}".format(self.host, self.port)
         with socks.SOCKSProxyManager(proxy_url, ca_certs=DEFAULT_CA) as pm:
             response = pm.request("GET", "https://localhost")
 

--- a/test/test_no_ssl.py
+++ b/test/test_no_ssl.py
@@ -27,7 +27,7 @@ class ImportBlocker(object):
         return None
 
     def load_module(self, fullname):
-        raise ImportError("import of {0} is blocked".format(fullname))
+        raise ImportError("import of {} is blocked".format(fullname))
 
 
 class ModuleStash(object):

--- a/test/test_response.py
+++ b/test/test_response.py
@@ -1046,12 +1046,12 @@ class MockChunkedInvalidChunkLength(MockChunkedEncodingResponse):
     BAD_LENGTH_LINE = "ZZZ\r\n"
 
     def _encode_chunk(self, chunk):
-        return "%s%s\r\n" % (self.BAD_LENGTH_LINE, chunk.decode())
+        return "{}{}\r\n".format(self.BAD_LENGTH_LINE, chunk.decode())
 
 
 class MockChunkedEncodingWithoutCRLFOnEnd(MockChunkedEncodingResponse):
     def _encode_chunk(self, chunk):
-        return "%X\r\n%s%s" % (
+        return "{:X}\r\n{}{}".format(
             len(chunk),
             chunk.decode(),
             "\r\n" if len(chunk) > 0 else "",
@@ -1060,7 +1060,7 @@ class MockChunkedEncodingWithoutCRLFOnEnd(MockChunkedEncodingResponse):
 
 class MockChunkedEncodingWithExtensions(MockChunkedEncodingResponse):
     def _encode_chunk(self, chunk):
-        return "%X;asd=qwe\r\n%s\r\n" % (len(chunk), chunk.decode())
+        return "{:X};asd=qwe\r\n{}\r\n".format(len(chunk), chunk.decode())
 
 
 class MockSock(object):

--- a/test/tz_stub.py
+++ b/test/tz_stub.py
@@ -25,7 +25,7 @@ def stub_timezone_ctx(tzname):
     # Make sure the new timezone exists, at least in dateutil
     new_tz = tz.gettz(tzname)
     if new_tz is None:
-        raise ValueError("Invalid timezone specified: %r" % (tzname,))
+        raise ValueError("Invalid timezone specified: {!r}".format(tzname))
 
     # Get the current timezone
     local_tz = tz.tzlocal()

--- a/test/with_dummyserver/test_connectionpool.py
+++ b/test/with_dummyserver/test_connectionpool.py
@@ -711,7 +711,7 @@ class TestConnectionPool(HTTPDummyServerTestCase):
                 self.host, self.port, source_address=addr, retries=False
             ) as pool:
                 with pytest.raises(NewConnectionError):
-                    pool.request("GET", "/source_address?{0}".format(addr))
+                    pool.request("GET", "/source_address?{}".format(addr))
 
     def test_stream_keepalive(self):
         x = 2

--- a/test/with_dummyserver/test_poolmanager.py
+++ b/test/with_dummyserver/test_poolmanager.py
@@ -56,7 +56,9 @@ class TestPoolManager(HTTPDummyServerTestCase):
                 "GET",
                 "%s/redirect" % self.base_url,
                 fields={
-                    "target": "%s/redirect?target=%s/" % (self.base_url, self.base_url)
+                    "target": "{}/redirect?target={}/".format(
+                        self.base_url, self.base_url
+                    )
                 },
             )
 
@@ -251,7 +253,9 @@ class TestPoolManager(HTTPDummyServerTestCase):
                 "GET",
                 "%s/redirect" % self.base_url,
                 fields={
-                    "target": "%s/redirect?target=%s/" % (self.base_url, self.base_url)
+                    "target": "{}/redirect?target={}/".format(
+                        self.base_url, self.base_url
+                    )
                 },
                 retries=Retry(total=None, redirect=1, raise_on_redirect=False),
             )
@@ -343,12 +347,12 @@ class TestPoolManager(HTTPDummyServerTestCase):
 
     def test_http_with_ssl_keywords(self):
         with PoolManager(ca_certs="REQUIRED") as http:
-            r = http.request("GET", "http://%s:%s/" % (self.host, self.port))
+            r = http.request("GET", "http://{}:{}/".format(self.host, self.port))
             assert r.status == 200
 
     def test_http_with_ca_cert_dir(self):
         with PoolManager(ca_certs="REQUIRED", ca_cert_dir="/nosuchdir") as http:
-            r = http.request("GET", "http://%s:%s/" % (self.host, self.port))
+            r = http.request("GET", "http://{}:{}/".format(self.host, self.port))
             assert r.status == 200
 
     @pytest.mark.parametrize(

--- a/test/with_dummyserver/test_proxy_poolmanager.py
+++ b/test/with_dummyserver/test_proxy_poolmanager.py
@@ -161,7 +161,7 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
     def test_proxy_conn_fail(self):
         host, port = get_unreachable_address()
         with proxy_from_url(
-            "http://%s:%s/" % (host, port), retries=1, timeout=LONG_TIMEOUT
+            "http://{}:{}/".format(host, port), retries=1, timeout=LONG_TIMEOUT
         ) as http:
             with pytest.raises(MaxRetryError):
                 http.request("GET", "%s/" % self.https_url)
@@ -283,7 +283,7 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
             returned_headers = json.loads(r.data.decode())
             assert returned_headers.get("Foo") == "bar"
             assert returned_headers.get("Hickory") == "dickory"
-            assert returned_headers.get("Host") == "%s:%s" % (
+            assert returned_headers.get("Host") == "{}:{}".format(
                 self.http_host,
                 self.http_port,
             )
@@ -292,7 +292,7 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
             returned_headers = json.loads(r.data.decode())
             assert returned_headers.get("Foo") == "bar"
             assert returned_headers.get("Hickory") == "dickory"
-            assert returned_headers.get("Host") == "%s:%s" % (
+            assert returned_headers.get("Host") == "{}:{}".format(
                 self.http_host_alt,
                 self.http_port,
             )
@@ -301,7 +301,7 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
             returned_headers = json.loads(r.data.decode())
             assert returned_headers.get("Foo") == "bar"
             assert returned_headers.get("Hickory") is None
-            assert returned_headers.get("Host") == "%s:%s" % (
+            assert returned_headers.get("Host") == "{}:{}".format(
                 self.https_host,
                 self.https_port,
             )
@@ -310,7 +310,7 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
             returned_headers = json.loads(r.data.decode())
             assert returned_headers.get("Foo") == "bar"
             assert returned_headers.get("Hickory") == "dickory"
-            assert returned_headers.get("Host") == "%s:%s" % (
+            assert returned_headers.get("Host") == "{}:{}".format(
                 self.http_host,
                 self.http_port,
             )
@@ -322,7 +322,7 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
             assert returned_headers.get("Foo") is None
             assert returned_headers.get("Baz") == "quux"
             assert returned_headers.get("Hickory") == "dickory"
-            assert returned_headers.get("Host") == "%s:%s" % (
+            assert returned_headers.get("Host") == "{}:{}".format(
                 self.http_host,
                 self.http_port,
             )
@@ -334,7 +334,7 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
             assert returned_headers.get("Foo") is None
             assert returned_headers.get("Baz") == "quux"
             assert returned_headers.get("Hickory") is None
-            assert returned_headers.get("Host") == "%s:%s" % (
+            assert returned_headers.get("Host") == "{}:{}".format(
                 self.https_host,
                 self.https_port,
             )
@@ -346,7 +346,7 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
             assert returned_headers.get("Foo") is None
             assert returned_headers.get("Baz") == "quux"
             assert returned_headers.get("Hickory") == "dickory"
-            assert returned_headers.get("Host") == "%s:%s" % (
+            assert returned_headers.get("Host") == "{}:{}".format(
                 self.http_host,
                 self.http_port,
             )
@@ -358,7 +358,7 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
             assert returned_headers.get("Foo") is None
             assert returned_headers.get("Baz") == "quux"
             assert returned_headers.get("Hickory") is None
-            assert returned_headers.get("Host") == "%s:%s" % (
+            assert returned_headers.get("Host") == "{}:{}".format(
                 self.https_host,
                 self.https_port,
             )
@@ -376,7 +376,7 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
             returned_headers = json.loads(r.data.decode())
             assert returned_headers.get("Foo") == "bar"
             assert returned_headers.get("Hickory") == "dickory"
-            assert returned_headers.get("Host") == "%s:%s" % (
+            assert returned_headers.get("Host") == "{}:{}".format(
                 self.http_host,
                 self.http_port,
             )
@@ -385,7 +385,7 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
             returned_headers = json.loads(r.data.decode())
             assert returned_headers.get("Foo") == "bar"
             assert returned_headers.get("Hickory") == "dickory"
-            assert returned_headers.get("Host") == "%s:%s" % (
+            assert returned_headers.get("Host") == "{}:{}".format(
                 self.http_host_alt,
                 self.http_port,
             )
@@ -397,7 +397,7 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
             assert returned_headers.get("Foo") is None
             assert returned_headers.get("Baz") == "quux"
             assert returned_headers.get("Hickory") is None
-            assert returned_headers.get("Host") == "%s:%s" % (
+            assert returned_headers.get("Host") == "{}:{}".format(
                 self.https_host,
                 self.https_port,
             )
@@ -415,7 +415,7 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
             returned_headers = json.loads(r.data.decode())
             assert returned_headers.get("Foo") == "bar"
             assert returned_headers.get("Hickory") == "dickory"
-            assert returned_headers.get("Host") == "%s:%s" % (
+            assert returned_headers.get("Host") == "{}:{}".format(
                 self.https_host,
                 self.https_port,
             )
@@ -549,7 +549,7 @@ class TestHTTPSProxyVerification:
     @onlyPy3
     def test_https_proxy_hostname_verification(self, no_localhost_san_server):
         bad_server = no_localhost_san_server
-        bad_proxy_url = "https://%s:%s" % (bad_server.host, bad_server.port)
+        bad_proxy_url = "https://{}:{}".format(bad_server.host, bad_server.port)
 
         # An exception will be raised before we contact the destination domain.
         test_url = "testing.com"

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -759,14 +759,12 @@ class TestSocketClosing(SocketDummyServerTestCase):
 
             # Send partial chunked response and then hang.
             sock.send(
-                (
-                    "HTTP/1.1 200 OK\r\n"
-                    "Content-Type: text/plain\r\n"
-                    "Transfer-Encoding: chunked\r\n"
-                    "\r\n"
-                    "8\r\n"
-                    "12345678\r\n"
-                ).encode("utf-8")
+                b"HTTP/1.1 200 OK\r\n"
+                b"Content-Type: text/plain\r\n"
+                b"Transfer-Encoding: chunked\r\n"
+                b"\r\n"
+                b"8\r\n"
+                b"12345678\r\n"
             )
             timed_out.wait(5)
 
@@ -785,15 +783,13 @@ class TestSocketClosing(SocketDummyServerTestCase):
 
             # Send complete chunked response.
             new_sock.send(
-                (
-                    "HTTP/1.1 200 OK\r\n"
-                    "Content-Type: text/plain\r\n"
-                    "Transfer-Encoding: chunked\r\n"
-                    "\r\n"
-                    "8\r\n"
-                    "12345678\r\n"
-                    "0\r\n\r\n"
-                ).encode("utf-8")
+                b"HTTP/1.1 200 OK\r\n"
+                b"Content-Type: text/plain\r\n"
+                b"Transfer-Encoding: chunked\r\n"
+                b"\r\n"
+                b"8\r\n"
+                b"12345678\r\n"
+                b"0\r\n\r\n"
             )
 
             new_sock.close()
@@ -829,12 +825,10 @@ class TestSocketClosing(SocketDummyServerTestCase):
                 buf = sock.recv(65536)
 
             sock.send(
-                (
-                    "HTTP/1.1 200 OK\r\n"
-                    "Content-Type: text/plain\r\n"
-                    "Content-Length: 0\r\n"
-                    "\r\n"
-                ).encode("utf-8")
+                b"HTTP/1.1 200 OK\r\n"
+                b"Content-Type: text/plain\r\n"
+                b"Content-Length: 0\r\n"
+                b"\r\n"
             )
 
             # Wait for the socket to close.
@@ -890,15 +884,13 @@ class TestSocketClosing(SocketDummyServerTestCase):
 
             # Send complete chunked response.
             sock.send(
-                (
-                    "HTTP/1.1 200 OK\r\n"
-                    "Content-Type: text/plain\r\n"
-                    "Transfer-Encoding: chunked\r\n"
-                    "\r\n"
-                    "8\r\n"
-                    "12345678\r\n"
-                    "0\r\n\r\n"
-                ).encode("utf-8")
+                b"HTTP/1.1 200 OK\r\n"
+                b"Content-Type: text/plain\r\n"
+                b"Transfer-Encoding: chunked\r\n"
+                b"\r\n"
+                b"8\r\n"
+                b"12345678\r\n"
+                b"0\r\n\r\n"
             )
 
             sock.close()
@@ -1060,20 +1052,16 @@ class TestProxyManager(SocketDummyServerTestCase):
                 buf += sock.recv(65536)
             s = buf.decode("utf-8")
             if not s.startswith("CONNECT "):
-                sock.send(
-                    (
-                        "HTTP/1.1 405 Method not allowed\r\nAllow: CONNECT\r\n\r\n"
-                    ).encode("utf-8")
-                )
+                sock.send(b"HTTP/1.1 405 Method not allowed\r\nAllow: CONNECT\r\n\r\n")
                 sock.close()
                 return
 
-            if not s.startswith("CONNECT %s:443" % (self.host,)):
-                sock.send(("HTTP/1.1 403 Forbidden\r\n\r\n").encode("utf-8"))
+            if not s.startswith("CONNECT {}:443".format(self.host)):
+                sock.send(b"HTTP/1.1 403 Forbidden\r\n\r\n")
                 sock.close()
                 return
 
-            sock.send(("HTTP/1.1 200 Connection Established\r\n\r\n").encode("utf-8"))
+            sock.send(b"HTTP/1.1 200 Connection Established\r\n\r\n")
             ssl_sock = ssl.wrap_socket(
                 sock,
                 server_side=True,
@@ -1087,14 +1075,12 @@ class TestProxyManager(SocketDummyServerTestCase):
                 buf += ssl_sock.recv(65536)
 
             ssl_sock.send(
-                (
-                    "HTTP/1.1 200 OK\r\n"
-                    "Content-Type: text/plain\r\n"
-                    "Content-Length: 2\r\n"
-                    "Connection: close\r\n"
-                    "\r\n"
-                    "Hi"
-                ).encode("utf-8")
+                b"HTTP/1.1 200 OK\r\n"
+                b"Content-Type: text/plain\r\n"
+                b"Content-Length: 2\r\n"
+                b"Connection: close\r\n"
+                b"\r\n"
+                b"Hi"
             )
             ssl_sock.close()
 
@@ -1106,7 +1092,7 @@ class TestProxyManager(SocketDummyServerTestCase):
         base_url = "http://%s:%d" % (self.host, self.port)
 
         with proxy_from_url(base_url, ca_certs=DEFAULT_CA) as proxy:
-            url = "https://{0}".format(self.host)
+            url = "https://{}".format(self.host)
             conn = proxy.connection_from_url(url)
             r = conn.urlopen("GET", url, retries=0)
             assert r.status == 200
@@ -1124,7 +1110,7 @@ class TestProxyManager(SocketDummyServerTestCase):
                 buf += sock.recv(65536)
             s = buf.decode("utf-8")
 
-            if s.startswith("CONNECT [%s]:443" % (ipv6_addr,)):
+            if s.startswith("CONNECT [{}]:443".format(ipv6_addr)):
                 sock.send(b"HTTP/1.1 200 Connection Established\r\n\r\n")
                 ssl_sock = ssl.wrap_socket(
                     sock,
@@ -1152,7 +1138,7 @@ class TestProxyManager(SocketDummyServerTestCase):
         base_url = "http://%s:%d" % (self.host, self.port)
 
         with proxy_from_url(base_url, cert_reqs="NONE") as proxy:
-            url = "https://[{0}]".format(ipv6_addr)
+            url = "https://[{}]".format(ipv6_addr)
             conn = proxy.connection_from_url(url)
             try:
                 r = conn.urlopen("GET", url, retries=0)
@@ -1180,13 +1166,11 @@ class TestSSL(SocketDummyServerTestCase):
 
             # Deliberately send from the non-SSL socket.
             sock2.send(
-                (
-                    "HTTP/1.1 200 OK\r\n"
-                    "Content-Type: text/plain\r\n"
-                    "Content-Length: 2\r\n"
-                    "\r\n"
-                    "Hi"
-                ).encode("utf-8")
+                b"HTTP/1.1 200 OK\r\n"
+                b"Content-Type: text/plain\r\n"
+                b"Content-Length: 2\r\n"
+                b"\r\n"
+                b"Hi"
             )
             sock2.close()
             ssl_sock.close()
@@ -1216,13 +1200,11 @@ class TestSSL(SocketDummyServerTestCase):
 
             # Send incomplete message (note Content-Length)
             ssl_sock.send(
-                (
-                    "HTTP/1.1 200 OK\r\n"
-                    "Content-Type: text/plain\r\n"
-                    "Content-Length: 10\r\n"
-                    "\r\n"
-                    "Hi-"
-                ).encode("utf-8")
+                b"HTTP/1.1 200 OK\r\n"
+                b"Content-Type: text/plain\r\n"
+                b"Content-Length: 10\r\n"
+                b"\r\n"
+                b"Hi-"
             )
             timed_out.wait()
 
@@ -1303,13 +1285,11 @@ class TestSSL(SocketDummyServerTestCase):
 
             # Deliberately send from the non-SSL socket to trigger an SSLError
             sock2.send(
-                (
-                    "HTTP/1.1 200 OK\r\n"
-                    "Content-Type: text/plain\r\n"
-                    "Content-Length: 4\r\n"
-                    "\r\n"
-                    "Fail"
-                ).encode("utf-8")
+                b"HTTP/1.1 200 OK\r\n"
+                b"Content-Type: text/plain\r\n"
+                b"Content-Length: 4\r\n"
+                b"\r\n"
+                b"Fail"
             )
             sock2.close()
             ssl_sock.close()
@@ -1522,9 +1502,7 @@ class TestHeaders(SocketDummyServerTestCase):
                 (key, value) = header.split(b": ")
                 self.parsed_headers[key.decode("ascii")] = value.decode("ascii")
 
-            sock.send(
-                ("HTTP/1.1 204 No Content\r\nContent-Length: 0\r\n\r\n").encode("utf-8")
-            )
+            sock.send(b"HTTP/1.1 204 No Content\r\nContent-Length: 0\r\n\r\n")
 
             sock.close()
 
@@ -1536,7 +1514,7 @@ class TestHeaders(SocketDummyServerTestCase):
         self.start_parsing_handler()
         expected_headers = {
             "Accept-Encoding": "identity",
-            "Host": "{0}:{1}".format(self.host, self.port),
+            "Host": "{}:{}".format(self.host, self.port),
             "User-Agent": _get_default_user_agent(),
         }
         expected_headers.update(headers)
@@ -1551,7 +1529,7 @@ class TestHeaders(SocketDummyServerTestCase):
         self.start_parsing_handler()
         expected_headers = {
             "Accept-Encoding": "identity",
-            "Host": "{0}:{1}".format(self.host, self.port),
+            "Host": "{}:{}".format(self.host, self.port),
         }
         expected_headers.update(headers)
 
@@ -1588,7 +1566,7 @@ class TestHeaders(SocketDummyServerTestCase):
         with HTTPConnectionPool(self.host + ".", self.port, retries=False) as pool:
             pool.request("GET", "/")
             self.assert_header_received(
-                self.received_headers, "Host", "%s:%s" % (self.host, self.port)
+                self.received_headers, "Host", "{}:{}".format(self.host, self.port)
             )
 
     def test_response_headers_are_returned_in_the_original_order(self):


### PR DESCRIPTION
I'd like to bring `1.26.x` CI closer to the `main` CI because we're making a lot 1.26.x releases and they are often stressful, in part because they tend to include CVEs, in part due to bad CI. https://twitter.com/sethmlarson/status/1397603959733243908

I'm starting with lint: this uses pre-commit just like in main but omits mypy and configures pyupgrade/black to use Python 2.7. Consider reviewing/merging the two commits separately due to the amount of noise black/pyupgrade introduce.