### PR TITLE
Drop support for Python 3.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,26 +13,26 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
-      - name: Set up Python 3.7
+      - name: Set up Python 3
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3
       - name: Check packages
         run: |
-          python3.7 -m pip install wheel twine rstcheck;
-          python3.7 setup.py sdist bdist_wheel;
+          python3 -m pip install wheel twine rstcheck;
+          python3 setup.py sdist bdist_wheel;
           rstcheck README.rst CHANGES.rst
-          python3.7 -m twine check dist/*
+          python3 -m twine check dist/*
   test:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
         os: [macos-latest, windows-latest, ubuntu-latest]
         experimental: [false]
         nox-session: ['']
         include:
-          - python-version: pypy3
+          - python-version: pypy-3.7
             os: ubuntu-latest
             experimental: false
             nox-session: test-pypy

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,13 +3,13 @@ repos:
     rev: v2.7.4
     hooks:
       - id: pyupgrade
-        args: ["--py36-plus"]
+        args: ["--py37-plus"]
 
   - repo: https://github.com/psf/black
     rev: 20.8b1
     hooks:
       - id: black
-        args: ["--target-version", "py36"]
+        args: ["--target-version", "py37"]
 
   - repo: https://github.com/PyCQA/isort
     rev: 5.6.4

--- a/noxfile.py
+++ b/noxfile.py
@@ -82,7 +82,7 @@ def tests_impl(session, extras="socks,secure,brotli"):
     session.run("coverage", "xml")
 
 
-@nox.session(python=["3.6", "3.7", "3.8", "3.9", "3.10", "pypy"])
+@nox.session(python=["3.7", "3.8", "3.9", "3.10", "pypy"])
 def test(session):
     tests_impl(session)
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ import sys
 from setuptools import setup
 
 CURRENT_PYTHON = sys.version_info[:2]
-REQUIRED_PYTHON = (3, 6)
+REQUIRED_PYTHON = (3, 7)
 
 # This check and everything above must remain compatible with Python 2.7.
 if CURRENT_PYTHON < REQUIRED_PYTHON:
@@ -77,7 +77,6 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
@@ -91,9 +90,9 @@ setup(
     keywords="urllib httplib threadsafe filepost http https ssl pooling",
     author="Andrey Petrov",
     author_email="andrey.petrov@shazow.net",
-    url="https://urllib3.readthedocs.io/",
+    url="https://urllib3.readthedocs.io",
     project_urls={
-        "Documentation": "https://urllib3.readthedocs.io/",
+        "Documentation": "https://urllib3.readthedocs.io",
         "Code": "https://github.com/urllib3/urllib3",
         "Issue tracker": "https://github.com/urllib3/urllib3/issues",
     },
@@ -106,7 +105,7 @@ setup(
     ],
     package_dir={"": "src"},
     requires=[],
-    python_requires=">=3.6, <4",
+    python_requires=">=3.7, <4",
     extras_require={
         "brotli": [
             "brotli>=1.0.9; platform_python_implementation == 'CPython'",

--- a/src/urllib3/_compat.py
+++ b/src/urllib3/_compat.py
@@ -1,8 +1,0 @@
-class RLock:  # Python 3.6
-    # We shim out a context manager to be used as a compatibility layer
-    # if the system `threading` module doesn't have a real `RLock` available.
-    def __enter__(self) -> None:
-        pass
-
-    def __exit__(self, exc_type: object, exc_value: object, traceback: object) -> None:
-        pass

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -3,7 +3,6 @@ import logging
 import os
 import re
 import socket
-import sys
 import warnings
 from copy import copy
 from http.client import HTTPConnection as _HTTPConnection
@@ -145,18 +144,13 @@ class HTTPConnection(_HTTPConnection):
         self.proxy = proxy
         self.proxy_config = proxy_config
 
-        if sys.version_info >= (3, 7):
-            super().__init__(
-                host=host,
-                port=port,
-                timeout=timeout,
-                source_address=source_address,
-                blocksize=blocksize,
-            )
-        else:
-            super().__init__(
-                host=host, port=port, timeout=timeout, source_address=source_address
-            )
+        super().__init__(
+            host=host,
+            port=port,
+            timeout=timeout,
+            source_address=source_address,
+            blocksize=blocksize,
+        )
 
     # https://github.com/python/mypy/issues/4125
     # Mypy treats this as LSP violation, which is considered a bug.

--- a/src/urllib3/util/ssl_.py
+++ b/src/urllib3/util/ssl_.py
@@ -13,6 +13,7 @@ from .url import _BRACELESS_IPV6_ADDRZ_RE, _IPV4_RE
 SSLContext = None
 SSLTransport = None
 HAS_SNI = False
+HAS_NEVER_CHECK_COMMON_NAME = False
 IS_PYOPENSSL = False
 IS_SECURETRANSPORT = False
 ALPN_PROTOCOLS = ["http/1.1"]
@@ -44,6 +45,7 @@ try:  # Do we have ssl at all?
     import ssl
     from ssl import (  # type: ignore
         CERT_REQUIRED,
+        HAS_NEVER_CHECK_COMMON_NAME,
         HAS_SNI,
         OP_NO_COMPRESSION,
         OP_NO_TICKET,
@@ -278,7 +280,7 @@ def create_urllib3_context(
         context.check_hostname = False
         context.verify_mode = cert_reqs
 
-    if hasattr(context, "hostname_checks_common_name"):
+    if HAS_NEVER_CHECK_COMMON_NAME:
         context.hostname_checks_common_name = False
 
     # Enable logging of TLS session keys via defacto standard environment variable

--- a/test/with_dummyserver/test_https.py
+++ b/test/with_dummyserver/test_https.py
@@ -279,8 +279,10 @@ class TestHTTPS(HTTPSDummyServerTestCase):
             with pytest.raises(MaxRetryError) as e:
                 https_pool.request("GET", "/")
             assert isinstance(e.value.reason, SSLError)
-            assert "certificate verify failed" in str(
-                e.value.reason
+            assert (
+                "certificate verify failed" in str(e.value.reason)
+                # PyPy is more specific
+                or "self signed certificate in certificate chain" in str(e.value.reason)
             ), f"Expected 'certificate verify failed', instead got: {e.value.reason!r}"
 
     def test_verified_without_ca_certs(self):

--- a/test/with_dummyserver/test_https.py
+++ b/test/with_dummyserver/test_https.py
@@ -297,6 +297,8 @@ class TestHTTPS(HTTPSDummyServerTestCase):
             # not pyopenssl is injected
             assert (
                 "No root certificates specified" in str(e.value.reason)
+                # PyPy is more specific
+                or "self signed certificate in certificate chain" in str(e.value.reason)
                 # PyPy sometimes uses all-caps here
                 or "certificate verify failed" in str(e.value.reason).lower()
                 or "invalid certificate chain" in str(e.value.reason)

--- a/test/with_dummyserver/test_proxy_poolmanager.py
+++ b/test/with_dummyserver/test_proxy_poolmanager.py
@@ -179,8 +179,10 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
             with pytest.raises(MaxRetryError) as e:
                 https_pool.request("GET", "/", retries=0)
             assert isinstance(e.value.reason, SSLError)
-            assert "certificate verify failed" in str(
-                e.value.reason
+            assert (
+                "certificate verify failed" in str(e.value.reason)
+                # PyPy is more specific
+                or "self signed certificate in certificate chain" in str(e.value.reason)
             ), f"Expected 'certificate verify failed', instead got: {e.value.reason!r}"
 
             http = proxy_from_url(


### PR DESCRIPTION
This PR only effects the v2.x development branch, v1.26.x will continue to support Python 3.6.

The reason for this PR is two-fold:
- We're unlikely to release v2.0 before Python 3.6 being EOL in December of 2021.
- There are multiple features in the v2.0 timeline that will be dramatically easier to implement without having to think about Python 3.6 (see https://github.com/urllib3/urllib3/pull/2220 for an in-progress example)

I think removing now is best to not impede development and if by some stroke of luck we complete all v2.0 deliverables in the Python 3.6 timeline we'll re-evaluate.