### PR TITLE
Add mypy configuration file

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -156,7 +156,7 @@ def mypy(session):
     session.install("idna>=2.0.0")
     session.install("cryptography>=1.3.4")
     session.run("mypy", "--version")
-    session.run("mypy", "--strict", "src/urllib3")
+    session.run("mypy", "src/urllib3")
 
 
 @nox.session

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,3 +24,21 @@ python_classes = Test *TestCase
 
 [isort]
 profile=black
+
+[mypy]
+mypy_path = src
+check_untyped_defs = True
+disallow_any_generics = True
+disallow_incomplete_defs = True
+disallow_subclassing_any = True
+disallow_untyped_calls = True
+disallow_untyped_decorators = True
+disallow_untyped_defs = True
+no_implicit_optional = True
+no_implicit_reexport = True
+show_error_codes = True
+strict_equality = True
+warn_redundant_casts = True
+warn_return_any = True
+warn_unused_configs = True
+warn_unused_ignores = True


### PR DESCRIPTION
This allows text editors, standalone `mypy` runs, etc. to get the correct configuration.

The flags correspond to `--strict` as of mypy 0.910 + `--show-error-codes`.

<!---
Thanks for your contribution! ♥️

If this is your first PR to urllib3 please review the Contributing Guide:
https://urllib3.readthedocs.io/en/latest/contributing.html

Adhering to the Contributing Guide means we can review, merge, and release your change faster! :)
--->
