### PR TITLE
Add missing brackets to __get__ bound method call in HTTPResponse.closed

### DIFF
--- a/src/urllib3/response.py
+++ b/src/urllib3/response.py
@@ -770,7 +770,7 @@ class HTTPResponse(BaseHTTPResponse):
     @property
     def closed(self) -> bool:
         if not self.auto_close:
-            return io.IOBase.closed.__get__(self)  # type: ignore[no-any-return, attr-defined]
+            return io.IOBase.closed.__get__(self)()
         elif self._fp is None:
             return True
         elif hasattr(self._fp, "isclosed"):


### PR DESCRIPTION
<!---
Thanks for your contribution! ♥️

If this is your first PR to urllib3 please review the Contributing Guide:
https://urllib3.readthedocs.io/en/latest/contributing.html

Adhering to the Contributing Guide means we can review, merge, and release your change faster! :)
--->
We're doing some work in typeshed to update the typing of function attributes and spotted that urllib3 uses `__get__` to get a bound method but is missing the brackets to call that method, hence why mypy is complaining that it expects `bool` but gets `MethodType`: https://github.com/python/typeshed/pull/6804#issuecomment-1004431743

I removed those type ignores to see if they're still needed after this change (can re-add them if needed) 😄 
