### PR TITLE
Add missed type hints for test.with_dummyserver.test_poolmanager

### DIFF
--- a/test/with_dummyserver/test_poolmanager.py
+++ b/test/with_dummyserver/test_poolmanager.py
@@ -506,7 +506,7 @@ class TestPoolManager(HTTPDummyServerTestCase):
             HTTPHeaderDict(cookie="foo, bar"),
         ],
     )
-    def test_request_with_json(self, headers):
+    def test_request_with_json(self, headers: HTTPHeaderDict) -> None:
         body = {"attribute": "value"}
         r = request(
             method="POST", url=f"{self.base_url}/echo_json", headers=headers, json=body
@@ -520,7 +520,7 @@ class TestPoolManager(HTTPDummyServerTestCase):
                 " ", ""
             ).split(",")
 
-    def test_top_level_request_with_json_with_httpheaderdict(self):
+    def test_top_level_request_with_json_with_httpheaderdict(self) -> None:
         body = {"attribute": "value"}
         header = HTTPHeaderDict(cookie="foo, bar")
         with PoolManager(headers=header) as http:
@@ -531,11 +531,11 @@ class TestPoolManager(HTTPDummyServerTestCase):
                 " ", ""
             ).split(",")
 
-    def test_top_level_request_with_body_and_json(self):
+    def test_top_level_request_with_body_and_json(self) -> None:
         match = "request got values for both 'body' and 'json' parameters which are mutually exclusive"
         with pytest.raises(TypeError, match=match):
             body = {"attribute": "value"}
-            request(method="POST", url=f"{self.base_url}/echo", body=body, json=body)
+            request(method="POST", url=f"{self.base_url}/echo", body="", json=body)
 
 
 @pytest.mark.skipif(not HAS_IPV6, reason="IPv6 is not supported on this system")


### PR DESCRIPTION
Added type hints for tests of https://github.com/urllib3/urllib3/commit/c5bc7163022c0ac2e765cdb7309937a53e32d368
<!---
Thanks for your contribution! ♥️

If this is your first PR to urllib3 please review the Contributing Guide:
https://urllib3.readthedocs.io/en/latest/contributing.html

Adhering to the Contributing Guide means we can review, merge, and release your change faster! :)
--->
