### PR TITLE
Make poolmanger threadsafe.

### DIFF
--- a/changelog/1252.bugfix.rst
+++ b/changelog/1252.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed thread-safety issue where accessing a `PoolManager` with many distinct origins
+would cause connection pools to be closed while requests are in progress.

--- a/src/urllib3/poolmanager.py
+++ b/src/urllib3/poolmanager.py
@@ -215,11 +215,8 @@ class PoolManager(RequestMethods):
         super().__init__(headers)
         self.connection_pool_kw = connection_pool_kw
 
-        def dispose_func(p: Any) -> None:
-            p.close()
-
         self.pools: RecentlyUsedContainer[PoolKey, HTTPConnectionPool]
-        self.pools = RecentlyUsedContainer(num_pools, dispose_func=dispose_func)
+        self.pools = RecentlyUsedContainer(num_pools)
 
         # Locally set the pool classes and keys so other PoolManagers can
         # override them.


### PR DESCRIPTION
This pull request is a follow up on 

* https://github.com/urllib3/urllib3/issues/1252#issuecomment-954958872
* https://github.com/urllib3/urllib3/issues/1252#issuecomment-957450016

As mentioned in the comment the fix is to close the pool when all references to it are gone.

I need a bit help with the changelog. Should I create a file called `changelog/1252.bugfix.rst` ?