### PR TITLE
Close #2654, fix type hint of geturl

### DIFF
--- a/src/urllib3/response.py
+++ b/src/urllib3/response.py
@@ -411,7 +411,7 @@ class BaseHTTPResponse(io.IOBase):
     def info(self) -> HTTPHeaderDict:
         return self.headers
 
-    def geturl(self) -> Optional[Union[str, "Literal[False]"]]:
+    def geturl(self) -> Optional[str]:
         return self.url
 
 


### PR DESCRIPTION
<!---
Thanks for your contribution! ♥️

If this is your first PR to urllib3 please review the Contributing Guide:
https://urllib3.readthedocs.io/en/latest/contributing.html

Adhering to the Contributing Guide means we can review, merge, and release your change faster! :)
--->
`geturl` simply returns `self.url`, and `self.url` is a property with type hint `def url(self) -> Optional[str]:`, I think we can simply write `Optional[str]` here.
