### PR TITLE
[1.26] Fix git installation instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,7 +51,8 @@ urllib3 can be installed with `pip <https://pip.pypa.io>`_::
 
 Alternatively, you can grab the latest source code from `GitHub <https://github.com/urllib3/urllib3>`_::
 
-    $ git clone git://github.com/urllib3/urllib3.git
+    $ git clone https://github.com/urllib3/urllib3.git
+    $ cd urllib3
     $ pip install .
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -85,7 +85,8 @@ Alternatively, you can grab the latest source code from `GitHub <https://github.
 
 .. code-block:: bash
 
-  $ git clone git://github.com/urllib3/urllib3.git
+  $ git clone https://github.com/urllib3/urllib3.git
+  $ cd urllib3
   $ pip install .
 
 Usage


### PR DESCRIPTION
GitHub no longer supports the git:// protocol

backports #2585 and #2587 to 1.26
