### PR TITLE
Fix `test_default_ssl_context_ssl_min_max_versions` on Fedora 36

### DIFF
--- a/test/with_dummyserver/test_https.py
+++ b/test/with_dummyserver/test_https.py
@@ -947,7 +947,12 @@ class TestHTTPS(HTTPSDummyServerTestCase):
     def test_default_ssl_context_ssl_min_max_versions(self) -> None:
         ctx = urllib3.util.ssl_.create_urllib3_context()
         assert ctx.minimum_version == ssl.TLSVersion.TLSv1_2
-        assert ctx.maximum_version == ssl.TLSVersion.MAXIMUM_SUPPORTED
+        # urllib3 is not expected to change the maximum version, so the
+        # version should be the same as in a pure context. It will be
+        # either the `ssl.TLSVersion.MAXIMUM_SUPPORTED` magic constant
+        # or one of the exact versions if a system defines it.
+        # https://github.com/urllib3/urllib3/issues/2477#issuecomment-1151452150
+        assert ctx.maximum_version == ssl.SSLContext().maximum_version
 
     def test_ssl_context_ssl_version_uses_ssl_min_max_versions(self) -> None:
         ctx = urllib3.util.ssl_.create_urllib3_context(ssl_version=self.ssl_version())


### PR DESCRIPTION
This fixes an OS-specific error found in https://github.com/urllib3/urllib3/issues/2477#issuecomment-1151381159 and explained in https://github.com/urllib3/urllib3/issues/2477#issuecomment-1151452150.