### PR TITLE
[1.26] Test how headers are folded and sent with .add()

### DIFF
--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -1668,7 +1668,7 @@ class TestHeaders(SocketDummyServerTestCase):
             sock.send(b"HTTP/1.1 200 OK\r\n\r\n")
             sock.close()
 
-        headers = urllib3.HTTPHeaderDict()
+        headers = HTTPHeaderDict()
         headers.add("A", "1")
         headers.add("B", "2")
         headers.add("C", "3")

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -1656,10 +1656,10 @@ class TestHeaders(SocketDummyServerTestCase):
             ]
             assert expected_response_headers == actual_response_headers
 
-    def test_headers_sent_with_add(self) -> None:
+    def test_headers_sent_with_add(self):
         buf = b""
 
-        def socket_handler(listener: socket.socket) -> None:
+        def socket_handler(listener):
             sock = listener.accept()[0]
 
             while not buf.endswith(b"\r\n\r\n"):

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -1657,16 +1657,18 @@ class TestHeaders(SocketDummyServerTestCase):
             assert expected_response_headers == actual_response_headers
 
     def test_headers_sent_with_add(self):
-        buf = b""
+        data_sent = []
 
         def socket_handler(listener):
             sock = listener.accept()[0]
 
+            buf = b""
             while not buf.endswith(b"\r\n\r\n"):
                 buf += sock.recv(65536)
 
             sock.send(b"HTTP/1.1 200 OK\r\n\r\n")
             sock.close()
+            data_sent.append(buf)
 
         headers = HTTPHeaderDict()
         headers.add("A", "1")
@@ -1681,7 +1683,7 @@ class TestHeaders(SocketDummyServerTestCase):
             r = pool.request("GET", "/", retries=0, headers=headers)
             assert r.status == 200
 
-        assert b"\r\nA: 1, 4\r\nB: 2\r\nC: 3, 5\r\n" in buf
+        assert b"\r\nA: 1, 4\r\nB: 2\r\nC: 3, 5\r\n" in data_sent[0]
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
Part of https://github.com/urllib3/urllib3/issues/2242, adds tests to 1.26.x for how headers are sent and folded by default.