### PR TITLE
Add simple HTTPS proxy that can be run locally.

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -94,6 +94,23 @@ further parameterize pytest for local testing.
 For all valid arguments, check `the pytest documentation
 <https://docs.pytest.org/en/stable/usage.html#stopping-after-the-first-or-n-failures>`_.
 
+Running local proxies
+---------------------
+
+If the feature you are developing involves a proxy, you can rely on scripts we have developed to run a proxy locally.
+
+Run an HTTP proxy locally:
+
+.. code-block:: bash
+
+   $ python -m dummyserver.proxy
+
+Run an HTTPS proxy locally:
+
+.. code-block:: bash
+
+   $ python -m dummyserver.https_proxy
+
 Contributing to documentation
 -----------------------------
 

--- a/dummyserver/https_proxy.py
+++ b/dummyserver/https_proxy.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+
+import sys
+from typing import Any, Dict
+
+import tornado.httpserver
+import tornado.ioloop
+import tornado.web
+
+from dummyserver.proxy import ProxyHandler
+from dummyserver.server import DEFAULT_CERTS, ssl_options_to_context
+
+
+def run_proxy(port: int, certs: Dict[str, Any] = DEFAULT_CERTS) -> None:
+    """
+    Run proxy on the specified port using the provided certs.
+
+    Example usage:
+
+    python -m dummyserver.proxy
+
+    You'll need to ensure you have access to certain packages such as trustme,
+    tornado, urllib3.
+    """
+    upstream_ca_certs = certs.get("ca_certs")
+    app = tornado.web.Application(
+        [(r".*", ProxyHandler)], upstream_ca_certs=upstream_ca_certs
+    )
+    ssl_opts = ssl_options_to_context(**certs)
+    http_server = tornado.httpserver.HTTPServer(app, ssl_options=ssl_opts)
+    http_server.listen(port)
+
+    ioloop = tornado.ioloop.IOLoop.instance()
+    try:
+        ioloop.start()
+    except KeyboardInterrupt:
+        ioloop.stop()
+
+
+if __name__ == "__main__":
+    port = 8443
+    if len(sys.argv) > 1:
+        port = int(sys.argv[1])
+
+    print(f"Starting HTTPS proxy on port {port}")
+    run_proxy(port)

--- a/dummyserver/https_proxy.py
+++ b/dummyserver/https_proxy.py
@@ -17,7 +17,7 @@ def run_proxy(port: int, certs: Dict[str, Any] = DEFAULT_CERTS) -> None:
 
     Example usage:
 
-    python -m dummyserver.proxy
+    python -m dummyserver.https_proxy
 
     You'll need to ensure you have access to certain packages such as trustme,
     tornado, urllib3.


### PR DESCRIPTION
Introduces ``dummyserver/https_proxy.py`` which can be run as a local HTTPS proxy. It's pretty simple and you can override the certs as needed. I decided to use the ``DEFAULT_CERTS`` but we could have also created ones through ``trustme``. Let me know if we prefer that. 

It works pretty well:

```
(env) urllib3 - dummy_https_proxy ❯ python -m dummyserver.https_proxy
Starting HTTPS proxy on port 8443
...
# On another terminal.
curl -x https://localhost:8443 http://google.com --proxy-insecure -o /dev/null -v
...
> GET http://google.com/ HTTP/1.1
> Host: google.com
> User-Agent: curl/7.78.0
> Accept: */*
> Proxy-Connection: Keep-Alive
...
< HTTP/1.1 301 Moved Permanently
< Server: gws
< Content-Type: text/html; charset=UTF-8
< Date: Sun, 26 Sep 2021 23:58:46 GMT
< Cache-Control: public, max-age=2592000
< Location: http://www.google.com/
< Content-Length: 219
```

Using HTTP CONNECT

```
 curl -x https://localhost:8443 https://google.com --proxy-insecure -o /dev/null -v
....
> CONNECT google.com:443 HTTP/1.1
> Host: google.com:443
> User-Agent: curl/7.78.0
> Proxy-Connection: Keep-Alive
...
* Proxy replied 200 to CONNECT request
* CONNECT phase completed!
...
> GET / HTTP/2
> Host: google.com
> user-agent: curl/7.78.0
> accept: */*
...
< HTTP/2 301
< location: https://www.google.com/
< content-type: text/html; charset=UTF-8
< date: Sun, 26 Sep 2021 23:59:52 GMT
< expires: Tue, 26 Oct 2021 23:59:52 GMT
< cache-control: public, max-age=2592000
< server: gws
```