### PR TITLE
[1.26] Point setuptools to use standard library distutils as a fallback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,11 +19,13 @@ jobs:
           python-version: "3.7"
       - name: Check packages
         run: |
-          python3.7 -m pip install wheel twine rstcheck;
+          python3.7 -m pip install pip setuptools wheel twine rstcheck;
           python3.7 setup.py sdist bdist_wheel;
           rstcheck README.rst CHANGES.rst
           python3.7 -m twine check dist/*
   test:
+    env:
+      SETUPTOOLS_USE_DISTUTILS: stdlib
     strategy:
       fail-fast: false
       matrix:
@@ -76,7 +78,7 @@ jobs:
           python-version: "3"
 
       - name: Install Dependencies
-        run: python -m pip install --upgrade nox
+        run: python -m pip install --upgrade pip setuptools nox
 
       - name: Run Tests
         run: ./ci/run_tests.sh


### PR DESCRIPTION
Backporting #2509 to 1.26.x