### PR TITLE
Create our own logic for chunking, content framing

### DIFF
--- a/changelog/2515.feature.rst
+++ b/changelog/2515.feature.rst
@@ -1,0 +1,5 @@
+Added the ``chunked`` parameter to ``urllib3.connection.HTTPConnection.request()``.
+
+Changed ``urllib3.connection.HTTPConnection.request_chunked()`` to be an alias for `HTTPConnection.request(..., chunked=True)``.
+
+Changed ``urllib3.connection.HTTPConnection.request()`` to use ``http.client.HTTPConnection.putrequest()``, ``putheader()``, ``.endheaders()``, and ``.send()`` methods directly.

--- a/changelog/2515.feature.rst
+++ b/changelog/2515.feature.rst
@@ -1,5 +1,1 @@
-Added the ``chunked`` parameter to ``urllib3.connection.HTTPConnection.request()``.
-
-Changed ``urllib3.connection.HTTPConnection.request_chunked()`` to be an alias for `HTTPConnection.request(..., chunked=True)``.
-
-Changed ``urllib3.connection.HTTPConnection.request()`` to use ``http.client.HTTPConnection.putrequest()``, ``putheader()``, ``.endheaders()``, and ``.send()`` methods directly.
+Changed ``HTTPConnection.request()`` to always use lowercase chunk boundaries when sending requests with ``Transfer-Encoding: chunked``.

--- a/ci/0001-Mark-100-Continue-tests-as-failing.patch
+++ b/ci/0001-Mark-100-Continue-tests-as-failing.patch
@@ -1,0 +1,67 @@
+From 633cd3b445e1f0617c30b4c25dcbf865eadcd44b Mon Sep 17 00:00:00 2001
+From: Quentin Pradet <quentin.pradet@gmail.com>
+Date: Mon, 2 May 2022 23:25:00 +0400
+Subject: [PATCH] Mark 100 Continue tests as failing
+
+This appears to be an issue in botocore that they plan to fix at some
+point. See https://github.com/urllib3/urllib3/pull/2565 for more
+details.
+---
+ tests/unit/test_awsrequest.py | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/tests/unit/test_awsrequest.py b/tests/unit/test_awsrequest.py
+index 5005d50fd..766e0b583 100644
+--- a/tests/unit/test_awsrequest.py
++++ b/tests/unit/test_awsrequest.py
+@@ -334,6 +334,7 @@ class TestAWSHTTPConnection(unittest.TestCase):
+         conn.response_class.return_value = self.mock_response
+         return conn
+ 
++    @pytest.mark.xfail(reason="https://github.com/urllib3/urllib3/pull/2565")
+     def test_expect_100_continue_returned(self):
+         with mock.patch('urllib3.util.wait_for_read') as wait_mock:
+             # Shows the server first sending a 100 continue response
+@@ -350,6 +351,7 @@ class TestAWSHTTPConnection(unittest.TestCase):
+             # Now we should verify that our final response is the 200 OK
+             self.assertEqual(response.status, 200)
+ 
++    @pytest.mark.xfail(reason="https://github.com/urllib3/urllib3/pull/2565")
+     def test_handles_expect_100_with_different_reason_phrase(self):
+         with mock.patch('urllib3.util.wait_for_read') as wait_mock:
+             # Shows the server first sending a 100 continue response
+@@ -369,6 +371,7 @@ class TestAWSHTTPConnection(unittest.TestCase):
+             # continue.
+             self.assertIn(b'body', s.sent_data)
+ 
++    @pytest.mark.xfail(reason="https://github.com/urllib3/urllib3/pull/2565")
+     def test_expect_100_sends_connection_header(self):
+         # When using squid as an HTTP proxy, it will also send
+         # a Connection: keep-alive header back with the 100 continue
+@@ -393,6 +396,7 @@ class TestAWSHTTPConnection(unittest.TestCase):
+             response = conn.getresponse()
+             self.assertEqual(response.status, 500)
+ 
++    @pytest.mark.xfail(reason="https://github.com/urllib3/urllib3/pull/2565")
+     def test_expect_100_continue_sends_307(self):
+         # This is the case where we send a 100 continue and the server
+         # immediately sends a 307
+@@ -413,6 +417,7 @@ class TestAWSHTTPConnection(unittest.TestCase):
+             # Now we should verify that our final response is the 307.
+             self.assertEqual(response.status, 307)
+ 
++    @pytest.mark.xfail(reason="https://github.com/urllib3/urllib3/pull/2565")
+     def test_expect_100_continue_no_response_from_server(self):
+         with mock.patch('urllib3.util.wait_for_read') as wait_mock:
+             # Shows the server first sending a 100 continue response
+@@ -510,6 +515,7 @@ class TestAWSHTTPConnection(unittest.TestCase):
+         response = conn.getresponse()
+         self.assertEqual(response.status, 200)
+ 
++    @pytest.mark.xfail(reason="https://github.com/urllib3/urllib3/pull/2565")
+     def test_state_reset_on_connection_close(self):
+         # This simulates what urllib3 does with connections
+         # in its connection pool logic.
+-- 
+2.35.1
+

--- a/ci/0001-Mark-100-Continue-tests-as-failing.patch
+++ b/ci/0001-Mark-100-Continue-tests-as-failing.patch
@@ -1,20 +1,28 @@
-From 633cd3b445e1f0617c30b4c25dcbf865eadcd44b Mon Sep 17 00:00:00 2001
+From 3da76f0f850bca8cd3e463a8e3011992bc605762 Mon Sep 17 00:00:00 2001
 From: Quentin Pradet <quentin.pradet@gmail.com>
-Date: Mon, 2 May 2022 23:25:00 +0400
+Date: Mon, 2 May 2022 23:34:00 +0400
 Subject: [PATCH] Mark 100 Continue tests as failing
 
 This appears to be an issue in botocore that they plan to fix at some
 point. See https://github.com/urllib3/urllib3/pull/2565 for more
 details.
 ---
- tests/unit/test_awsrequest.py | 6 ++++++
- 1 file changed, 6 insertions(+)
+ tests/unit/test_awsrequest.py | 7 +++++++
+ 1 file changed, 7 insertions(+)
 
 diff --git a/tests/unit/test_awsrequest.py b/tests/unit/test_awsrequest.py
-index 5005d50fd..766e0b583 100644
+index 5005d50fd..b9ea692b8 100644
 --- a/tests/unit/test_awsrequest.py
 +++ b/tests/unit/test_awsrequest.py
-@@ -334,6 +334,7 @@ class TestAWSHTTPConnection(unittest.TestCase):
+@@ -19,6 +19,7 @@ import socket
+ import tempfile
+ 
+ from urllib3.connectionpool import HTTPConnectionPool, HTTPSConnectionPool
++import pytest
+ 
+ from botocore.awsrequest import (
+     AWSHTTPConnection,
+@@ -334,6 +335,7 @@ class TestAWSHTTPConnection(unittest.TestCase):
          conn.response_class.return_value = self.mock_response
          return conn
  
@@ -22,7 +30,7 @@ index 5005d50fd..766e0b583 100644
      def test_expect_100_continue_returned(self):
          with mock.patch('urllib3.util.wait_for_read') as wait_mock:
              # Shows the server first sending a 100 continue response
-@@ -350,6 +351,7 @@ class TestAWSHTTPConnection(unittest.TestCase):
+@@ -350,6 +352,7 @@ class TestAWSHTTPConnection(unittest.TestCase):
              # Now we should verify that our final response is the 200 OK
              self.assertEqual(response.status, 200)
  
@@ -30,7 +38,7 @@ index 5005d50fd..766e0b583 100644
      def test_handles_expect_100_with_different_reason_phrase(self):
          with mock.patch('urllib3.util.wait_for_read') as wait_mock:
              # Shows the server first sending a 100 continue response
-@@ -369,6 +371,7 @@ class TestAWSHTTPConnection(unittest.TestCase):
+@@ -369,6 +372,7 @@ class TestAWSHTTPConnection(unittest.TestCase):
              # continue.
              self.assertIn(b'body', s.sent_data)
  
@@ -38,7 +46,7 @@ index 5005d50fd..766e0b583 100644
      def test_expect_100_sends_connection_header(self):
          # When using squid as an HTTP proxy, it will also send
          # a Connection: keep-alive header back with the 100 continue
-@@ -393,6 +396,7 @@ class TestAWSHTTPConnection(unittest.TestCase):
+@@ -393,6 +397,7 @@ class TestAWSHTTPConnection(unittest.TestCase):
              response = conn.getresponse()
              self.assertEqual(response.status, 500)
  
@@ -46,7 +54,7 @@ index 5005d50fd..766e0b583 100644
      def test_expect_100_continue_sends_307(self):
          # This is the case where we send a 100 continue and the server
          # immediately sends a 307
-@@ -413,6 +417,7 @@ class TestAWSHTTPConnection(unittest.TestCase):
+@@ -413,6 +418,7 @@ class TestAWSHTTPConnection(unittest.TestCase):
              # Now we should verify that our final response is the 307.
              self.assertEqual(response.status, 307)
  
@@ -54,7 +62,7 @@ index 5005d50fd..766e0b583 100644
      def test_expect_100_continue_no_response_from_server(self):
          with mock.patch('urllib3.util.wait_for_read') as wait_mock:
              # Shows the server first sending a 100 continue response
-@@ -510,6 +515,7 @@ class TestAWSHTTPConnection(unittest.TestCase):
+@@ -510,6 +516,7 @@ class TestAWSHTTPConnection(unittest.TestCase):
          response = conn.getresponse()
          self.assertEqual(response.status, 200)
  

--- a/ci/0001-Mark-100-Continue-tests-as-failing.patch
+++ b/ci/0001-Mark-100-Continue-tests-as-failing.patch
@@ -1,28 +1,16 @@
-From 3da76f0f850bca8cd3e463a8e3011992bc605762 Mon Sep 17 00:00:00 2001
-From: Quentin Pradet <quentin.pradet@gmail.com>
-Date: Mon, 2 May 2022 23:34:00 +0400
-Subject: [PATCH] Mark 100 Continue tests as failing
-
-This appears to be an issue in botocore that they plan to fix at some
-point. See https://github.com/urllib3/urllib3/pull/2565 for more
-details.
----
- tests/unit/test_awsrequest.py | 7 +++++++
- 1 file changed, 7 insertions(+)
-
 diff --git a/tests/unit/test_awsrequest.py b/tests/unit/test_awsrequest.py
-index 5005d50fd..b9ea692b8 100644
+index 22bd9a7..862a244 100644
 --- a/tests/unit/test_awsrequest.py
 +++ b/tests/unit/test_awsrequest.py
-@@ -19,6 +19,7 @@ import socket
- import tempfile
+@@ -34,6 +34,7 @@ from botocore.compat import file_type, six
+ from botocore.exceptions import UnseekableStreamError
+ from tests import mock, unittest
  
- from urllib3.connectionpool import HTTPConnectionPool, HTTPSConnectionPool
 +import pytest
  
- from botocore.awsrequest import (
-     AWSHTTPConnection,
-@@ -334,6 +335,7 @@ class TestAWSHTTPConnection(unittest.TestCase):
+ class IgnoreCloseBytesIO(io.BytesIO):
+     def close(self):
+@@ -370,6 +371,7 @@ class TestAWSHTTPConnection(unittest.TestCase):
          conn.response_class.return_value = self.mock_response
          return conn
  
@@ -30,7 +18,7 @@ index 5005d50fd..b9ea692b8 100644
      def test_expect_100_continue_returned(self):
          with mock.patch('urllib3.util.wait_for_read') as wait_mock:
              # Shows the server first sending a 100 continue response
-@@ -350,6 +352,7 @@ class TestAWSHTTPConnection(unittest.TestCase):
+@@ -387,6 +389,7 @@ class TestAWSHTTPConnection(unittest.TestCase):
              # Now we should verify that our final response is the 200 OK
              self.assertEqual(response.status, 200)
  
@@ -38,7 +26,7 @@ index 5005d50fd..b9ea692b8 100644
      def test_handles_expect_100_with_different_reason_phrase(self):
          with mock.patch('urllib3.util.wait_for_read') as wait_mock:
              # Shows the server first sending a 100 continue response
-@@ -369,6 +372,7 @@ class TestAWSHTTPConnection(unittest.TestCase):
+@@ -412,6 +415,7 @@ class TestAWSHTTPConnection(unittest.TestCase):
              # continue.
              self.assertIn(b'body', s.sent_data)
  
@@ -46,7 +34,7 @@ index 5005d50fd..b9ea692b8 100644
      def test_expect_100_sends_connection_header(self):
          # When using squid as an HTTP proxy, it will also send
          # a Connection: keep-alive header back with the 100 continue
-@@ -393,6 +397,7 @@ class TestAWSHTTPConnection(unittest.TestCase):
+@@ -439,6 +443,7 @@ class TestAWSHTTPConnection(unittest.TestCase):
              response = conn.getresponse()
              self.assertEqual(response.status, 500)
  
@@ -54,7 +42,7 @@ index 5005d50fd..b9ea692b8 100644
      def test_expect_100_continue_sends_307(self):
          # This is the case where we send a 100 continue and the server
          # immediately sends a 307
-@@ -413,6 +418,7 @@ class TestAWSHTTPConnection(unittest.TestCase):
+@@ -461,6 +466,7 @@ class TestAWSHTTPConnection(unittest.TestCase):
              # Now we should verify that our final response is the 307.
              self.assertEqual(response.status, 307)
  
@@ -62,7 +50,7 @@ index 5005d50fd..b9ea692b8 100644
      def test_expect_100_continue_no_response_from_server(self):
          with mock.patch('urllib3.util.wait_for_read') as wait_mock:
              # Shows the server first sending a 100 continue response
-@@ -510,6 +516,7 @@ class TestAWSHTTPConnection(unittest.TestCase):
+@@ -566,6 +572,7 @@ class TestAWSHTTPConnection(unittest.TestCase):
          response = conn.getresponse()
          self.assertEqual(response.status, 200)
  
@@ -70,6 +58,3 @@ index 5005d50fd..b9ea692b8 100644
      def test_state_reset_on_connection_close(self):
          # This simulates what urllib3 does with connections
          # in its connection pool logic.
--- 
-2.35.1
-

--- a/dummyserver/handlers.py
+++ b/dummyserver/handlers.py
@@ -279,6 +279,9 @@ class TestingApp(RequestHandler):
     def headers(self, request: httputil.HTTPServerRequest) -> Response:
         return Response(json.dumps(dict(request.headers)))
 
+    def multi_headers(self, request: httputil.HTTPServerRequest) -> Response:
+        return Response(json.dumps({"headers": list(request.headers.get_all())}))
+
     def successful_retry(self, request: httputil.HTTPServerRequest) -> Response:
         """Handler which will return an error and then success
 

--- a/dummyserver/testcase.py
+++ b/dummyserver/testcase.py
@@ -301,7 +301,6 @@ class ConnectionMarker:
         """
 
         orig_request = HTTPConnection.request
-        orig_request_chunked = HTTPConnection.request_chunked
 
         def call_and_mark(target: Callable[..., None]) -> Callable[..., None]:
             def part(self: HTTPConnection, *args: Any, **kwargs: Any) -> None:
@@ -312,9 +311,6 @@ class ConnectionMarker:
 
         with monkeypatch.context() as m:
             m.setattr(HTTPConnection, "request", call_and_mark(orig_request))
-            m.setattr(
-                HTTPConnection, "request_chunked", call_and_mark(orig_request_chunked)
-            )
             yield
 
     @classmethod

--- a/noxfile.py
+++ b/noxfile.py
@@ -92,6 +92,12 @@ def downstream_botocore(session: nox.Session) -> None:
     session.cd(tmp_dir)
     git_clone(session, "https://github.com/boto/botocore")
     session.chdir("botocore")
+    session.run(
+        "git",
+        "apply",
+        f"{root}/ci/0001-Mark-100-Continue-tests-as-failing.patch",
+        external=True,
+    )
     session.run("git", "rev-parse", "HEAD", external=True)
     session.run("python", "scripts/ci/install")
 

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -4,7 +4,6 @@ import os
 import re
 import socket
 import warnings
-from copy import copy
 from http.client import HTTPConnection as _HTTPConnection
 from http.client import HTTPException as HTTPException  # noqa: F401
 from socket import timeout as SocketTimeout
@@ -29,7 +28,7 @@ if TYPE_CHECKING:
     from .util.ssltransport import SSLTransport
 
 from .util.timeout import _DEFAULT_TIMEOUT, _TYPE_TIMEOUT, Timeout
-from .util.util import to_bytes, to_str
+from .util.util import to_str
 
 try:  # Compiled with SSL?
     import ssl
@@ -51,6 +50,7 @@ from .exceptions import (
     SystemTimeWarning,
 )
 from .util import SKIP_HEADER, SKIPPABLE_HEADERS, connection, ssl_
+from .util.request import body_to_chunks
 from .util.ssl_ import assert_fingerprint as _assert_fingerprint
 from .util.ssl_ import (
     create_urllib3_context,
@@ -126,6 +126,7 @@ class HTTPConnection(_HTTPConnection):
     #: certificate. If no HTTPS proxy is being used will be ``None``.
     proxy_is_verified: Optional[bool] = None
 
+    blocksize: int
     source_address: Optional[Tuple[str, int]]
     socket_options: Optional[connection._TYPE_SOCKET_OPTIONS]
     _tunnel_host: Optional[str]
@@ -288,25 +289,72 @@ class HTTPConnection(_HTTPConnection):
         url: str,
         body: Optional[_TYPE_BODY] = None,
         headers: Optional[Mapping[str, str]] = None,
+        chunked: bool = False,
     ) -> None:
+
         if headers is None:
             headers = {}
-        else:
-            # Avoid modifying the headers passed into .request()
-            headers = copy(headers)
-            # Don't send bytes keys to httplib to avoid bytes/str comparison
-            # HTTPHeaderDict is already safe, but other types are not
-            for key, value in list(headers.items()):
-                if isinstance(key, bytes):
-                    headers.pop(key)
-                    # httplib would have decoded to latin-1 anyway
-                    headers[key.decode("latin-1")] = value
+        header_keys = frozenset(to_str(k.lower()) for k in headers)
+        skip_accept_encoding = "accept-encoding" in header_keys
+        skip_host = "host" in header_keys
+        self.putrequest(
+            method, url, skip_accept_encoding=skip_accept_encoding, skip_host=skip_host
+        )
 
-        if "user-agent" not in (to_str(k.lower()) for k in headers):
-            updated_headers = {"User-Agent": _get_default_user_agent()}
-            updated_headers.update(headers)
-            headers = updated_headers
-        super().request(method, url, body=body, headers=headers)
+        # Transform the body into an iterable of sendall()-able chunks
+        # and detect if an explicit Content-Length is doable.
+        chunks_and_cl = body_to_chunks(body, method=method, blocksize=self.blocksize)
+        chunks = chunks_and_cl.chunks
+        content_length = chunks_and_cl.content_length
+
+        # When chunked is explicit set to 'True' we respect that.
+        if chunked:
+            if "transfer-encoding" not in header_keys:
+                self.putheader("Transfer-Encoding", "chunked")
+        else:
+            # Detect whether a framing mechanism is already in use. If so
+            # we respect that value, otherwise we pick chunked vs content-length
+            # depending on the type of 'body'.
+            if "content-length" in header_keys:
+                chunked = False
+            elif "transfer-encoding" in header_keys:
+                chunked = True
+
+            # Otherwise we go off the recommendation of 'body_to_chunks()'.
+            else:
+                chunked = False
+                if content_length is None:
+                    if chunks is not None:
+                        chunked = True
+                        self.putheader("Transfer-Encoding", "chunked")
+                else:
+                    self.putheader("Content-Length", str(content_length))
+
+        # Now that framing headers are out of the way we send all the other headers.
+        if "user-agent" not in header_keys:
+            self.putheader("User-Agent", _get_default_user_agent())
+        for header, value in headers.items():
+            self.putheader(header, value)
+        self.endheaders()
+
+        # If we're given a body we start sending that in chunks.
+        if chunks is not None:
+            for chunk in chunks:
+                # Sending empty chunks isn't allowed for TE: chunked
+                # as it indicates the end of the body.
+                if not chunk:
+                    continue
+                if not isinstance(chunk, bytes):
+                    chunk = chunk.encode("utf-8")
+                if chunked:
+                    self.send(b"%x\r\n%b\r\n" % (len(chunk), chunk))
+                else:
+                    self.send(chunk)
+
+        # Regardless of whether we have a body or not, if we're in
+        # chunked mode we want to send an explicit empty chunk.
+        if chunked:
+            self.send(b"0\r\n\r\n")
 
     def request_chunked(
         self,
@@ -319,39 +367,7 @@ class HTTPConnection(_HTTPConnection):
         Alternative to the common request method, which sends the
         body with chunked encoding and not as one block
         """
-        if headers is None:
-            headers = {}
-        header_keys = {to_str(k.lower()) for k in headers}
-        skip_accept_encoding = "accept-encoding" in header_keys
-        skip_host = "host" in header_keys
-        self.putrequest(
-            method, url, skip_accept_encoding=skip_accept_encoding, skip_host=skip_host
-        )
-        if "user-agent" not in header_keys:
-            self.putheader("User-Agent", _get_default_user_agent())
-        for header, value in headers.items():
-            self.putheader(header, value)
-        if "transfer-encoding" not in header_keys:
-            self.putheader("Transfer-Encoding", "chunked")
-        self.endheaders()
-
-        if body is not None:
-            if isinstance(body, (str, bytes)):
-                body = (to_bytes(body),)
-            for chunk in body:
-                if not chunk:
-                    continue
-                if not isinstance(chunk, bytes):
-                    chunk = chunk.encode("utf8")
-                len_str = hex(len(chunk))[2:]
-                to_send = bytearray(len_str.encode())
-                to_send += b"\r\n"
-                to_send += chunk
-                to_send += b"\r\n"
-                self.send(to_send)
-
-        # After the if clause, to always have a closed body
-        self.send(b"0\r\n\r\n")
+        self.request(method, url, body=body, headers=headers, chunked=True)
 
 
 class HTTPSConnection(HTTPConnection):

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -344,7 +344,7 @@ class HTTPConnection(_HTTPConnection):
                 # as it indicates the end of the body.
                 if not chunk:
                     continue
-                if not isinstance(chunk, bytes):
+                if isinstance(chunk, str):
                     chunk = chunk.encode("utf-8")
                 if chunked:
                     self.send(b"%x\r\n%b\r\n" % (len(chunk), chunk))

--- a/test/test_poolmanager.py
+++ b/test/test_poolmanager.py
@@ -427,7 +427,7 @@ class TestPoolManager:
             "http://example.com", {"blocksize": input_blocksize}
         )
         assert pool_blocksize.conn_kw["blocksize"] == expected_blocksize
-        assert pool_blocksize._get_conn().blocksize == expected_blocksize  # type: ignore[attr-defined]
+        assert pool_blocksize._get_conn().blocksize == expected_blocksize
 
     @pytest.mark.parametrize(
         "url",

--- a/test/with_dummyserver/test_poolmanager.py
+++ b/test/with_dummyserver/test_poolmanager.py
@@ -370,7 +370,6 @@ class TestPoolManager(HTTPDummyServerTestCase):
                 },
             )
             returned_headers = r.json()["headers"]
-            print(returned_headers)
             assert returned_headers[-4:] == [
                 ["Foo", "new"],
                 ["Multi", "1, 2"],

--- a/test/with_dummyserver/test_poolmanager.py
+++ b/test/with_dummyserver/test_poolmanager.py
@@ -351,26 +351,32 @@ class TestPoolManager(HTTPDummyServerTestCase):
         headers.add("Multi", "2")
 
         with PoolManager(headers=headers) as http:
-            r = http.request("GET", f"{self.base_url}/headers")
-            returned_headers = r.json()
-            assert returned_headers["Foo"] == "bar"
-            assert returned_headers["Multi"] == "1, 2"
-            assert returned_headers["Baz"] == "quux"
+            r = http.request("GET", f"{self.base_url}/multi_headers")
+            returned_headers = r.json()["headers"]
+            assert returned_headers[-4:] == [
+                ["Foo", "bar"],
+                ["Multi", "1"],
+                ["Multi", "2"],
+                ["Baz", "quux"],
+            ]
 
             r = http.request(
                 "GET",
-                f"{self.base_url}/headers",
+                f"{self.base_url}/multi_headers",
                 headers={
                     **headers,
                     "Extra": "extra",
                     "Foo": "new",
                 },
             )
-            returned_headers = r.json()
-            assert returned_headers["Foo"] == "new"
-            assert returned_headers["Multi"] == "1, 2"
-            assert returned_headers["Baz"] == "quux"
-            assert returned_headers["Extra"] == "extra"
+            returned_headers = r.json()["headers"]
+            print(returned_headers)
+            assert returned_headers[-4:] == [
+                ["Foo", "new"],
+                ["Multi", "1, 2"],
+                ["Baz", "quux"],
+                ["Extra", "extra"],
+            ]
 
     def test_body(self) -> None:
         with PoolManager() as http:

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -2035,9 +2035,7 @@ class TestContentFraming(SocketDummyServerTestCase):
         assert b"Transfer-Encoding: chunked\r\n" in sent_bytes
         assert b"User-Agent: python-urllib3/" in sent_bytes
         assert b"content-length" not in sent_bytes.lower()
-
-        # TODO: Remove the .lower() after solving #2515
-        assert b"\r\n\r\na\r\nxxxxxxxxxx\r\n0\r\n\r\n" in sent_bytes.lower()
+        assert b"\r\n\r\na\r\nxxxxxxxxxx\r\n0\r\n\r\n" in sent_bytes
 
     @pytest.mark.parametrize("method", ["POST", "PUT", "PATCH"])
     @pytest.mark.parametrize("body_type", ["file", "generator", "bytes"])


### PR DESCRIPTION
- Changes `HTTPConnection.request_chunked()` into an alias for `HTTPConnection.request(..., chunked=True)`
- Adds a `chunked` parameter to `HTTPConnection.request()`
- Adds a new internal function `body_to_chunks()` which does discovery of Content-Length if applicable for the body/method and converts the body if any into an iterable of `socket.sendall()`-able chunks.
- Changes `HTTPConnection.request()` to use `.putrequest()`, `putheader()`, and `.endheaders()` and to send the body via `.send()` in chunks which was previously handled by `http.client.HTTPConnection`.

All of these changes are necessary for us to one day add another HTTP implementation as we're not relying on `http.client` logic for figuring out content framing, sending of data.

Closes https://github.com/urllib3/urllib3/issues/2515
Closes https://github.com/urllib3/urllib3/issues/2291