### PR TITLE
[#2287] Fixes repeated `Transfer-Encoding` header issue.

### DIFF
--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -307,7 +307,7 @@ class HTTPConnection(_HTTPConnection):
             self.putheader("User-Agent", _get_default_user_agent())
         for header, value in headers.items():
             self.putheader(header, value)
-        if "transfer-encoding" not in headers:
+        if "transfer-encoding" not in header_keys:
             self.putheader("Transfer-Encoding", "chunked")
         self.endheaders()
 

--- a/test/with_dummyserver/test_chunked_transfer.py
+++ b/test/with_dummyserver/test_chunked_transfer.py
@@ -37,7 +37,7 @@ class TestChunkedTransfer(SocketDummyServerTestCase):
         self.start_chunked_handler()
         chunks = ["foo", "bar", "", "bazzzzzzzzzzzzzzzzzzzzzz"]
         with HTTPConnectionPool(self.host, self.port, retries=False) as pool:
-            pool.urlopen("GET", "/", chunks, headers=dict(DNT="1"), chunked=True)
+            pool.urlopen("GET", "/", body=chunks, headers=dict(DNT="1"), chunked=True)
 
             assert b"Transfer-Encoding" in self.buffer
             body = self.buffer.split(b"\r\n\r\n", 1)[1]
@@ -90,7 +90,9 @@ class TestChunkedTransfer(SocketDummyServerTestCase):
         self.start_chunked_handler()
         chunks = ["foo", "bar", "", "bazzzzzzzzzzzzzzzzzzzzzz"]
         with HTTPConnectionPool(self.host, self.port, retries=False) as pool:
-            pool.urlopen("GET", "/", chunks, headers={"Host": "test.org"}, chunked=True)
+            pool.urlopen(
+                "GET", "/", body=chunks, headers={"Host": "test.org"}, chunked=True
+            )
 
             host_headers = self._get_header_lines(b"host")
             assert len(host_headers) == 1
@@ -99,7 +101,7 @@ class TestChunkedTransfer(SocketDummyServerTestCase):
         self.start_chunked_handler()
         chunks = ["foo", "bar", "", "bazzzzzzzzzzzzzzzzzzzzzz"]
         with HTTPConnectionPool(self.host, self.port, retries=False) as pool:
-            pool.urlopen("GET", "/", chunks, chunked=True)
+            pool.urlopen("GET", "/", body=chunks, chunked=True)
 
             host_headers = self._get_header_lines(b"host")
             assert len(host_headers) == 1
@@ -108,7 +110,7 @@ class TestChunkedTransfer(SocketDummyServerTestCase):
         self.start_chunked_handler()
         chunks = ["foo", "bar", "", "bazzzzzzzzzzzzzzzzzzzzzz"]
         with HTTPConnectionPool(self.host, self.port, retries=False) as pool:
-            pool.urlopen("GET", "/", chunks, chunked=True)
+            pool.urlopen("GET", "/", body=chunks, chunked=True)
 
             ua_headers = self._get_header_lines(b"user-agent")
             assert len(ua_headers) == 1
@@ -120,8 +122,8 @@ class TestChunkedTransfer(SocketDummyServerTestCase):
             pool.urlopen(
                 "GET",
                 "/",
-                chunks,
-                headers={"User-Agent": "test-agent"},
+                body=chunks,
+                headers={"user-Agent": "test-agent"},
                 chunked=True,
             )
 
@@ -139,7 +141,7 @@ class TestChunkedTransfer(SocketDummyServerTestCase):
             pool.urlopen(
                 "GET",
                 "/",
-                chunks,
+                body=chunks,
                 headers={"User-Agent": SKIP_HEADER},
                 chunked=True,
             )
@@ -151,7 +153,7 @@ class TestChunkedTransfer(SocketDummyServerTestCase):
         self.start_chunked_handler()
         chunks = ["foo", "bar", "", "bazzzzzzzzzzzzzzzzzzzzzz"]
         with HTTPConnectionPool(self.host, self.port, retries=False) as pool:
-            pool.urlopen("GET", "/", chunks, chunked=True)
+            pool.urlopen("GET", "/", body=chunks, chunked=True)
 
             te_headers = self._get_header_lines(b"transfer-encoding")
             assert len(te_headers) == 1
@@ -163,8 +165,8 @@ class TestChunkedTransfer(SocketDummyServerTestCase):
             pool.urlopen(
                 "GET",
                 "/",
-                chunks,
-                headers={"Transfer-Encoding": "test-transfer-encoding"},
+                body=chunks,
+                headers={"transfer-Encoding": "test-transfer-encoding"},
                 chunked=True,
             )
 


### PR DESCRIPTION
This PR:

1. Fixes the repeated addition of `Transfer-Encoding` header while making chunked requests.
2. Adds 3 new tests to validate that we preserve the `User-Agent` and `Transfer-Encoding` headers when provided to us as part of the request, and add a default header of the above forms when no such header is provided as part of the request.

Closes https://github.com/urllib3/urllib3/issues/2287

<!---
Thanks for your contribution! ♥️

If this is your first PR to urllib3 please review the Contributing Guide:
https://urllib3.readthedocs.io/en/latest/contributing.html

Adhering to the Contributing Guide means we can review, merge, and release your change faster! :)
--->
