### PR TITLE
Point to `RequestField.from_tuples` in `encode_multipart_formdata` docstring

### DIFF
--- a/src/urllib3/filepost.py
+++ b/src/urllib3/filepost.py
@@ -54,6 +54,7 @@ def encode_multipart_formdata(
 
     :param fields:
         Dictionary of fields or list of (key, :class:`~urllib3.fields.RequestField`).
+        Values are processed by :func:`urllib3.fields.RequestField.from_tuples`.
 
     :param boundary:
         If not specified, then a random boundary will be generated using


### PR DESCRIPTION
When trying to understand what I can and can't pass to `encode_multipart_formdata` I got a bit lost in the type definition and the doc string. In the end reading the code is what made me understand how it all works.

This PR adds a short sentence that might have helped me as a reader. I think it could be word-smithed a bit more (and I am not sure about the correct formatting/syntax to get the linking to work, waiting to see the preview). However I wanted to start this PR and get some feedback before trying to finesse it too much on my own (and heading down a blind alley).