### PR TITLE
Updated docs to use top-level request wherever needed

### DIFF
--- a/docs/advanced-usage.rst
+++ b/docs/advanced-usage.rst
@@ -69,8 +69,7 @@ content.
 
     import urllib3
 
-    http = urllib3.PoolManager()
-    resp = http.request(
+    resp = urllib3.request(
         "GET",
         "https://httpbin.org/bytes/1024",
         preload_content=False
@@ -96,8 +95,7 @@ a file-like object. This allows you to do buffering:
 
     import urllib3
 
-    http = urllib3.PoolManager()
-    resp = http.request(
+    resp = urllib3.request(
         "GET",
         "https://httpbin.org/bytes/1024",
         preload_content=False
@@ -114,8 +112,7 @@ data is available.
     import io
     import urllib3
 
-    http = urllib3.PoolManager()
-    resp = http.request(
+    resp = urllib3.request(
         "GET",
         "https://httpbin.org/bytes/1024",
         preload_content=False
@@ -137,8 +134,8 @@ You can use this file-like object to do things like decode the content using
     import urllib3
 
     reader = codecs.getreader("utf-8")
-    http = urllib3.PoolManager()
-    resp = http.request(
+
+    resp = urllib3.request(
         "GET",
         "https://httpbin.org/ip",
         preload_content=False
@@ -430,8 +427,7 @@ Here's an example using brotli encoding via the ``Accept-Encoding`` header:
 
     import urllib3
 
-    http = urllib3.PoolManager()
-    http.request(
+    urllib3.request(
         "GET",
         "https://www.google.com/",
         headers={"Accept-Encoding": "br"}

--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -90,6 +90,7 @@ The :class:`~response.HTTPResponse` object provides
     import urllib3
 
     # Making the request (The request function returns HTTPResponse object)
+    # Here we're using module's request method. See the note in above section for details.
     resp = urllib3.request("GET", "https://httpbin.org/ip")
 
     print(resp.status)

--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -146,9 +146,7 @@ to ``False``. By default HTTP responses are closed after reading all bytes, this
     import io
     import urllib3
 
-    http = urllib3.PoolManager() # Creating a seprate PoolManager instance.
-
-    resp = http.request("GET", "https://example.com", preload_content=False)
+    resp = urllib3.request("GET", "https://example.com", preload_content=False)
     resp.auto_close = False
 
     for line in io.TextIOWrapper(resp):
@@ -433,9 +431,7 @@ to :meth:`~poolmanager.PoolManager.request`:
 
     import urllib3
 
-    http = urllib3.PoolManager()
-
-    resp = http.request(
+    resp = urllib3.request(
         "GET",
         "https://httpbin.org/delay/3",
         timeout=4.0
@@ -445,8 +441,7 @@ to :meth:`~poolmanager.PoolManager.request`:
     # <class "urllib3.response.HTTPResponse">
 
     # This request will take more time to process than timeout.
-    http.request(
-        "GET",
+    urllib3.request("GET",
         "https://httpbin.org/delay/3",
         timeout=2.5
     )
@@ -458,18 +453,17 @@ instance which lets you specify separate connect and read timeouts:
 .. code-block:: python
 
     import urllib3
-    http = urllib3.PoolManager()
 
-    resp = http.request(
+    resp = urllib3.request(
         "GET",
         "https://httpbin.org/delay/3",
         timeout=urllib3.Timeout(connect=1.0)
     )
-    
+
     print(type(resp))
     # <urllib3.response.HTTPResponse>
 
-    http.request(
+    urllib3.request(
         "GET",
         "https://httpbin.org/delay/3",
         timeout=urllib3.Timeout(connect=1.0, read=2.0)
@@ -482,7 +476,10 @@ the timeout at the :class:`~urllib3.poolmanager.PoolManager` level:
 
 .. code-block:: python
 
+    import urllib3
+
     http = urllib3.PoolManager(timeout=3.0)
+    
     http = urllib3.PoolManager(
         timeout=urllib3.Timeout(connect=1.0, read=2.0)
     )
@@ -504,8 +501,7 @@ To change the number of retries just specify an integer:
 
     import urllib3
 
-    http = urllib3.PoolManager()
-    http.request("GET", "https://httpbin.org/ip", retries=10)
+    urllib3.request("GET", "https://httpbin.org/ip", retries=10)
 
 To disable all retry and redirect logic specify ``retries=False``:
 
@@ -513,16 +509,14 @@ To disable all retry and redirect logic specify ``retries=False``:
 
     import urllib3
 
-    http = urllib3.PoolManager()
-
-    http.request(
+    urllib3.request(
         "GET",
         "https://nxdomain.example.com",
         retries=False
     )
     # NewConnectionError
 
-    resp = http.request(
+    resp = urllib3.request(
         "GET",
         "https://httpbin.org/redirect/1",
         retries=False
@@ -535,7 +529,7 @@ To disable redirects but keep the retrying logic, specify ``redirect=False``:
 
 .. code-block:: python
 
-    resp = http.request(
+    resp = urllib3.request(
         "GET",
         "https://httpbin.org/redirect/1",
         redirect=False
@@ -551,7 +545,7 @@ For example, to do a total of 3 retries, but limit to only 2 redirects:
 
 .. code-block:: python
 
-    http.request(
+    urllib3.request(
         "GET",
         "https://httpbin.org/redirect/3",
         retries=urllib3.Retry(3, redirect=2)
@@ -563,7 +557,7 @@ You can also disable exceptions for too many redirects and just return the
 
 .. code-block:: python
 
-    resp = http.request(
+    resp = urllib3.request(
         "GET",
         "https://httpbin.org/redirect/3",
         retries=urllib3.Retry(
@@ -580,7 +574,10 @@ specify the retry at the :class:`~urllib3.poolmanager.PoolManager` level:
 
 .. code-block:: python
 
+    import urllib3
+
     http = urllib3.PoolManager(retries=False)
+
     http = urllib3.PoolManager(
         retries=urllib3.Retry(5, redirect=2)
     )
@@ -597,10 +594,8 @@ urllib3 wraps lower-level exceptions, for example:
 
     import urllib3
 
-    http = urllib3.PoolManager()
-
     try:
-        http.request("GET","https://nx.example.com", retries=False)
+        urllib3.request("GET","https://nx.example.com", retries=False)
 
     except urllib3.exceptions.NewConnectionError:
         print("Connection failed.")

--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -90,7 +90,6 @@ The :class:`~response.HTTPResponse` object provides
     import urllib3
 
     # Making the request (The request function returns HTTPResponse object)
-    # Here we're using module's request method. See the note in above section for details.
     resp = urllib3.request("GET", "https://httpbin.org/ip")
 
     print(resp.status)
@@ -442,7 +441,8 @@ to :meth:`~poolmanager.PoolManager.request`:
     # <class "urllib3.response.HTTPResponse">
 
     # This request will take more time to process than timeout.
-    urllib3.request("GET",
+    urllib3.request(
+        "GET",
         "https://httpbin.org/delay/3",
         timeout=2.5
     )


### PR DESCRIPTION
Now, all the examples in docs are using top-level request wrapper wherever possible.