### PR TITLE
Bump requirements

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,12 +1,12 @@
-coverage==5.5
+coverage==6.0
 tornado==6.1
 PySocks==1.7.1
-pytest==6.2.4
+pytest==6.2.5
 pytest-timeout==1.4.2
 pytest-freezegun==0.4.2
 flaky==3.7.0
 trustme==0.9.0
-cryptography==3.4.7
+cryptography==35.0.0
 backports.zoneinfo==0.2.1;python_version<"3.9"
 # https://github.com/twisted/towncrier/pull/356
 git+https://github.com/twisted/towncrier.git


### PR DESCRIPTION
I know coverage is not going to fix our codecov problems, but hey, it does not hurt to use the latest and greatest and encourage projects that drop Python 2.7.