### PR TITLE
Add type hints to urllib3.contrib.pyopenssl

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -12,6 +12,7 @@ TYPED_FILES = {
     "src/urllib3/contrib/_securetransport/bindings.py",
     "src/urllib3/contrib/_securetransport/low_level.py",
     "src/urllib3/contrib/ntlmpool.py",
+    "src/urllib3/contrib/pyopenssl.py",
     "src/urllib3/contrib/securetransport.py",
     "src/urllib3/contrib/socks.py",
     "src/urllib3/__init__.py",


### PR DESCRIPTION
Here are the errors. I think we have to ignore most of them.
```
src/urllib3/contrib/pyopenssl.py:126: error: Incompatible types in assignment (expression has type "Type[PyOpenSSLContext]", variable has type "None")
src/urllib3/contrib/pyopenssl.py:127: error: Incompatible types in assignment (expression has type "Type[PyOpenSSLContext]", variable has type "None")
src/urllib3/contrib/pyopenssl.py:316: error: Returning Any from function declared to return "bytes"
src/urllib3/contrib/pyopenssl.py:320: error: Returning Any from function declared to return "int"
src/urllib3/contrib/pyopenssl.py:347: error: Returning Any from function declared to return "int"
src/urllib3/contrib/pyopenssl.py:371: error: Returning Any from function declared to return "None"
src/urllib3/contrib/pyopenssl.py:381: error: Returning Any from function declared to return "Dict[str, List[Any]]"
src/urllib3/contrib/pyopenssl.py:384: error: Returning Any from function declared to return "Dict[str, List[Any]]"
src/urllib3/contrib/pyopenssl.py:387: error: Dict entry 0 has incompatible type "str": "Tuple[Tuple[Tuple[str, Any]]]"; expected "str": "List[Any]"
src/urllib3/contrib/pyopenssl.py:392: error: Returning Any from function declared to return "str"
src/urllib3/contrib/pyopenssl.py:395: error: "Type[WrappedSocket]" has no attribute "makefile"
src/urllib3/contrib/pyopenssl.py:443: error: Incompatible types in assignment (expression has type "bytes", variable has type "Optional[str]")
src/urllib3/contrib/pyopenssl.py:445: error: Incompatible types in assignment (expression has type "bytes", variable has type "Optional[str]")
src/urllib3/contrib/pyopenssl.py:462: error: Incompatible types in assignment (expression has type "bytes", variable has type "Optional[str]")
src/urllib3/contrib/pyopenssl.py:468: error: Returning Any from function declared to return "None".
```