### PR TITLE
Include py.typed file in package to comply with PEP 561 

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-include README.rst CHANGES.rst LICENSE.txt dev-requirements.txt Makefile
+include README.rst CHANGES.rst LICENSE.txt dev-requirements.txt Makefile src/urllib3/py.typed
 recursive-include dummyserver *
 recursive-include test *
 recursive-include docs *

--- a/setup.py
+++ b/setup.py
@@ -104,6 +104,9 @@ setup(
         "urllib3.contrib._securetransport",
         "urllib3.util",
     ],
+    package_data={
+        "urllib3": ["py.typed"],
+    },
     package_dir={"": "src"},
     requires=[],
     python_requires=">=3.6, <4",

--- a/src/urllib3/py.typed
+++ b/src/urllib3/py.typed
@@ -1,0 +1,2 @@
+# Instruct type checkers to look for inline type annotations in this package.
+# See PEP 561.


### PR DESCRIPTION
See https://www.python.org/dev/peps/pep-0561/

`mypy` and other type checkers use the presence of a `py.typed` file in the root of the package to signal that the package has inline type annotations to be used for type checking. Including this file allows users of this library to properly type check their usage of this package.