### PR TITLE
Add type hints to urllib3.connectionpool

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -10,6 +10,7 @@ import nox
 TYPED_FILES = {
     "src/urllib3/contrib/__init__.py",
     "src/urllib3/connection.py",
+    "src/urllib3/connectionpool.py",
     "src/urllib3/exceptions.py",
     "src/urllib3/_collections.py",
     "src/urllib3/fields.py",

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -336,11 +336,11 @@ class HTTPSConnection(HTTPConnection):
 
     default_port = port_by_scheme["https"]
 
-    cert_reqs: Optional[int] = None
+    cert_reqs: Optional[Union[int, str]] = None
     ca_certs: Optional[str] = None
     ca_cert_dir: Optional[str] = None
     ca_cert_data: Union[None, str, bytes] = None
-    ssl_version: Optional[int] = None
+    ssl_version: Optional[Union[int, str]] = None
     assert_fingerprint: Optional[str] = None
     tls_in_tls_required: bool = False
 
@@ -384,7 +384,7 @@ class HTTPSConnection(HTTPConnection):
         self,
         key_file: Optional[str] = None,
         cert_file: Optional[str] = None,
-        cert_reqs: Optional[int] = None,
+        cert_reqs: Optional[Union[int, str]] = None,
         key_password: Optional[str] = None,
         ca_certs: Optional[str] = None,
         assert_hostname: Union[None, str, "Literal[False]"] = None,

--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -7,7 +7,7 @@ import warnings
 from http.client import HTTPResponse as _HttplibHTTPResponse
 from http.client import HTTPSConnection as _HttplibHTTPSConnection
 from socket import timeout as SocketTimeout
-from typing import TYPE_CHECKING, Any, Mapping, Optional, Type, Union
+from typing import TYPE_CHECKING, Any, Mapping, Optional, Type, Union, overload
 
 from .connection import (
     BaseSSLError,
@@ -874,7 +874,7 @@ class HTTPSConnectionPool(HTTPConnectionPool):
 
     def __init__(
         self,
-        host: Optional[str],
+        host: str,
         port: Optional[int] = None,
         timeout: _TYPE_TIMEOUT = Timeout.DEFAULT_TIMEOUT,
         maxsize: int = 1,
@@ -970,9 +970,9 @@ class HTTPSConnectionPool(HTTPConnectionPool):
                 "Can't connect to HTTPS URL because the SSL module is not available."
             )
 
-        actual_host: Optional[str] = self.host
+        actual_host: str = self.host
         actual_port = self.port
-        if self.proxy is not None:
+        if self.proxy is not None and self.proxy.host is not None:
             actual_host = self.proxy.host
             actual_port = self.proxy.port
 
@@ -1037,6 +1037,16 @@ def connection_from_url(url: str, **kw: Any) -> ConnectionPool:
         return HTTPSConnectionPool(host, port=port, **kw)
     else:
         return HTTPConnectionPool(host, port=port, **kw)
+
+
+@overload
+def _normalize_host(host: None, scheme: Optional[str]) -> None:
+    ...
+
+
+@overload
+def _normalize_host(host: str, scheme: Optional[str]) -> str:
+    ...
 
 
 def _normalize_host(host: Optional[str], scheme: Optional[str]) -> Optional[str]:

--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -9,7 +9,7 @@ from http.client import HTTPSConnection as _HttplibHTTPSConnection
 from socket import timeout as SocketTimeout
 from typing import TYPE_CHECKING, Any, Mapping, Optional, Type, Union, overload
 
-from .connection import (
+from .connection import (  # type: ignore
     BaseSSLError,
     BrokenPipeError,
     DummyConnection,
@@ -445,9 +445,9 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
             method,
             url,
             # HTTP version
-            conn._http_vsn_str,
+            conn._http_vsn_str,  # type: ignore
             httplib_response.status,
-            httplib_response.length,
+            httplib_response.length,  # type: ignore
         )
 
         try:
@@ -1034,9 +1034,9 @@ def connection_from_url(url: str, **kw: Any) -> ConnectionPool:
     scheme = scheme or "http"
     port = port or port_by_scheme.get(scheme, 80)
     if scheme == "https":
-        return HTTPSConnectionPool(host, port=port, **kw)
+        return HTTPSConnectionPool(host, port=port, **kw)  # type: ignore
     else:
-        return HTTPConnectionPool(host, port=port, **kw)
+        return HTTPConnectionPool(host, port=port, **kw)  # type: ignore
 
 
 @overload

--- a/src/urllib3/exceptions.py
+++ b/src/urllib3/exceptions.py
@@ -6,6 +6,7 @@ if TYPE_CHECKING:
 
     from urllib3.connectionpool import ConnectionPool
     from urllib3.response import HTTPResponse
+    from urllib3.util.retry import Retry
 
 # Base Exceptions
 
@@ -119,9 +120,11 @@ class MaxRetryError(RequestError):
 class HostChangedError(RequestError):
     """Raised when an existing pool gets a request for a foreign host."""
 
-    retries: int
+    retries: Union["Retry", int]
 
-    def __init__(self, pool: "ConnectionPool", url: str, retries: int = 3) -> None:
+    def __init__(
+        self, pool: "ConnectionPool", url: str, retries: Union["Retry", int] = 3
+    ) -> None:
         message = f"Tried to open a foreign host with url: {url}"
         super().__init__(pool, url, message)
         self.retries = retries

--- a/src/urllib3/response.py
+++ b/src/urllib3/response.py
@@ -3,7 +3,9 @@ import logging
 import typing
 import zlib
 from contextlib import contextmanager
+from http.client import HTTPResponse as _HttplibHTTPResponse
 from socket import timeout as SocketTimeout
+from typing import Any, Type
 
 try:
     try:
@@ -435,7 +437,7 @@ class HTTPResponse(BaseHTTPResponse):
         self._pool._put_conn(self._connection)
         self._connection = None
 
-    def drain_conn(self):
+    def drain_conn(self) -> None:
         """
         Read and discard any remaining HTTP response data in the response connection.
 
@@ -678,7 +680,9 @@ class HTTPResponse(BaseHTTPResponse):
                     yield data
 
     @classmethod
-    def from_httplib(ResponseCls, r, **response_kw):
+    def from_httplib(
+        ResponseCls: Type["HTTPResponse"], r: _HttplibHTTPResponse, **response_kw: Any
+    ) -> "HTTPResponse":
         """
         Given an :class:`http.client.HTTPResponse` instance ``r``, return a
         corresponding :class:`urllib3.response.HTTPResponse` object.

--- a/src/urllib3/util/proxy.py
+++ b/src/urllib3/util/proxy.py
@@ -45,8 +45,8 @@ def connection_requires_http_tunnel(
 
 
 def create_proxy_ssl_context(
-    ssl_version: Optional[int] = None,
-    cert_reqs: Optional[int] = None,
+    ssl_version: Optional[Union[int, str]] = None,
+    cert_reqs: Optional[Union[int, str]] = None,
     ca_certs: Optional[str] = None,
     ca_cert_dir: Optional[str] = None,
     ca_cert_data: Union[None, str, bytes] = None,

--- a/src/urllib3/util/request.py
+++ b/src/urllib3/util/request.py
@@ -1,5 +1,5 @@
 from base64 import b64encode
-from typing import IO, Any, AnyStr, Dict, List, Optional, Union, overload
+from typing import IO, Any, AnyStr, Dict, List, Optional, Union
 
 from ..exceptions import UnrewindableBodyError
 
@@ -103,22 +103,8 @@ def make_headers(
     return headers
 
 
-@overload
-def set_file_position(
-    body: IO[Any], pos: Optional[Union[int, object]]
-) -> Optional[Union[int, object]]:
-    ...
-
-
-@overload
 def set_file_position(
     body: Any, pos: Optional[Union[int, object]]
-) -> Optional[Union[int, object]]:
-    ...
-
-
-def set_file_position(
-    body: IO[AnyStr], pos: Optional[Union[int, object]]
 ) -> Optional[Union[int, object]]:
     """
     If a position is provided, move file to that point.

--- a/src/urllib3/util/request.py
+++ b/src/urllib3/util/request.py
@@ -1,5 +1,5 @@
 from base64 import b64encode
-from typing import IO, AnyStr, Dict, List, Optional, Union
+from typing import IO, Any, AnyStr, Dict, List, Optional, Union, overload
 
 from ..exceptions import UnrewindableBodyError
 
@@ -101,6 +101,20 @@ def make_headers(
         headers["cache-control"] = "no-cache"
 
     return headers
+
+
+@overload
+def set_file_position(
+    body: IO[Any], pos: Optional[Union[int, object]]
+) -> Optional[Union[int, object]]:
+    ...
+
+
+@overload
+def set_file_position(
+    body: Any, pos: Optional[Union[int, object]]
+) -> Optional[Union[int, object]]:
+    ...
 
 
 def set_file_position(

--- a/src/urllib3/util/timeout.py
+++ b/src/urllib3/util/timeout.py
@@ -169,7 +169,7 @@ class Timeout:
         return value
 
     @classmethod
-    def from_float(cls, timeout: float) -> "Timeout":
+    def from_float(cls, timeout: Optional[Union[int, float, object]]) -> "Timeout":
         """Create a new Timeout from a legacy timeout value.
 
         The timeout value used by httplib.py sets the same timeout on the


### PR DESCRIPTION
```
src/urllib3/connectionpool.py:1037: error: Argument 1 to "HTTPSConnectionPool" has incompatible type "Optional[str]"; expected "str"
src/urllib3/connectionpool.py:1039: error: Argument 1 to "HTTPConnectionPool" has incompatible type "Optional[str]"; expected "str"
src/urllib3/connectionpool.py:12: error: Module 'urllib3.connection' does not explicitly export attribute 'HTTPException'; implicit reexport disabled
src/urllib3/connectionpool.py:235: error: Argument "timeout" to "HTTPConnection" has incompatible type "object"; expected "Optional[float]"
src/urllib3/connectionpool.py:386: error: Incompatible types in assignment (expression has type "object", variable has type "Optional[float]")
src/urllib3/connectionpool.py:448: error: "HTTPConnection" has no attribute "_http_vsn_str"
src/urllib3/connectionpool.py:450: error: "HTTPResponse" has no attribute "length"
src/urllib3/connectionpool.py:673: error: Argument 1 to "set_file_position" has incompatible type "Union[bytes, IO[Any], Iterable[bytes], str, None]"; expected "IO[Any]"
src/urllib3/connectionpool.py:680: error: Incompatible types in assignment (expression has type "object", variable has type "Optional[float]")
src/urllib3/connectionpool.py:932: error: Argument "cert_reqs" to "set_cert" of "HTTPSConnection" has incompatible type "Union[int, str, None]"; expected "Optional[int]"
src/urllib3/connectionpool.py:938: error: Incompatible types in assignment (expression has type "Union[int, str, None]", variable has type "Optional[int]")
src/urllib3/connectionpool.py:939: error: Incompatible return value type (got "urllib3.connection.HTTPSConnection", expected "http.client.HTTPSConnection")
src/urllib3/connectionpool.py:968: error: Non-overlapping identity check (left operand type: "Type[HTTPSConnection]", right operand type: "Type[DummyConnection]")
src/urllib3/connectionpool.py:982: error: Argument "timeout" has incompatible type "object"; expected "Optional[float]".```