### PR TITLE
[1.26] Strip brackets from IPv6 hosts before certificate hostname matching

### DIFF
--- a/src/urllib3/packages/ssl_match_hostname/_implementation.py
+++ b/src/urllib3/packages/ssl_match_hostname/_implementation.py
@@ -110,7 +110,7 @@ def match_hostname(cert, hostname):
         )
     try:
         # Divergence from upstream: ipaddress can't handle byte str
-        host_ip = ipaddress.ip_address(_to_unicode(hostname))
+        host_ip = ipaddress.ip_address(_to_unicode(hostname).strip(u"[]"))
     except ValueError:
         # Not an IP address (common case)
         host_ip = None

--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -43,7 +43,7 @@ class TestConnection(object):
             )
             assert e._peer_cert == cert
 
-    def test_match_hostname_ip_address_ipv6(self) -> None:
+    def test_match_hostname_ip_address_ipv6(self):
         cert = {"subjectAltName": (("IP Address", "1:2::2:1"),)}
         asserted_hostname = "1:2::2:2"
         try:
@@ -58,7 +58,7 @@ class TestConnection(object):
             )
             assert e._peer_cert == cert
 
-    def test_match_hostname_ip_address_ipv6_brackets(self) -> None:
+    def test_match_hostname_ip_address_ipv6_brackets(self):
         cert = {"subjectAltName": (("IP Address", "1:2::2:1"),)}
         asserted_hostname = "[1:2::2:1]"
         # Assert no error is raised

--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -43,6 +43,27 @@ class TestConnection(object):
             )
             assert e._peer_cert == cert
 
+    def test_match_hostname_ip_address_ipv6(self) -> None:
+        cert = {"subjectAltName": (("IP Address", "1:2::2:1"),)}
+        asserted_hostname = "1:2::2:2"
+        try:
+            with mock.patch("urllib3.connection.log.warning") as mock_log:
+                _match_hostname(cert, asserted_hostname)
+        except CertificateError as e:
+            assert "hostname '1:2::2:2' doesn't match '1:2::2:1'" in str(e)
+            mock_log.assert_called_once_with(
+                "Certificate did not match expected hostname: %s. Certificate: %s",
+                "1:2::2:2",
+                {"subjectAltName": (("IP Address", "1:2::2:1"),)},
+            )
+            assert e._peer_cert == cert
+
+    def test_match_hostname_ip_address_ipv6_brackets(self) -> None:
+        cert = {"subjectAltName": (("IP Address", "1:2::2:1"),)}
+        asserted_hostname = "[1:2::2:1]"
+        # Assert no error is raised
+        _match_hostname(cert, asserted_hostname)
+
     def test_recent_date(self):
         # This test is to make sure that the RECENT_DATE value
         # doesn't get too far behind what the current date is.


### PR DESCRIPTION
Backport of #2241 

Not working yet, but can be a starting point.