### PR TITLE
[1.26] Stop advertising python setup.py install

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -52,7 +52,7 @@ urllib3 can be installed with `pip <https://pip.pypa.io>`_::
 Alternatively, you can grab the latest source code from `GitHub <https://github.com/urllib3/urllib3>`_::
 
     $ git clone git://github.com/urllib3/urllib3.git
-    $ python setup.py install
+    $ pip install .
 
 
 Documentation

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -86,7 +86,7 @@ Alternatively, you can grab the latest source code from `GitHub <https://github.
 .. code-block:: bash
 
   $ git clone git://github.com/urllib3/urllib3.git
-  $ python setup.py install
+  $ pip install .
 
 Usage
 -----


### PR DESCRIPTION
It's deprecated in favor of pip install.

(We still use it in deploy.sh, though.)