### PR TITLE
Add keywork arg to request #2283

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,8 @@ Changes
   deprecated names for ``format_multipart_header_param``. #2257
 * The ``RequestField`` ``header_formatter`` parameter is deprecated in
   favor of overriding the ``_render_part`` method. #2257
+* Make all parameters after `method` and `url` for `urllib3.request()` 
+  keyword only. #2283
 
 
 1.26.5 (2021-05-26)

--- a/src/urllib3/__init__.py
+++ b/src/urllib3/__init__.py
@@ -91,6 +91,7 @@ _DEFAULT_POOL = PoolManager()
 def request(
     method: str,
     url: str,
+    *,
     body: Optional[HTTPBody] = None,
     fields: Optional[_TYPE_FIELDS] = None,
     headers: Optional[Mapping[str, str]] = None,

--- a/test/with_dummyserver/test_poolmanager.py
+++ b/test/with_dummyserver/test_poolmanager.py
@@ -407,6 +407,11 @@ class TestPoolManager(HTTPDummyServerTestCase):
         assert r.status == 200
         assert r.data == b"Dummy server!"
 
+    def test_top_level_request_without_keyword_args(self):
+        body = ""
+        with pytest.raises(TypeError):
+            request("GET", f"{self.base_url}/", body)
+
     def test_top_level_request_with_body(self):
         r = request("POST", f"{self.base_url}/echo", body=b"test")
         assert r.status == 200


### PR DESCRIPTION
<!---
Thanks for your contribution! ♥️

If this is your first PR to urllib3 please review the Contributing Guide:
https://urllib3.readthedocs.io/en/latest/contributing.html

Adhering to the Contributing Guide means we can review, merge, and release your change faster! :)
--->

Make all parameters after method and url for urllib3.request() keyword only by adding *

Closes https://github.com/urllib3/urllib3/issues/2283