### PR TITLE
Use Towncrier from PyPI

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -8,5 +8,4 @@ flaky==3.7.0
 trustme==0.9.0
 cryptography==35.0.0
 backports.zoneinfo==0.2.1;python_version<"3.9"
-# https://github.com/twisted/towncrier/pull/356
-git+https://github.com/twisted/towncrier.git
+towncrier==21.9.0 


### PR DESCRIPTION
Now that https://github.com/twisted/towncrier/pull/356 is released we can start using Towncrier from PyPI again :tada: 