### PR TITLE
Cache installed dependencies in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: "3"
+          cache: pip
       - name: Check packages
         run: |
           python3 -m pip install wheel twine rstcheck;
@@ -67,12 +68,14 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
+          cache: pip
 
       - name: Set Up Python - ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         if: "!endsWith(matrix.python-version, '-dev')"
         with:
           python-version: ${{ matrix.python-version }}
+          cache: pip
 
       - name: Set Up Python (Development version) - ${{ matrix.python-version }}
         uses: deadsnakes/action@v2.0.2
@@ -85,6 +88,7 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: "3"
+          cache: pip
 
       - name: Install Dependencies
         run: python -m pip install --upgrade nox

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,6 +14,7 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: "3.8"
+          cache: pip
       - name: Lint the code
         uses: pre-commit/action@v2.0.0
       - name: Install dependencies


### PR DESCRIPTION
See: https://github.blog/changelog/2021-11-23-github-actions-setup-python-now-supports-dependency-caching/