### PR TITLE
Make return type of {PoolManager,*ConnectionPool}.__enter__ more precise

### DIFF
--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -6,7 +6,7 @@ import sys
 import warnings
 from http.client import HTTPResponse as _HttplibHTTPResponse
 from socket import timeout as SocketTimeout
-from typing import TYPE_CHECKING, Any, Mapping, Optional, Type, Union, overload
+from typing import TYPE_CHECKING, Any, Mapping, Optional, Type, TypeVar, Union, overload
 
 from .connection import (
     _TYPE_BODY,
@@ -61,6 +61,8 @@ _Default = object()
 
 _TYPE_TIMEOUT = Union[Timeout, int, float, object]
 
+_SelfT = TypeVar("_SelfT")
+
 
 # Pool objects
 class ConnectionPool:
@@ -88,7 +90,7 @@ class ConnectionPool:
     def __str__(self) -> str:
         return f"{type(self).__name__}(host={self.host!r}, port={self.port!r})"
 
-    def __enter__(self) -> "ConnectionPool":
+    def __enter__(self: _SelfT) -> _SelfT:
         return self
 
     def __exit__(

--- a/src/urllib3/poolmanager.py
+++ b/src/urllib3/poolmanager.py
@@ -11,6 +11,7 @@ from typing import (
     Optional,
     Tuple,
     Type,
+    TypeVar,
     Union,
 )
 from urllib.parse import urljoin
@@ -52,6 +53,8 @@ SSL_KEYWORDS = (
     "ssl_context",
     "key_password",
 )
+
+_SelfT = TypeVar("_SelfT")
 
 
 class PoolKey(NamedTuple):
@@ -209,7 +212,7 @@ class PoolManager(RequestMethods):
         self.pool_classes_by_scheme = pool_classes_by_scheme
         self.key_fn_by_scheme = key_fn_by_scheme.copy()
 
-    def __enter__(self) -> "PoolManager":
+    def __enter__(self: _SelfT) -> _SelfT:
         return self
 
     def __exit__(


### PR DESCRIPTION
Particularly for `ConnectionPool` subclasses, e.g. `HTTPConnnectionPool`, previously the static type of `pool` in

```py
with HTTPConnectionPool(..) as pool:
    ...
```

would be `ConnectionPool` instead of the more useful `HTTPConnectionPool` subtype.

<!---
Thanks for your contribution! ♥️

If this is your first PR to urllib3 please review the Contributing Guide:
https://urllib3.readthedocs.io/en/latest/contributing.html

Adhering to the Contributing Guide means we can review, merge, and release your change faster! :)
--->
