### PR TITLE
Link to changelog guildelines from contributing docs

### DIFF
--- a/changelog/README.rst
+++ b/changelog/README.rst
@@ -1,5 +1,6 @@
 This directory contains "newsfragments" which are short files that contain a small
-**ReST**-formatted text that will be added to ``CHANGES.rst``.
+**ReST**-formatted text that will be added to ``CHANGES.rst`` by `towncrier
+<https://towncrier.readthedocs.io/en/actual-freaking-docs/>`__.
 
 The ``CHANGELOG`` will be read by **users**, so this description should be aimed to
 urllib3 users instead of describing internal changes which are only relevant to the

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -15,8 +15,8 @@ If you wish to add a new feature or fix a bug:
    as expected.
 #. Format your changes with black using command `$ nox -rs format` and lint your
    changes using command `nox -rs lint`.
-#. Add a changelog entry using `towncrier
-   <https://towncrier.readthedocs.io/en/actual-freaking-docs/quickstart.html#creating-news-fragments>`__.
+#. Add a `changelog entry
+   <https://github.com/urllib3/urllib3/blob/main/changelog/README.rst>`__.
 #. Send a pull request and bug the maintainer until it gets merged and published.
 
 


### PR DESCRIPTION
As noticed in https://github.com/urllib3/urllib3/pull/2393 where we had to ask for a changelog and it wasn't in the past tense.