### PR TITLE
 Remove python2 compat stuff from test_socketlevel.py 

### DIFF
--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -1,6 +1,28 @@
 # TODO: Break this module up into pieces. Maybe group by functionality tested
 # rather than the socket level-ness of it.
+import errno
 import http.client as httplib
+import os
+import os.path
+import select
+import shutil
+import socket
+import ssl
+import tempfile
+from collections import OrderedDict
+from test import (
+    LONG_TIMEOUT,
+    SHORT_TIMEOUT,
+    notSecureTransport,
+    notWindows,
+    requires_ssl_context_keyfile_password,
+    resolvesLocalhostFQDN,
+)
+from threading import Event
+from unittest import mock
+
+import pytest
+import trustme
 
 from dummyserver.server import (
     DEFAULT_CA,
@@ -33,29 +55,6 @@ except ImportError:
     class MimeToolMessage:
         pass
 
-
-import errno
-import os
-import os.path
-import select
-import shutil
-import socket
-import ssl
-import tempfile
-from collections import OrderedDict
-from test import (
-    LONG_TIMEOUT,
-    SHORT_TIMEOUT,
-    notSecureTransport,
-    notWindows,
-    requires_ssl_context_keyfile_password,
-    resolvesLocalhostFQDN,
-)
-from threading import Event
-from unittest import mock
-
-import pytest
-import trustme
 
 # Retry failed tests
 pytestmark = pytest.mark.flaky

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -1,7 +1,6 @@
 # TODO: Break this module up into pieces. Maybe group by functionality tested
 # rather than the socket level-ness of it.
 import errno
-import http.client as httplib
 import os
 import os.path
 import select
@@ -47,14 +46,6 @@ from urllib3.util.retry import Retry
 from urllib3.util.timeout import Timeout
 
 from .. import LogRecorder, has_alpn
-
-try:
-    from mimetools import Message as MimeToolMessage
-except ImportError:
-
-    class MimeToolMessage:
-        pass
-
 
 # Retry failed tests
 pytestmark = pytest.mark.flaky
@@ -1615,10 +1606,6 @@ class TestHeaders(SocketDummyServerTestCase):
             assert expected_response_headers == actual_response_headers
 
 
-@pytest.mark.skipif(
-    issubclass(httplib.HTTPMessage, MimeToolMessage),
-    reason="Header parsing errors not available",
-)
 class TestBrokenHeaders(SocketDummyServerTestCase):
     def _test_broken_header_parsing(self, headers, unparsed_data_check=None):
         self.start_response_handler(


### PR DESCRIPTION
The `TestBrokenHeaders` test has a skip on condition involving `mimetools` which no longer exists by this name in Python 3, so I assume it's no longer relevant.

The change makes isort reformat all of the imports so I split the formatting to a separate commit. I recommend looking at the second commit for the actual change here.