### PR TITLE
Update CI workflow for the new year

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/release.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release.md
@@ -18,8 +18,8 @@
     python -m venv
     source venv/bin/activate
     python -m pip install -U pip
-    python -m pip install -U twine setuptools wheel
-    python setup.py sdist bdist_wheel
+    python -m pip install -U twine setuptools wheel build
+    python -m build
     
     twine check dist/*
     # Inspect the output to make sure it looks right

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,8 @@ jobs:
           cache: pip
       - name: Check packages
         run: |
-          python3 -m pip install -U pip setuptools wheel twine rstcheck;
-          python3 setup.py sdist bdist_wheel;
+          python3 -m pip install -U pip setuptools wheel build twine rstcheck
+          python3 -m build
           rstcheck README.rst CHANGES.rst
           python3 -m twine check dist/*
   test:
@@ -68,13 +68,6 @@ jobs:
 
       - name: Set Up Python - ${{ matrix.python-version }}
         uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-          cache: pip
-
-      - name: Set Up Python - ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
-        if: "!endsWith(matrix.python-version, '-dev')"
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip

--- a/ci/deploy.sh
+++ b/ci/deploy.sh
@@ -2,6 +2,6 @@
 
 set -exo pipefail
 
-python3 -m pip install --upgrade twine wheel
-python3 setup.py sdist bdist_wheel
+python3 -m pip install --upgrade twine wheel build
+python3 -m build
 python3 -m twine upload dist/* -u $PYPI_USERNAME -p $PYPI_PASSWORD --skip-existing


### PR DESCRIPTION
We don't need to set things up twice in a row (which we were doing in
restoring the cache) and let's use pypa/build instead of python setup.py
since that's better supported and the future

<!---
Thanks for your contribution! ♥️

If this is your first PR to urllib3 please review the Contributing Guide:
https://urllib3.readthedocs.io/en/latest/contributing.html

Adhering to the Contributing Guide means we can review, merge, and release your change faster! :)
--->
