### PR TITLE
Create test for IPv6 proxy cert hostname verification

### DIFF
--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -56,6 +56,7 @@ from .util import SKIP_HEADER, SKIPPABLE_HEADERS, connection
 from .util.ssl_ import (
     assert_fingerprint,
     create_urllib3_context,
+    is_ipaddress,
     resolve_cert_reqs,
     resolve_ssl_version,
     ssl_wrap_socket,
@@ -530,6 +531,13 @@ class HTTPSConnection(HTTPConnection):
 
 
 def _match_hostname(cert, asserted_hostname):
+    # Our upstream implementation of ssl.match_hostname()
+    # only applies this normalization to IP addresses so it doesn't
+    # match DNS SANs so we do the same thing!
+    stripped_hostname = asserted_hostname.strip("u[]")
+    if is_ipaddress(stripped_hostname):
+        asserted_hostname = stripped_hostname
+
     try:
         match_hostname(cert, asserted_hostname)
     except CertificateError as e:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -159,13 +159,13 @@ def ipv6_san_proxy(tmp_path_factory):
 
 
 @pytest.fixture
-def ip_san_server(tmp_path_factory):
+def ipv4_san_server(tmp_path_factory):
     tmpdir = tmp_path_factory.mktemp("certs")
     ca = trustme.CA()
     # IP address in Subject Alternative Name
-    server_cert = ca.issue_cert(u"127.0.0.1", "::1")
+    server_cert = ca.issue_cert(u"127.0.0.1")
 
-    with run_server_in_thread("https", "localhost", tmpdir, ca, server_cert) as cfg:
+    with run_server_in_thread("https", "127.0.0.1", tmpdir, ca, server_cert) as cfg:
         yield cfg
 
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -129,7 +129,7 @@ def no_localhost_san_server(tmp_path_factory):
 
 
 @pytest.fixture
-def ip_san_proxy(tmp_path_factory):
+def ipv4_san_proxy(tmp_path_factory):
     tmpdir = tmp_path_factory.mktemp("certs")
     ca = trustme.CA()
     # IP address in Subject Alternative Name
@@ -144,13 +144,28 @@ def ip_san_proxy(tmp_path_factory):
 
 
 @pytest.fixture
+def ipv6_san_proxy(tmp_path_factory):
+    tmpdir = tmp_path_factory.mktemp("certs")
+    ca = trustme.CA()
+    # IP addresses in Subject Alternative Name
+    proxy_cert = ca.issue_cert(u"::1")
+
+    server_cert = ca.issue_cert(u"localhost")
+
+    with run_server_and_proxy_in_thread(
+        "https", "::1", tmpdir, ca, proxy_cert, server_cert
+    ) as cfg:
+        yield cfg
+
+
+@pytest.fixture
 def ip_san_server(tmp_path_factory):
     tmpdir = tmp_path_factory.mktemp("certs")
     ca = trustme.CA()
     # IP address in Subject Alternative Name
-    server_cert = ca.issue_cert(u"127.0.0.1")
+    server_cert = ca.issue_cert(u"127.0.0.1", "::1")
 
-    with run_server_in_thread("https", "127.0.0.1", tmpdir, ca, server_cert) as cfg:
+    with run_server_in_thread("https", "localhost", tmpdir, ca, server_cert) as cfg:
         yield cfg
 
 

--- a/test/contrib/test_pyopenssl.py
+++ b/test/contrib/test_pyopenssl.py
@@ -34,7 +34,7 @@ def teardown_module():
 from ..test_util import TestUtilSSL  # noqa: E402, F401
 from ..with_dummyserver.test_https import (  # noqa: E402, F401
     TestHTTPS,
-    TestHTTPS_IPSAN,
+    TestHTTPS_IPV4SAN,
     TestHTTPS_IPv6Addr,
     TestHTTPS_IPV6SAN,
     TestHTTPS_NoSAN,

--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -43,6 +43,42 @@ class TestConnection(object):
             )
             assert e._peer_cert == cert
 
+    def test_match_hostname_ip_address_ipv6(self):
+        cert = {"subjectAltName": (("IP Address", "1:2::2:1"),)}
+        asserted_hostname = "1:2::2:2"
+        try:
+            with mock.patch("urllib3.connection.log.warning") as mock_log:
+                _match_hostname(cert, asserted_hostname)
+        except CertificateError as e:
+            assert "hostname '1:2::2:2' doesn't match '1:2::2:1'" in str(e)
+            mock_log.assert_called_once_with(
+                "Certificate did not match expected hostname: %s. Certificate: %s",
+                "1:2::2:2",
+                {"subjectAltName": (("IP Address", "1:2::2:1"),)},
+            )
+            assert e._peer_cert == cert
+
+    def test_match_hostname_dns_with_brackets_doesnt_match(self):
+        cert = {
+            "subjectAltName": (
+                ("DNS", "localhost"),
+                ("IP Address", "localhost"),
+            )
+        }
+        asserted_hostname = "[localhost]"
+        with pytest.raises(CertificateError) as e:
+            _match_hostname(cert, asserted_hostname)
+        assert (
+            "hostname '[localhost]' doesn't match either of 'localhost', 'localhost'"
+            in str(e.value)
+        )
+
+    def test_match_hostname_ip_address_ipv6_brackets(self):
+        cert = {"subjectAltName": (("IP Address", "1:2::2:1"),)}
+        asserted_hostname = "[1:2::2:1]"
+        # Assert no error is raised
+        _match_hostname(cert, asserted_hostname)
+
     def test_recent_date(self):
         # This test is to make sure that the RECENT_DATE value
         # doesn't get too far behind what the current date is.

--- a/test/with_dummyserver/test_https.py
+++ b/test/with_dummyserver/test_https.py
@@ -859,29 +859,25 @@ class TestHTTPS_NoSAN:
                 assert warn.called
 
 
-class TestHTTPS_IPSAN:
-    def test_can_validate_ip_san(self, ip_san_server):
+class TestHTTPS_IPV4SAN:
+    def test_can_validate_ip_san(self, ipv4_san_server):
         """Ensure that urllib3 can validate SANs with IP addresses in them."""
-        try:
-            import ipaddress  # noqa: F401
-        except ImportError:
-            pytest.skip("Only runs on systems with an ipaddress module")
-
         with HTTPSConnectionPool(
-            ip_san_server.host,
-            ip_san_server.port,
+            ipv4_san_server.host,
+            ipv4_san_server.port,
             cert_reqs="CERT_REQUIRED",
-            ca_certs=ip_san_server.ca_certs,
+            ca_certs=ipv4_san_server.ca_certs,
         ) as https_pool:
             r = https_pool.request("GET", "/")
             assert r.status == 200
 
 
 class TestHTTPS_IPv6Addr:
-    def test_strip_square_brackets_before_validating(self, ipv6_addr_server):
+    @pytest.mark.parametrize("host", ["::1", "[::1]"])
+    def test_strip_square_brackets_before_validating(self, ipv6_addr_server, host):
         """Test that the fix for #760 works."""
         with HTTPSConnectionPool(
-            "[::1]",
+            host,
             ipv6_addr_server.port,
             cert_reqs="CERT_REQUIRED",
             ca_certs=ipv6_addr_server.ca_certs,
@@ -891,15 +887,11 @@ class TestHTTPS_IPv6Addr:
 
 
 class TestHTTPS_IPV6SAN:
-    def test_can_validate_ipv6_san(self, ipv6_san_server):
+    @pytest.mark.parametrize("host", ["::1", "[::1]"])
+    def test_can_validate_ipv6_san(self, ipv6_san_server, host):
         """Ensure that urllib3 can validate SANs with IPv6 addresses in them."""
-        try:
-            import ipaddress  # noqa: F401
-        except ImportError:
-            pytest.skip("Only runs on systems with an ipaddress module")
-
         with HTTPSConnectionPool(
-            "[::1]",
+            host,
             ipv6_san_server.port,
             cert_reqs="CERT_REQUIRED",
             ca_certs=ipv6_san_server.ca_certs,

--- a/test/with_dummyserver/test_proxy_poolmanager.py
+++ b/test/with_dummyserver/test_proxy_poolmanager.py
@@ -588,9 +588,18 @@ class TestHTTPSProxyVerification:
             ) or "Hostname mismatch" in str(e.value.reason)
 
     @onlyPy3
-    def test_https_proxy_ip_san(self, ip_san_proxy):
-        proxy, server = ip_san_proxy
+    def test_https_proxy_ipv4_san(self, ipv4_san_proxy):
+        proxy, server = ipv4_san_proxy
         proxy_url = "https://%s:%s" % (proxy.host, proxy.port)
+        destination_url = "https://%s:%s" % (server.host, server.port)
+        with proxy_from_url(proxy_url, ca_certs=proxy.ca_certs) as https:
+            r = https.request("GET", destination_url)
+            assert r.status == 200
+
+    @onlyPy3
+    def test_https_proxy_ipv6_san(self, ipv6_san_proxy):
+        proxy, server = ipv6_san_proxy
+        proxy_url = "https://[%s]:%s" % (proxy.host, proxy.port)
         destination_url = "https://%s:%s" % (server.host, server.port)
         with proxy_from_url(proxy_url, ca_certs=proxy.ca_certs) as https:
             r = https.request("GET", destination_url)


### PR DESCRIPTION
Created a failing test as a useful starting point for backporting https://github.com/urllib3/urllib3/pull/2241 cc @jalopezsilva @pquentin 