### PR TITLE
Fix `OverflowError` when SSL is used on some Python versions

### DIFF
--- a/changelog/2513.bugfix.rst
+++ b/changelog/2513.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed reading 2 or more GiB of data at a time using ``urllib3.response.HTTPResponse.read``.

--- a/src/urllib3/contrib/securetransport.py
+++ b/src/urllib3/contrib/securetransport.py
@@ -570,49 +570,40 @@ class WrappedSocket:
         if nbytes is None:
             nbytes = len(buffer)
 
+        buffer = (ctypes.c_char * nbytes).from_buffer(buffer)
         processed_bytes = ctypes.c_size_t(0)
-        processed_bytes_total = 0
 
-        while nbytes:
-            buffer = (ctypes.c_char * nbytes).from_buffer(buffer, processed_bytes.value)
+        with self._raise_on_error():
+            result = Security.SSLRead(
+                self.context, buffer, nbytes, ctypes.byref(processed_bytes)
+            )
 
-            with self._raise_on_error():
-                result = Security.SSLRead(
-                    self.context, buffer, nbytes, ctypes.byref(processed_bytes)
-                )
-
-            nbytes -= processed_bytes.value
-            processed_bytes_total += processed_bytes.value
-
-            # There are some result codes that we want to treat as "not always
-            # errors". Specifically, those are errSSLWouldBlock,
-            # errSSLClosedGraceful, and errSSLClosedNoNotify.
-            if result == SecurityConst.errSSLWouldBlock:
-                # If we didn't process any bytes, then this was just a time out.
-                # However, we can get errSSLWouldBlock in situations when we *did*
-                # read some data, and in those cases we should just read "short"
-                # and return.
-                if processed_bytes.value == 0:
-                    # Timed out, no data read.
-                    raise socket.timeout("recv timed out")
-            elif result in (
-                SecurityConst.errSSLClosedGraceful,
-                SecurityConst.errSSLClosedNoNotify,
-            ):
-                # The remote peer has closed this connection. We should do so as
-                # well. Note that we don't actually return here because in
-                # principle this could actually be fired along with return data.
-                # It's unlikely though.
-                self.close()
-                break
-            else:
-                _assert_no_error(result)
-                if processed_bytes.value == 0:
-                    break
+        # There are some result codes that we want to treat as "not always
+        # errors". Specifically, those are errSSLWouldBlock,
+        # errSSLClosedGraceful, and errSSLClosedNoNotify.
+        if result == SecurityConst.errSSLWouldBlock:
+            # If we didn't process any bytes, then this was just a time out.
+            # However, we can get errSSLWouldBlock in situations when we *did*
+            # read some data, and in those cases we should just read "short"
+            # and return.
+            if processed_bytes.value == 0:
+                # Timed out, no data read.
+                raise socket.timeout("recv timed out")
+        elif result in (
+            SecurityConst.errSSLClosedGraceful,
+            SecurityConst.errSSLClosedNoNotify,
+        ):
+            # The remote peer has closed this connection. We should do so as
+            # well. Note that we don't actually return here because in
+            # principle this could actually be fired along with return data.
+            # It's unlikely though.
+            self.close()
+        else:
+            _assert_no_error(result)
 
         # Ok, we read and probably succeeded. We should return whatever data
         # was actually read.
-        return processed_bytes_total
+        return processed_bytes.value
 
     def settimeout(self, timeout: float) -> None:
         self._timeout = timeout

--- a/src/urllib3/response.py
+++ b/src/urllib3/response.py
@@ -685,16 +685,12 @@ class HTTPResponse(BaseHTTPResponse):
         c_int_max = 2**31 - 1
         if (
             (
-                amt
-                and amt > c_int_max
-                and (util.IS_PYOPENSSL or sys.version_info < (3, 10))
+                (amt and amt > c_int_max)
+                or (self.length_remaining and self.length_remaining > c_int_max)
             )
-            or (
-                self.length_remaining
-                and self.length_remaining > c_int_max
-                and (util.IS_PYOPENSSL or (3, 8) <= sys.version_info < (3, 9, 7))
-            )
-        ) and not util.IS_SECURETRANSPORT:
+            and not util.IS_SECURETRANSPORT
+            and (util.IS_PYOPENSSL or sys.version_info < (3, 10))
+        ):
             buffer = io.BytesIO()
             # Besides `max_chunk_amt` being a maximum chunk size, it
             # affects memory overhead of reading a response by this

--- a/src/urllib3/response.py
+++ b/src/urllib3/response.py
@@ -703,17 +703,14 @@ class HTTPResponse(BaseHTTPResponse):
         fp_closed = getattr(self._fp, "closed", False)
 
         # Reading more than 2 GiB (`int` max value in C) via SSL on some
-        # CPython 3.8, 3.9, and 3.10 versions leads to an overflow error
+        # CPython 3.8 and 3.9 versions leads to an overflow error
         # that has to be prevented if `amt` or `self.length_remaining`
         # indicate that it may happen.
         c_int_max = (2**31) - 1
         if (
             (amt and amt > c_int_max)
             or (self.length_remaining and self.length_remaining > c_int_max)
-        ) and (
-            (3, 8, 0, "a", 4) <= sys.version_info < (3, 9, 7)
-            or (3, 10, 0, "b", 1) <= sys.version_info < (3, 10, 0, "rc", 1)
-        ):
+        ) and (3, 8) <= sys.version_info < (3, 9, 7):
 
             def read(amt: Optional[int] = None) -> bytes:
                 if self._fp is None:

--- a/src/urllib3/response.py
+++ b/src/urllib3/response.py
@@ -733,7 +733,7 @@ class HTTPResponse(BaseHTTPResponse):
 
         with self._error_catcher():
             if amt is None:
-                # cStringIO doesn't like amt=None
+                # StringIO doesn't like amt=None
                 data = read() if not fp_closed else b""
                 flush_decoder = True
             else:

--- a/src/urllib3/response.py
+++ b/src/urllib3/response.py
@@ -695,7 +695,8 @@ class HTTPResponse(BaseHTTPResponse):
                 buffer.write(data)
             return buffer.getvalue()
         else:
-            return self._fp.read(amt)
+            # StringIO doesn't like amt=None
+            return self._fp.read(amt) if amt is not None else self._fp.read()
 
     def read(
         self,
@@ -734,13 +735,11 @@ class HTTPResponse(BaseHTTPResponse):
         fp_closed = getattr(self._fp, "closed", False)
 
         with self._error_catcher():
+            data = self._fp_read(amt) if not fp_closed else b""
             if amt is None:
-                # StringIO doesn't like amt=None
-                data = self._fp_read() if not fp_closed else b""
                 flush_decoder = True
             else:
                 cache_content = False
-                data = self._fp_read(amt) if not fp_closed else b""
                 if (
                     amt != 0 and not data
                 ):  # Platform-specific: Buggy versions of Python.

--- a/src/urllib3/response.py
+++ b/src/urllib3/response.py
@@ -673,8 +673,7 @@ class HTTPResponse(BaseHTTPResponse):
         3.9 versions leads to an overflow error that has to be prevented
         if `amt` or `self.length_remaining` indicate that it may happen.
         """
-        if self._fp is None:
-            return b""
+        assert self._fp
         c_int_max = (2**31) - 1
         expected_length = amt or self.length_remaining
         if (

--- a/src/urllib3/response.py
+++ b/src/urllib3/response.py
@@ -700,7 +700,9 @@ class HTTPResponse(BaseHTTPResponse):
                 and (util.IS_PYOPENSSL or (3, 8) <= sys.version_info < (3, 9, 7))
             )
         ):
-            chunk_max_amt = securetransport_max_amt if util.IS_SECURETRANSPORT else c_int_max
+            chunk_max_amt = (
+                securetransport_max_amt if util.IS_SECURETRANSPORT else c_int_max
+            )
             buffer = io.BytesIO()
             while amt is None or amt != 0:
                 if amt is not None:

--- a/src/urllib3/response.py
+++ b/src/urllib3/response.py
@@ -679,6 +679,8 @@ class HTTPResponse(BaseHTTPResponse):
           * 3.8 <= CPython < 3.9.7 because of a bug
             https://github.com/urllib3/urllib3/issues/2513#issuecomment-1152559900.
           * urllib3 injected with pyOpenSSL-backed SSL-support.
+          * urllib3 injected with SecureTransport-backed SSL-support
+            only when `amt` does not fit 32-bit int.
           * CPython < 3.10 only when `amt` does not fit 32-bit int.
         """
         assert self._fp
@@ -686,7 +688,11 @@ class HTTPResponse(BaseHTTPResponse):
         if (
             amt
             and amt > c_int_max
-            and (util.IS_PYOPENSSL or sys.version_info < (3, 10))
+            and (
+                util.IS_PYOPENSSL
+                or util.IS_SECURETRANSPORT
+                or sys.version_info < (3, 10)
+            )
         ) or (
             self.length_remaining
             and self.length_remaining > c_int_max

--- a/src/urllib3/response.py
+++ b/src/urllib3/response.py
@@ -675,7 +675,7 @@ class HTTPResponse(BaseHTTPResponse):
             def read(amt: Optional[int] = None) -> bytes:
                 if self._fp is None:
                     return b""
-                chunks = []
+                buffer = io.BytesIO()
                 while amt is None or amt != 0:
                     if amt is not None:
                         chunk_amt = min(amt, c_int_max)
@@ -685,8 +685,8 @@ class HTTPResponse(BaseHTTPResponse):
                     data = self._fp.read(chunk_amt)
                     if not data:
                         break
-                    chunks.append(data)
-                return b"".join(chunks)
+                    buffer.write(data)
+                return buffer.getvalue()
 
         else:
             read = self._fp.read

--- a/src/urllib3/response.py
+++ b/src/urllib3/response.py
@@ -679,37 +679,32 @@ class HTTPResponse(BaseHTTPResponse):
           * 3.8 <= CPython < 3.9.7 because of a bug
             https://github.com/urllib3/urllib3/issues/2513#issuecomment-1152559900.
           * urllib3 injected with pyOpenSSL-backed SSL-support.
+          * urllib3 injected with SecureTransport-backed SSL-support
+            only when `amt` does not fit 32-bit int.
           * CPython < 3.10 only when `amt` does not fit 32-bit int.
-
-        Also, take into account that SecureTransport reads at most 16 KiB
-        when `amt` is specified.
         """
         assert self._fp
-        securetransport_max_amt = 16384
         c_int_max = 2**31 - 1
         if (
-            (util.IS_SECURETRANSPORT and amt and amt > securetransport_max_amt)
-            or (
-                amt
-                and amt > c_int_max
-                and (util.IS_PYOPENSSL or sys.version_info < (3, 10))
+            amt
+            and amt > c_int_max
+            and (
+                util.IS_PYOPENSSL
+                or util.IS_SECURETRANSPORT
+                or sys.version_info < (3, 10)
             )
-            or (
-                self.length_remaining
-                and self.length_remaining > c_int_max
-                and (util.IS_PYOPENSSL or (3, 8) <= sys.version_info < (3, 9, 7))
-            )
+        ) or (
+            self.length_remaining
+            and self.length_remaining > c_int_max
+            and (util.IS_PYOPENSSL or (3, 8) <= sys.version_info < (3, 9, 7))
         ):
-            chunk_max_amt = (
-                securetransport_max_amt if util.IS_SECURETRANSPORT else c_int_max
-            )
             buffer = io.BytesIO()
             while amt is None or amt != 0:
                 if amt is not None:
-                    chunk_amt = min(amt, chunk_max_amt)
+                    chunk_amt = min(amt, c_int_max)
                     amt -= chunk_amt
                 else:
-                    chunk_amt = chunk_max_amt
+                    chunk_amt = c_int_max
                 data = self._fp.read(chunk_amt)
                 if not data:
                     break

--- a/src/urllib3/response.py
+++ b/src/urllib3/response.py
@@ -693,6 +693,7 @@ class HTTPResponse(BaseHTTPResponse):
                 if not data:
                     break
                 buffer.write(data)
+                del data  # to reduce memory consumption.
             return buffer.getvalue()
         else:
             # StringIO doesn't like amt=None

--- a/src/urllib3/response.py
+++ b/src/urllib3/response.py
@@ -682,7 +682,7 @@ class HTTPResponse(BaseHTTPResponse):
           * CPython < 3.10 only when `amt` does not fit 32-bit int.
         """
         assert self._fp
-        c_int_max = (2**31) - 1
+        c_int_max = 2**31 - 1
         if (
             amt
             and amt > c_int_max

--- a/src/urllib3/response.py
+++ b/src/urllib3/response.py
@@ -679,25 +679,22 @@ class HTTPResponse(BaseHTTPResponse):
           * 3.8 <= CPython < 3.9.7 because of a bug
             https://github.com/urllib3/urllib3/issues/2513#issuecomment-1152559900.
           * urllib3 injected with pyOpenSSL-backed SSL-support.
-          * urllib3 injected with SecureTransport-backed SSL-support
-            only when `amt` does not fit 32-bit int.
           * CPython < 3.10 only when `amt` does not fit 32-bit int.
         """
         assert self._fp
         c_int_max = 2**31 - 1
         if (
-            amt
-            and amt > c_int_max
-            and (
-                util.IS_PYOPENSSL
-                or util.IS_SECURETRANSPORT
-                or sys.version_info < (3, 10)
+            (
+                amt
+                and amt > c_int_max
+                and (util.IS_PYOPENSSL or sys.version_info < (3, 10))
             )
-        ) or (
-            self.length_remaining
-            and self.length_remaining > c_int_max
-            and (util.IS_PYOPENSSL or (3, 8) <= sys.version_info < (3, 9, 7))
-        ):
+            or (
+                self.length_remaining
+                and self.length_remaining > c_int_max
+                and (util.IS_PYOPENSSL or (3, 8) <= sys.version_info < (3, 9, 7))
+            )
+        ) and not util.IS_SECURETRANSPORT:
             buffer = io.BytesIO()
             # Besides `max_chunk_amt` being a maximum chunk size, it
             # affects memory overhead of reading a response by this

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -1526,7 +1526,7 @@ class TestSSL(SocketDummyServerTestCase):
             # Send the body in chunks to reduce memory consumption.
             chunks = 64
             for i in range(chunks):
-                ssl_sock.send(bytes(content_length // chunks))
+                ssl_sock.sendall(bytes(content_length // chunks))
 
             ssl_sock.close()
             sock.close()

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -8,6 +8,7 @@ import select
 import shutil
 import socket
 import ssl
+import sys
 import tempfile
 import time
 from collections import OrderedDict
@@ -1491,6 +1492,10 @@ class TestSSL(SocketDummyServerTestCase):
                 pool.request("GET", "/", retries=False, timeout=LONG_TIMEOUT)
         assert server_closed.wait(LONG_TIMEOUT), "The socket was not terminated"
 
+    @pytest.mark.skipif(
+        os.environ.get("CI") == "true" and sys.implementation.name == "pypy",
+        reason="too slow to run in CI",
+    )
     @pytest.mark.parametrize(
         "preload_content,read_amt", [(True, None), (False, None), (False, 2**31)]
     )

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -1531,8 +1531,7 @@ class TestSSL(SocketDummyServerTestCase):
                 b"Content-Length: %d\r\n\r\n" % content_length
             )
 
-            # Send the body in chunks to reduce memory consumption.
-            chunks = 64
+            chunks = 2
             for i in range(chunks):
                 ssl_sock.sendall(bytes(content_length // chunks))
 
@@ -1540,7 +1539,9 @@ class TestSSL(SocketDummyServerTestCase):
             sock.close()
 
         self._start_server(socket_handler)
-        with HTTPSConnectionPool(self.host, self.port, ca_certs=DEFAULT_CA) as pool:
+        with HTTPSConnectionPool(
+            self.host, self.port, ca_certs=DEFAULT_CA, retries=False
+        ) as pool:
             response = pool.request("GET", "/", preload_content=preload_content)
             data = response.data if preload_content else response.read(read_amt)
             assert len(data) == content_length

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -1492,6 +1492,9 @@ class TestSSL(SocketDummyServerTestCase):
                 pool.request("GET", "/", retries=False, timeout=LONG_TIMEOUT)
         assert server_closed.wait(LONG_TIMEOUT), "The socket was not terminated"
 
+    # SecureTransport can read only small pieces of data at the moment.
+    # https://github.com/urllib3/urllib3/pull/2674
+    @notSecureTransport()
     @pytest.mark.skipif(
         os.environ.get("CI") == "true" and sys.implementation.name == "pypy",
         reason="too slow to run in CI",

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -1507,9 +1507,6 @@ class TestSSL(SocketDummyServerTestCase):
         socket.
         https://github.com/urllib3/urllib3/issues/2513
         """
-        if util.IS_SECURETRANSPORT and read_amt:
-            pytest.xfail("https://github.com/urllib3/urllib3/pull/2674")
-
         content_length = 2**31  # (`int` max value in C) + 1.
 
         def socket_handler(listener: socket.socket) -> None:

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -1494,7 +1494,7 @@ class TestSSL(SocketDummyServerTestCase):
     @pytest.mark.parametrize(
         "preload_content,read_amt", [(True, None), (False, None), (False, 2**31)]
     )
-    def test_ssl_no_overflow_error(
+    def test_requesting_large_resources_via_ssl(
         self, preload_content: bool, read_amt: Optional[int]
     ) -> None:
         """

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -1507,6 +1507,9 @@ class TestSSL(SocketDummyServerTestCase):
         socket.
         https://github.com/urllib3/urllib3/issues/2513
         """
+        if util.IS_SECURETRANSPORT and read_amt:
+            pytest.xfail("https://github.com/urllib3/urllib3/pull/2674")
+
         content_length = 2**31  # (`int` max value in C) + 1.
 
         def socket_handler(listener: socket.socket) -> None:


### PR DESCRIPTION
Fixes #2513.