### PR TITLE
Link code examples to reference documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,6 +33,7 @@ extensions = [
     "sphinx_copybutton",
     "sphinx.ext.doctest",
     "sphinx.ext.intersphinx",
+    "sphinx_codeautolink",
 ]
 
 # Test code blocks only when explicitly specified
@@ -82,3 +83,4 @@ html_theme_options = {
 }
 
 intersphinx_mapping = {"python": ("https://docs.python.org/3", None)}
+codeautolink_global_preface = "import urllib3"

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,3 +3,4 @@ sphinx>3.0.0
 requests>=2,<2.16
 furo
 sphinx-copybutton
+sphinx-codeautolink


### PR DESCRIPTION
From #2491: this PR contains an example about adding links to code examples using `sphinx-codeautolink`.

Testing with urllib3 prompted felix-hilden/sphinx-codeautolink#68, so some links are still missing. I'm working on resolving the issue.