### PR TITLE
Enable enforce_content_length by default

### DIFF
--- a/changelog/2514.bugfix.rst
+++ b/changelog/2514.bugfix.rst
@@ -1,0 +1,1 @@
+Change `enforce_content_length` default to True, preventing silent data loss when reading streamed responses.

--- a/src/urllib3/response.py
+++ b/src/urllib3/response.py
@@ -419,7 +419,7 @@ class HTTPResponse(BaseHTTPResponse):
         connection: Optional[HTTPConnection] = None,
         msg: Optional[_HttplibHTTPMessage] = None,
         retries: Optional[Retry] = None,
-        enforce_content_length: bool = False,
+        enforce_content_length: bool = True,
         request_method: Optional[str] = None,
         request_url: Optional[str] = None,
         auto_close: bool = True,


### PR DESCRIPTION
This is a follow up to #949 making a breaking change to how urllib3 handles reading streamed responses. There's a bug in httplib that allows for short reads when streaming responses. This hasn't been patched due to backwards compatibility concerns, so we implemented a layer above it in urllib3 to track our reads match the responses' Content-Length.

The initial implementation had this disabled by default allowing users to enable it if they wanted to enforce reading exactly the content-length. The end goal was for urllib3 2.0 to change this default and stop silently dropping data. The issue is summarized pretty well in https://github.com/psf/requests/issues/4956.

I've already included tests on this behavior [here](https://github.com/urllib3/urllib3/blob/main/test/with_dummyserver/test_socketlevel.py#L1767-L1834), and [here](https://github.com/urllib3/urllib3/blob/main/test/test_response.py#L591-L655). If there any other concerns, I'm happy to address them or add additional testing.
