### PR TITLE
Stop executing python setup.py install

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -55,7 +55,7 @@ Alternatively, you can grab the latest source code from `GitHub <https://github.
 .. code-block:: bash
 
     $ git clone git://github.com/urllib3/urllib3.git
-    $ python setup.py install
+    $ pip install .
 
 
 Documentation

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -87,7 +87,7 @@ Alternatively, you can grab the latest source code from `GitHub <https://github.
 .. code-block:: bash
 
   $ git clone git://github.com/urllib3/urllib3.git
-  $ python setup.py install
+  $ pip install .
 
 Usage
 -----

--- a/noxfile.py
+++ b/noxfile.py
@@ -61,7 +61,7 @@ def test(session: nox.Session) -> None:
 def unsupported_python2(session: nox.Session) -> None:
     # Can't check both returncode and output with session.run
     process = subprocess.run(
-        ["python", "setup.py", "install"],
+        ["pip", "install", "."],
         env={**session.env},
         text=True,
         capture_output=True,


### PR DESCRIPTION
It's deprecated in favor of pip install.