### PR TITLE
Advance-usage.rst: Adds missing import for codecs section

### DIFF
--- a/docs/advanced-usage.rst
+++ b/docs/advanced-usage.rst
@@ -99,13 +99,16 @@ You can use this file-like object to do things like decode the content using
 :mod:`codecs`::
 
     >>> import codecs
+    >>> import json
+    >>> import urllib3
     >>> reader = codecs.getreader('utf-8')
+    >>> http = urllib3.PoolManager()
     >>> r = http.request(
     ...     'GET',
     ...     'http://httpbin.org/ip',
     ...     preload_content=False)
-    >>> json.load(reader(r))
-    {'origin': '127.0.0.1'}
+    >>> print(json.load(reader(r)))
+    # {'origin': '127.0.0.1'}
     >>> r.release_conn()
 
 .. _proxies:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -87,6 +87,7 @@ Alternatively, you can grab the latest source code from `GitHub <https://github.
 
   $ git clone https://github.com/urllib3/urllib3.git
   $ cd urllib3
+  $ git checkout 1.26.x
   $ pip install .
 
 Usage


### PR DESCRIPTION
Advance-usage.rst: Adds missing import for codecs section
* Adds missing import for json, urllib3
* Adds print statement for better formating

<!---
Thanks for your contribution! ♥️

If this is your first PR to urllib3 please review the Contributing Guide:
https://urllib3.readthedocs.io/en/latest/contributing.html

Adhering to the Contributing Guide means we can review, merge, and release your change faster! :)
--->
