### PR TITLE
Use ProxyError to warn against HTTPS proxy issues

### DIFF
--- a/docs/advanced-usage.rst
+++ b/docs/advanced-usage.rst
@@ -212,10 +212,10 @@ full visibility of your requests.
 
 .. _https_proxy_error_http_proxy:
 
-How to fix HTTPSProxyError?
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Your proxy appears to only use HTTP and not HTTPS
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If you're receiving the :class:`~urllib3.exceptions.HTTPSProxyError` and it mentions
+If you're receiving the :class:`~urllib3.exceptions.ProxyError` and it mentions
 your proxy only speaks HTTP and not HTTPS here's what to do to solve your issue:
 
 If you're using ``urllib3`` directly, make sure the URL you're passing into :class:`urllib3.ProxyManager`

--- a/src/urllib3/exceptions.py
+++ b/src/urllib3/exceptions.py
@@ -69,12 +69,6 @@ class ProxyError(HTTPError):
         self.original_error = error
 
 
-class HTTPSProxyError(ProxyError):
-    """Used only when establishing a TLS connection to a proxy"""
-
-    pass
-
-
 class DecodeError(HTTPError):
     """Raised when automatic decoding based on Content-Type fails."""
 


### PR DESCRIPTION
Created as an alternative to https://github.com/urllib3/urllib3/pull/2133. Discussed this with @jalopezsilva and I wasn't sure if adding an additional exception `HTTPSProxyError` captured anything extra over a normal `ProxyError`. `ProxyError` exists to differentiate between an error that occurred on the proxy versus the target/origin.

If merged would need to be backported to 1.26.x and would close https://github.com/urllib3/urllib3/pull/2441.