### PR TITLE
Fix #2589, don't retry if the ssl module is missing

### DIFF
--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -1020,7 +1020,7 @@ class HTTPSConnectionPool(HTTPConnectionPool):
         )
 
         if not self.ConnectionCls or self.ConnectionCls is DummyConnection:  # type: ignore[comparison-overlap]
-            raise SSLError(
+            raise ImportError(
                 "Can't connect to HTTPS URL because the SSL module is not available."
             )
 

--- a/test/with_dummyserver/test_https.py
+++ b/test/with_dummyserver/test_https.py
@@ -376,11 +376,10 @@ class TestHTTPS(HTTPSDummyServerTestCase):
     def test_no_ssl(self) -> None:
         with HTTPSConnectionPool(self.host, self.port) as pool:
             pool.ConnectionCls = None  # type: ignore[assignment]
-            with pytest.raises(SSLError):
+            with pytest.raises(ImportError):
                 pool._new_conn()
-            with pytest.raises(MaxRetryError) as cm:
+            with pytest.raises(ImportError):
                 pool.request("GET", "/", retries=0)
-            assert isinstance(cm.value.reason, SSLError)
 
     def test_unverified_ssl(self) -> None:
         """Test that bare HTTPSConnection can connect, make requests"""


### PR DESCRIPTION
<!---
Thanks for your contribution! ♥️

If this is your first PR to urllib3 please review the Contributing Guide:
https://urllib3.readthedocs.io/en/latest/contributing.html

Adhering to the Contributing Guide means we can review, merge, and release your change faster! :)
--->
A subclass of `SSLError` is created for this kind of error so that we can easily identify it when handling exceptions.

Closes #2589 
