### PR TITLE
Fix incorrect error message during connection errors to HTTPS websites using a HTTP proxy

### DIFF
--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -60,6 +60,7 @@ from .util.ssl_ import (
     ssl_wrap_socket,
 )
 from .util.ssl_match_hostname import CertificateError, match_hostname
+from .util.url import Url
 
 # Not a no-op, we're adding this to the namespace so it can be imported.
 ConnectionError = ConnectionError
@@ -141,7 +142,7 @@ class HTTPConnection(_HTTPConnection):
         socket_options: Optional[
             connection._TYPE_SOCKET_OPTIONS
         ] = default_socket_options,
-        proxy: Optional[str] = None,
+        proxy: Optional[Url] = None,
         proxy_config: Optional[ProxyConfig] = None,
     ) -> None:
         # Pre-set source_address.
@@ -386,7 +387,7 @@ class HTTPSConnection(HTTPConnection):
         socket_options: Optional[
             connection._TYPE_SOCKET_OPTIONS
         ] = HTTPConnection.default_socket_options,
-        proxy: Optional[str] = None,
+        proxy: Optional[Url] = None,
         proxy_config: Optional[ProxyConfig] = None,
     ) -> None:
 
@@ -685,7 +686,7 @@ def _match_hostname(
         raise
 
 
-def _wrap_proxy_error(err: Exception) -> ProxyError:
+def _wrap_proxy_error(err: Exception, proxy_scheme: Optional[str]) -> ProxyError:
     # Look for the phrase 'wrong version number', if found
     # then we should warn the user that we're very sure that
     # this proxy is HTTP-only and they have a configuration issue.
@@ -702,7 +703,7 @@ def _wrap_proxy_error(err: Exception) -> ProxyError:
     )
     new_err = ProxyError(
         f"Unable to connect to proxy"
-        f"{http_proxy_warning if is_likely_http_proxy else ''}",
+        f"{http_proxy_warning if is_likely_http_proxy and proxy_scheme == 'https' else ''}",
         err,
     )
     new_err.__cause__ = err

--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -420,8 +420,8 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
                 new_e = SSLError(e)
             if isinstance(
                 new_e, (OSError, NewConnectionError, TimeoutError, SSLError)
-            ) and (conn and conn._connecting_to_proxy):
-                new_e = _wrap_proxy_error(new_e)
+            ) and (conn and conn._connecting_to_proxy and conn.proxy):
+                new_e = _wrap_proxy_error(new_e, conn.proxy.scheme)
             raise new_e
 
         # conn.request() calls http.client.*.request, not the method in
@@ -786,8 +786,8 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
                     SSLError,
                     HTTPException,
                 ),
-            ) and (conn and conn._connecting_to_proxy):
-                new_e = _wrap_proxy_error(new_e)
+            ) and (conn and conn._connecting_to_proxy and conn.proxy):
+                new_e = _wrap_proxy_error(new_e, conn.proxy.scheme)
             elif isinstance(new_e, (OSError, HTTPException)):
                 new_e = ProtocolError("Connection aborted.", new_e)
 


### PR DESCRIPTION
Fixes https://github.com/urllib3/urllib3/issues/2564
After unsuccessful attempts to add a regression test like [test_https_proxymanager_connected_to_http_proxy](https://github.com/urllib3/urllib3/blob/dda4beee0784e6f55a55bba42e5bf77f2b7b2447/test/with_dummyserver/test_socketlevel.py#L1163), I decided to test the [urllib3.conneciton._wrap_proxy_error](https://github.com/urllib3/urllib3/blob/9f4d05c11eb2f80682c1b7a2671b0636292ef932/src/urllib3/connection.py#L688) function itself. Because the change that handles the fix was added to this function.

https://github.com/urllib3/urllib3/blob/dda4beee0784e6f55a55bba42e5bf77f2b7b2447/test/with_dummyserver/test_socketlevel.py#L1163

https://github.com/urllib3/urllib3/blob/9f4d05c11eb2f80682c1b7a2671b0636292ef932/src/urllib3/connection.py#L688

<!---
Thanks for your contribution! ♥️

If this is your first PR to urllib3 please review the Contributing Guide:
https://urllib3.readthedocs.io/en/latest/contributing.html

Adhering to the Contributing Guide means we can review, merge, and release your change faster! :)
--->
