### PR TITLE
Use coverage==6.4 for Python 3.11 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
             os: ubuntu-latest
             experimental: false
             nox-session: test-3.9
-          - python-version: 3.11-dev
+          - python-version: 3.11.0b3
             os: ubuntu-latest
             experimental: true
             nox-session: test-3.11

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
             os: ubuntu-latest
             experimental: false
             nox-session: test-3.9
-          - python-version: 3.11.0-beta.1
+          - python-version: 3.11-dev
             os: ubuntu-latest
             experimental: true
             nox-session: test-3.11

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
             os: ubuntu-latest
             experimental: false
             nox-session: test-3.9
-          - python-version: 3.11.0b1
+          - python-version: 3.11.0-beta.1
             os: ubuntu-latest
             experimental: true
             nox-session: test-3.11

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
             os: ubuntu-latest
             experimental: false
             nox-session: test-3.9
-          - python-version: 3.11.0b3
+          - python-version: 3.11.0b1
             os: ubuntu-latest
             experimental: true
             nox-session: test-3.11

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,4 @@
-coverage==6.3.1
+coverage==6.4
 tornado==6.1
 PySocks==1.7.1
 pytest==7.0.0


### PR DESCRIPTION
Discovered that https://github.com/nedbat/coveragepy/releases/tag/6.3.3 fixed something related to CPython 3.11.0b1 and this upgrade seemed to work locally? So let's try upgrading coverage and see if 3.11 tests pass.

Closes https://github.com/urllib3/urllib3/issues/2602