### PR TITLE
Improve request debug log readability

### DIFF
--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -450,12 +450,12 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
             raise
 
         log.debug(
-            '%s://%s:%s "%s %s %s" %s %s',
+            '%s://%s:%s%s "%s %s" status:%s len:%s',
             self.scheme,
             self.host,
             self.port,
-            method,
             url,
+            method,
             # HTTP version
             conn._http_vsn_str,  # type: ignore[attr-defined]
             httplib_response.status,


### PR DESCRIPTION
Hello,  
I think it would greatly improve readability of debug log printed after making request.

This log in current form may be not readable for users of this library  
```
DEBUG:urllib3.connectionpool:https://mywebsite.com:443 "GET /configuration HTTP/1.1" 200 1405
```
It is not obvious what these numbers at the end mean (at least for users not familiar with this library)

I think something like this would be better
```
DEBUG:urllib3.connectionpool:https://mywebsite.com:443/configuration "GET HTTP/1.1" status:200 len:1405
```
