### PR TITLE
Couple of ntlmpool changes

### DIFF
--- a/src/urllib3/contrib/ntlmpool.py
+++ b/src/urllib3/contrib/ntlmpool.py
@@ -3,13 +3,12 @@ NTLM authenticating pool, contributed by erikcederstran
 
 Issue #10, see: http://code.google.com/p/urllib3/issues/detail?id=10
 """
-
-from http.client import HTTPSConnection
 from logging import getLogger
 
 from ntlm import ntlm
 
 from .. import HTTPSConnectionPool
+from ..connection import HTTPSConnection
 
 log = getLogger(__name__)
 

--- a/src/urllib3/contrib/ntlmpool.py
+++ b/src/urllib3/contrib/ntlmpool.py
@@ -49,7 +49,11 @@ class NTLMConnectionPool(HTTPSConnectionPool):
         req_header = "Authorization"
         resp_header = "www-authenticate"
 
-        conn = HTTPSConnection(host=self.host, port=self.port)
+        conn = HTTPSConnection(
+            host=self.host,
+            port=self.port,
+            timeout=self.timeout.connect_timeout,  # type: ignore
+        )
 
         # Send negotiation message
         headers[req_header] = f"NTLM {ntlm.create_NTLM_NEGOTIATE_MESSAGE(self.rawuser)}"


### PR DESCRIPTION
First commit: Make ntlmpool use urllib3's HTTPSConnection instead of httplib's.  The main urllib3 doesn't use http.client.HTTPSConnection, but rolls its own instead. ntlmpool should follow suit.

Second commit:  Respect connection timeout in ntlmpool.

It seems to me like ntlmpool is missing a lot of additional stuff in its `_new_conn` compared to `HTTPSConnectionPool` but I only added timeout.

I should note I don't use ntlmpool at all, I only saw this when looking at how urllib3 uses httplib.