### PR TITLE
Remove confusing unused argument from dummyserver SocketServerThread

### DIFF
--- a/dummyserver/server.py
+++ b/dummyserver/server.py
@@ -101,7 +101,7 @@ class SocketServerThread(threading.Thread):
 
     USE_IPV6 = HAS_IPV6_AND_DNS
 
-    def __init__(self, socket_handler, host="localhost", port=8081, ready_event=None):
+    def __init__(self, socket_handler, host="localhost", ready_event=None):
         super().__init__()
         self.daemon = True
 


### PR DESCRIPTION
Actually a dynamic port is used and the argument is ignored.

<!---
Thanks for your contribution! ♥️

If this is your first PR to urllib3 please review the Contributing Guide:
https://urllib3.readthedocs.io/en/latest/contributing.html

Adhering to the Contributing Guide means we can review, merge, and release your change faster! :)
--->
