### PR TITLE
Adds branch switch instruction in docs for 1.26x

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -53,6 +53,7 @@ Alternatively, you can grab the latest source code from `GitHub <https://github.
 
     $ git clone https://github.com/urllib3/urllib3.git
     $ cd urllib3
+    $ git checkout 1.26.x
     $ pip install .
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -87,6 +87,7 @@ Alternatively, you can grab the latest source code from `GitHub <https://github.
 
   $ git clone https://github.com/urllib3/urllib3.git
   $ cd urllib3
+  $ git checkout 1.26.x
   $ pip install .
 
 Usage


### PR DESCRIPTION
* Updates `docs/index.rst` for `1.26x` version to checkout branch 1.26.x
  in the installation step.

Closes https://github.com/urllib3/urllib3/issues/2578

<!---
Thanks for your contribution! ♥️

If this is your first PR to urllib3 please review the Contributing Guide:
https://urllib3.readthedocs.io/en/latest/contributing.html

Adhering to the Contributing Guide means we can review, merge, and release your change faster! :)
--->
