### PR TITLE
Change parent class of NameResolutionError to NewConnectionError

### DIFF
--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -207,7 +207,7 @@ class HTTPConnection(_HTTPConnection):
                 socket_options=self.socket_options,
             )
         except socket.gaierror as e:
-            raise NameResolutionError(self.host, e)
+            raise NameResolutionError(self.host, self, e)
         except SocketTimeout:
             raise ConnectTimeoutError(
                 self,

--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -30,7 +30,6 @@ from .exceptions import (
     InsecureRequestWarning,
     LocationValueError,
     MaxRetryError,
-    NameResolutionError,
     NewConnectionError,
     ProtocolError,
     ProxyError,
@@ -739,15 +738,12 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
             SSLError,
             CertificateError,
             HTTPSProxyError,
-            NameResolutionError,
         ) as e:
             # Discard the connection for these exceptions. It will be
             # replaced during the next _get_conn() call.
             clean_exit = False
             if isinstance(e, (BaseSSLError, CertificateError)):
                 e = SSLError(e)
-            elif isinstance(e, NameResolutionError):
-                pass
             elif isinstance(e, (OSError, NewConnectionError)) and self.proxy:
                 e = ProxyError("Cannot connect to proxy.", e)
             elif isinstance(e, (OSError, HTTPException)):

--- a/src/urllib3/exceptions.py
+++ b/src/urllib3/exceptions.py
@@ -184,6 +184,14 @@ class NewConnectionError(ConnectTimeoutError, HTTPError):
         return self.conn
 
 
+class NameResolutionError(NewConnectionError):
+    """Raised when host name resolution fails."""
+
+    def __init__(self, host: str, conn: "HTTPConnection", reason: socket.gaierror):
+        message = f"Failed to resolve '{host}' ({reason})"
+        super().__init__(conn, message)
+
+
 class EmptyPoolError(PoolError):
     """Raised when a pool runs out of connections and no more are allowed."""
 
@@ -377,11 +385,3 @@ class UnrewindableBodyError(HTTPError):
     """urllib3 encountered an error when trying to rewind a body"""
 
     pass
-
-
-class NameResolutionError(HTTPError, socket.gaierror):
-    """Raised when host name resolution fails."""
-
-    def __init__(self, host: str, reason: socket.gaierror):
-        message = f"Failed to resolve '{host}' ({reason})"
-        HTTPError.__init__(self, message)

--- a/test/with_dummyserver/test_proxy_poolmanager.py
+++ b/test/with_dummyserver/test_proxy_poolmanager.py
@@ -16,7 +16,7 @@ from urllib3.exceptions import (
     ConnectTimeoutError,
     HTTPSProxyError,
     MaxRetryError,
-    NameResolutionError,
+    ProxyError,
     ProxySchemeUnknown,
     ProxySchemeUnsupported,
     SSLError,
@@ -146,7 +146,7 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
 
             with pytest.raises(MaxRetryError) as e:
                 http.request("GET", f"{self.http_url}/")
-            assert type(e.value.reason) == NameResolutionError
+            assert type(e.value.reason) == ProxyError
 
     def test_https_conn_failed(self):
         """


### PR DESCRIPTION
This solves various problems:

 * Adding `NameResolutionError` is no longer a breaking change
 * Retries are supported again
 * `ProxyError` is raised again for all proxy related errors

Closes #1003

---

I've been using this small script to test that this change restores the 1.26.x behavior:

```
import urllib3
import urllib3.exceptions

with urllib3.PoolManager() as http:
    try:
        http.request("GET", "bad.domain")
    except urllib3.exceptions.MaxRetryError as e:
        print(type(e.reason))
        print(e.reason)

    try:
        http.request("GET", "github.com", timeout=0.00001)
    except urllib3.exceptions.MaxRetryError as e:
        print(type(e.reason))
        print(e.reason)
```