### PR TITLE
Remove GitCoin Grants from FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,4 +1,3 @@
 tidelift: pypi/urllib3
 github: urllib3
 open_collective: urllib3
-custom: https://gitcoin.co/grants/65/urllib3


### PR DESCRIPTION
Our grant isn't supportable right now so we should stop advertising it.