### PR TITLE
Remove leading white spaces when parsing input

### DIFF
--- a/src/urllib3/util/url.py
+++ b/src/urllib3/util/url.py
@@ -365,6 +365,7 @@ def parse_url(url: str) -> Url:
     if not url:
         # Empty
         return Url()
+    url = url.lstrip()
 
     source_url = url
     if not _SCHEME_RE.search(url):

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -190,6 +190,7 @@ class TestUtil:
                 "http://google.com/p%5B%5d?parameter%5b%5D=%22hello%22#fragment%23",
                 "http://google.com/p%5B%5D?parameter%5B%5D=%22hello%22#fragment%23",
             ),
+            ("  https://google.com", "https://google.com"),
         ],
     )
     def test_parse_url_normalization(self, url, expected_normalized_url):


### PR DESCRIPTION
<!---
Thanks for your contribution! ♥️

If this is your first PR to urllib3 please review the Contributing Guide:
https://urllib3.readthedocs.io/en/latest/contributing.html

Adhering to the Contributing Guide means we can review, merge, and release your change faster! :)
--->

When a user passes strings such as "<tt>&nbsp;&nbsp;&nbsp;&nbsp;https&colon;//google.com</tt>", `parse_url` silently fails. If this method is used by another utility, it is often difficult for the user to understand that the leading white space is there, leading to some lost time.

This PR tries to be friendly and removes the leading white space from the user input to avoid this situation. #653 talks about removing white spaces in fragments, but I didn't see anything that addresses the user input in entirety.

Additionally, the trailing white spaces in the user inputs should be kept because they may need to be encoded.