### PR TITLE
[1.26] Add test to complete the coverage of urllib3.util.ssl_match_hostname.match_hostname

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -103,6 +103,16 @@ def no_san_server(tmp_path_factory):
         yield cfg
 
 
+@pytest.fixture()
+def no_san_server_with_different_commmon_name(tmp_path_factory):
+    tmpdir = tmp_path_factory.mktemp("certs")
+    ca = trustme.CA()
+    server_cert = ca.issue_cert(common_name=u"example.com")
+
+    with run_server_in_thread("https", "localhost", tmpdir, ca, server_cert) as cfg:
+        yield cfg
+
+
 @pytest.fixture
 def no_san_proxy(tmp_path_factory):
     tmpdir = tmp_path_factory.mktemp("certs")

--- a/test/with_dummyserver/test_https.py
+++ b/test/with_dummyserver/test_https.py
@@ -858,6 +858,19 @@ class TestHTTPS_NoSAN:
                 assert r.status == 200
                 assert warn.called
 
+    def test_common_name_without_san_with_different_common_name(
+        self, no_san_server_with_different_commmon_name
+    ):
+        with HTTPSConnectionPool(
+            no_san_server_with_different_commmon_name.host,
+            no_san_server_with_different_commmon_name.port,
+            cert_reqs="CERT_REQUIRED",
+            ca_certs=no_san_server_with_different_commmon_name.ca_certs,
+        ) as https_pool:
+            with pytest.raises(MaxRetryError) as cm:
+                https_pool.request("GET", "/")
+            assert isinstance(cm.value.reason, SSLError)
+
 
 class TestHTTPS_IPV4SAN:
     def test_can_validate_ip_san(self, ipv4_san_server):


### PR DESCRIPTION
Ref: https://github.com/urllib3/urllib3/issues/2543
This path Covers https://github.com/urllib3/urllib3/blob/b1f60e44d43b13e5272d5b6003f125af9c25c8ad/src/urllib3/util/ssl_match_hostname.py#L150