### PR TITLE
 Fix bad error handling given an invalid trust bundle in contrib.securetransport

### DIFF
--- a/src/urllib3/contrib/_securetransport/low_level.py
+++ b/src/urllib3/contrib/_securetransport/low_level.py
@@ -202,6 +202,7 @@ def _cert_array_from_pem(pem_bundle: bytes) -> CFArray:
         # We only want to do that if an error occurs: otherwise, the caller
         # should free.
         CoreFoundation.CFRelease(cert_array)
+        raise
 
     return cert_array
 

--- a/test/contrib/test_securetransport.py
+++ b/test/contrib/test_securetransport.py
@@ -1,3 +1,4 @@
+import base64
 import contextlib
 import socket
 import ssl
@@ -51,3 +52,15 @@ def test_no_crash_with_empty_trust_bundle():
         ws = WrappedSocket(s)
         with pytest.raises(ssl.SSLError):
             ws._custom_validate(True, b"")
+
+
+def test_no_crash_with_invalid_trust_bundle():
+    invalid_cert = base64.b64encode(b"invalid-cert")
+    cert_bundle = (
+        b"-----BEGIN CERTIFICATE-----\n" + invalid_cert + b"\n-----END CERTIFICATE-----"
+    )
+
+    with contextlib.closing(socket.socket()) as s:
+        ws = WrappedSocket(s)
+        with pytest.raises(ssl.SSLError):
+            ws._custom_validate(True, cert_bundle)


### PR DESCRIPTION
Fixes #2338.