### PR TITLE
[#2221] Private type aliases

### DIFF
--- a/src/urllib3/__init__.py
+++ b/src/urllib3/__init__.py
@@ -11,7 +11,7 @@ from typing import Mapping, Optional, Type, Union
 from . import exceptions
 from ._collections import HTTPHeaderDict
 from ._version import __version__
-from .connection import HTTPBody
+from .connection import _TYPE_HTTP_BODY
 from .connectionpool import HTTPConnectionPool, HTTPSConnectionPool, connection_from_url
 from .filepost import _TYPE_FIELDS, encode_multipart_formdata
 from .poolmanager import PoolManager, ProxyManager, proxy_from_url
@@ -92,7 +92,7 @@ def request(
     method: str,
     url: str,
     *,
-    body: Optional[HTTPBody] = None,
+    body: Optional[_TYPE_HTTP_BODY] = None,
     fields: Optional[_TYPE_FIELDS] = None,
     headers: Optional[Mapping[str, str]] = None,
     preload_content: Optional[bool] = True,

--- a/src/urllib3/__init__.py
+++ b/src/urllib3/__init__.py
@@ -11,7 +11,7 @@ from typing import Mapping, Optional, Type, Union
 from . import exceptions
 from ._collections import HTTPHeaderDict
 from ._version import __version__
-from .connection import _TYPE_HTTP_BODY
+from .connection import _TYPE_BODY
 from .connectionpool import HTTPConnectionPool, HTTPSConnectionPool, connection_from_url
 from .filepost import _TYPE_FIELDS, encode_multipart_formdata
 from .poolmanager import PoolManager, ProxyManager, proxy_from_url
@@ -92,7 +92,7 @@ def request(
     method: str,
     url: str,
     *,
-    body: Optional[_TYPE_HTTP_BODY] = None,
+    body: Optional[_TYPE_BODY] = None,
     fields: Optional[_TYPE_FIELDS] = None,
     headers: Optional[Mapping[str, str]] = None,
     preload_content: Optional[bool] = True,

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -111,7 +111,7 @@ class HTTPConnection(_HTTPConnection):
 
     #: Disable Nagle's algorithm by default.
     #: ``[(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)]``
-    default_socket_options: connection.SocketOptions = [
+    default_socket_options: connection._TYPE_SOCKET_OPTIONS = [
         (socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
     ]
 
@@ -119,7 +119,7 @@ class HTTPConnection(_HTTPConnection):
     is_verified: bool = False
 
     source_address: Optional[Tuple[str, int]]
-    socket_options: Optional[connection.SocketOptions]
+    socket_options: Optional[connection._TYPE_SOCKET_OPTIONS]
     _tunnel_host: Optional[str]
     _tunnel: Callable[["HTTPConnection"], None]
 
@@ -130,7 +130,9 @@ class HTTPConnection(_HTTPConnection):
         timeout: Optional[float] = connection.SOCKET_GLOBAL_DEFAULT_TIMEOUT,
         source_address: Optional[Tuple[str, int]] = None,
         blocksize: int = 8192,
-        socket_options: Optional[connection.SocketOptions] = default_socket_options,
+        socket_options: Optional[
+            connection._TYPE_SOCKET_OPTIONS
+        ] = default_socket_options,
         proxy: Optional[str] = None,
         proxy_config: Optional[ProxyConfig] = None,
     ) -> None:
@@ -357,7 +359,7 @@ class HTTPSConnection(HTTPConnection):
         source_address: Optional[Tuple[str, int]] = None,
         blocksize: int = 8192,
         socket_options: Optional[
-            connection.SocketOptions
+            connection._TYPE_SOCKET_OPTIONS
         ] = HTTPConnection.default_socket_options,
         proxy: Optional[str] = None,
         proxy_config: Optional[ProxyConfig] = None,

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -49,7 +49,7 @@ from .exceptions import (
 )
 from .util import SKIP_HEADER, SKIPPABLE_HEADERS, connection, ssl_
 from .util.ssl_ import (
-    PeerCertRetType,
+    _TYPE_PEER_CERT_RET,
     assert_fingerprint,
     create_urllib3_context,
     resolve_cert_reqs,
@@ -585,7 +585,7 @@ class HTTPSConnection(HTTPConnection):
             )
 
 
-def _match_hostname(cert: PeerCertRetType, asserted_hostname: str) -> None:
+def _match_hostname(cert: _TYPE_PEER_CERT_RET, asserted_hostname: str) -> None:
     try:
         match_hostname(cert, asserted_hostname)
     except CertificateError as e:

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -74,7 +74,7 @@ RECENT_DATE = datetime.date(2020, 7, 1)
 _CONTAINS_CONTROL_CHAR_RE = re.compile(r"[^-!#$%&'*+.^_`|~0-9a-zA-Z]")
 
 
-HTTPBody = Union[bytes, IO[Any], Iterable[bytes], str]
+_TYPE_HTTP_BODY = Union[bytes, IO[Any], Iterable[bytes], str]
 
 
 class ProxyConfig(NamedTuple):
@@ -268,7 +268,7 @@ class HTTPConnection(_HTTPConnection):
         self,
         method: str,
         url: str,
-        body: Optional[HTTPBody] = None,
+        body: Optional[_TYPE_HTTP_BODY] = None,
         headers: Optional[Mapping[str, str]] = None,
     ) -> None:
         if headers is None:
@@ -286,7 +286,7 @@ class HTTPConnection(_HTTPConnection):
         self,
         method: str,
         url: str,
-        body: Union[None, HTTPBody, Tuple[Union[bytes, str]]] = None,
+        body: Union[None, _TYPE_HTTP_BODY, Tuple[Union[bytes, str]]] = None,
         headers: Optional[Mapping[str, str]] = None,
     ) -> None:
         """

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
     from typing_extensions import Literal
 
 from .util.proxy import create_proxy_ssl_context
-from .util.util import to_str
+from .util.util import to_bytes, to_str
 
 try:  # Compiled with SSL?
     import ssl
@@ -74,7 +74,7 @@ RECENT_DATE = datetime.date(2020, 7, 1)
 _CONTAINS_CONTROL_CHAR_RE = re.compile(r"[^-!#$%&'*+.^_`|~0-9a-zA-Z]")
 
 
-_TYPE_HTTP_BODY = Union[bytes, IO[Any], Iterable[bytes], str]
+_TYPE_BODY = Union[bytes, IO[Any], Iterable[bytes], str]
 
 
 class ProxyConfig(NamedTuple):
@@ -270,7 +270,7 @@ class HTTPConnection(_HTTPConnection):
         self,
         method: str,
         url: str,
-        body: Optional[_TYPE_HTTP_BODY] = None,
+        body: Optional[_TYPE_BODY] = None,
         headers: Optional[Mapping[str, str]] = None,
     ) -> None:
         if headers is None:
@@ -288,7 +288,7 @@ class HTTPConnection(_HTTPConnection):
         self,
         method: str,
         url: str,
-        body: Union[None, _TYPE_HTTP_BODY, Tuple[Union[bytes, str]]] = None,
+        body: Optional[_TYPE_BODY] = None,
         headers: Optional[Mapping[str, str]] = None,
     ) -> None:
         """
@@ -313,7 +313,7 @@ class HTTPConnection(_HTTPConnection):
 
         if body is not None:
             if isinstance(body, (str, bytes)):
-                body = (body,)
+                body = (to_bytes(body),)
             for chunk in body:
                 if not chunk:
                     continue

--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -9,10 +9,10 @@ from socket import timeout as SocketTimeout
 from typing import TYPE_CHECKING, Any, Mapping, Optional, Type, Union, overload
 
 from .connection import (  # type: ignore
+    _TYPE_HTTP_BODY,
     BaseSSLError,
     BrokenPipeError,
     DummyConnection,
-    HTTPBody,
     HTTPConnection,
     HTTPException,
     HTTPSConnection,
@@ -515,7 +515,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         self,
         method: str,
         url: str,
-        body: Optional[HTTPBody] = None,
+        body: Optional[_TYPE_HTTP_BODY] = None,
         headers: Optional[Mapping[str, str]] = None,
         retries: Optional[Union[Retry, bool, int]] = None,
         redirect: bool = True,

--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -9,7 +9,7 @@ from socket import timeout as SocketTimeout
 from typing import TYPE_CHECKING, Any, Mapping, Optional, Type, Union, overload
 
 from .connection import (  # type: ignore
-    _TYPE_HTTP_BODY,
+    _TYPE_BODY,
     BaseSSLError,
     BrokenPipeError,
     DummyConnection,
@@ -515,7 +515,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         self,
         method: str,
         url: str,
-        body: Optional[_TYPE_HTTP_BODY] = None,
+        body: Optional[_TYPE_BODY] = None,
         headers: Optional[Mapping[str, str]] = None,
         retries: Optional[Union[Retry, bool, int]] = None,
         redirect: bool = True,

--- a/src/urllib3/contrib/ntlmpool.py
+++ b/src/urllib3/contrib/ntlmpool.py
@@ -11,7 +11,7 @@ from typing import Any, Dict, Optional, Union
 from ntlm import ntlm  # type:ignore
 
 from .. import HTTPSConnectionPool
-from ..connection import HTTPBody
+from ..connection import _TYPE_HTTP_BODY
 from ..response import BaseHTTPResponse
 from ..util.retry import Retry
 
@@ -108,7 +108,7 @@ class NTLMConnectionPool(HTTPSConnectionPool):
         self,
         method: str,
         url: str,
-        body: Optional[HTTPBody] = None,
+        body: Optional[_TYPE_HTTP_BODY] = None,
         headers: Optional[Dict[str, str]] = None,
         retries: Union[Retry, bool, int] = 3,
         redirect: bool = True,

--- a/src/urllib3/contrib/ntlmpool.py
+++ b/src/urllib3/contrib/ntlmpool.py
@@ -11,7 +11,7 @@ from typing import Any, Dict, Optional, Union
 from ntlm import ntlm  # type:ignore
 
 from .. import HTTPSConnectionPool
-from ..connection import _TYPE_HTTP_BODY
+from ..connection import _TYPE_BODY
 from ..response import BaseHTTPResponse
 from ..util.retry import Retry
 
@@ -108,7 +108,7 @@ class NTLMConnectionPool(HTTPSConnectionPool):
         self,
         method: str,
         url: str,
-        body: Optional[_TYPE_HTTP_BODY] = None,
+        body: Optional[_TYPE_BODY] = None,
         headers: Optional[Dict[str, str]] = None,
         retries: Union[Retry, bool, int] = 3,
         redirect: bool = True,

--- a/src/urllib3/exceptions.py
+++ b/src/urllib3/exceptions.py
@@ -25,7 +25,7 @@ class HTTPWarning(Warning):
     pass
 
 
-ReduceResult = Tuple[Callable[..., object], Tuple[object, ...]]
+_TYPE_REDUCE_RESULT = Tuple[Callable[..., object], Tuple[object, ...]]
 
 
 class PoolError(HTTPError):
@@ -37,7 +37,7 @@ class PoolError(HTTPError):
         self.pool = pool
         super().__init__(f"{pool}: {message}")
 
-    def __reduce__(self) -> ReduceResult:
+    def __reduce__(self) -> _TYPE_REDUCE_RESULT:
         # For pickling purposes.
         return self.__class__, (None, None)
 
@@ -51,7 +51,7 @@ class RequestError(PoolError):
         self.url = url
         super().__init__(pool, message)
 
-    def __reduce__(self) -> ReduceResult:
+    def __reduce__(self) -> _TYPE_REDUCE_RESULT:
         # For pickling purposes.
         return self.__class__, (None, self.url, None)
 

--- a/src/urllib3/poolmanager.py
+++ b/src/urllib3/poolmanager.py
@@ -30,7 +30,7 @@ from .exceptions import (
 )
 from .request import RequestMethods
 from .response import BaseHTTPResponse
-from .util.connection import SocketOptions
+from .util.connection import _TYPE_SOCKET_OPTIONS
 from .util.proxy import connection_requires_http_tunnel
 from .util.retry import Retry
 from .util.timeout import Timeout
@@ -86,7 +86,7 @@ class PoolKey(NamedTuple):
     key__proxy: Optional[Url]
     key__proxy_headers: Optional[FrozenSet[Tuple[str, str]]]
     key__proxy_config: Optional[ProxyConfig]
-    key_socket_options: Optional[SocketOptions]
+    key_socket_options: Optional[_TYPE_SOCKET_OPTIONS]
     key__socks_options: Optional[FrozenSet[Tuple[str, str]]]
     key_assert_hostname: Optional[Union[bool, str]]
     key_assert_fingerprint: Optional[str]

--- a/src/urllib3/request.py
+++ b/src/urllib3/request.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict, Mapping, Optional, Sequence, Tuple, Union
 from urllib.parse import urlencode
 
-from .connection import HTTPBody
+from .connection import _TYPE_HTTP_BODY
 from .filepost import _TYPE_FIELDS, encode_multipart_formdata
 from .response import BaseHTTPResponse
 
@@ -50,7 +50,7 @@ class RequestMethods:
         self,
         method: str,
         url: str,
-        body: Optional[HTTPBody] = None,
+        body: Optional[_TYPE_HTTP_BODY] = None,
         headers: Optional[Mapping[str, str]] = None,
         encode_multipart: bool = True,
         multipart_boundary: Optional[str] = None,
@@ -65,7 +65,7 @@ class RequestMethods:
         self,
         method: str,
         url: str,
-        body: Optional[HTTPBody] = None,
+        body: Optional[_TYPE_HTTP_BODY] = None,
         fields: Optional[_TYPE_FIELDS] = None,
         headers: Optional[Mapping[str, str]] = None,
         **urlopen_kw: Any,

--- a/src/urllib3/request.py
+++ b/src/urllib3/request.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict, Mapping, Optional, Sequence, Tuple, Union
 from urllib.parse import urlencode
 
-from .connection import _TYPE_HTTP_BODY
+from .connection import _TYPE_BODY
 from .filepost import _TYPE_FIELDS, encode_multipart_formdata
 from .response import BaseHTTPResponse
 
@@ -50,7 +50,7 @@ class RequestMethods:
         self,
         method: str,
         url: str,
-        body: Optional[_TYPE_HTTP_BODY] = None,
+        body: Optional[_TYPE_BODY] = None,
         headers: Optional[Mapping[str, str]] = None,
         encode_multipart: bool = True,
         multipart_boundary: Optional[str] = None,
@@ -65,7 +65,7 @@ class RequestMethods:
         self,
         method: str,
         url: str,
-        body: Optional[_TYPE_HTTP_BODY] = None,
+        body: Optional[_TYPE_BODY] = None,
         fields: Optional[_TYPE_FIELDS] = None,
         headers: Optional[Mapping[str, str]] = None,
         **urlopen_kw: Any,

--- a/src/urllib3/util/connection.py
+++ b/src/urllib3/util/connection.py
@@ -6,7 +6,7 @@ from urllib3.exceptions import LocationParseError
 from .wait import wait_for_read
 
 SOCKET_GLOBAL_DEFAULT_TIMEOUT = socket._GLOBAL_DEFAULT_TIMEOUT  # type: ignore
-SocketOptions = Sequence[Tuple[int, int, Union[int, bytes]]]
+_TYPE_SOCKET_OPTIONS = Sequence[Tuple[int, int, Union[int, bytes]]]
 
 
 def is_connection_dropped(conn: socket.socket) -> bool:  # Platform-specific
@@ -31,7 +31,7 @@ def create_connection(
     address: Tuple[str, int],
     timeout: Optional[float] = SOCKET_GLOBAL_DEFAULT_TIMEOUT,
     source_address: Optional[Tuple[str, int]] = None,
-    socket_options: Optional[SocketOptions] = None,
+    socket_options: Optional[_TYPE_SOCKET_OPTIONS] = None,
 ) -> socket.socket:
     """Connect to *address* and return the socket object.
 
@@ -93,7 +93,9 @@ def create_connection(
         raise OSError("getaddrinfo returns an empty list")
 
 
-def _set_socket_options(sock: socket.socket, options: Optional[SocketOptions]) -> None:
+def _set_socket_options(
+    sock: socket.socket, options: Optional[_TYPE_SOCKET_OPTIONS]
+) -> None:
     if options is None:
         return
 

--- a/src/urllib3/util/ssl_.py
+++ b/src/urllib3/util/ssl_.py
@@ -72,8 +72,8 @@ except ImportError:
 
 _PCTRTT = Tuple[Tuple[str, str], ...]
 _PCTRTTT = Tuple[_PCTRTT, ...]
-PeerCertRetDictType = Dict[str, Union[str, _PCTRTTT, _PCTRTT]]
-PeerCertRetType = Union[PeerCertRetDictType, bytes, None]
+_TYPE_PEER_CERT_RET_DICT = Dict[str, Union[str, _PCTRTTT, _PCTRTT]]
+PeerCertRetType = Union[_TYPE_PEER_CERT_RET_DICT, bytes, None]
 
 
 # A secure default.

--- a/src/urllib3/util/ssl_.py
+++ b/src/urllib3/util/ssl_.py
@@ -73,7 +73,7 @@ except ImportError:
 _PCTRTT = Tuple[Tuple[str, str], ...]
 _PCTRTTT = Tuple[_PCTRTT, ...]
 _TYPE_PEER_CERT_RET_DICT = Dict[str, Union[str, _PCTRTTT, _PCTRTT]]
-PeerCertRetType = Union[_TYPE_PEER_CERT_RET_DICT, bytes, None]
+_TYPE_PEER_CERT_RET = Union[_TYPE_PEER_CERT_RET_DICT, bytes, None]
 
 
 # A secure default.

--- a/src/urllib3/util/ssl_match_hostname.py
+++ b/src/urllib3/util/ssl_match_hostname.py
@@ -7,7 +7,7 @@ import ipaddress
 import re
 from typing import Any, Match, Optional, Union
 
-from .ssl_ import PeerCertRetType
+from .ssl_ import _TYPE_PEER_CERT_RET
 
 __version__ = "3.5.0.1"
 
@@ -84,7 +84,7 @@ def _ipaddress_match(ipname: Any, host_ip: str) -> bool:
     return bool(ip == host_ip)
 
 
-def match_hostname(cert: PeerCertRetType, hostname: str) -> None:
+def match_hostname(cert: _TYPE_PEER_CERT_RET, hostname: str) -> None:
     """Verify that *cert* (in decoded format as returned by
     SSLSocket.getpeercert()) matches the *hostname*.  RFC 2818 and RFC 6125
     rules are followed, but IP addresses are not accepted for *hostname*.

--- a/src/urllib3/util/ssltransport.py
+++ b/src/urllib3/util/ssltransport.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 
     from typing_extensions import Literal
 
-    from .ssl_ import PeerCertRetDictType, PeerCertRetType
+    from .ssl_ import _TYPE_PEER_CERT_RET_DICT, PeerCertRetType
 
 
 _SelfT = TypeVar("_SelfT", bound="SSLTransport")
@@ -186,7 +186,7 @@ class SSLTransport:
     @overload
     def getpeercert(
         self, binary_form: "Literal[False]" = ...
-    ) -> Optional["PeerCertRetDictType"]:
+    ) -> Optional["_TYPE_PEER_CERT_RET_DICT"]:
         ...
 
     @overload
@@ -199,7 +199,7 @@ class SSLTransport:
 
     def getpeercert(
         self, binary_form: bool = False
-    ) -> Union[None, bytes, "PeerCertRetDictType", "PeerCertRetType"]:
+    ) -> Union[None, bytes, "_TYPE_PEER_CERT_RET_DICT", "PeerCertRetType"]:
         return self.sslobj.getpeercert(binary_form)
 
     def version(self) -> Optional[str]:

--- a/src/urllib3/util/ssltransport.py
+++ b/src/urllib3/util/ssltransport.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 
     from typing_extensions import Literal
 
-    from .ssl_ import _TYPE_PEER_CERT_RET_DICT, PeerCertRetType
+    from .ssl_ import _TYPE_PEER_CERT_RET, _TYPE_PEER_CERT_RET_DICT
 
 
 _SelfT = TypeVar("_SelfT", bound="SSLTransport")
@@ -194,12 +194,12 @@ class SSLTransport:
         ...
 
     @overload
-    def getpeercert(self, binary_form: bool) -> "PeerCertRetType":
+    def getpeercert(self, binary_form: bool) -> "_TYPE_PEER_CERT_RET":
         ...
 
     def getpeercert(
         self, binary_form: bool = False
-    ) -> Union[None, bytes, "_TYPE_PEER_CERT_RET_DICT", "PeerCertRetType"]:
+    ) -> Union[None, bytes, "_TYPE_PEER_CERT_RET_DICT", "_TYPE_PEER_CERT_RET"]:
         return self.sslobj.getpeercert(binary_form)
 
     def version(self) -> Optional[str]:


### PR DESCRIPTION
This PR converts the following type aliases to private.

1. `HTTPBody` to `_TYPE_HTTP_BODY`
2. `ReduceResult` to `_TYPE_REDUCE_RESULT`
3. `SocketOptions` to `_TYPE_SOCKET_OPTIONS`
4. `PeerCertRetDictType` to `_TYPE_PEER_CERT_RET_DICT`
5. `PeerCertRetType` to `_TYPE_PEER_CERT_RET`

### Notes

1. Type definitions within `contrib/_securetransport/bindings.py` have been ignored in this PR.
2. `nox --reuse-existing-virtualenvs --sessions format` has been run on every commit.

Closes #2221 
