### PR TITLE
Test against Python 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,10 @@ jobs:
             os: ubuntu-latest
             experimental: false
             nox-session: app_engine
+          - python-version: 3.11-dev
+            os: ubuntu-latest
+            experimental: true
+            nox-session: test-3.11
 
     runs-on: ${{ matrix.os }}
     name: ${{ fromJson('{"macos-latest":"macOS","windows-latest":"Windows","ubuntu-latest":"Ubuntu"}')[matrix.os] }} ${{ matrix.python-version }} ${{ matrix.nox-session}}

--- a/noxfile.py
+++ b/noxfile.py
@@ -50,7 +50,7 @@ def tests_impl(session, extras="socks,secure,brotli"):
     session.run("coverage", "xml")
 
 
-@nox.session(python=["2.7", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10", "pypy"])
+@nox.session(python=["2.7", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "pypy"])
 def test(session):
     tests_impl(session)
 


### PR DESCRIPTION
Python 3.11 now has an alpha release: https://www.python.org/downloads/release/python-3110a1