### PR TITLE
Improve typing

### DIFF
--- a/dummyserver/handlers.py
+++ b/dummyserver/handlers.py
@@ -8,7 +8,7 @@ import zlib
 from datetime import datetime, timedelta
 from http.client import responses
 from io import BytesIO
-from typing import Any, Dict, Optional, Sequence, Tuple, Union
+from typing import Any, Dict, NoReturn, Optional, Sequence, Tuple, Union
 from urllib.parse import urlsplit
 
 from tornado import httputil
@@ -347,5 +347,5 @@ class TestingApp(RequestHandler):
         headers = [("Location", target), ("Retry-After", retry_after)]
         return Response(status="303 See Other", headers=headers)
 
-    def shutdown(self, request: httputil.HTTPServerRequest) -> None:
+    def shutdown(self, request: httputil.HTTPServerRequest) -> NoReturn:
         sys.exit()

--- a/mypy-requirements.txt
+++ b/mypy-requirements.txt
@@ -1,4 +1,4 @@
-mypy==0.930
+mypy==0.931
 idna>=2.0.0
 cryptography>=1.3.4
 tornado>=6.1

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -6,7 +6,7 @@ import sys
 import warnings
 from itertools import chain
 from test import ImportBlocker, ModuleStash, notBrotli, onlyBrotli
-from typing import TYPE_CHECKING, Dict, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Dict, NoReturn, Optional, Tuple, Union
 from unittest import mock
 from unittest.mock import MagicMock, Mock, patch
 
@@ -536,7 +536,7 @@ class TestUtil:
 
     def test_rewind_body_failed_seek(self) -> None:
         class BadSeek(io.StringIO):
-            def seek(self, offset: int, whence: int = 0) -> int:
+            def seek(self, offset: int, whence: int = 0) -> NoReturn:
                 raise OSError
 
         with pytest.raises(UnrewindableBodyError):

--- a/test/with_dummyserver/test_connectionpool.py
+++ b/test/with_dummyserver/test_connectionpool.py
@@ -6,7 +6,7 @@ import time
 import warnings
 from test import LONG_TIMEOUT, SHORT_TIMEOUT
 from threading import Event
-from typing import Dict, List, Optional, Tuple, Type, Union
+from typing import Dict, List, NoReturn, Optional, Tuple, Type, Union
 from unittest import mock
 from urllib.parse import urlencode
 
@@ -1338,7 +1338,7 @@ class TestFileBodiesOnRetryOrRedirect(HTTPDummyServerTestCase):
         """Abort request if failed to get a position from tell()"""
 
         class BadTellObject(io.BytesIO):
-            def tell(self) -> int:
+            def tell(self) -> NoReturn:
                 raise OSError
 
         body = BadTellObject(b"the data")


### PR DESCRIPTION
- Update mypy to 0.931
- Change return type to NoReturn where it makes sence

Note: The changing return type to `NoReturn` is not related to new version of mypy