### PR TITLE
Remove a few `# type: ignore`

### DIFF
--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -7,7 +7,7 @@ import sys
 import warnings
 from copy import copy
 from http.client import HTTPConnection as _HTTPConnection
-from http.client import HTTPException  # noqa: F401
+from http.client import HTTPException as HTTPException  # noqa: F401
 from socket import timeout as SocketTimeout
 from typing import (
     IO,

--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -8,7 +8,7 @@ from http.client import HTTPResponse as _HttplibHTTPResponse
 from socket import timeout as SocketTimeout
 from typing import TYPE_CHECKING, Any, Mapping, Optional, Type, Union, overload
 
-from .connection import (  # type: ignore
+from .connection import (
     _TYPE_BODY,
     BaseSSLError,
     BrokenPipeError,
@@ -18,8 +18,8 @@ from .connection import (  # type: ignore
     HTTPSConnection,
     ProxyConfig,
     VerifiedHTTPSConnection,
-    port_by_scheme,
 )
+from .connection import port_by_scheme as port_by_scheme
 from .exceptions import (
     ClosedPoolError,
     EmptyPoolError,
@@ -744,17 +744,18 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
             # Discard the connection for these exceptions. It will be
             # replaced during the next _get_conn() call.
             clean_exit = False
+            new_e: Exception = e
             if isinstance(e, (BaseSSLError, CertificateError)):
-                e = SSLError(e)
+                new_e = SSLError(e)
             elif isinstance(e, NameResolutionError):
                 pass
             elif isinstance(e, (OSError, NewConnectionError)) and self.proxy:
-                e = ProxyError("Cannot connect to proxy.", e)
+                new_e = ProxyError("Cannot connect to proxy.", e)
             elif isinstance(e, (OSError, HTTPException)):
-                e = ProtocolError("Connection aborted.", e)
+                new_e = ProtocolError("Connection aborted.", e)
 
             retries = retries.increment(
-                method, url, error=e, _pool=self, _stacktrace=sys.exc_info()[2]
+                method, url, error=new_e, _pool=self, _stacktrace=sys.exc_info()[2]
             )
             retries.sleep()
 

--- a/src/urllib3/poolmanager.py
+++ b/src/urllib3/poolmanager.py
@@ -17,11 +17,7 @@ from urllib.parse import urljoin
 
 from ._collections import RecentlyUsedContainer
 from .connection import ProxyConfig
-from .connectionpool import (  # type: ignore
-    HTTPConnectionPool,
-    HTTPSConnectionPool,
-    port_by_scheme,
-)
+from .connectionpool import HTTPConnectionPool, HTTPSConnectionPool, port_by_scheme
 from .exceptions import (
     LocationValueError,
     MaxRetryError,

--- a/src/urllib3/response.py
+++ b/src/urllib3/response.py
@@ -27,12 +27,7 @@ except ImportError:
     brotli = None
 
 from ._collections import HTTPHeaderDict
-from .connection import (  # type: ignore
-    _TYPE_BODY,
-    BaseSSLError,
-    HTTPConnection,
-    HTTPException,
-)
+from .connection import _TYPE_BODY, BaseSSLError, HTTPConnection, HTTPException
 from .exceptions import (
     BodyNotHttplibCompatible,
     DecodeError,


### PR DESCRIPTION
I figured out there would be a few quick wins now that everything is typed. (Note: `import a as a` is a way to tell mypy that a should be considered as a reexport, without having to define `__all__`.)