### PR TITLE
Test development versions of Python

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Set Up Python - ${{ matrix.python-version }}
         uses: actions/setup-python@v2
-        if: "!endsWith(matrix.python-version, '-dev') && matrix.python-version != 'nightly'"
+        if: "(!endsWith(matrix.python-version, '-dev')) && matrix.python-version != 'nightly'"
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,14 @@ jobs:
             os: ubuntu-latest
             experimental: false
             nox-session: test-3.9
+          - python-version: 3.11-dev
+            os: ubuntu-latest
+            experimental: true
+            nox-session: test
+          - python-version: nightly
+            os: ubuntu-latest
+            experimental: true
+            nox-session: test
 
     runs-on: ${{ matrix.os }}
     name: ${{ fromJson('{"macos-latest":"macOS","windows-latest":"Windows","ubuntu-latest":"Ubuntu"}')[matrix.os] }} ${{ matrix.python-version }} ${{ matrix.nox-session}}
@@ -66,13 +74,13 @@ jobs:
 
       - name: Set Up Python - ${{ matrix.python-version }}
         uses: actions/setup-python@v2
-        if: "!endsWith(matrix.python-version, '-dev')"
+        if: "!endsWith(matrix.python-version, '-dev') && matrix.python-version != 'nightly'"
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Set Up Python - ${{ matrix.python-version }}
         uses: deadsnakes/action@v2.0.2
-        if: endsWith(matrix.python-version, '-dev')
+        if: "endsWith(matrix.python-version, '-dev') || matrix.python-version == 'nightly'"
         with:
           python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
Uses the `3.11-dev` and `nightly` deadsnakes release streams to test urllib3 against Python versions.