### PR TITLE
Add authority property to the Url class

### DIFF
--- a/changelog/2520.feature.rst
+++ b/changelog/2520.feature.rst
@@ -1,0 +1,3 @@
+Added the ``authority`` property to the Url class as per RFC 3986 3.2.
+This property should be used in place of ``netloc`` for users who
+want to include the userinfo (auth) component of the URI.

--- a/src/urllib3/util/url.py
+++ b/src/urllib3/util/url.py
@@ -129,8 +129,29 @@ class Url(
         return uri
 
     @property
+    def authority(self) -> Optional[str]:
+        """
+        Authority component as defined in RFC 3986 3.2.
+        This includes userinfo (auth), host and port.
+
+        i.e.
+            userinfo@host:port
+        """
+        userinfo = self.auth
+        netloc = self.netloc
+        if netloc is None or userinfo is None:
+            return netloc
+        else:
+            return f"{userinfo}@{netloc}"
+
+    @property
     def netloc(self) -> Optional[str]:
-        """Network location including host and port"""
+        """
+        Network location including host and port.
+
+        If you need the equivalent of urllib.parse's ``netloc``,
+        use the ``authority`` property instead.
+        """
         if self.host is None:
             return None
         if self.port:


### PR DESCRIPTION
This is a proposal for a new property on the `Url` class to expose the concept of "authority" as defined in [RFC 3986 § 3.2](https://datatracker.ietf.org/doc/html/rfc3986#section-3.2). This comes from a recent discovery in Requests (psf/requests#6027) when swapping our use of [urllib.parse.urlparse](https://docs.python.org/3/library/urllib.parse.html#urllib.parse.urlparse) for urllib3's [`parse_url`](https://urllib3.readthedocs.io/en/latest/reference/urllib3.util.html#urllib3.util.parse_url). The `netloc` attribute provided by urllib3 differs from the standard library in that it's missing userinfo (or auth info) which may surprise some users.

This newly introduced `authority` property will return the composed userinfo, host, and port of a given URI. This matches the behavior of the current `netloc` provided by urllib and provides an alternative to users composing their own.
