### PR TITLE
Don't unconditionally wrap errors with HTTPSProxyError

### DIFF
--- a/docs/advanced-usage.rst
+++ b/docs/advanced-usage.rst
@@ -239,9 +239,9 @@ and not ``https://``:
 
 .. code-block:: bash
 
-     # Check environment variables in bash
+     # Check your existing environment variables in bash
      $ env | grep "_PROXY"
-     HTTP_PROXY=https://127.0.0.1:8888
+     HTTP_PROXY=http://127.0.0.1:8888
      HTTPS_PROXY=https://127.0.0.1:8888  # <--- This setting is the problem!
      
      # Make the fix in your current session and test your script

--- a/docs/advanced-usage.rst
+++ b/docs/advanced-usage.rst
@@ -210,6 +210,78 @@ an `absolute URI <https://tools.ietf.org/html/rfc7230#section-5.3.2>`_ if the
 **only use this option with trusted or corporate proxies** as the proxy will have
 full visibility of your requests.
 
+.. _https_proxy_error_http_proxy:
+
+How to fix HTTPSProxyError?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you're receiving the :class:`~urllib3.exceptions.HTTPSProxyError` and it mentions
+your proxy only speaks HTTP and not HTTPS here's what to do to solve your issue:
+
+If you're using ``urllib3`` directly, make sure the URL you're passing into :class:`urllib3.ProxyManager`
+starts with ``http://`` instead of ``https://``:
+
+.. code-block:: python
+
+     # Do this:
+     http = urllib3.ProxyManager("http://...")
+     
+     # Not this:
+     http = urllib3.ProxyManager("https://...")
+
+If instead you're using ``urllib3`` through another library like Requests
+there are multiple ways your proxy could be mis-configured. You need to figure out
+where the configuration isn't correct and make the fix there. Some common places
+to look are environment variables like ``HTTP_PROXY``, ``HTTPS_PROXY``, and ``ALL_PROXY``.
+
+Ensure that the values for all of these environment variables starts with ``http://``
+and not ``https://``:
+
+.. code-block:: bash
+
+     # Check environment variables in bash
+     $ env | grep "_PROXY"
+     HTTP_PROXY=https://127.0.0.1:8888
+     HTTPS_PROXY=https://127.0.0.1:8888  # <--- This setting is the problem!
+     
+     # Make the fix in your current session and test your script
+     $ export HTTPS_PROXY="http://127.0.0.1:8888"
+     $ python test-proxy.py  # This should now pass.
+     
+     # Persist your change in your shell 'profile' (~/.bashrc, ~/.profile, ~/.bash_profile, etc)
+     # You may need to logout and log back in to ensure this works across all programs.
+     $ vim ~/.bashrc
+
+If you're on Windows or macOS your proxy may be getting set at a system level.
+To check this first ensure that the above environment variables aren't set
+then run the following:
+
+.. code-block:: bash
+
+    $ python -c 'import urllib.request; print(urllib.request.getproxies())'
+
+If the output of the above command isn't empty and looks like this:
+
+.. code-block:: python
+
+    {
+      "http": "http://127.0.0.1:8888",
+      "https": "https://127.0.0.1:8888"  # <--- This setting is the problem!
+    }
+
+Search how to configure proxies on your operating system and change the ``https://...`` URL into ``http://``.
+After you make the change the return value of ``urllib.request.getproxies()`` should be:
+
+.. code-block:: python
+
+    {  # Everything is good here! :)
+      "http": "http://127.0.0.1:8888",
+      "https": "http://127.0.0.1:8888"
+    }
+
+If you still can't figure out how to configure your proxy after all these steps
+please `join our community Discord <https://discord.gg/urllib3>`_ and we'll try to help you with your issue.
+
 SOCKS Proxies
 ~~~~~~~~~~~~~
 

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -45,7 +45,6 @@ from .exceptions import (
     HTTPSProxyError,
     NameResolutionError,
     NewConnectionError,
-    ProxyError,
     SystemTimeWarning,
 )
 from .util import SKIP_HEADER, SKIPPABLE_HEADERS, connection, ssl_
@@ -595,8 +594,6 @@ def _match_hostname(cert: _TYPE_PEER_CERT_RET, asserted_hostname: str) -> None:
 
 def _should_wrap_https_proxy_error(err: Exception) -> bool:
     """Detects if the error should be wrapped into :class:`urllib3.exceptions.HTTPSProxyError`"""
-    if isinstance(err, ProxyError):
-        err = err.original_error
     return isinstance(err, (CertificateError, BaseSSLError, ssl_.SSLError))  # type: ignore[attr-defined]
 
 
@@ -604,8 +601,6 @@ def _wrap_https_proxy_error(err: Exception, hostname: str) -> "NoReturn":
     # Look for the phrase 'wrong version number', if found
     # then we should warn the user that we're very sure that
     # this proxy is HTTP-only and they have a configuration issue.
-    if isinstance(err, ProxyError):
-        err = err.original_error
     error_normalized = " ".join(re.split("[^a-z]", str(err).lower()))
     is_likely_http_proxy = "wrong version number" in error_normalized
     http_proxy_warning = (

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -34,6 +34,7 @@ from urllib3 import HTTPConnectionPool, HTTPSConnectionPool, util
 from urllib3._collections import HTTPHeaderDict
 from urllib3.connection import HTTPConnection, _get_default_user_agent
 from urllib3.exceptions import (
+    HTTPSProxyError,
     MaxRetryError,
     ProtocolError,
     ProxyError,
@@ -1144,6 +1145,30 @@ class TestProxyManager(SocketDummyServerTestCase):
                 assert r.status == 200
             except MaxRetryError:
                 self.fail("Invalid IPv6 format in HTTP CONNECT request")
+
+    @pytest.mark.parametrize("target_scheme", ["http", "https"])
+    def test_https_proxymanager_connected_to_http_proxy(
+        self, target_scheme: str
+    ) -> None:
+        def http_socket_handler(listener):
+            sock = listener.accept()[0]
+            sock.send(
+                b"HTTP/1.0 501 Not Implemented\r\n" b"Connection: close\r\n" b"\r\n"
+            )
+            sock.close()
+
+        self._start_server(http_socket_handler)
+        base_url = f"https://{self.host}:{self.port}"
+
+        import urllib3
+
+        with urllib3.ProxyManager(base_url, cert_reqs="NONE") as proxy:
+            with pytest.raises(MaxRetryError) as e:
+                proxy.request("GET", f"{target_scheme}://example.com", retries=0)
+            assert type(e.value.reason) == HTTPSProxyError
+            assert "Your proxy appears to only use HTTP and not HTTPS" in str(
+                e.value.reason
+            )
 
 
 class TestSSL(SocketDummyServerTestCase):

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -30,7 +30,7 @@ from dummyserver.server import (
     get_unreachable_address,
 )
 from dummyserver.testcase import SocketDummyServerTestCase, consume_socket
-from urllib3 import HTTPConnectionPool, HTTPSConnectionPool, util
+from urllib3 import HTTPConnectionPool, HTTPSConnectionPool, ProxyManager, util
 from urllib3._collections import HTTPHeaderDict
 from urllib3.connection import HTTPConnection, _get_default_user_agent
 from urllib3.exceptions import (
@@ -1150,21 +1150,24 @@ class TestProxyManager(SocketDummyServerTestCase):
     def test_https_proxymanager_connected_to_http_proxy(
         self, target_scheme: str
     ) -> None:
+
+        errored = Event()
+
         def http_socket_handler(listener):
             sock = listener.accept()[0]
-            sock.send(
-                b"HTTP/1.0 501 Not Implemented\r\n" b"Connection: close\r\n" b"\r\n"
-            )
+            sock.send(b"HTTP/1.0 501 Not Implemented\r\nConnection: close\r\n\r\n")
+            errored.wait()
             sock.close()
 
         self._start_server(http_socket_handler)
         base_url = f"https://{self.host}:{self.port}"
 
-        import urllib3
-
-        with urllib3.ProxyManager(base_url, cert_reqs="NONE") as proxy:
+        with ProxyManager(base_url, cert_reqs="NONE") as proxy:
             with pytest.raises(MaxRetryError) as e:
                 proxy.request("GET", f"{target_scheme}://example.com", retries=0)
+
+            errored.set()  # Avoid a ConnectionAbortedError on Windows.
+
             assert type(e.value.reason) == HTTPSProxyError
             assert "Your proxy appears to only use HTTP and not HTTPS" in str(
                 e.value.reason


### PR DESCRIPTION
Noticed that when we unconditionally wrap all exceptions with `HTTPSProxyError` we're likely to report inability to connect via TLS when TLS isn't always the problem (DNS, timeouts, etc) so instead we wrap only when we are certain the error is TLS related.

Also adds documentation to help users debug a common scenario where they specify an HTTPS proxy but are actually talking to an HTTP proxy. Will update the error message with the link to this fragment in the docs after docs build.