### PR TITLE
[2.0] Add tests for IPv6 proxy subjectAltNames (forward-port #2419)

### DIFF
--- a/src/urllib3/util/ssl_match_hostname.py
+++ b/src/urllib3/util/ssl_match_hostname.py
@@ -106,7 +106,7 @@ def match_hostname(
         )
     try:
         # Divergence from upstream: ipaddress can't handle byte str
-        host_ip = ipaddress.ip_address(hostname.strip("[]"))
+        host_ip = ipaddress.ip_address(hostname)
     except ValueError:
         # Not an IP address (common case)
         host_ip = None

--- a/test/contrib/test_pyopenssl.py
+++ b/test/contrib/test_pyopenssl.py
@@ -35,7 +35,6 @@ from ..test_util import TestUtilSSL  # noqa: E402, F401
 from ..with_dummyserver.test_https import (  # noqa: E402, F401
     TestHTTPS,
     TestHTTPS_IPV4SAN,
-    TestHTTPS_IPv6Addr,
     TestHTTPS_IPV6SAN,
     TestHTTPS_TLSv1,
     TestHTTPS_TLSv1_1,

--- a/test/contrib/test_pyopenssl.py
+++ b/test/contrib/test_pyopenssl.py
@@ -34,7 +34,9 @@ from ..test_ssl import TestSSL  # noqa: E402, F401
 from ..test_util import TestUtilSSL  # noqa: E402, F401
 from ..with_dummyserver.test_https import (  # noqa: E402, F401
     TestHTTPS,
-    TestHTTPS_Hostname,
+    TestHTTPS_IPV4SAN,
+    TestHTTPS_IPv6Addr,
+    TestHTTPS_IPV6SAN,
     TestHTTPS_TLSv1,
     TestHTTPS_TLSv1_1,
     TestHTTPS_TLSv1_2,

--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -149,6 +149,21 @@ class TestConnection:
             )
             assert e._peer_cert == cert
 
+    def test_match_hostname_dns_with_brackets_doesnt_match(self) -> None:
+        cert: "_TYPE_PEER_CERT_RET_DICT" = {
+            "subjectAltName": (
+                ("DNS", "localhost"),
+                ("IP Address", "localhost"),
+            )
+        }
+        asserted_hostname = "[localhost]"
+        with pytest.raises(CertificateError) as e:
+            _match_hostname(cert, asserted_hostname)
+        assert (
+            "hostname '[localhost]' doesn't match either of 'localhost', 'localhost'"
+            in str(e.value)
+        )
+
     def test_match_hostname_ip_address_ipv6_brackets(self) -> None:
         cert: "_TYPE_PEER_CERT_RET_DICT" = {
             "subjectAltName": (("IP Address", "1:2::2:1"),)

--- a/test/with_dummyserver/test_https.py
+++ b/test/with_dummyserver/test_https.py
@@ -1065,36 +1065,6 @@ class TestHTTPS_IPV4SAN:
             assert r.status == 200
 
 
-class TestHTTPS_IPv6Addr:
-    @pytest.mark.xfail  # TODO: Remove test in urllib3/urllib3#2532
-    @pytest.mark.parametrize("host", ["::1", "[::1]"])
-    def test_strip_square_brackets_before_validating(
-        self, ipv6_no_san_server: ServerConfig, host: str
-    ) -> None:
-        """Test that the fix for #760 works."""
-
-        ctx = urllib3.util.ssl_.create_urllib3_context()
-        try:
-            ctx.hostname_checks_common_name = True
-        except AttributeError:
-            pass
-        if (
-            not getattr(ctx, "hostname_checks_common_name", False)
-            or not urllib3.util.ssl_.HAS_NEVER_CHECK_COMMON_NAME
-        ):
-            pytest.skip("Couldn't set SSLContext.hostname_checks_common_name = True")
-
-        with HTTPSConnectionPool(
-            host,
-            ipv6_no_san_server.port,
-            cert_reqs="CERT_REQUIRED",
-            ca_certs=ipv6_no_san_server.ca_certs,
-            ssl_context=ctx,
-        ) as https_pool:
-            r = https_pool.request("GET", "/")
-            assert r.status == 200
-
-
 class TestHTTPS_IPV6SAN:
     @pytest.mark.parametrize("host", ["::1", "[::1]"])
     def test_can_validate_ipv6_san(


### PR DESCRIPTION
Brings #2419 to the `main` branch. Notably this changes where the stripping of `[]` characters happens to match what was released in 1.26.7.

Part of https://github.com/urllib3/urllib3/issues/2530