### PR TITLE
Remove > signs from links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ urllib3 can be installed with [pip](https://pip.pypa.io):
 $ python -m pip install urllib3
 ```
 
-Alternatively, you can grab the latest source code from [GitHub](https://github.com/urllib3/urllib3>):
+Alternatively, you can grab the latest source code from [GitHub](https://github.com/urllib3/urllib3):
 
 ```bash
 $ git clone git://github.com/urllib3/urllib3.git
@@ -57,7 +57,7 @@ $ pip install .
 
 ## Documentation
 
-urllib3 has usage and reference documentation at [urllib3.readthedocs.io](https://urllib3.readthedocs.io>).
+urllib3 has usage and reference documentation at [urllib3.readthedocs.io](https://urllib3.readthedocs.io).
 
 
 ## Community


### PR DESCRIPTION
<!---
Thanks for your contribution! ♥️

If this is your first PR to urllib3 please review the Contributing Guide:
https://urllib3.readthedocs.io/en/latest/contributing.html

Adhering to the Contributing Guide means we can review, merge, and release your change faster! :)
--->
Removed `>` signs from two links in README so they are clickable