### PR TITLE
Keep full backtrace when raising LocationParseError in parse_url

### DIFF
--- a/src/urllib3/util/url.py
+++ b/src/urllib3/util/url.py
@@ -413,8 +413,8 @@ def parse_url(url: str) -> Url:
         if normalize_uri and fragment:
             fragment = _encode_invalid_chars(fragment, _FRAGMENT_CHARS)
 
-    except (ValueError, AttributeError) as parse_exc:
-        raise LocationParseError(source_url) from parse_exc
+    except (ValueError, AttributeError) as e:
+        raise LocationParseError(source_url) from e
 
     # For the sake of backwards compatibility we put empty
     # string values for path if there are any defined values

--- a/src/urllib3/util/url.py
+++ b/src/urllib3/util/url.py
@@ -413,8 +413,8 @@ def parse_url(url: str) -> Url:
         if normalize_uri and fragment:
             fragment = _encode_invalid_chars(fragment, _FRAGMENT_CHARS)
 
-    except (ValueError, AttributeError):
-        raise LocationParseError(source_url) from None
+    except (ValueError, AttributeError) as parse_exc:
+        raise LocationParseError(source_url) from parse_exc
 
     # For the sake of backwards compatibility we put empty
     # string values for path if there are any defined values


### PR DESCRIPTION
Recently ran into an issue where I needed to modify the system `url.py` to add this additional debug info and figured it made sense to make everyone else's lives easier as well.
