### PR TITLE
Use a lower timeout on CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ defaults:
 jobs:
   package:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - name: Checkout Repository
@@ -52,6 +53,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     name: ${{ fromJson('{"macos-latest":"macOS","windows-latest":"Windows","ubuntu-latest":"Ubuntu"}')[matrix.os] }} ${{ matrix.python-version }} ${{ matrix.nox-session}}
     continue-on-error: ${{ matrix.experimental }}
+    timeout-minutes: 20
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -9,6 +9,7 @@ jobs:
       matrix:
         downstream: [botocore, requests]
     runs-on: ubuntu-18.04
+    timeout-minutes: 20
 
     steps:
       - name: Checkout Repository

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,7 @@ on: [push, pull_request]
 jobs:
   lint:
     runs-on: ubuntu-20.04
+    timeout-minutes: 10
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
If a CI job gets stuck, wait 10 or 20 minutes instead of 6 hours.

Fixes #2341.

<!---
Thanks for your contribution! ♥️

If this is your first PR to urllib3 please review the Contributing Guide:
https://urllib3.readthedocs.io/en/latest/contributing.html

Adhering to the Contributing Guide means we can review, merge, and release your change faster! :)
--->
