### PR TITLE
Update paid contributor program with early feedback

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -98,15 +98,19 @@ Getting paid for your contributions
 -----------------------------------
 
 urllib3 has a `pool of money hosted on Open Collective <https://opencollective.com/urllib3#category-BUDGET>`_
-which the team uses to pay contributors for their work. **That could be you, too!** If you close an issue
-that is marked with the `"Paid $X00" label <https://github.com/urllib3/urllib3/issues?q=is%3Aopen+is%3Aissue+label%3A%22Paid%3A+%24100+%F0%9F%92%B5%22%2C%22Paid%3A+%24200+%F0%9F%92%B5%22%2C%22Paid%3A+%24300+%F0%9F%92%B5%22%2C%22Paid%3A+%24400+%F0%9F%92%B5%22%2C%22Paid%3A+%24500+%F0%9F%92%B5%22>`_ then you're eligible to be paid for your work.
+which the team uses to pay contributors for their work. **That could be you, too!** If you complete all tasks in an issue
+that is marked with the `"💰 Bounty $X00" label <https://github.com/urllib3/urllib3/issues?q=is%3Aopen+is%3Aissue+label%3A%22Paid%3A+%24100+%F0%9F%92%B5%22%2C%22Paid%3A+%24200+%F0%9F%92%B5%22%2C%22Paid%3A+%24300+%F0%9F%92%B5%22%2C%22Paid%3A+%24400+%F0%9F%92%B5%22%2C%22Paid%3A+%24500+%F0%9F%92%B5%22>`_ then you're eligible to be paid for your work.
 
 - Ensure that you're able to `receive funds from Open Collective for working on OSS <https://docs.opencollective.com/help/expenses-and-getting-paid/submitting-expenses>`_.
   Consider your employment contract and taxes for possible restrictions.
+- If an issue is already assigned to someone on GitHub then it's likely they've
+  made substantial progress on the issue and will be given the bounty.
+  If you're interested in bounties you should look for issues which
+  aren't assigned to anyone.
 - **Don't "claim" issues or ask whether someone is already working on an issue.**
   Instead, focus on creating a pull request which solves the issue. Once you
-  create a pull request we can assign your account to the issue to
-  ensure others don't start working on it in parallel.
+  have made considerable progress on the tasks in an issue we can assign your
+  account to the issue to ensure others don't start working on it in parallel.
 - The amount you will be paid for the completing an issue is shown in the label (either $100, $200, $300, etc).
 - If you have questions about how to create an invoice on Open Collective
   `try reading their FAQ <https://docs.opencollective.com/help/expenses-and-getting-paid/expenses>`_.
@@ -114,8 +118,11 @@ that is marked with the `"Paid $X00" label <https://github.com/urllib3/urllib3/i
   with your proposal and our team will discuss whether we'd pay for your work on your proposal.
 - If you have other questions get in contact with a maintainer in the `urllib3 Discord channel <https://discord.gg/urllib3>`_ or via email.
 - The list above isn't an exhaustive list of criteria or rules for how/when money is distributed.
-  The final say on whether money will be distributed is up to maintainers.
+  **The final say on whether money will be distributed is up to maintainers.**
 
+This program is an experiment so if you have positive or negative feedback on the process you can contact the maintainers through one of the above channels. 
+
+Note that this program isn't a "bug bounty" program, we don't distribute funds to reporters of bugs or security vulnerabilities at this time.
 
 Running local proxies
 ---------------------

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -99,7 +99,7 @@ Getting paid for your contributions
 
 urllib3 has a `pool of money hosted on Open Collective <https://opencollective.com/urllib3#category-BUDGET>`_
 which the team uses to pay contributors for their work. **That could be you, too!** If you complete all tasks in an issue
-that is marked with the `"💰 Bounty $X00" label <https://github.com/urllib3/urllib3/issues?q=is%3Aopen+is%3Aissue+label%3A%22Paid%3A+%24100+%F0%9F%92%B5%22%2C%22Paid%3A+%24200+%F0%9F%92%B5%22%2C%22Paid%3A+%24300+%F0%9F%92%B5%22%2C%22Paid%3A+%24400+%F0%9F%92%B5%22%2C%22Paid%3A+%24500+%F0%9F%92%B5%22>`_ then you're eligible to be paid for your work.
+that is marked with the `"💰 Bounty $X00" label <https://github.com/urllib3/urllib3/issues?q=is%3Aopen+is%3Aissue+label%3A%22%F0%9F%92%B0+Bounty+%24100%22%2C%22%F0%9F%92%B0+Bounty+%24200%22%2C%22%F0%9F%92%B0+Bounty+%24300%22%2C%22%F0%9F%92%B0+Bounty+%24400%22%2C%22%F0%9F%92%B0+Bounty+%24500%22+no%3Aassignee>`_ then you're eligible to be paid for your work.
 
 - Ensure that you're able to `receive funds from Open Collective for working on OSS <https://docs.opencollective.com/help/expenses-and-getting-paid/submitting-expenses>`_.
   Consider your employment contract and taxes for possible restrictions.
@@ -108,9 +108,12 @@ that is marked with the `"💰 Bounty $X00" label <https://github.com/urllib3/ur
   If you're interested in bounties you should look for issues which
   aren't assigned to anyone.
 - **Don't "claim" issues or ask whether someone is already working on an issue.**
-  Instead, focus on creating a pull request which solves the issue. Once you
+  Instead, focus on researching and working on the tasks in the issue. Once you
   have made considerable progress on the tasks in an issue we can assign your
   account to the issue to ensure others don't start working on it in parallel.
+- If you've been assigned to an issue and haven't made progress or given an update
+  in over a week you will be unassigned from the issue to allow others a chance
+  at solving the issue.
 - The amount you will be paid for the completing an issue is shown in the label (either $100, $200, $300, etc).
 - If you have questions about how to create an invoice on Open Collective
   `try reading their FAQ <https://docs.opencollective.com/help/expenses-and-getting-paid/expenses>`_.


### PR DESCRIPTION
Received a handful of feedback and potential improvements to the program:

- The `Paid X` labels make the issues look like they've already been paid, not that they have a bounty on them. Changes the labels to `Bounty X`
- Update the URL to by default only show issues without an assignee and use the new labels.
- Clarifies that this program isn't a "bug bounty program" for paying reporters of bugs/security vulns
- Steer people away from issues which already have an assigned user
- Give a time frame for when we'd unassign someone if they haven't made any progress on a task and can't be contacted.
- Changes the language to "makes substantial progress" instead of "open a PR" to include any amount of substantial work determined by maintainers.
- Ask for feedback on the experiment