### PR TITLE
Improve testing for IPv6 scoped addresses support

### DIFF
--- a/src/urllib3/util/url.py
+++ b/src/urllib3/util/url.py
@@ -295,6 +295,9 @@ def _normalize_host(host: Optional[str], scheme: Optional[str]) -> Optional[str]
         if scheme in _NORMALIZABLE_SCHEMES:
             is_ipv6 = _IPV6_ADDRZ_RE.match(host)
             if is_ipv6:
+                # IPv6 hosts of the form 'a::b%zone' are encoded in a URL as
+                # such per RFC 6874: 'a::b%25zone'. Unquote the ZoneID
+                # separator as necessary to return a valid RFC 4007 scoped IP.
                 match = _ZONE_ID_RE.search(host)
                 if match:
                     start, end = match.span(1)
@@ -357,7 +360,7 @@ def parse_url(url: str) -> Url:
     """
     Given a url, return a parsed :class:`.Url` namedtuple. Best-effort is
     performed to parse incomplete urls. Fields not provided will be None.
-    This parser is RFC 3986 compliant.
+    This parser is RFC 3986 and RFC 6874 compliant.
 
     The parser logic and helper functions are based heavily on
     work done in the ``rfc3986`` module.

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -112,6 +112,9 @@ class TestUtil:
             "http://[2010:836b:4179::836b:4179]",
             ("http", "[2010:836b:4179::836b:4179]", None),
         ),
+        # Scoped IPv6 (with ZoneID), both RFC 6874 compliant and not.
+        ("http://[a::b%25zone]", ("http", "[a::b%zone]", None)),
+        ("http://[a::b%zone]", ("http", "[a::b%zone]", None)),
         # Hosts
         ("HTTP://GOOGLE.COM/mail/", ("http", "google.com", None)),
         ("GOogle.COM/mail", ("http", "google.com", None)),
@@ -187,6 +190,10 @@ class TestUtil:
             ),
             ("HTTPS://Example.Com/?Key=Value", "https://example.com/?Key=Value"),
             ("Https://Example.Com/#Fragment", "https://example.com/#Fragment"),
+            # IPv6 addresses with zone IDs. Both RFC 6874 (%25) as well as
+            # non-standard (unquoted %) variants.
+            ("[::1%zone]", "[::1%zone]"),
+            ("[::1%25zone]", "[::1%zone]"),
             ("[::1%25]", "[::1%25]"),
             ("[::Ff%etH0%Ff]/%ab%Af", "[::ff%etH0%FF]/%AB%AF"),
             (

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -856,6 +856,30 @@ class TestUtil:
             # macos: [Errno 8] nodename nor servname provided, or not known
             create_connection(("badhost.invalid", 80))
 
+    @patch("socket.getaddrinfo")
+    @patch("socket.socket")
+    def test_create_connection_with_scoped_ipv6(
+        self, socket: MagicMock, getaddrinfo: MagicMock
+    ) -> None:
+        # Check that providing create_connection with a scoped IPv6 address
+        # properly propagates the scope to getaddrinfo, and that the returned
+        # scoped ID makes it to the socket creation call.
+        fake_scoped_sa6 = ("a::b", 80, 0, 42)
+        getaddrinfo.return_value = [
+            (
+                socket.AF_INET6,
+                socket.SOCK_STREAM,
+                socket.IPPROTO_TCP,
+                "",
+                fake_scoped_sa6,
+            )
+        ]
+        socket.return_value = fake_sock = MagicMock()
+
+        create_connection(("a::b%iface", 80))
+        assert getaddrinfo.call_args[0][0] == "a::b%iface"
+        fake_sock.connect.assert_called_once_with(fake_scoped_sa6)
+
     @pytest.mark.parametrize(
         "input,params,expected",
         (


### PR DESCRIPTION
(A lot) more context in #1641 which ended up motivating this PR. I was thinking of also adding an e2e test checking that opening a connection to 'http://[a::b%iface]' flows properly all the way to create_connection or even socket.socket.connect, but I couldn't find anything similar in the codebase at this point. Instead, the two main parts that could break get tested separately: host extraction for an IPv6 scoped address (as well as normalization), and actually using the zone ID on the "backend" side (GAI/connect).

```
$ pre-commit run --all-files
pyupgrade................................................................Passed
black....................................................................Passed
isort....................................................................Passed
flake8...................................................................Passed

$ pytest test/test_util.py
======================================== test session starts ========================================
platform linux -- Python 3.7.13, pytest-7.0.0, pluggy-1.0.0
rootdir: /home/delroth/work/urllib3/zoneid/urllib3, configfile: setup.cfg
plugins: flaky-3.7.0, timeout-2.1.0, freezegun-0.4.2
collected 330 items

test/test_util.py ........................................................................... [ 22%]
............................................................................................. [ 50%]
.....................................................................s...s................... [ 79%]
.....................................................................                         [100%]

================================== 328 passed, 2 skipped in 0.58s ===================================
```