### PR TITLE
Allow for requests to send repeat headers through HTTPHeaderDict

### DIFF
--- a/test/test_collections.py
+++ b/test/test_collections.py
@@ -251,6 +251,33 @@ class TestHTTPHeaderDict(object):
         assert d["e"] == "foofoo"
         assert len(d) == 2
 
+    def test_header_repeats(self, d):
+        d["other-header"] = "hello"
+        d.add("other-header", "world")
+        # our default behavior: iteration just duplicates headers
+        assert list(d.items()) == [
+            ("Cookie", "foo"),
+            ("Cookie", "bar"),
+            ("other-header", "hello"),
+            ("other-header", "world"),
+        ]
+
+        d.respect_duplicates_in_items = True
+        # header-respecting iter will merge items by default
+        assert list(d.items()) == [
+            ("Cookie", "foo, bar"),
+            ("other-header", "hello, world"),
+        ]
+
+        d.add("other-header", "!", combine=False)
+
+        assert list(d.items()) == [
+            ("Cookie", "foo, bar"),
+            ("other-header", "hello"),
+            ("other-header", "world"),
+            ("other-header", "!"),
+        ]
+
     @pytest.mark.parametrize("args", [(1, 2), (1, 2, 3, 4, 5)])
     def test_extend_with_wrong_number_of_args_is_typeerror(self, d, args):
         with pytest.raises(TypeError) as err:

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -1668,7 +1668,7 @@ class TestHeaders(SocketDummyServerTestCase):
             sock.send(b"HTTP/1.1 200 OK\r\n\r\n")
             sock.close()
 
-        headers = urllib3.HTTPHeaderDict()
+        headers = HTTPHeaderDict()
         headers.add("A", "1")
         headers.add("B", "2")
         headers.add("C", "3")

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -1656,10 +1656,10 @@ class TestHeaders(SocketDummyServerTestCase):
             ]
             assert expected_response_headers == actual_response_headers
 
-    def test_headers_sent_with_add(self) -> None:
+    def test_headers_sent_with_add(self):
         buf = b""
 
-        def socket_handler(listener: socket.socket) -> None:
+        def socket_handler(listener):
             sock = listener.accept()[0]
 
             while not buf.endswith(b"\r\n\r\n"):

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -1657,16 +1657,18 @@ class TestHeaders(SocketDummyServerTestCase):
             assert expected_response_headers == actual_response_headers
 
     def test_headers_sent_with_add(self):
-        buf = b""
+        data_sent = []
 
         def socket_handler(listener):
             sock = listener.accept()[0]
 
+            buf = b""
             while not buf.endswith(b"\r\n\r\n"):
                 buf += sock.recv(65536)
 
             sock.send(b"HTTP/1.1 200 OK\r\n\r\n")
             sock.close()
+            data_sent.append(buf)
 
         headers = HTTPHeaderDict()
         headers.add("A", "1")
@@ -1681,7 +1683,7 @@ class TestHeaders(SocketDummyServerTestCase):
             r = pool.request("GET", "/", retries=0, headers=headers)
             assert r.status == 200
 
-        assert b"\r\nA: 1, 4\r\nB: 2\r\nC: 3, 5\r\n" in buf
+        assert b"\r\nA: 1, 4\r\nB: 2\r\nC: 3, 5\r\n" in data_sent[0]
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
This is an attempt to resolve #2242, and builds off of #2572

 This adds a `combine` parameter to `HTTPHeaderDict.add`, which 
 lets you say whether multiple values should be combined (via `,`), or 
 whether we should instead duplicate the header.

 This doesn't allow for both to happen on the same header, and will
 only work if a "behaviour change bit" is set on the header.

 The relevant change is in how `items` works.
 ```
        >>> headers = HTTPHeaderDict(foo='bar', password='hunter')
        >>> headers.respect_duplicates_in_items = True
        >>> headers.add('Foo', 'baz', combine=False)
        >>> headers.add('PASSWORD', '2', combine=True)
        >>> list(headers.items())
        [('foo', 'bar'), ('foo', 'baz'), ('password', 'hunter, 2')]
 ```

 This tries to maintain backwards compatibility by adding an opt-in
 parameter which "fixes" the HTTPHeaderDict to offer iteration that
 matches what http.client expects.

 While working on this, it became a bit unclear whether, when passing
 headers into requests, we should treat the dictionaries as mutable or
 not. I tried to go for "assume immutable" and opting for correctness
 over performance when trying to manage this.

 If we are OK totally breaking backwards compatibility on this class
 then a cleaner way of handling this would be to change how the items
 method works to respect these options. That would definitely lead to
 cleaner code.

 Another option: leave this dictionary, add another implementation with
 the incompatibilities but in a public namespace, and tell people to
 use that one instead when having issues.