### PR TITLE
Update mypy to 0.920

### DIFF
--- a/dummyserver/handlers.py
+++ b/dummyserver/handlers.py
@@ -134,7 +134,7 @@ class TestingApp(RequestHandler):
 
     def source_address(self, request: httputil.HTTPServerRequest) -> Response:
         """Return the requester's IP address."""
-        return Response(request.remote_ip)
+        return Response(request.remote_ip)  # type: ignore[arg-type]
 
     def set_up(self, request: httputil.HTTPServerRequest) -> Response:
         params = request_params(request)

--- a/mypy-requirements.txt
+++ b/mypy-requirements.txt
@@ -1,4 +1,4 @@
-mypy==0.920
+mypy==0.930
 idna>=2.0.0
 cryptography>=1.3.4
 tornado>=6.1

--- a/mypy-requirements.txt
+++ b/mypy-requirements.txt
@@ -1,4 +1,4 @@
-mypy==0.910
+mypy==0.920
 idna>=2.0.0
 cryptography>=1.3.4
 tornado>=6.1

--- a/src/urllib3/__init__.py
+++ b/src/urllib3/__init__.py
@@ -6,7 +6,7 @@ Python HTTP library with thread-safe connection pooling, file post support, user
 import logging
 import warnings
 from logging import NullHandler
-from typing import Any, Mapping, Optional, Type, Union
+from typing import Any, Mapping, Optional, TextIO, Type, Union
 
 from . import exceptions
 from ._collections import HTTPHeaderDict
@@ -45,7 +45,7 @@ __all__ = (
 logging.getLogger(__name__).addHandler(NullHandler())
 
 
-def add_stderr_logger(level: int = logging.DEBUG) -> logging.StreamHandler:
+def add_stderr_logger(level: int = logging.DEBUG) -> "logging.StreamHandler[TextIO]":
     """
     Helper for quickly adding a StreamHandler to the logger. Useful for
     debugging.

--- a/src/urllib3/_collections.py
+++ b/src/urllib3/_collections.py
@@ -158,7 +158,7 @@ class RecentlyUsedContainer(Generic[_KT, _VT], MutableMapping[_KT, _VT]):
             for value in values:
                 self.dispose_func(value)
 
-    def keys(self) -> Set[_KT]:
+    def keys(self) -> Set[_KT]:  # type: ignore[override]
         with self.lock:
             return set(self._container.keys())
 
@@ -413,7 +413,7 @@ class HTTPHeaderDict(MutableMapping[str, str]):
             val = self._container[key.lower()]
             yield val[0], ", ".join(val[1:])
 
-    def items(self) -> HTTPHeaderDictItemView:
+    def items(self) -> HTTPHeaderDictItemView:  # type: ignore[override]
         return HTTPHeaderDictItemView(self)
 
     def _has_value_for_header(self, header_name: str, potential_value: str) -> bool:

--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -476,7 +476,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
             # HTTP version
             conn._http_vsn_str,  # type: ignore[attr-defined]
             httplib_response.status,
-            httplib_response.length,  # type: ignore[attr-defined]
+            httplib_response.length,
         )
 
         try:

--- a/src/urllib3/contrib/pyopenssl.py
+++ b/src/urllib3/contrib/pyopenssl.py
@@ -343,7 +343,7 @@ class WrappedSocket:
                 raise
         except OpenSSL.SSL.WantReadError as e:
             if not util.wait_for_read(self.socket, self.socket.gettimeout()):
-                raise timeout("The read operation timed out") from e  # type: ignore[arg-type]
+                raise timeout("The read operation timed out") from e
             else:
                 return self.recv(*args, **kwargs)
 
@@ -368,7 +368,7 @@ class WrappedSocket:
                 raise
         except OpenSSL.SSL.WantReadError as e:
             if not util.wait_for_read(self.socket, self.socket.gettimeout()):
-                raise timeout("The read operation timed out") from e  # type: ignore[arg-type]
+                raise timeout("The read operation timed out") from e
             else:
                 return self.recv_into(*args, **kwargs)
 
@@ -462,7 +462,7 @@ class PyOpenSSLContext:
         return _openssl_to_stdlib_verify[self._ctx.get_verify_mode()]
 
     @verify_mode.setter
-    def verify_mode(self, value: int) -> None:
+    def verify_mode(self, value: ssl.VerifyMode) -> None:
         self._ctx.set_verify(_stdlib_to_openssl_verify[value], _verify_callback)
 
     def set_default_verify_paths(self) -> None:
@@ -530,7 +530,7 @@ class PyOpenSSLContext:
                 cnx.do_handshake()
             except OpenSSL.SSL.WantReadError as e:
                 if not util.wait_for_read(sock, sock.gettimeout()):
-                    raise timeout("select timed out") from e  # type: ignore[arg-type]
+                    raise timeout("select timed out") from e
                 continue
             except OpenSSL.SSL.Error as e:
                 raise ssl.SSLError(f"bad handshake: {e!r}") from e

--- a/src/urllib3/contrib/securetransport.py
+++ b/src/urllib3/contrib/securetransport.py
@@ -231,7 +231,7 @@ def _read_callback(
                 buffer = (ctypes.c_char * remaining).from_address(
                     data_buffer + read_count
                 )
-                chunk_size = base_socket.recv_into(buffer, remaining)  # type: ignore[arg-type]
+                chunk_size = base_socket.recv_into(buffer, remaining)
                 read_count += chunk_size
                 if not chunk_size:
                     if not read_count:

--- a/src/urllib3/contrib/securetransport.py
+++ b/src/urllib3/contrib/securetransport.py
@@ -536,7 +536,7 @@ class WrappedSocket:
                 result = Security.SSLHandshake(self.context)
 
                 if result == SecurityConst.errSSLWouldBlock:
-                    raise socket.timeout("handshake timed out")  # type: ignore[arg-type]
+                    raise socket.timeout("handshake timed out")
                 elif result == SecurityConst.errSSLServerAuthCompleted:
                     self._custom_validate(verify, trust_bundle)
                     continue
@@ -588,7 +588,7 @@ class WrappedSocket:
             # and return.
             if processed_bytes.value == 0:
                 # Timed out, no data read.
-                raise socket.timeout("recv timed out")  # type: ignore[arg-type]
+                raise socket.timeout("recv timed out")
         elif result in (
             SecurityConst.errSSLClosedGraceful,
             SecurityConst.errSSLClosedNoNotify,
@@ -621,7 +621,7 @@ class WrappedSocket:
 
         if result == SecurityConst.errSSLWouldBlock and processed_bytes.value == 0:
             # Timed out
-            raise socket.timeout("send timed out")  # type: ignore[arg-type]
+            raise socket.timeout("send timed out")
         else:
             _assert_no_error(result)
 

--- a/src/urllib3/exceptions.py
+++ b/src/urllib3/exceptions.py
@@ -290,12 +290,12 @@ class IncompleteRead(HTTPError, httplib_IncompleteRead):
     """
 
     def __init__(self, partial: int, expected: int) -> None:
-        self.partial = partial
+        self.partial = partial  # type: ignore[assignment]
         self.expected = expected
 
     def __repr__(self) -> str:
         return "IncompleteRead(%i bytes read, %i more expected)" % (
-            self.partial,
+            self.partial,  # type: ignore[str-format]
             self.expected,
         )
 
@@ -304,7 +304,7 @@ class InvalidChunkLength(HTTPError, httplib_IncompleteRead):
     """Invalid chunk length in a chunked response."""
 
     def __init__(self, response: "HTTPResponse", length: bytes) -> None:
-        self.partial: int = response.tell()
+        self.partial: int = response.tell()  # type: ignore[assignment]
         self.expected: Optional[int] = response.length_remaining
         self.response = response
         self.length = length

--- a/src/urllib3/response.py
+++ b/src/urllib3/response.py
@@ -905,7 +905,7 @@ class HTTPResponse(BaseHTTPResponse):
 
             # Chunk content ends with \r\n: discard it.
             while self._fp is not None:
-                line = self._fp.fp.readline()  # type: ignore[attr-defined]
+                line = self._fp.fp.readline()
                 if not line:
                     # Some sites may not end with '\r\n'.
                     break

--- a/src/urllib3/util/ssl_.py
+++ b/src/urllib3/util/ssl_.py
@@ -88,6 +88,8 @@ def _is_has_never_check_common_name_reliable(
 
 
 if TYPE_CHECKING:
+    from ssl import VerifyMode
+
     from typing_extensions import Literal
 
     from .ssltransport import SSLTransport as SSLTransportType
@@ -144,8 +146,8 @@ except ImportError:
     OP_NO_TICKET = 0x4000  # type: ignore[assignment]
     OP_NO_SSLv2 = 0x1000000  # type: ignore[assignment]
     OP_NO_SSLv3 = 0x2000000  # type: ignore[assignment]
-    PROTOCOL_SSLv23 = PROTOCOL_TLS = 2
-    PROTOCOL_TLS_CLIENT = 16
+    PROTOCOL_SSLv23 = PROTOCOL_TLS = 2  # type: ignore[assignment]
+    PROTOCOL_TLS_CLIENT = 16  # type: ignore[assignment]
 
 
 _PCTRTT = Tuple[Tuple[str, str], ...]
@@ -221,7 +223,7 @@ def assert_fingerprint(cert: Optional[bytes], fingerprint: str) -> None:
         )
 
 
-def resolve_cert_reqs(candidate: Union[None, int, str]) -> int:
+def resolve_cert_reqs(candidate: Union[None, int, str]) -> "VerifyMode":
     """
     Resolves the argument to a numeric constant, which can be passed to
     the wrap_socket function/method from the ssl module.
@@ -239,9 +241,9 @@ def resolve_cert_reqs(candidate: Union[None, int, str]) -> int:
         res = getattr(ssl, candidate, None)
         if res is None:
             res = getattr(ssl, "CERT_" + candidate)
-        return cast(int, res)
+        return res  # type: ignore[no-any-return]
 
-    return candidate
+    return candidate  # type: ignore[return-value]
 
 
 def resolve_ssl_version(candidate: Union[None, int, str]) -> int:

--- a/src/urllib3/util/ssltransport.py
+++ b/src/urllib3/util/ssltransport.py
@@ -134,7 +134,7 @@ class SSLTransport:
         encoding: Optional[str] = None,
         errors: Optional[str] = None,
         newline: Optional[str] = None,
-    ) -> Union[BinaryIO, TextIO]:
+    ) -> Union[BinaryIO, TextIO, socket.SocketIO]:
         """
         Python's httpclient uses makefile and buffered io when reading HTTP
         messages and we need to support it.
@@ -154,7 +154,7 @@ class SSLTransport:
             rawmode += "r"
         if writing:
             rawmode += "w"
-        raw = socket.SocketIO(self, rawmode)
+        raw = socket.SocketIO(self, rawmode)  # type: ignore[arg-type]
         self.socket._io_refs += 1  # type: ignore[attr-defined]
         if buffering is None:
             buffering = -1
@@ -163,7 +163,7 @@ class SSLTransport:
         if buffering == 0:
             if not binary:
                 raise ValueError("unbuffered streams must be binary")
-            return raw  # type: ignore[no-any-return]
+            return raw
         buffer: BinaryIO
         if reading and writing:
             buffer = io.BufferedRWPair(raw, raw, buffering)  # type: ignore[assignment]

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -114,11 +114,11 @@ RESOLVES_LOCALHOST_FQDN = _can_resolve("localhost.")
 
 def clear_warnings(cls: Type[Warning] = HTTPWarning) -> None:
     new_filters = []
-    for f in warnings.filters:  # type: ignore[attr-defined]
+    for f in warnings.filters:
         if issubclass(f[2], cls):
             continue
         new_filters.append(f)
-    warnings.filters[:] = new_filters  # type: ignore[attr-defined]
+    warnings.filters[:] = new_filters  # type: ignore[index]
 
 
 def setUp() -> None:

--- a/test/test_connectionpool.py
+++ b/test/test_connectionpool.py
@@ -515,7 +515,7 @@ class TestConnectionPool:
                     ex, self._ex = self._ex, None
                     raise ex()
                 response = httplib.HTTPResponse(MockSock)  # type: ignore[arg-type]
-                response.fp = MockChunkedEncodingResponse([b"f", b"o", b"o"])  # type: ignore[attr-defined]
+                response.fp = MockChunkedEncodingResponse([b"f", b"o", b"o"])  # type: ignore[assignment]
                 response.headers = response.msg = httplib.HTTPMessage()
                 return response
 
@@ -567,7 +567,7 @@ class TestConnectionPool:
 
             def _make_request(self, *args: Any, **kwargs: Any) -> httplib.HTTPResponse:
                 httplib_response = httplib.HTTPResponse(MockSock)  # type: ignore[arg-type]
-                httplib_response.fp = MockChunkedEncodingResponse([b"f", b"o", b"o"])  # type: ignore[attr-defined]
+                httplib_response.fp = MockChunkedEncodingResponse([b"f", b"o", b"o"])  # type: ignore[assignment]
                 httplib_response.headers = httplib_response.msg = httplib.HTTPMessage()
                 return httplib_response
 

--- a/test/test_response.py
+++ b/test/test_response.py
@@ -777,7 +777,7 @@ class TestResponse:
 
         orig_ex = ctx.value.args[1]
         assert isinstance(orig_ex, IncompleteRead)
-        assert orig_ex.partial == 0
+        assert orig_ex.partial == 0  # type: ignore[comparison-overlap]
         assert orig_ex.expected == content_length
 
     def test_incomplete_chunk(self) -> None:

--- a/test/test_response.py
+++ b/test/test_response.py
@@ -320,7 +320,7 @@ class TestResponse:
         with pytest.raises(IOError):
             resp3.fileno()
 
-        resp3._fp = 2  # type: ignore[assignment]
+        resp3._fp = 2
         # A corner case where _fp is present but doesn't have `closed`,
         # `isclosed`, or `fileno`.  Unlikely, but possible.
         assert resp3.closed
@@ -330,9 +330,9 @@ class TestResponse:
     def test_io_closed_consistently(self, sock: socket.socket) -> None:
         try:
             hlr = httplib.HTTPResponse(sock)
-            hlr.fp = BytesIO(b"foo")  # type: ignore[attr-defined]
-            hlr.chunked = 0  # type: ignore[attr-defined]
-            hlr.length = 3  # type: ignore[attr-defined]
+            hlr.fp = BytesIO(b"foo")  # type: ignore[assignment]
+            hlr.chunked = 0  # type: ignore[assignment]
+            hlr.length = 3
             with HTTPResponse(hlr, preload_content=False) as resp:
                 assert not resp.closed
                 assert resp._fp is not None
@@ -688,7 +688,7 @@ class TestResponse:
         stream = [b"fo", b"o", b"bar"]
         fp = MockChunkedEncodingResponse(stream)
         r = httplib.HTTPResponse(MockSock)  # type: ignore[arg-type]
-        r.fp = fp  # type: ignore[attr-defined]
+        r.fp = fp  # type: ignore[assignment]
         resp = HTTPResponse(
             r, preload_content=False, headers={"transfer-encoding": "chunked"}
         )
@@ -709,7 +709,7 @@ class TestResponse:
 
         fp = MockChunkedEncodingResponse(list(stream()))
         r = httplib.HTTPResponse(MockSock)  # type: ignore[arg-type]
-        r.fp = fp  # type: ignore[attr-defined]
+        r.fp = fp  # type: ignore[assignment]
         headers = {"transfer-encoding": "chunked", "content-encoding": "gzip"}
         resp = HTTPResponse(r, preload_content=False, headers=headers)
 
@@ -723,9 +723,9 @@ class TestResponse:
         stream = [b"foooo", b"bbbbaaaaar"]
         fp = MockChunkedEncodingResponse(stream)
         r = httplib.HTTPResponse(MockSock)  # type: ignore[arg-type]
-        r.fp = fp  # type: ignore[attr-defined]
-        r.chunked = True  # type: ignore[attr-defined]
-        r.chunk_left = None  # type: ignore[attr-defined]
+        r.fp = fp  # type: ignore[assignment]
+        r.chunked = True
+        r.chunk_left = None
         resp = HTTPResponse(
             r, preload_content=False, headers={"transfer-encoding": "chunked"}
         )
@@ -737,9 +737,9 @@ class TestResponse:
         stream = [b"foooo", b"bbbbaaaaar"]
         fp = MockChunkedEncodingResponse(stream)
         r = httplib.HTTPResponse(MockSock)  # type: ignore[arg-type]
-        r.fp = fp  # type: ignore[attr-defined]
-        r.chunked = True  # type: ignore[attr-defined]
-        r.chunk_left = None  # type: ignore[attr-defined]
+        r.fp = fp  # type: ignore[assignment]
+        r.chunked = True
+        r.chunk_left = None
         resp = HTTPResponse(
             r, preload_content=False, headers={"transfer-encoding": "chunked"}
         )
@@ -784,9 +784,9 @@ class TestResponse:
         stream = [b"foooo", b"bbbbaaaaar"]
         fp = MockChunkedIncompleteRead(stream)
         r = httplib.HTTPResponse(MockSock)  # type: ignore[arg-type]
-        r.fp = fp  # type: ignore[attr-defined]
-        r.chunked = True  # type: ignore[attr-defined]
-        r.chunk_left = None  # type: ignore[attr-defined]
+        r.fp = fp  # type: ignore[assignment]
+        r.chunked = True
+        r.chunk_left = None
         resp = HTTPResponse(
             r, preload_content=False, headers={"transfer-encoding": "chunked"}
         )
@@ -800,9 +800,9 @@ class TestResponse:
         stream = [b"foooo", b"bbbbaaaaar"]
         fp = MockChunkedInvalidChunkLength(stream)
         r = httplib.HTTPResponse(MockSock)  # type: ignore[arg-type]
-        r.fp = fp  # type: ignore[attr-defined]
-        r.chunked = True  # type: ignore[attr-defined]
-        r.chunk_left = None  # type: ignore[attr-defined]
+        r.fp = fp  # type: ignore[assignment]
+        r.chunked = True
+        r.chunk_left = None
         resp = HTTPResponse(
             r, preload_content=False, headers={"transfer-encoding": "chunked"}
         )
@@ -822,9 +822,9 @@ class TestResponse:
         stream = [b"foo", b"bar", b"baz"]
         fp = MockChunkedEncodingWithoutCRLFOnEnd(stream)
         r = httplib.HTTPResponse(MockSock)  # type: ignore[arg-type]
-        r.fp = fp  # type: ignore[attr-defined]
-        r.chunked = True  # type: ignore[attr-defined]
-        r.chunk_left = None  # type: ignore[attr-defined]
+        r.fp = fp  # type: ignore[assignment]
+        r.chunked = True
+        r.chunk_left = None
         resp = HTTPResponse(
             r, preload_content=False, headers={"transfer-encoding": "chunked"}
         )
@@ -834,9 +834,9 @@ class TestResponse:
         stream = [b"foo", b"bar"]
         fp = MockChunkedEncodingWithExtensions(stream)
         r = httplib.HTTPResponse(MockSock)  # type: ignore[arg-type]
-        r.fp = fp  # type: ignore[attr-defined]
-        r.chunked = True  # type: ignore[attr-defined]
-        r.chunk_left = None  # type: ignore[attr-defined]
+        r.fp = fp  # type: ignore[assignment]
+        r.chunked = True
+        r.chunk_left = None
         resp = HTTPResponse(
             r, preload_content=False, headers={"transfer-encoding": "chunked"}
         )
@@ -844,8 +844,8 @@ class TestResponse:
 
     def test_chunked_head_response(self) -> None:
         r = httplib.HTTPResponse(MockSock, method="HEAD")  # type: ignore[arg-type]
-        r.chunked = True  # type: ignore[attr-defined]
-        r.chunk_left = None  # type: ignore[attr-defined]
+        r.chunked = True
+        r.chunk_left = None
         resp = HTTPResponse(
             "",
             preload_content=False,
@@ -939,7 +939,7 @@ class TestResponse:
 
         fp = MockChunkedEncodingResponse(list(stream()))
         r = httplib.HTTPResponse(MockSock)  # type: ignore[arg-type]
-        r.fp = fp  # type: ignore[attr-defined]
+        r.fp = fp  # type: ignore[assignment]
         headers = {"transfer-encoding": "chunked", "content-encoding": "gzip"}
         resp = HTTPResponse(r, preload_content=False, headers=headers)
 

--- a/test/test_ssltransport.py
+++ b/test/test_ssltransport.py
@@ -476,6 +476,7 @@ class TlsInTlsTestCase(SocketDummyServerTestCase):
                 write.flush()
 
                 response = read.read()
+                assert isinstance(response, str)
                 if "\r" not in response:
                     # Carriage return will be removed when reading as a file on
                     # some platforms.  We add it before the comparison.

--- a/test/test_wait.py
+++ b/test/test_wait.py
@@ -3,7 +3,7 @@ import threading
 import time
 from socket import socket, socketpair
 from types import FrameType
-from typing import Callable, Generator, List, Tuple
+from typing import Any, Callable, Generator, List, Optional, Tuple
 
 import pytest
 
@@ -106,7 +106,7 @@ def test_eintr(wfs: TYPE_WAIT_FOR, spair: TYPE_SOCKET_PAIR) -> None:
     a, b = spair
     interrupt_count = [0]
 
-    def handler(sig: int, frame: FrameType) -> None:
+    def handler(sig: int, frame: Optional[FrameType]) -> Any:
         assert sig == signal.SIGALRM
         interrupt_count[0] += 1
 
@@ -137,7 +137,7 @@ def test_eintr_zero_timeout(wfs: TYPE_WAIT_FOR, spair: TYPE_SOCKET_PAIR) -> None
     a, b = spair
     interrupt_count = [0]
 
-    def handler(sig: int, frame: FrameType) -> None:
+    def handler(sig: int, frame: Optional[FrameType]) -> Any:
         assert sig == signal.SIGALRM
         interrupt_count[0] += 1
 
@@ -168,7 +168,7 @@ def test_eintr_infinite_timeout(wfs: TYPE_WAIT_FOR, spair: TYPE_SOCKET_PAIR) -> 
     a, b = spair
     interrupt_count = [0]
 
-    def handler(sig: int, frame: FrameType) -> None:
+    def handler(sig: int, frame: Optional[FrameType]) -> Any:
         assert sig == signal.SIGALRM
         interrupt_count[0] += 1
 


### PR DESCRIPTION
we still have some mypy errors because of `IncompleteRead.partial` and  `InvalidChunkLength.partial`. the `httplib.IncompleteRead.partial` type is `bytes` but we defined as `int`
```
src/urllib3/exceptions.py:293: error: Incompatible types in assignment (expression has type "int", variable has type "bytes")  [assignment]
src/urllib3/exceptions.py:297: error: Incompatible types in string interpolation (expression has type "bytes", placeholder has type "Union[int, float, SupportsInt]")  [str-format]
src/urllib3/exceptions.py:297: error: Incompatible types in string interpolation (expression has type "Optional[int]", placeholder has type "Union[int, float, SupportsInt]")  [str-format]
src/urllib3/exceptions.py:307: error: Incompatible types in assignment (expression has type "int", base class "IncompleteRead" defined the type as "bytes")  [assignment]
test/test_response.py:780: error: Non-overlapping equality check (left operand type: "bytes", right operand type: "Literal[0]")  [comparison-overlap]
```