### PR TITLE
[1.26] Don't unconditionally wrap proxy connection errors with HTTPSProxyError

### DIFF
--- a/docs/advanced-usage.rst
+++ b/docs/advanced-usage.rst
@@ -168,6 +168,78 @@ an `absolute URI <https://tools.ietf.org/html/rfc7230#section-5.3.2>`_ if the
 **only use this option with trusted or corporate proxies** as the proxy will have
 full visibility of your requests.
 
+.. _https_proxy_error_http_proxy:
+
+How to fix HTTPSProxyError?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you're receiving the :class:`~urllib3.exceptions.HTTPSProxyError` and it mentions
+your proxy only speaks HTTP and not HTTPS here's what to do to solve your issue:
+
+If you're using ``urllib3`` directly, make sure the URL you're passing into :class:`urllib3.ProxyManager`
+starts with ``http://`` instead of ``https://``:
+
+.. code-block:: python
+
+     # Do this:
+     http = urllib3.ProxyManager("http://...")
+     
+     # Not this:
+     http = urllib3.ProxyManager("https://...")
+
+If instead you're using ``urllib3`` through another library like Requests
+there are multiple ways your proxy could be mis-configured. You need to figure out
+where the configuration isn't correct and make the fix there. Some common places
+to look are environment variables like ``HTTP_PROXY``, ``HTTPS_PROXY``, and ``ALL_PROXY``.
+
+Ensure that the values for all of these environment variables starts with ``http://``
+and not ``https://``:
+
+.. code-block:: bash
+
+     # Check your existing environment variables in bash
+     $ env | grep "_PROXY"
+     HTTP_PROXY=http://127.0.0.1:8888
+     HTTPS_PROXY=https://127.0.0.1:8888  # <--- This setting is the problem!
+     
+     # Make the fix in your current session and test your script
+     $ export HTTPS_PROXY="http://127.0.0.1:8888"
+     $ python test-proxy.py  # This should now pass.
+     
+     # Persist your change in your shell 'profile' (~/.bashrc, ~/.profile, ~/.bash_profile, etc)
+     # You may need to logout and log back in to ensure this works across all programs.
+     $ vim ~/.bashrc
+
+If you're on Windows or macOS your proxy may be getting set at a system level.
+To check this first ensure that the above environment variables aren't set
+then run the following:
+
+.. code-block:: bash
+
+    $ python -c 'import urllib.request; print(urllib.request.getproxies())'
+
+If the output of the above command isn't empty and looks like this:
+
+.. code-block:: python
+
+    {
+      "http": "http://127.0.0.1:8888",
+      "https": "https://127.0.0.1:8888"  # <--- This setting is the problem!
+    }
+
+Search how to configure proxies on your operating system and change the ``https://...`` URL into ``http://``.
+After you make the change the return value of ``urllib.request.getproxies()`` should be:
+
+.. code-block:: python
+
+    {  # Everything is good here! :)
+      "http": "http://127.0.0.1:8888",
+      "https": "http://127.0.0.1:8888"
+    }
+
+If you still can't figure out how to configure your proxy after all these steps
+please `join our community Discord <https://discord.gg/urllib3>`_ and we'll try to help you with your issue.
+
 SOCKS Proxies
 ~~~~~~~~~~~~~
 

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -581,11 +581,14 @@ def _wrap_https_proxy_error(err, hostname):
     # Wrap into an HTTPSProxyError for easier diagnosis.
     # Original exception is available on original_error and
     # as __cause__.
-    raise HTTPSProxyError(
-        "Unable to establish a TLS connection to %s%s"
-        % (hostname, http_proxy_warning if is_likely_http_proxy else ""),
+    six.raise_from(
+        HTTPSProxyError(
+            "Unable to establish a TLS connection to %s%s"
+            % (hostname, http_proxy_warning if is_likely_http_proxy else ""),
+            err,
+        ),
         err,
-    ) from err
+    )
 
 
 def _get_default_user_agent():

--- a/test/with_dummyserver/test_proxy_poolmanager.py
+++ b/test/with_dummyserver/test_proxy_poolmanager.py
@@ -167,12 +167,12 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
 
     @pytest.mark.parametrize("proxy_scheme", ["http", "https"])
     @pytest.mark.parametrize("target_scheme", ["http", "https"])
-    def test_proxy_conn_fail_from_dns(
-        self, proxy_scheme: str, target_scheme: str
-    ) -> None:
+    def test_proxy_conn_fail_from_dns(self, proxy_scheme, target_scheme):
         host, port = get_unreachable_address()
         with proxy_from_url(
-            f"{proxy_scheme}://{host}:{port}/", retries=1, timeout=LONG_TIMEOUT
+            "{}://{}:{}/".format(proxy_scheme, host, port),
+            retries=1,
+            timeout=LONG_TIMEOUT,
         ) as http:
             if target_scheme == "https":
                 target_url = self.https_url
@@ -180,7 +180,7 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
                 target_url = self.http_url
 
             with pytest.raises(MaxRetryError) as e:
-                http.request("GET", f"{target_url}/")
+                http.request("GET", "{}/".format(target_url))
             assert type(e.value.reason) == ProxyError
             assert (
                 type(e.value.reason.original_error)
@@ -189,14 +189,15 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
 
     @onlyPy3
     @pytest.mark.parametrize("target_scheme", ["http", "https"])
-    def test_https_proxy_error_doesnt_wrap_timeouts(self, target_scheme: str) -> None:
+    def test_https_proxy_error_doesnt_wrap_timeouts(self, target_scheme):
         bad_proxy_url = "https://{}:{}".format(self.proxy_host, int(self.proxy_port))
         with proxy_from_url(
             bad_proxy_url, ca_certs=DEFAULT_CA, timeout=LONG_TIMEOUT
         ) as http:
             with pytest.raises(MaxRetryError) as e:
                 http.request(
-                    "GET", f"{target_scheme}://{self.http_host}:{self.http_port}"
+                    "GET",
+                    "{}://{}:{}".format(target_scheme, self.http_host, self.http_port),
                 )
 
             if type(e.value.reason) == ProxyError:

--- a/test/with_dummyserver/test_proxy_poolmanager.py
+++ b/test/with_dummyserver/test_proxy_poolmanager.py
@@ -3,6 +3,7 @@ import os.path
 import shutil
 import socket
 import ssl
+import sys
 import tempfile
 import warnings
 from test import (
@@ -168,6 +169,8 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
     @pytest.mark.parametrize("proxy_scheme", ["http", "https"])
     @pytest.mark.parametrize("target_scheme", ["http", "https"])
     def test_proxy_conn_fail_from_dns(self, proxy_scheme, target_scheme):
+        if target_scheme == "https" and sys.version_info <= (3,):
+            pytest.skip("HTTPS proxies are not supported on Python 2")
         host, port = get_unreachable_address()
         with proxy_from_url(
             "{}://{}:{}/".format(proxy_scheme, host, port),

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -1161,6 +1161,7 @@ class TestProxyManager(SocketDummyServerTestCase):
             except MaxRetryError:
                 self.fail("Invalid IPv6 format in HTTP CONNECT request")
 
+    @onlyPy3
     @pytest.mark.parametrize("target_scheme", ["http", "https"])
     def test_https_proxymanager_connected_to_http_proxy(self, target_scheme):
 

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -1162,9 +1162,7 @@ class TestProxyManager(SocketDummyServerTestCase):
                 self.fail("Invalid IPv6 format in HTTP CONNECT request")
 
     @pytest.mark.parametrize("target_scheme", ["http", "https"])
-    def test_https_proxymanager_connected_to_http_proxy(
-        self, target_scheme: str
-    ) -> None:
+    def test_https_proxymanager_connected_to_http_proxy(self, target_scheme):
 
         errored = Event()
 
@@ -1175,11 +1173,13 @@ class TestProxyManager(SocketDummyServerTestCase):
             sock.close()
 
         self._start_server(http_socket_handler)
-        base_url = f"https://{self.host}:{self.port}"
+        base_url = "https://{}:{}".format(self.host, self.port)
 
         with ProxyManager(base_url, cert_reqs="NONE") as proxy:
             with pytest.raises(MaxRetryError) as e:
-                proxy.request("GET", f"{target_scheme}://example.com", retries=0)
+                proxy.request(
+                    "GET", "{}://example.com".format(target_scheme), retries=0
+                )
 
             errored.set()  # Avoid a ConnectionAbortedError on Windows.
 

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -7,10 +7,11 @@ from dummyserver.server import (
     get_unreachable_address,
 )
 from dummyserver.testcase import SocketDummyServerTestCase, consume_socket
-from urllib3 import HTTPConnectionPool, HTTPSConnectionPool, util
+from urllib3 import HTTPConnectionPool, HTTPSConnectionPool, ProxyManager, util
 from urllib3._collections import HTTPHeaderDict
 from urllib3.connection import HTTPConnection, _get_default_user_agent
 from urllib3.exceptions import (
+    HTTPSProxyError,
     MaxRetryError,
     ProtocolError,
     ProxyError,
@@ -1159,6 +1160,33 @@ class TestProxyManager(SocketDummyServerTestCase):
                 assert r.status == 200
             except MaxRetryError:
                 self.fail("Invalid IPv6 format in HTTP CONNECT request")
+
+    @pytest.mark.parametrize("target_scheme", ["http", "https"])
+    def test_https_proxymanager_connected_to_http_proxy(
+        self, target_scheme: str
+    ) -> None:
+
+        errored = Event()
+
+        def http_socket_handler(listener):
+            sock = listener.accept()[0]
+            sock.send(b"HTTP/1.0 501 Not Implemented\r\nConnection: close\r\n\r\n")
+            errored.wait()
+            sock.close()
+
+        self._start_server(http_socket_handler)
+        base_url = f"https://{self.host}:{self.port}"
+
+        with ProxyManager(base_url, cert_reqs="NONE") as proxy:
+            with pytest.raises(MaxRetryError) as e:
+                proxy.request("GET", f"{target_scheme}://example.com", retries=0)
+
+            errored.set()  # Avoid a ConnectionAbortedError on Windows.
+
+            assert type(e.value.reason) == HTTPSProxyError
+            assert "Your proxy appears to only use HTTP and not HTTPS" in str(
+                e.value.reason
+            )
 
 
 class TestSSL(SocketDummyServerTestCase):


### PR DESCRIPTION
This is a pretty simple cherry-pick, will likely fail on Python 2.7. Will update after failures.

Relates #2434 