### PR TITLE
Revert socks.py exception chaining

### DIFF
--- a/src/urllib3/contrib/socks.py
+++ b/src/urllib3/contrib/socks.py
@@ -120,11 +120,11 @@ class SOCKSConnection(HTTPConnection):
                 **extra_kw,
             )
 
-        except SocketTimeout as e:
+        except SocketTimeout:
             raise ConnectTimeoutError(
                 self,
                 f"Connection to {self.host} timed out. (connect timeout={self.timeout})",
-            ) from e
+            )
 
         except socks.ProxyError as e:
             # This is fragile as hell, but it seems to be the only way to raise
@@ -135,20 +135,18 @@ class SOCKSConnection(HTTPConnection):
                     raise ConnectTimeoutError(
                         self,
                         f"Connection to {self.host} timed out. (connect timeout={self.timeout})",
-                    ) from e
+                    )
                 else:
                     raise NewConnectionError(
                         self, f"Failed to establish a new connection: {error}"
-                    ) from e
+                    )
             else:
                 raise NewConnectionError(
                     self, f"Failed to establish a new connection: {e}"
-                ) from e
+                )
 
         except OSError as e:  # Defensive: PySocks should catch all these.
-            raise NewConnectionError(
-                self, f"Failed to establish a new connection: {e}"
-            ) from e
+            raise NewConnectionError(self, f"Failed to establish a new connection: {e}")
 
         return conn
 

--- a/src/urllib3/contrib/socks.py
+++ b/src/urllib3/contrib/socks.py
@@ -137,7 +137,11 @@ class SOCKSConnection(HTTPConnection):
                         f"Connection to {self.host} timed out. (connect timeout={self.timeout})",
                     ) from e
                 else:
-                    raise BaseException("BOOM")
+                    # Adding `from e` messes with coverage somehow, so it's omitted.
+                    # See #2386.
+                    raise NewConnectionError(
+                        self, f"Failed to establish a new connection: {error}"
+                    )
             else:
                 raise NewConnectionError(
                     self, f"Failed to establish a new connection: {e}"

--- a/src/urllib3/contrib/socks.py
+++ b/src/urllib3/contrib/socks.py
@@ -139,7 +139,7 @@ class SOCKSConnection(HTTPConnection):
                 else:
                     raise NewConnectionError(
                         self, f"Failed to establish a new connection: {error}"
-                    )
+                    ) from e
             else:
                 raise NewConnectionError(
                     self, f"Failed to establish a new connection: {e}"

--- a/src/urllib3/contrib/socks.py
+++ b/src/urllib3/contrib/socks.py
@@ -137,9 +137,7 @@ class SOCKSConnection(HTTPConnection):
                         f"Connection to {self.host} timed out. (connect timeout={self.timeout})",
                     ) from e
                 else:
-                    raise NewConnectionError(
-                        self, f"Failed to establish a new connection: {error}"
-                    )
+                    raise BaseException("BOOM")
             else:
                 raise NewConnectionError(
                     self, f"Failed to establish a new connection: {e}"

--- a/src/urllib3/contrib/socks.py
+++ b/src/urllib3/contrib/socks.py
@@ -135,11 +135,11 @@ class SOCKSConnection(HTTPConnection):
                     raise ConnectTimeoutError(
                         self,
                         f"Connection to {self.host} timed out. (connect timeout={self.timeout})",
-                    )
+                    ) from e
                 else:
                     raise NewConnectionError(
                         self, f"Failed to establish a new connection: {error}"
-                    ) from e
+                    )
             else:
                 raise NewConnectionError(
                     self, f"Failed to establish a new connection: {e}"

--- a/src/urllib3/contrib/socks.py
+++ b/src/urllib3/contrib/socks.py
@@ -120,11 +120,11 @@ class SOCKSConnection(HTTPConnection):
                 **extra_kw,
             )
 
-        except SocketTimeout:
+        except SocketTimeout as e:
             raise ConnectTimeoutError(
                 self,
                 f"Connection to {self.host} timed out. (connect timeout={self.timeout})",
-            )
+            ) from e
 
         except socks.ProxyError as e:
             # This is fragile as hell, but it seems to be the only way to raise
@@ -146,7 +146,9 @@ class SOCKSConnection(HTTPConnection):
                 )
 
         except OSError as e:  # Defensive: PySocks should catch all these.
-            raise NewConnectionError(self, f"Failed to establish a new connection: {e}")
+            raise NewConnectionError(
+                self, f"Failed to establish a new connection: {e}"
+            ) from e
 
         return conn
 

--- a/src/urllib3/contrib/socks.py
+++ b/src/urllib3/contrib/socks.py
@@ -143,7 +143,7 @@ class SOCKSConnection(HTTPConnection):
             else:
                 raise NewConnectionError(
                     self, f"Failed to establish a new connection: {e}"
-                )
+                ) from e
 
         except OSError as e:  # Defensive: PySocks should catch all these.
             raise NewConnectionError(


### PR DESCRIPTION
Related to #2386

This should not be merged as is, but this pull request restores the 100% coverage. Now someone will be able to understand what's going on.

