### PR TITLE
multipart header formatting matches current WHATWG HTML Standard

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,19 @@
 Changes
 =======
 
+
+2.0.0 (unreleased)
+------------------
+
+* ``multipart/form-data`` header parameter formatting matches the WHATWG
+  HTML Standard as of 2021-06-10. Control characters in filenames are no
+  longer percent encoded. #2257
+* ``format_header_param_html5`` and ``format_header_param`` are
+  deprecated names for ``format_multipart_header_param``. #2257
+* The ``RequestField`` ``header_formatter`` parameter is deprecated in
+  favor of overriding the ``_render_part`` method. #2257
+
+
 1.26.5 (2021-05-26)
 -------------------
 
@@ -61,7 +74,7 @@ Changes
 
 * Added default ``User-Agent`` header to every request (Pull #1750)
 
-* Added ``urllib3.util.SKIP_HEADER`` for skipping ``User-Agent``, ``Accept-Encoding``, 
+* Added ``urllib3.util.SKIP_HEADER`` for skipping ``User-Agent``, ``Accept-Encoding``,
   and ``Host`` headers from being automatically emitted with requests (Pull #2018)
 
 * Collapse ``transfer-encoding: chunked`` request data and framing into

--- a/noxfile.py
+++ b/noxfile.py
@@ -135,7 +135,7 @@ def lint(session):
 @nox.session()
 def mypy(session):
     """Run mypy."""
-    session.install("mypy")
+    session.install("mypy==0.812")
     session.run("mypy", "--version")
 
     session.log("mypy --strict src/urllib3")


### PR DESCRIPTION
Formatting header parameters for `multipart/form-data` matches the current WHATWG HTML Standard. Closes #1062, which has a lot of background discussion.

* Values are sent as UTF-8. Only `\n`, `\r`, and `"` are percent encoded. Other control characters, and `\`, are not encoded.
* Optimized the format function by pre-compiling the regular expression instead of compiling it for every formatted parameter. Previously, `re.compile` would be called for `name` (and `filename` for files) for every field in the form data.
* Renamed `format_header_param_html5` to `format_multipart_header_param` to more accurately reflect where it is valid.
* Deprecated `format_header_param_html5` and `format_header_param` in favor of `format_multipart_header_param`.
* Deprecated `format_header_param_rfc2231`, producing a `filename*` key is invalid for multipart headers.
* Deprecated the `RequestField` `header_formatter` parameter in favor of subclassing and overriding `RequestField._render_part`.
* Made `_render_part` part of the publicly documented API. It was already documented as being something that could be overridden, but had a private name so was not shown in the docs.
* Used `pytest.mark.parametrize` in tests. Added more filename test cases. Used `with pytest.deprecated_call()` to suppress deprecation warnings in test output.