### PR TITLE
Add changelog synchronization to release template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/release.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release.md
@@ -36,3 +36,4 @@
   * [ ]  OpenCollective
   * [ ]  GitCoin Grants
 * [ ]  Update Tidelift metadata
+* [ ]  If this was a 1.26.x release, add changes to the `main` branch


### PR DESCRIPTION
I thought about adding this line when seeing https://github.com/urllib3/urllib3/pull/2546