### PR TITLE
[1.26] Add exception wrapper for HTTPS proxy connection failure

### DIFF
--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -514,7 +514,7 @@ class HTTPSConnection(HTTPConnection):
             # Wrap into an HTTPSProxyError for easier diagnosis.
             # Original exception is available on original_error
             raise HTTPSProxyError(
-                f"Unable to establish a TLS connection to {hostname}", e
+                "Unable to establish a TLS connection to {}".format(hostname), e
             )
 
         if ssl_context.verify_mode != ssl.CERT_NONE and not getattr(

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -47,6 +47,7 @@ from ._collections import HTTPHeaderDict  # noqa (historical, removed in v2)
 from ._version import __version__
 from .exceptions import (
     ConnectTimeoutError,
+    HTTPSProxyError,
     NewConnectionError,
     SubjectAltNameWarning,
     SystemTimeWarning,
@@ -477,35 +478,44 @@ class HTTPSConnection(HTTPConnection):
         """
         Establish a TLS connection to the proxy using the provided SSL context.
         """
+
         proxy_config = self.proxy_config
         ssl_context = proxy_config.ssl_context
-        if ssl_context:
-            # If the user provided a proxy context, we assume CA and client
-            # certificates have already been set
-            return ssl_wrap_socket(
+
+        try:
+            if ssl_context:
+                # If the user provided a proxy context, we assume CA and client
+                # certificates have already been set
+                return ssl_wrap_socket(
+                    sock=conn,
+                    server_hostname=hostname,
+                    ssl_context=ssl_context,
+                )
+
+            ssl_context = create_proxy_ssl_context(
+                self.ssl_version,
+                self.cert_reqs,
+                self.ca_certs,
+                self.ca_cert_dir,
+                self.ca_cert_data,
+            )
+
+            # If no cert was provided, use only the default options for server
+            # certificate validation
+            socket = ssl_wrap_socket(
                 sock=conn,
+                ca_certs=self.ca_certs,
+                ca_cert_dir=self.ca_cert_dir,
+                ca_cert_data=self.ca_cert_data,
                 server_hostname=hostname,
                 ssl_context=ssl_context,
             )
-
-        ssl_context = create_proxy_ssl_context(
-            self.ssl_version,
-            self.cert_reqs,
-            self.ca_certs,
-            self.ca_cert_dir,
-            self.ca_cert_data,
-        )
-
-        # If no cert was provided, use only the default options for server
-        # certificate validation
-        socket = ssl_wrap_socket(
-            sock=conn,
-            ca_certs=self.ca_certs,
-            ca_cert_dir=self.ca_cert_dir,
-            ca_cert_data=self.ca_cert_data,
-            server_hostname=hostname,
-            ssl_context=ssl_context,
-        )
+        except Exception as e:
+            # Wrap into an HTTPSProxyError for easier diagnosis.
+            # Original exception is available on original_error
+            raise HTTPSProxyError(
+                f"Unable to establish a TLS connection to {hostname}", e
+            )
 
         if ssl_context.verify_mode != ssl.CERT_NONE and not getattr(
             ssl_context, "check_hostname", False

--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -23,6 +23,7 @@ from .exceptions import (
     EmptyPoolError,
     HeaderParsingError,
     HostChangedError,
+    HTTPSProxyError,
     InsecureRequestWarning,
     LocationValueError,
     MaxRetryError,
@@ -741,6 +742,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
             BaseSSLError,
             SSLError,
             CertificateError,
+            HTTPSProxyError,
         ) as e:
             # Discard the connection for these exceptions. It will be
             # replaced during the next _get_conn() call.

--- a/src/urllib3/exceptions.py
+++ b/src/urllib3/exceptions.py
@@ -55,6 +55,13 @@ class ProxyError(HTTPError):
         self.original_error = error
 
 
+class HTTPSProxyError(ProxyError):
+    """Used only when establishing a TLS connection to a proxy"""
+
+    def __init__(self, message, error, *args):
+        super().__init__(message, error, *args)
+
+
 class DecodeError(HTTPError):
     """Raised when automatic decoding based on Content-Type fails."""
 

--- a/test/with_dummyserver/test_proxy_poolmanager.py
+++ b/test/with_dummyserver/test_proxy_poolmanager.py
@@ -181,12 +181,12 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
         Simulates a misconfiguration that is common for users. The test attempts
         to establish a TLS connection to a non-TLS proxy
         """
-        bad_proxy_url = f"https://{self.proxy_host}:{int(self.proxy_port)}"
+        bad_proxy_url = "https://{}:{}".format(self.proxy_host, int(self.proxy_port))
         with proxy_from_url(
             bad_proxy_url, ca_certs=DEFAULT_CA, timeout=LONG_TIMEOUT
         ) as http:
             with pytest.raises(MaxRetryError) as e:
-                http.request("GET", f"{self.https_url}/")
+                http.request("GET", "{}/".format(self.https_url))
             assert type(e.value.reason) == HTTPSProxyError
 
     def test_oldapi(self):

--- a/test/with_dummyserver/test_proxy_poolmanager.py
+++ b/test/with_dummyserver/test_proxy_poolmanager.py
@@ -176,6 +176,7 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
                 http.request("GET", "%s/" % self.http_url)
             assert type(e.value.reason) == ProxyError
 
+    @onlyPy3
     def test_https_conn_failed(self):
         """
         Simulates a misconfiguration that is common for users. The test attempts

--- a/test/with_dummyserver/test_proxy_poolmanager.py
+++ b/test/with_dummyserver/test_proxy_poolmanager.py
@@ -22,6 +22,7 @@ from urllib3._collections import HTTPHeaderDict
 from urllib3.connectionpool import VerifiedHTTPSConnection, connection_from_url
 from urllib3.exceptions import (
     ConnectTimeoutError,
+    HTTPSProxyError,
     InsecureRequestWarning,
     MaxRetryError,
     ProxyError,
@@ -174,6 +175,19 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
             with pytest.raises(MaxRetryError) as e:
                 http.request("GET", "%s/" % self.http_url)
             assert type(e.value.reason) == ProxyError
+
+    def test_https_conn_failed(self):
+        """
+        Simulates a misconfiguration that is common for users. The test attempts
+        to establish a TLS connection to a non-TLS proxy
+        """
+        bad_proxy_url = f"https://{self.proxy_host}:{int(self.proxy_port)}"
+        with proxy_from_url(
+            bad_proxy_url, ca_certs=DEFAULT_CA, timeout=LONG_TIMEOUT
+        ) as http:
+            with pytest.raises(MaxRetryError) as e:
+                http.request("GET", f"{self.https_url}/")
+            assert type(e.value.reason) == HTTPSProxyError
 
     def test_oldapi(self):
         with ProxyManager(


### PR DESCRIPTION
This backports #2133 and could help with various reports we're receiving.