### PR TITLE
Test development versions of Python

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,10 @@ jobs:
             os: ubuntu-latest
             experimental: false
             nox-session: test-3.9
+          - python-version: 3.11-dev
+            os: ubuntu-latest
+            experimental: true
+            nox-session: test-3.11
 
     runs-on: ${{ matrix.os }}
     name: ${{ fromJson('{"macos-latest":"macOS","windows-latest":"Windows","ubuntu-latest":"Ubuntu"}')[matrix.os] }} ${{ matrix.python-version }} ${{ matrix.nox-session}}
@@ -70,7 +74,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Set Up Python - ${{ matrix.python-version }}
+      - name: Set Up Python (Development version) - ${{ matrix.python-version }}
         uses: deadsnakes/action@v2.0.2
         if: endsWith(matrix.python-version, '-dev')
         with:

--- a/noxfile.py
+++ b/noxfile.py
@@ -57,7 +57,7 @@ def tests_impl(
     session.run("coverage", "xml")
 
 
-@nox.session(python=["3.7", "3.8", "3.9", "3.10", "pypy"])
+@nox.session(python=["3.7", "3.8", "3.9", "3.10", "3.11", "pypy"])
 def test(session: nox.Session) -> None:
     tests_impl(session)
 


### PR DESCRIPTION
Closes #2483

The original pull request had two issues:
 * "nightly" is not an actual deadsnakes version. Per https://launchpad.net/~deadsnakes/+archive/ubuntu/nightly, this PPA provides nightly builds for all Python versions. We could test 3.7-dev, for example. I removed the nightly action.
 * We need to tell nox about "3.11"