### PR TITLE
[1.26] Avoid socket leak if HTTPSConnection.connect() fails

### DIFF
--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -355,16 +355,14 @@ class HTTPSConnection(HTTPConnection):
 
     def connect(self):
         # Add certificate verification
-        conn = self._new_conn()
+        self.sock = conn = self._new_conn()
         hostname = self.host
         tls_in_tls = False
 
         if self._is_using_tunnel():
             if self.tls_in_tls_required:
-                conn = self._connect_tls_proxy(hostname, conn)
+                self.sock = conn = self._connect_tls_proxy(hostname, conn)
                 tls_in_tls = True
-
-            self.sock = conn
 
             # Calls self._set_hostport(), so self.host is
             # self._tunnel_host below.

--- a/test/with_dummyserver/test_https.py
+++ b/test/with_dummyserver/test_https.py
@@ -336,6 +336,22 @@ class TestHTTPS(HTTPSDummyServerTestCase):
                 "Expected 'certificate verify failed', instead got: %r" % e.value.reason
             )
 
+    def test_wrap_socket_failure_resource_leak(self):
+        with HTTPSConnectionPool(
+            self.host,
+            self.port,
+            cert_reqs="CERT_REQUIRED",
+            ca_certs=self.bad_ca_path,
+        ) as https_pool:
+            conn = https_pool._get_conn()
+            try:
+                with pytest.raises(ssl.SSLError):
+                    conn.connect()
+
+                assert conn.sock
+            finally:
+                conn.close()
+
     def test_verified_without_ca_certs(self):
         # default is cert_reqs=None which is ssl.CERT_NONE
         with HTTPSConnectionPool(


### PR DESCRIPTION
Backport of https://github.com/urllib3/urllib3/pull/2571