### PR TITLE
Ignore type check for urllib3.contrib._securetransport.bindings

### DIFF
--- a/src/urllib3/contrib/_securetransport/bindings.py
+++ b/src/urllib3/contrib/_securetransport/bindings.py
@@ -1,3 +1,5 @@
+# type: ignore
+
 """
 This module uses ctypes to bind a whole bunch of functions and constants from
 SecureTransport. The goal here is to provide the low-level API to
@@ -46,6 +48,7 @@ from ctypes import (
     c_void_p,
 )
 from ctypes.util import find_library
+from typing import Optional
 
 if platform.system() != "Darwin":
     raise ImportError("Only macOS is supported")
@@ -58,11 +61,12 @@ if version_info < (10, 8):
     )
 
 
-def load_cdll(name, macos10_16_path):
+def load_cdll(name: str, macos10_16_path: str) -> CDLL:
     """Loads a CDLL by name, falling back to known path on 10.16+"""
     try:
         # Big Sur is technically 11 but we use 10.16 due to the Big Sur
         # beta being labeled as 10.16.
+        path: Optional[str]
         if version_info >= (10, 16):
             path = macos10_16_path
         else:


### PR DESCRIPTION
There are a lot of mypy errors that we have to ignore. So, after talking with @sethmlarson, we decided to ignore the whole file.
Here are the errors:

```
src/urllib3/contrib/_securetransport/bindings.py:243: error: "_NamedFuncPointer" has no attribute "argtype"
src/urllib3/contrib/_securetransport/bindings.py:268: error: "_NamedFuncPointer" has no attribute "argstypes"
src/urllib3/contrib/_securetransport/bindings.py:306: error: "CDLL" has no attribute "SSLReadFunc"
src/urllib3/contrib/_securetransport/bindings.py:307: error: "CDLL" has no attribute "SSLWriteFunc"
src/urllib3/contrib/_securetransport/bindings.py:308: error: "CDLL" has no attribute "SSLContextRef"
src/urllib3/contrib/_securetransport/bindings.py:309: error: "CDLL" has no attribute "SSLProtocol"
src/urllib3/contrib/_securetransport/bindings.py:310: error: "CDLL" has no attribute "SSLCipherSuite"
src/urllib3/contrib/_securetransport/bindings.py:311: error: "CDLL" has no attribute "SecIdentityRef"
src/urllib3/contrib/_securetransport/bindings.py:312: error: "CDLL" has no attribute "SecKeychainRef"
src/urllib3/contrib/_securetransport/bindings.py:313: error: "CDLL" has no attribute "SecTrustRef"
src/urllib3/contrib/_securetransport/bindings.py:314: error: "CDLL" has no attribute "SecTrustResultType"
src/urllib3/contrib/_securetransport/bindings.py:315: error: "CDLL" has no attribute "SecExternalFormat"
src/urllib3/contrib/_securetransport/bindings.py:316: error: "CDLL" has no attribute "OSStatus"
src/urllib3/contrib/_securetransport/bindings.py:318: error: "CDLL" has no attribute "kSecImportExportPassphrase"
src/urllib3/contrib/_securetransport/bindings.py:321: error: "CDLL" has no attribute "kSecImportItemIdentity"
src/urllib3/contrib/_securetransport/bindings.py:399: error: "CDLL" has no attribute "kCFAllocatorDefault"
src/urllib3/contrib/_securetransport/bindings.py:402: error: "CDLL" has no attribute "kCFTypeArrayCallBacks"
src/urllib3/contrib/_securetransport/bindings.py:405: error: "CDLL" has no attribute "kCFTypeDictionaryKeyCallBacks"
src/urllib3/contrib/_securetransport/bindings.py:408: error: "CDLL" has no attribute "kCFTypeDictionaryValueCallBacks"
src/urllib3/contrib/_securetransport/bindings.py:412: error: "CDLL" has no attribute "CFTypeRef"
src/urllib3/contrib/_securetransport/bindings.py:413: error: "CDLL" has no attribute "CFArrayRef"
src/urllib3/contrib/_securetransport/bindings.py:414: error: "CDLL" has no attribute "CFStringRef"
src/urllib3/contrib/_securetransport/bindings.py:415: error: "CDLL" has no attribute "CFDictionaryRef"
```
