### PR TITLE
Added example of custom ssl context usage

### DIFF
--- a/docs/advanced-usage.rst
+++ b/docs/advanced-usage.rst
@@ -458,7 +458,7 @@ It is possible to provide a specific `SSL Context objects`_ directly to urllib3
 to exercise fine-grained control over the SSL configuration used in urllib3.
 
 For the purposes of compatibility, if you intend to customise an ``SSLContext``
-object we *strongly* recommend you obtain one from the following factory
+object we recommend you obtain one from the following factory
 function:
 
 .. autofunction:: urllib3.util.ssl_.create_urllib3_context
@@ -471,6 +471,7 @@ and then makes a HTTPS request to Google:
 .. code-block:: python
 
     import ssl
+
     from urllib3 import PoolManager
     from urllib3.util.ssl_ import create_urllib3_context
 
@@ -478,8 +479,8 @@ and then makes a HTTPS request to Google:
     ctx.load_default_certs()
     ctx.options |= ssl.OP_NO_RENEGOTIATION
 
-    p = PoolManager(ssl_context=ctx)
-    r = p.urlopen('GET', 'https://www.google.com/')
+    with PoolManager(ssl_context=ctx) as p:
+        r = p.urlopen("GET", "https://www.google.com/")
 
 Any customisation that is possible with the ``SSLContext`` object is possible here.
 

--- a/docs/advanced-usage.rst
+++ b/docs/advanced-usage.rst
@@ -459,8 +459,8 @@ of compatibility, we recommend you obtain one from
 
 Once you have a context object, you can mutate it to achieve whatever effect
 you'd like. For example, the code below loads the default SSL certificates, sets
-the :data:`ssl.OP_NO_TICKET<python:ssl.OP_NO_TICKET>` flag that isn't set by
-default, and then makes a HTTPS request:
+the :data:`ssl.OP_ENABLE_MIDDLEBOX_COMPAT<python:ssl.OP_ENABLE_MIDDLEBOX_COMPAT>`
+flag that isn't set by default, and then makes a HTTPS request:
 
 .. code-block:: python
 
@@ -471,7 +471,7 @@ default, and then makes a HTTPS request:
 
     ctx = create_urllib3_context()
     ctx.load_default_certs()
-    ctx.options |= ssl.OP_NO_TICKET
+    ctx.options |= ssl.OP_ENABLE_MIDDLEBOX_COMPAT
 
     with PoolManager(ssl_context=ctx) as pool:
         pool.request("GET", "https://www.google.com/")

--- a/docs/advanced-usage.rst
+++ b/docs/advanced-usage.rst
@@ -448,3 +448,39 @@ To enable this simply define environment variable `SSLKEYLOGFILE`:
 
 Then configure the key logfile in `Wireshark <https://wireshark.org>`_, see
 `Wireshark TLS Decryption <https://wiki.wireshark.org/TLS#TLS_Decryption>`_ for instructions.
+
+Custom SSL Contexts
+-------------------
+
+.. versionadded:: 1.17.0
+
+It is possible to provide a specific `SSL Context objects`_ directly to urllib3
+to exercise fine-grained control over the SSL configuration used in urllib3.
+
+For the purposes of compatibility, if you intend to customise an ``SSLContext``
+object we *strongly* recommend you obtain one from the following factory
+function:
+
+.. autofunction:: urllib3.util.ssl_.create_urllib3_context
+
+Once you have a context object, you can mutate that to achieve whatever affect
+you'd like. For example, the code below loads the default SSL certificates on
+Linux systems, sets the `OP_NO_RENEGOTIATION <https://docs.python.org/3/library/ssl.html#ssl.OP_NO_RENEGOTIATION>`_  flag that isn't set by default,
+and then makes a HTTPS request to Google:
+
+.. code-block:: python
+
+    import ssl
+    from urllib3 import PoolManager
+    from urllib3.util.ssl_ import create_urllib3_context
+
+    ctx = create_urllib3_context()
+    ctx.load_default_certs()
+    ctx.options |= ssl.OP_NO_RENEGOTIATION
+
+    p = PoolManager(ssl_context=ctx)
+    r = p.urlopen('GET', 'https://www.google.com/')
+
+Any customisation that is possible with the ``SSLContext`` object is possible here.
+
+.. _SSL Context objects: https://docs.python.org/3/library/ssl.html#ssl.SSLContext

--- a/docs/advanced-usage.rst
+++ b/docs/advanced-usage.rst
@@ -452,21 +452,15 @@ Then configure the key logfile in `Wireshark <https://wireshark.org>`_, see
 Custom SSL Contexts
 -------------------
 
-.. versionadded:: 1.17.0
+You can exercise fine-grained control over the urllib3 SSL configuration by
+providing a :class:`ssl.SSLContext <python:ssl.SSLContext>` object. For purposes
+of compatibility, we recommend you obtain one from
+:func:`~urllib3.util.ssl_.create_urllib3_context`.
 
-It is possible to provide a specific `SSL Context objects`_ directly to urllib3
-to exercise fine-grained control over the SSL configuration used in urllib3.
-
-For the purposes of compatibility, if you intend to customise an ``SSLContext``
-object we recommend you obtain one from the following factory
-function:
-
-.. autofunction:: urllib3.util.ssl_.create_urllib3_context
-
-Once you have a context object, you can mutate that to achieve whatever affect
-you'd like. For example, the code below loads the default SSL certificates on
-Linux systems, sets the `OP_NO_RENEGOTIATION <https://docs.python.org/3/library/ssl.html#ssl.OP_NO_RENEGOTIATION>`_  flag that isn't set by default,
-and then makes a HTTPS request to Google:
+Once you have a context object, you can mutate it to achieve whatever effect
+you'd like. For example, the code below loads the default SSL certificates, sets
+the :data:`ssl.OP_NO_TICKET<python:ssl.OP_NO_TICKET>` flag that isn't set by
+default, and then makes a HTTPS request:
 
 .. code-block:: python
 
@@ -477,11 +471,11 @@ and then makes a HTTPS request to Google:
 
     ctx = create_urllib3_context()
     ctx.load_default_certs()
-    ctx.options |= ssl.OP_NO_RENEGOTIATION
+    ctx.options |= ssl.OP_NO_TICKET
 
-    with PoolManager(ssl_context=ctx) as p:
-        r = p.urlopen("GET", "https://www.google.com/")
+    with PoolManager(ssl_context=ctx) as pool:
+        pool.request("GET", "https://www.google.com/")
 
-Any customisation that is possible with the ``SSLContext`` object is possible here.
-
-.. _SSL Context objects: https://docs.python.org/3/library/ssl.html#ssl.SSLContext
+Note that this is different from passing an ``options`` argument to
+:func:`~urllib3.util.ssl_.create_urllib3_context` because we don't overwrite
+the default options: we only add a new one.


### PR DESCRIPTION
FIxes #2320 
Basically it is a rip-off of a section in the previously deleted  (in #887) `docs/security.rst`, I just adapted the example adding a flag as per our conversation !
