### PR TITLE
Rely on urllib3 hostname matching for HTTPS proxy validation.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 Changes
 =======
 
+1.26.x (dev)
+-------------------
+* Fixed a bug with HTTPS hostname verification involving IP addresses and lack
+  of SNI. (Issue #2400)
+
+
 1.26.6 (2021-06-25)
 -------------------
 

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -506,8 +506,6 @@ class HTTPSConnection(HTTPConnection):
             ssl_context=ssl_context,
         )
 
-        # TODO(jls) - Discuss during review. Should we support
-        # assert_proxy_fingerprint  and assert_proxy_hostname?
         if ssl_context.verify_mode != ssl.CERT_NONE and not getattr(
             ssl_context, "check_hostname", False
         ):

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -107,6 +107,10 @@ class HTTPConnection(_HTTPConnection, object):
     #: Whether this connection verifies the host's certificate.
     is_verified = False
 
+    #: Whether this proxy connection (if used) verifies the proxy host's
+    #: certificate.
+    proxy_is_verified = None
+
     def __init__(self, *args, **kw):
         if not six.PY2:
             kw.pop("strict", None)
@@ -490,14 +494,10 @@ class HTTPSConnection(HTTPConnection):
             self.ca_cert_dir,
             self.ca_cert_data,
         )
-        # By default urllib3's SSLContext disables `check_hostname` and uses
-        # a custom check. For proxies we're good with relying on the default
-        # verification.
-        ssl_context.check_hostname = True
 
         # If no cert was provided, use only the default options for server
         # certificate validation
-        return ssl_wrap_socket(
+        socket = ssl_wrap_socket(
             sock=conn,
             ca_certs=self.ca_certs,
             ca_cert_dir=self.ca_cert_dir,
@@ -505,6 +505,30 @@ class HTTPSConnection(HTTPConnection):
             server_hostname=hostname,
             ssl_context=ssl_context,
         )
+
+        # TODO(jls) - Discuss during review. Should we support
+        # assert_proxy_fingerprint  and assert_proxy_hostname?
+        if ssl_context.verify_mode != ssl.CERT_NONE and not getattr(
+            ssl_context, "check_hostname", False
+        ):
+            # While urllib3 attempts to always turn off hostname matching from
+            # the TLS library, this cannot always be done. So we check whether
+            # the TLS Library still thinks it's matching hostnames.
+            cert = socket.getpeercert()
+            if not cert.get("subjectAltName", ()):
+                warnings.warn(
+                    (
+                        "Certificate for {0} has no `subjectAltName`, falling back to check for a "
+                        "`commonName` for now. This feature is being removed by major browsers and "
+                        "deprecated by RFC 2818. (See https://github.com/urllib3/urllib3/issues/497 "
+                        "for details.)".format(hostname)
+                    ),
+                    SubjectAltNameWarning,
+                )
+            _match_hostname(cert, hostname)
+
+        self.proxy_is_verified = ssl_context.verify_mode == ssl.CERT_REQUIRED
+        return socket
 
 
 def _match_hostname(cert, asserted_hostname):

--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -1020,7 +1020,7 @@ class HTTPSConnectionPool(HTTPConnectionPool):
                 InsecureRequestWarning,
             )
 
-        if conn.proxy_is_verified is False:
+        if getattr(conn, "proxy_is_verified", None) is False:
             warnings.warn(
                 (
                     "Unverified HTTPS connection done to an HTTPS proxy. "

--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -1020,6 +1020,17 @@ class HTTPSConnectionPool(HTTPConnectionPool):
                 InsecureRequestWarning,
             )
 
+        if conn.proxy_is_verified is False:
+            warnings.warn(
+                (
+                    "Unverified HTTPS connection done to an HTTPS proxy. "
+                    "Adding certificate verification is strongly advised. See: "
+                    "https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html"
+                    "#ssl-warnings"
+                ),
+                InsecureRequestWarning,
+            )
+
 
 def connection_from_url(url, **kw):
     """

--- a/src/urllib3/util/proxy.py
+++ b/src/urllib3/util/proxy.py
@@ -45,6 +45,8 @@ def create_proxy_ssl_context(
         ssl_version=resolve_ssl_version(ssl_version),
         cert_reqs=resolve_cert_reqs(cert_reqs),
     )
+    ssl_context.verify_mode = resolve_cert_reqs(cert_reqs)
+
     if (
         not ca_certs
         and not ca_cert_dir

--- a/src/urllib3/util/proxy.py
+++ b/src/urllib3/util/proxy.py
@@ -45,7 +45,6 @@ def create_proxy_ssl_context(
         ssl_version=resolve_ssl_version(ssl_version),
         cert_reqs=resolve_cert_reqs(cert_reqs),
     )
-    ssl_context.verify_mode = resolve_cert_reqs(cert_reqs)
 
     if (
         not ca_certs

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -11,6 +11,7 @@ import trustme
 from tornado import ioloop, web
 
 from dummyserver.handlers import TestingApp
+from dummyserver.proxy import ProxyHandler
 from dummyserver.server import HAS_IPV6, run_tornado_app
 from dummyserver.testcase import HTTPSDummyServerTestCase
 from urllib3.util import ssl_
@@ -30,16 +31,21 @@ def configure_windows_event_loop():
 ServerConfig = collections.namedtuple("ServerConfig", ["host", "port", "ca_certs"])
 
 
+def _write_cert_to_dir(cert, tmpdir, file_prefix="server"):
+    cert_path = str(tmpdir / ("%s.pem" % file_prefix))
+    key_path = str(tmpdir / ("%s.key" % file_prefix))
+    cert.private_key_pem.write_to_path(key_path)
+    cert.cert_chain_pems[0].write_to_path(cert_path)
+    certs = {"keyfile": key_path, "certfile": cert_path}
+    return certs
+
+
 @contextlib.contextmanager
 def run_server_in_thread(scheme, host, tmpdir, ca, server_cert):
     ca_cert_path = str(tmpdir / "ca.pem")
-    server_cert_path = str(tmpdir / "server.pem")
-    server_key_path = str(tmpdir / "server.key")
     ca.cert_pem.write_to_path(ca_cert_path)
-    server_cert.private_key_pem.write_to_path(server_key_path)
-    server_cert.cert_chain_pems[0].write_to_path(server_cert_path)
-    server_certs = {"keyfile": server_key_path, "certfile": server_cert_path}
 
+    server_certs = _write_cert_to_dir(server_cert, tmpdir)
     io_loop = ioloop.IOLoop.current()
     app = web.Application([(r".*", TestingApp)])
     server, port = run_tornado_app(app, io_loop, server_certs, scheme, host)
@@ -50,6 +56,39 @@ def run_server_in_thread(scheme, host, tmpdir, ca, server_cert):
 
     io_loop.add_callback(server.stop)
     io_loop.add_callback(io_loop.stop)
+    server_thread.join()
+
+
+@contextlib.contextmanager
+def run_server_and_proxy_in_thread(
+    proxy_scheme, proxy_host, tmpdir, ca, proxy_cert, server_cert
+):
+    ca_cert_path = str(tmpdir / "ca.pem")
+    ca.cert_pem.write_to_path(ca_cert_path)
+
+    server_certs = _write_cert_to_dir(server_cert, tmpdir)
+    proxy_certs = _write_cert_to_dir(proxy_cert, tmpdir, "proxy")
+
+    io_loop = ioloop.IOLoop.current()
+    server = web.Application([(r".*", TestingApp)])
+    server, port = run_tornado_app(server, io_loop, server_certs, "https", "localhost")
+    server_config = ServerConfig("localhost", port, ca_cert_path)
+
+    proxy = web.Application([(r".*", ProxyHandler)])
+    proxy_app, proxy_port = run_tornado_app(
+        proxy, io_loop, proxy_certs, proxy_scheme, proxy_host
+    )
+    proxy_config = ServerConfig(proxy_host, proxy_port, ca_cert_path)
+
+    server_thread = threading.Thread(target=io_loop.start)
+    server_thread.start()
+
+    yield (proxy_config, server_config)
+
+    io_loop.add_callback(server.stop)
+    io_loop.add_callback(proxy_app.stop)
+    io_loop.add_callback(io_loop.stop)
+
     server_thread.join()
 
 
@@ -65,6 +104,20 @@ def no_san_server(tmp_path_factory):
 
 
 @pytest.fixture
+def no_san_proxy(tmp_path_factory):
+    tmpdir = tmp_path_factory.mktemp("certs")
+    ca = trustme.CA()
+    # only common name, no subject alternative names
+    proxy_cert = ca.issue_cert(common_name=u"localhost")
+    server_cert = ca.issue_cert(u"localhost")
+
+    with run_server_and_proxy_in_thread(
+        "https", "localhost", tmpdir, ca, proxy_cert, server_cert
+    ) as cfg:
+        yield cfg
+
+
+@pytest.fixture
 def no_localhost_san_server(tmp_path_factory):
     tmpdir = tmp_path_factory.mktemp("certs")
     ca = trustme.CA()
@@ -72,6 +125,21 @@ def no_localhost_san_server(tmp_path_factory):
     server_cert = ca.issue_cert(u"example.com")
 
     with run_server_in_thread("https", "localhost", tmpdir, ca, server_cert) as cfg:
+        yield cfg
+
+
+@pytest.fixture
+def ip_san_proxy(tmp_path_factory):
+    tmpdir = tmp_path_factory.mktemp("certs")
+    ca = trustme.CA()
+    # IP address in Subject Alternative Name
+    proxy_cert = ca.issue_cert(u"127.0.0.1")
+
+    server_cert = ca.issue_cert(u"localhost")
+
+    with run_server_and_proxy_in_thread(
+        "https", "127.0.0.1", tmpdir, ca, proxy_cert, server_cert
+    ) as cfg:
         yield cfg
 
 

--- a/test/with_dummyserver/test_proxy_poolmanager.py
+++ b/test/with_dummyserver/test_proxy_poolmanager.py
@@ -223,9 +223,16 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
             with proxy_from_url(self.https_proxy_url, cert_reqs="NONE") as https:
                 r = https.request("GET", "%s/" % self.https_url)
                 assert r.status == 200
-        assert len(w) > 1  # We expect two warnings (proxy, destination)
+        assert len(w) == 2  # We expect two warnings (proxy, destination)
         assert w[0].category == InsecureRequestWarning
         assert w[1].category == InsecureRequestWarning
+        messages = set(str(x.message) for x in w)
+        expected = [
+            "Unverified HTTPS request is being made to host 'localhost'",
+            "Unverified HTTPS connection done to an HTTPS proxy.",
+        ]
+        for warn_message in expected:
+            assert [msg for msg in messages if warn_message in expected]
 
     def test_redirect(self):
         with proxy_from_url(self.proxy_url) as http:
@@ -600,5 +607,5 @@ class TestHTTPSProxyVerification:
                 r = https.request("GET", destination_url)
                 assert r.status == 200
 
-        assert len(w) > 0
+        assert len(w) == 1
         assert w[0].category == SubjectAltNameWarning

--- a/test/with_dummyserver/test_proxy_poolmanager.py
+++ b/test/with_dummyserver/test_proxy_poolmanager.py
@@ -3,6 +3,7 @@ import os.path
 import shutil
 import socket
 import tempfile
+import warnings
 from test import (
     LONG_TIMEOUT,
     SHORT_TIMEOUT,
@@ -21,11 +22,13 @@ from urllib3._collections import HTTPHeaderDict
 from urllib3.connectionpool import VerifiedHTTPSConnection, connection_from_url
 from urllib3.exceptions import (
     ConnectTimeoutError,
+    InsecureRequestWarning,
     MaxRetryError,
     ProxyError,
     ProxySchemeUnknown,
     ProxySchemeUnsupported,
     SSLError,
+    SubjectAltNameWarning,
 )
 from urllib3.poolmanager import ProxyManager, proxy_from_url
 from urllib3.util.ssl_ import create_urllib3_context
@@ -212,6 +215,17 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
                 https_fail_pool.request("GET", "/", retries=0)
             assert isinstance(e.value.reason, SSLError)
             assert "doesn't match" in str(e.value.reason)
+
+    @onlyPy3
+    def test_proxy_verified_warning(self):
+        """Skip proxy verification to validate warnings are generated"""
+        with warnings.catch_warnings(record=True) as w:
+            with proxy_from_url(self.https_proxy_url, cert_reqs="NONE") as https:
+                r = https.request("GET", "%s/" % self.https_url)
+                assert r.status == 200
+        assert len(w) > 1  # We expect two warnings (proxy, destination)
+        assert w[0].category == InsecureRequestWarning
+        assert w[1].category == InsecureRequestWarning
 
     def test_redirect(self):
         with proxy_from_url(self.proxy_url) as http:
@@ -565,3 +579,26 @@ class TestHTTPSProxyVerification:
             assert "hostname 'localhost' doesn't match" in str(
                 e.value.reason
             ) or "Hostname mismatch" in str(e.value.reason)
+
+    @onlyPy3
+    def test_https_proxy_ip_san(self, ip_san_proxy):
+        proxy, server = ip_san_proxy
+        proxy_url = "https://%s:%s" % (proxy.host, proxy.port)
+        destination_url = "https://%s:%s" % (server.host, server.port)
+        with proxy_from_url(proxy_url, ca_certs=proxy.ca_certs) as https:
+            r = https.request("GET", destination_url)
+            assert r.status == 200
+
+    @onlyPy3
+    def test_https_proxy_common_name_warning(self, no_san_proxy):
+        proxy, server = no_san_proxy
+        proxy_url = "https://%s:%s" % (proxy.host, proxy.port)
+        destination_url = "https://%s:%s" % (server.host, server.port)
+
+        with warnings.catch_warnings(record=True) as w:
+            with proxy_from_url(proxy_url, ca_certs=proxy.ca_certs) as https:
+                r = https.request("GET", destination_url)
+                assert r.status == 200
+
+        assert len(w) > 0
+        assert w[0].category == SubjectAltNameWarning


### PR DESCRIPTION
This PR aims to fix issue #2400. On that issue we discovered that if you attempt to do an HTTPS proxy connection to fetch an HTTPS website with a proxy that uses an IP address we won't validate its hostname correctly and we'll throw an error when we call ``wrap_socket``.  

The issue is caused by the fact that 1) HTTPS proxy validation relies on ``SSLContext.check_hostname`` for  its hostname validation. 2) IP addresses can't be used as an SNI hint so we don't pass them along with ``server_hostname``. The end result is that ``SSLContext`` throws on the ``wrap_socket`` call as it requires a ``server_hostname`` to be set if ``check_hostname`` is True.

To address that, I'm switching over HTTPS proxy hostname validation to use urllib3's default validation. 

Couple of items worth discussing:

1) I'm sending this PR directly to ``1.26.x`` to make it easier. Once merged, I'll create an equivalent PR to merge the changes into ``main`` too.
2) I didn't add ``assert_proxy_fingerprint`` or  ``assert_proxy_hostname`` options. We can discuss if we think they are needed. 