### PR TITLE
Add initial Towncrier newsfragments for 2.0 commits

### DIFF
--- a/changelog/1543.bugfix.rst
+++ b/changelog/1543.bugfix.rst
@@ -1,1 +1,1 @@
-Changed return type of ``HTTPResponse.getheaders()`` method to return a list key-value tuples to match CPython.
+Changed return type of ``HTTPResponse.getheaders()`` method to return a list of key-value tuples to match CPython.

--- a/changelog/1543.bugfix.rst
+++ b/changelog/1543.bugfix.rst
@@ -1,0 +1,1 @@
+Changed return type of ``HTTPResponse.getheaders()`` method to return a list key-value tuples to match CPython.

--- a/changelog/1897.feature.rst
+++ b/changelog/1897.feature.rst
@@ -1,0 +1,1 @@
+Added type hints to the ``urllib3`` module.

--- a/changelog/2044.removal.rst
+++ b/changelog/2044.removal.rst
@@ -1,0 +1,1 @@
+Removed ``urllib3.contrib.appengine.AppEngineManager`` and support for Google App Engine Standard Environment.

--- a/changelog/2080.feature.rst
+++ b/changelog/2080.feature.rst
@@ -1,0 +1,1 @@
+Changed internal implementation of ``HTTPHeaderDict`` to use ``dict`` instead of ``collections.OrderedDict`` for better performance.

--- a/changelog/2082.feature.rst
+++ b/changelog/2082.feature.rst
@@ -1,1 +1,1 @@
-Changed default TLS ciphers being used to ciphers configured by the system for OpenSSL 1.1.1+ and SecureTransport.
+Stopped configuring default ciphers for OpenSSL 1.1.1+ and SecureTransport as their own defaults are already secure.

--- a/changelog/2082.feature.rst
+++ b/changelog/2082.feature.rst
@@ -1,0 +1,1 @@
+Changed default TLS ciphers being used to ciphers configured by the system for OpenSSL 1.1.1+ and SecureTransport.

--- a/changelog/2083.feature.rst
+++ b/changelog/2083.feature.rst
@@ -1,1 +1,1 @@
-Added ``urllib3.response.BaseHTTPResponse`` type.
+Added ``urllib3.response.BaseHTTPResponse`` class. All future response classes will be subclasses of ``BaseHTTPResponse``.

--- a/changelog/2083.feature.rst
+++ b/changelog/2083.feature.rst
@@ -1,0 +1,1 @@
+Added ``urllib3.response.BaseHTTPResponse`` type.

--- a/changelog/2086.removal.rst
+++ b/changelog/2086.removal.rst
@@ -1,0 +1,1 @@
+Removed deprecated ``Retry`` options ``method_whitelist``, ``DEFAULT_REDIRECT_HEADERS_BLACKLIST``.

--- a/changelog/2099.feature.rst
+++ b/changelog/2099.feature.rst
@@ -1,3 +1,5 @@
 Changed ``urllib3[brotli]`` extra to install Google's Brotli C bindings on CPython.
 
-Continue to use Brotli CFFI bindings on non-CPython implementations.
+The Brotli CFFI bindings are still used on non-CPython implementations like PyPy.
+This change was made to increase performance for CPython as CFFI is typically
+is less performant than C extensions.

--- a/changelog/2099.feature.rst
+++ b/changelog/2099.feature.rst
@@ -1,0 +1,3 @@
+Changed ``urllib3[brotli]`` extra to install Google's Brotli C bindings on CPython.
+
+Continue to use Brotli CFFI bindings on non-CPython implementations.

--- a/changelog/2113.removal.rst
+++ b/changelog/2113.removal.rst
@@ -1,1 +1,5 @@
 Removed fallback on certificate ``commonName`` in ``match_hostname()`` function.
+
+This behavior was deprecated in May 2000 in RFC 2818. Instead only ``subjectAltName``
+is used to verify the hostname by default. To enable verifying the hostname against
+``commonName`` use ``SSLContext.hostname_checks_common_name = True``.

--- a/changelog/2113.removal.rst
+++ b/changelog/2113.removal.rst
@@ -1,0 +1,1 @@
+Removed fallback on certificate ``commonName`` in ``match_hostname()`` function.

--- a/changelog/2118.bugfix.rst
+++ b/changelog/2118.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed ``socket.error.errno`` when raised from pyOpenSSL's ``OpenSSL.SSL.SysCallError``.

--- a/changelog/2120.feature.rst
+++ b/changelog/2120.feature.rst
@@ -1,0 +1,1 @@
+Changed usage of the deprecated ``socket.error`` to ``OSError``.

--- a/changelog/2133.feature.rst
+++ b/changelog/2133.feature.rst
@@ -1,0 +1,1 @@
+Added ``HTTPSProxyError`` when the initial TLS handshake to the proxy fails.

--- a/changelog/2150.feature.rst
+++ b/changelog/2150.feature.rst
@@ -1,0 +1,1 @@
+Added top-level ``urllib3.request`` function which uses a preconfigured module-global ``PoolManager`` instance.

--- a/changelog/2197.feature.rst
+++ b/changelog/2197.feature.rst
@@ -1,0 +1,1 @@
+Added ``FullPoolError`` which is raised when ``PoolManager(block=True)`` and a connection is returned to a full pool.

--- a/changelog/2209.feature.rst
+++ b/changelog/2209.feature.rst
@@ -1,0 +1,1 @@
+Added support for Python 3.10.

--- a/changelog/2213.bugfix.rst
+++ b/changelog/2213.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed the default value of ``HTTPSConnection.socket_options`` to match ``HTTPConnection``.

--- a/changelog/2216.feature.rst
+++ b/changelog/2216.feature.rst
@@ -1,0 +1,1 @@
+Added ``HTTPHeaderDict`` to the top-level ``urllib3`` namespace.

--- a/changelog/2257.removal.rst
+++ b/changelog/2257.removal.rst
@@ -1,4 +1,4 @@
-``multipart/form-data`` header parameter formatting matches the WHATWG
+Changed ``multipart/form-data`` header parameter formatting matches the WHATWG
 HTML Standard as of 2021-06-10. Control characters in filenames are no
 longer percent encoded.
 

--- a/changelog/2267.removal.rst
+++ b/changelog/2267.removal.rst
@@ -1,0 +1,1 @@
+Deprecated the ``strict`` parameter as it's not longer needed in Python 3.x.

--- a/changelog/2271.removal.rst
+++ b/changelog/2271.removal.rst
@@ -1,2 +1,1 @@
-The ``NewConnectionError.pool`` attribute was deprecated and will be
-removed in a later urllib3 v2.x release.
+Deprecated the ``NewConnectionError.pool`` attribute which will be removed in a future urllib3 v2.x release.

--- a/changelog/2272.bugfix.rst
+++ b/changelog/2272.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a bug where ``headers`` would be modified by the ``remove_headers_on_redirect`` feature.

--- a/changelog/2277.bugfix.rst
+++ b/changelog/2277.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a reference cycle bug in ``urllib3.util.connection.create_connection()``.

--- a/changelog/2283.feature.rst
+++ b/changelog/2283.feature.rst
@@ -1,2 +1,0 @@
-Make all parameters after ``method`` and ``url`` for
-`urllib3.request()` keyword only.

--- a/changelog/2305.feature.rst
+++ b/changelog/2305.feature.rst
@@ -1,0 +1,1 @@
+Added ``NameResolutionError`` exception when a DNS error occurs.

--- a/changelog/2336.removal.rst
+++ b/changelog/2336.removal.rst
@@ -1,0 +1,1 @@
+Removed support for Python 3.6.

--- a/changelog/2339.removal.rst
+++ b/changelog/2339.removal.rst
@@ -1,0 +1,1 @@
+Removed the deprecated ``urllib3.contrib.ntlmpool`` module.

--- a/changelog/883.removal.rst
+++ b/changelog/883.removal.rst
@@ -1,0 +1,1 @@
+Removed support for Python 2.7 and 3.5.


### PR DESCRIPTION
Closes https://github.com/urllib3/urllib3/issues/2065 except for the "Lean on SSLContext" issue, I can't remember what the current state of support there is.