### PR TITLE
[1.26] Upgrade black to latest version that supports Python 2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,9 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 21.9b0
+    rev: 21.12b0
     hooks:
       - id: black
-        additional_dependencies: ['.[python2]']
+        additional_dependencies: ['.[python2]', 'click==8.0.4']
         args: ["--target-version", "py27"]
 
   - repo: https://github.com/PyCQA/isort

--- a/src/urllib3/contrib/pyopenssl.py
+++ b/src/urllib3/contrib/pyopenssl.py
@@ -406,7 +406,6 @@ if _fileobject:  # Platform-specific: Python 2
         self._makefile_refs += 1
         return _fileobject(self, mode, bufsize, close=True)
 
-
 else:  # Platform-specific: Python 3
     makefile = backport_makefile
 

--- a/src/urllib3/contrib/securetransport.py
+++ b/src/urllib3/contrib/securetransport.py
@@ -770,7 +770,6 @@ if _fileobject:  # Platform-specific: Python 2
         self._makefile_refs += 1
         return _fileobject(self, mode, bufsize, close=True)
 
-
 else:  # Platform-specific: Python 3
 
     def makefile(self, mode="r", buffering=None, *args, **kwargs):

--- a/src/urllib3/packages/six.py
+++ b/src/urllib3/packages/six.py
@@ -772,7 +772,6 @@ if PY3:
             value = None
             tb = None
 
-
 else:
 
     def exec_(_code_, _globs_=None, _locs_=None):

--- a/src/urllib3/util/wait.py
+++ b/src/urllib3/util/wait.py
@@ -42,7 +42,6 @@ if sys.version_info >= (3, 5):
     def _retry_on_intr(fn, timeout):
         return fn(timeout)
 
-
 else:
     # Old and broken Pythons.
     def _retry_on_intr(fn, timeout):


### PR DESCRIPTION
This allows us to get the same formatting as for Python 3.

We also pin click because black uses a private click API in 21.12b0.