### PR TITLE
Allow to change Retry message log level

### DIFF
--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -818,8 +818,12 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
 
         if not conn:
             # Try again
-            log.warning(
-                "Retrying (%r) after connection broken by '%r': %s", retries, err, url
+            log.log(
+                retries.log_level,
+                "Retrying (%r) after connection broken by '%r': %s",
+                retries,
+                err,
+                url,
             )
             return self.urlopen(
                 method,

--- a/src/urllib3/util/retry.py
+++ b/src/urllib3/util/retry.py
@@ -216,6 +216,7 @@ class Retry:
         remove_headers_on_redirect: Collection[
             str
         ] = DEFAULT_REMOVE_HEADERS_ON_REDIRECT,
+        log_level: int = logging.WARNING,
     ) -> None:
         self.total = total
         self.connect = connect
@@ -239,6 +240,7 @@ class Retry:
         self.remove_headers_on_redirect = frozenset(
             h.lower() for h in remove_headers_on_redirect
         )
+        self.log_level = log_level
 
     def new(self, **kw: Any) -> "Retry":
         params = dict(
@@ -257,6 +259,7 @@ class Retry:
             history=self.history,
             remove_headers_on_redirect=self.remove_headers_on_redirect,
             respect_retry_after_header=self.respect_retry_after_header,
+            log_level=self.log_level,
         )
 
         params.update(kw)

--- a/test/test_retry.py
+++ b/test/test_retry.py
@@ -1,3 +1,4 @@
+import logging
 from test import DUMMY_POOL
 from typing import Optional
 from unittest import mock
@@ -84,10 +85,12 @@ class TestRetry:
         assert retry.read is None
         assert retry.redirect is None
         assert retry.other is None
+        assert retry.log_level is logging.WARNING
 
         error = ConnectTimeoutError()
-        retry = Retry(connect=1)
+        retry = Retry(connect=1, log_level=logging.INFO)
         retry = retry.increment(error=error)
+        assert retry.log_level == logging.INFO
         with pytest.raises(MaxRetryError):
             retry.increment(error=error)
 


### PR DESCRIPTION

This is part of https://github.com/urllib3/urllib3/issues/2583, which can be closed once the default is changed from `WARNING` to `INFO`.