### PR TITLE
Check keylog_filename existence

### DIFF
--- a/src/urllib3/util/ssl_.py
+++ b/src/urllib3/util/ssl_.py
@@ -410,7 +410,7 @@ def create_urllib3_context(
     # 'SSLKEYLOGFILE', if the feature is available (Python 3.8+). Skip empty values.
     if hasattr(context, "keylog_filename"):
         sslkeylogfile = os.environ.get("SSLKEYLOGFILE")
-        if sslkeylogfile:
+        if sslkeylogfile and os.path.isfile(sslkeylogfile):
             context.keylog_filename = sslkeylogfile
 
     return context


### PR DESCRIPTION
Linked to #2015
If the file path doesn't exist it throw following exception:

> WARNING: Retrying (Retry(total=4, connect=None, read=None, redirect=None, status=None)) after connection broken by 'ProtocolError('Connection aborted.', FileNotFoundError(2, 'No such file or directory'))'

<!---
Thanks for your contribution! ♥️

If this is your first PR to urllib3 please review the Contributing Guide:
https://urllib3.readthedocs.io/en/latest/contributing.html

Adhering to the Contributing Guide means we can review, merge, and release your change faster! :)
--->
