### PR TITLE
Fix TypeError caused by interface mismatch

### DIFF
--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -138,6 +138,7 @@ class HTTPConnection(_HTTPConnection):
         ] = default_socket_options,
         proxy: Optional[str] = None,
         proxy_config: Optional[ProxyConfig] = None,
+        **noop_kw: Any,
     ) -> None:
         # Pre-set source_address.
         self.source_address = source_address
@@ -383,6 +384,7 @@ class HTTPSConnection(HTTPConnection):
         ] = HTTPConnection.default_socket_options,
         proxy: Optional[str] = None,
         proxy_config: Optional[ProxyConfig] = None,
+        **noop_kw: Any,
     ) -> None:
 
         super().__init__(


### PR DESCRIPTION
The PoolManager class takes the connection_pool_kw argument which
defines global parameters used for the connection pools managed by that
manager. Some of them are passed to the conn_kw argument to instantiate
a connection.

The problem here is that the PoolManager class instantiates different
classes of connection pools according to the protocol used. This
results in the issue caused by the different arguments in connection
classes(HTTPConnection vs HTTPSConnection).

This change introduces an additional kwargs to these connection classes
so that these classes can accept arguments which are not implemented.

Resolves: #2534
