### PR TITLE
Fix remove_headers_on_redirect feature modifying passed-in headers in-place

### DIFF
--- a/src/urllib3/poolmanager.py
+++ b/src/urllib3/poolmanager.py
@@ -415,7 +415,7 @@ class PoolManager(RequestMethods):
         kw["redirect"] = False
 
         if "headers" not in kw:
-            kw["headers"] = self.headers.copy()  # type: ignore
+            kw["headers"] = self.headers
 
         if self._proxy_requires_url_absolute_form(u):
             response = conn.urlopen(method, url, **kw)
@@ -443,10 +443,11 @@ class PoolManager(RequestMethods):
         if retries.remove_headers_on_redirect and not conn.is_same_host(
             redirect_location
         ):
-            headers = list(kw["headers"].keys())
-            for header in headers:
+            new_headers = kw["headers"].copy()
+            for header in kw["headers"]:
                 if header.lower() in retries.remove_headers_on_redirect:
-                    kw["headers"].pop(header, None)
+                    new_headers.pop(header, None)
+            kw["headers"] = new_headers
 
         try:
             retries = retries.increment(method, url, response=response, _pool=conn)  # type: ignore

--- a/test/with_dummyserver/test_poolmanager.py
+++ b/test/with_dummyserver/test_poolmanager.py
@@ -195,11 +195,12 @@ class TestPoolManager(HTTPDummyServerTestCase):
             assert "X-API-Secret" not in data
             assert data["Authorization"] == "bar"
 
+            headers = {"x-api-secret": "foo", "authorization": "bar"}
             r = http.request(
                 "GET",
                 f"{self.base_url}/redirect",
                 fields={"target": f"{self.base_url_alt}/headers"},
-                headers={"x-api-secret": "foo", "authorization": "bar"},
+                headers=headers,
                 retries=Retry(remove_headers_on_redirect=["X-API-Secret"]),
             )
 
@@ -210,6 +211,9 @@ class TestPoolManager(HTTPDummyServerTestCase):
             assert "x-api-secret" not in data
             assert "X-API-Secret" not in data
             assert data["Authorization"] == "bar"
+
+            # Ensure the header argument itself is not modified in-place.
+            assert headers == {"x-api-secret": "foo", "authorization": "bar"}
 
     def test_redirect_without_preload_releases_connection(self):
         with PoolManager(block=True, maxsize=2) as http:


### PR DESCRIPTION
In general I'd say it's expected in Python that when passing a dict to
to an argument like `headers` that it won't be modified in-place and
could be reused safely for further requests.

Previously the remove_headers_on_redirect feature didn't uphold this. Do
a copy to make sure that it does.

This commit additionally *avoids* an unneeded copy when the
`remove_headers_on_redirect` code isn't reached.