### PR TITLE
Use proxy_ssl_context as SSL ctx when forwarding

### DIFF
--- a/changelog/2577.bugfix.rst
+++ b/changelog/2577.bugfix.rst
@@ -2,5 +2,5 @@ The ``proxy_ssl_context`` argument for ``urllib3.ProxyManager`` will be used
 for the connection to the proxy when the connection is forwarded, either because
 ``use_forwarding_for_https`` is set to ``True`` or because the target is a HTTP destination.
 Previously, ``proxy_ssl_context`` was not used in these situations. If ``ssl_context``
-is passed as a keyword argument, it will be used if ``proxy_ssl_context`` is not set,
-but this use is deprecated.
+was passed as a keyword argument, it had been used if ``proxy_ssl_context`` were not set,
+but setting ``ssl_context`` will now raise an error.

--- a/changelog/2577.bugfix.rst
+++ b/changelog/2577.bugfix.rst
@@ -1,0 +1,6 @@
+The ``proxy_ssl_context`` argument for ``urllib3.ProxyManager`` will be used
+for the connection to the proxy when the connection is forwarded, either because
+``use_forwarding_for_https`` is set to ``True`` or because the target is a HTTP destination.
+Previously, ``proxy_ssl_context`` was not used in these situations. If ``ssl_context``
+is passed as a keyword argument, it will be used if ``proxy_ssl_context`` is not set,
+but this use is deprecated.

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -424,26 +424,16 @@ class HTTPSConnection(HTTPConnection):
 
         if proxy_config and proxy_config.use_forwarding_for_https:
             if proxy_config.ssl_context is not None and ssl_context is not None:
-                warnings.warn(
-                    "The 'ssl_context' parameter is not used to configure the connection to the proxy when the 'use_forwarding_for_https' parameter is set to True "
-                    "and should not be set. The 'proxy_ssl_context' parameter is used to configure the connection. "
-                    "In a later urllib3 v2.x release, setting ssl_context will result in an error",
-                    DeprecationWarning,
-                    stacklevel=2,
+                raise ValueError(
+                    "The 'ssl_context' parameter cannot be set when use_forwarding_for_https is True"
                 )
             elif proxy_config.ssl_context is None and ssl_context is not None:
-                warnings.warn(
-                    "The 'ssl_context' parameter should not be used to configure the connection to the proxy when the 'use_forwarding_for_https' parameter is set to True, "
-                    "Use the 'proxy_ssl_context' parameter to customize the connection. "
-                    "In a later urllib3 v2.x release, setting ssl_context will result in an error",
-                    DeprecationWarning,
-                    stacklevel=2,
+                raise ValueError(
+                    "The 'ssl_context' parameter cannot be set when use_forwarding_for_https is True. Use the 'proxy_ssl_context' parameter to customize the connection to the proxy"
                 )
-                self.proxy_config = ProxyConfig(
-                    ssl_context, proxy_config.use_forwarding_for_https
-                )
+            else:
 
-            self.ssl_context = proxy_config.ssl_context
+                self.ssl_context = proxy_config.ssl_context
         else:
             self.ssl_context = ssl_context
 

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -421,7 +421,32 @@ class HTTPSConnection(HTTPConnection):
         self.key_file = key_file
         self.cert_file = cert_file
         self.key_password = key_password
-        self.ssl_context = ssl_context
+
+        if proxy_config and proxy_config.use_forwarding_for_https:
+            if proxy_config.ssl_context is not None and ssl_context is not None:
+                warnings.warn(
+                    "The 'ssl_context' parameter is not used to configure the connection to the proxy when the 'use_forwarding_for_https' parameter is set to True "
+                    "and should not be set. The 'proxy_ssl_context' parameter is used to configure the connection. "
+                    "In a later urllib3 v2.x release, setting ssl_context will result in an error",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+            elif proxy_config.ssl_context is None and ssl_context is not None:
+                warnings.warn(
+                    "The 'ssl_context' parameter should not be used to configure the connection to the proxy when the 'use_forwarding_for_https' parameter is set to True, "
+                    "Use the 'proxy_ssl_context' parameter to customize the connection. "
+                    "In a later urllib3 v2.x release, setting ssl_context will result in an error",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+                self.proxy_config = ProxyConfig(
+                    ssl_context, proxy_config.use_forwarding_for_https
+                )
+
+            self.ssl_context = proxy_config.ssl_context
+        else:
+            self.ssl_context = ssl_context
+
         self.server_hostname = server_hostname
         self.ssl_version = None
         self.ssl_minimum_version = None
@@ -500,6 +525,11 @@ class HTTPSConnection(HTTPConnection):
                 SystemTimeWarning,
             )
 
+        if self._connecting_to_proxy and self.proxy_config:
+            ssl_context = self.proxy_config.ssl_context
+        else:
+            ssl_context = self.ssl_context
+
         sock_and_verified = _ssl_wrap_socket_and_match_hostname(
             sock=sock,
             cert_reqs=self.cert_reqs,
@@ -513,7 +543,7 @@ class HTTPSConnection(HTTPConnection):
             key_file=self.key_file,
             key_password=self.key_password,
             server_hostname=server_hostname,
-            ssl_context=self.ssl_context,
+            ssl_context=ssl_context,
             tls_in_tls=tls_in_tls,
             assert_hostname=self.assert_hostname,
             assert_fingerprint=self.assert_fingerprint,

--- a/test/with_dummyserver/test_proxy_poolmanager.py
+++ b/test/with_dummyserver/test_proxy_poolmanager.py
@@ -426,7 +426,9 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
             use_forwarding_for_https=True,
             ssl_context=ctx,
         ) as proxy:
-            with pytest.warns(DeprecationWarning):
+            with pytest.raises(
+                ValueError, match="The 'ssl_context' parameter cannot be set"
+            ):
                 proxy.request("GET", self.https_url)
 
     def test_forwarding_for_https_error_with_only_ssl_ctx(self) -> None:
@@ -435,7 +437,9 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
         with proxy_from_url(
             self.https_proxy_url, use_forwarding_for_https=True, ssl_context=ctx
         ) as proxy:
-            with pytest.warns(DeprecationWarning):
+            with pytest.raises(
+                ValueError, match="The 'ssl_context' parameter cannot be set"
+            ):
                 proxy.request("GET", self.https_url)
 
     def test_headerdict(self) -> None:


### PR DESCRIPTION
Fixes #2577 by setting ssl_context to be the provided proxy_ssl_context when ```use_forwarding_for_https``` is set to True.

I enabled the failing test, but because the test doesn't really make sense (I think) for when a forwarding proxy is used, I removed that case from the test. However, I added additional tests to cover the different cases of valid ```proxy_ssl_context``` and ```ssl_context``` being either provided or not provided (with the existing ```test_https_proxy_tls_error``` test covering the case when a valid ```proxy_ssl_context``` is not provided).

The issue described that providing ```ssl_context``` should only be a DeprecationWarning for version 1.26.x. Should that change be done as a separate PR against that branch?