### PR TITLE
Release 1.26.7

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,10 +1,12 @@
 Changes
 =======
 
-1.26.x (dev)
+1.26.7 (2021-09-22)
 -------------------
 * Fixed a bug with HTTPS hostname verification involving IP addresses and lack
   of SNI. (Issue #2400)
+* Fixed a bug where IPv6 braces weren't stripped during certificate hostname
+  matching. (Issue #2240)
 
 
 1.26.6 (2021-06-25)

--- a/src/urllib3/_version.py
+++ b/src/urllib3/_version.py
@@ -1,2 +1,2 @@
 # This file is protected via CODEOWNERS
-__version__ = "1.26.6"
+__version__ = "1.26.7"


### PR DESCRIPTION
* [x] See if all tests, including integration, pass
  * Botocore dropped support for Python 2.7 in July, expected to fail here.
* [x] Get the release pull request approved by a [CODEOWNER](https://github.com/urllib3/urllib3/blob/main/.github/CODEOWNERS)
* [x] Squash merge the release pull request with message "`Release <VERSION>`"
* [ ] Tag with X.Y.Z, push tag on urllib3/urllib3 (not on your fork, update `<REMOTE>` accordingly)
  * Notice that the `<VERSION>` shouldn't have a `v` prefix (Use `1.26.6` instead of `v.1.26.6`)
  * ```
    git tag -a '<VERSION>' -m 'Release: <VERSION>'
    git push <REMOTE> --tags
    ```
* [ ]  Push to PyPI
  * ```
    cd /tmp
    git clone ssh://git@github.com/urllib3/urllib3
    cd urllib3
    git checkout <TAG/VERSION>
    python -m venv
    source venv/bin/activate
    python -m pip install -U pip
    python -m pip install -U twine setuptools wheel
    python setup.py sdist bdist_wheel
    
    twine check dist/*
    # Inspect the output to make sure it looks right
    # Check versions, should be 1 wheel 1 sdist
    
    twine upload dist/*
    ```
* [ ]  Grab sdist and wheel from PyPI to attach to GitHub release
* [ ]  Announce on:
  * [ ]  GitHub releases
  * [ ]  Twitter
  * [ ]  Discord
  * [ ]  OpenCollective
  * [ ]  GitCoin Grants
* [ ]  Update Tidelift metadata