### PR TITLE
[1.26] Deprecate BACKOFF_MAX to introduce DEFAULT_BACKOFF_MAX

### DIFF
--- a/src/urllib3/util/retry.py
+++ b/src/urllib3/util/retry.py
@@ -69,6 +69,24 @@ class _RetryMeta(type):
         )
         cls.DEFAULT_REMOVE_HEADERS_ON_REDIRECT = value
 
+    @property
+    def BACKOFF_MAX(cls):
+        warnings.warn(
+            "Using 'Retry.BACKOFF_MAX' is deprecated and "
+            "will be removed in v2.0. Use 'Retry.DEFAULT_BACKOFF_MAX' instead",
+            DeprecationWarning,
+        )
+        return cls.DEFAULT_BACKOFF_MAX
+
+    @BACKOFF_MAX.setter
+    def BACKOFF_MAX(cls, value):
+        warnings.warn(
+            "Using 'Retry.DEFAULT_METHOD_WHITELIST' is deprecated and "
+            "will be removed in v2.0. Use 'Retry.DEFAULT_BACKOFF_MAX' instead",
+            DeprecationWarning,
+        )
+        cls.DEFAULT_BACKOFF_MAX = value
+
 
 @six.add_metaclass(_RetryMeta)
 class Retry(object):
@@ -181,7 +199,7 @@ class Retry(object):
 
         seconds. If the backoff_factor is 0.1, then :func:`.sleep` will sleep
         for [0.0s, 0.2s, 0.4s, ...] between retries. It will never be longer
-        than :attr:`Retry.BACKOFF_MAX`.
+        than :attr:`Retry.DEFAULT_BACKOFF_MAX`.
 
         By default, backoff is disabled (set to 0).
 
@@ -220,7 +238,7 @@ class Retry(object):
     DEFAULT_REMOVE_HEADERS_ON_REDIRECT = frozenset(["Authorization"])
 
     #: Maximum backoff time.
-    BACKOFF_MAX = 120
+    DEFAULT_BACKOFF_MAX = 120
 
     def __init__(
         self,
@@ -348,7 +366,7 @@ class Retry(object):
             return 0
 
         backoff_value = self.backoff_factor * (2 ** (consecutive_errors_len - 1))
-        return min(self.BACKOFF_MAX, backoff_value)
+        return min(self.DEFAULT_BACKOFF_MAX, backoff_value)
 
     def parse_retry_after(self, retry_after):
         # Whitespace: https://tools.ietf.org/html/rfc7230#section-3.2.4

--- a/src/urllib3/util/retry.py
+++ b/src/urllib3/util/retry.py
@@ -81,7 +81,7 @@ class _RetryMeta(type):
     @BACKOFF_MAX.setter
     def BACKOFF_MAX(cls, value):
         warnings.warn(
-            "Using 'Retry.DEFAULT_METHOD_WHITELIST' is deprecated and "
+            "Using 'Retry.BACKOFF_MAX' is deprecated and "
             "will be removed in v2.0. Use 'Retry.DEFAULT_BACKOFF_MAX' instead",
             DeprecationWarning,
         )

--- a/test/test_retry.py
+++ b/test/test_retry.py
@@ -141,7 +141,7 @@ class TestRetry(object):
 
     def test_backoff(self):
         """Backoff is computed correctly"""
-        max_backoff = Retry.BACKOFF_MAX
+        max_backoff = Retry.DEFAULT_BACKOFF_MAX
 
         retry = Retry(total=100, backoff_factor=0.2)
         assert retry.get_backoff_time() == 0  # First request

--- a/test/test_retry_deprecated.py
+++ b/test/test_retry_deprecated.py
@@ -143,7 +143,7 @@ class TestRetry(object):
 
     def test_backoff(self):
         """Backoff is computed correctly"""
-        max_backoff = Retry.BACKOFF_MAX
+        max_backoff = Retry.DEFAULT_BACKOFF_MAX
 
         retry = Retry(total=100, backoff_factor=0.2)
         assert retry.get_backoff_time() == 0  # First request
@@ -384,6 +384,9 @@ class TestRetryDeprecations(object):
             == Retry.DEFAULT_REDIRECT_HEADERS_BLACKLIST
         )
 
+    def test_cls_get_default_backoff_max(self, expect_retry_deprecation):
+        assert Retry.DEFAULT_BACKOFF_MAX == Retry.BACKOFF_MAX
+
     def test_cls_set_default_method_whitelist(self, expect_retry_deprecation):
         old_setting = Retry.DEFAULT_METHOD_WHITELIST
         try:
@@ -428,6 +431,17 @@ class TestRetryDeprecations(object):
         finally:
             Retry.DEFAULT_REDIRECT_HEADERS_BLACKLIST = old_setting
             assert Retry.DEFAULT_REDIRECT_HEADERS_BLACKLIST == old_setting
+
+    def test_cls_set_default_backoff_max(self, expect_retry_deprecation):
+        old_setting = Retry.BACKOFF_MAX
+        try:
+            Retry.BACKOFF_MAX = 99
+            retry = Retry()
+            assert retry.DEFAULT_BACKOFF_MAX == 99
+            assert retry.BACKOFF_MAX == 99
+        finally:
+            Retry.BACKOFF_MAX = old_setting
+            assert Retry.BACKOFF_MAX == old_setting
 
     @pytest.mark.parametrize(
         "options", [(None, None), ({"GET"}, None), (None, {"GET"}), ({"GET"}, {"GET"})]


### PR DESCRIPTION
This PR is the deprecation part of the following one: https://github.com/urllib3/urllib3/pull/2494