### PR TITLE
Add missing changelog entries for past PRs

### DIFF
--- a/changelog/1992.feature.rst
+++ b/changelog/1992.feature.rst
@@ -1,0 +1,2 @@
+Added support for Zstandard (RFC 8878) when ``zstandard`` 1.18.0 or later is installed.
+Added the ``zstd`` extra which installs the ``zstandard`` package.

--- a/changelog/2589.feature.rst
+++ b/changelog/2589.feature.rst
@@ -1,0 +1,2 @@
+Changed the error raised when connecting via HTTPS when the ``ssl`` module isn't
+available from ``SSLError`` to ``ImportError``.


### PR DESCRIPTION
These PRs didn't add changelog entries but probably should have: https://github.com/urllib3/urllib3/pull/2656 and https://github.com/urllib3/urllib3/pull/2624. We've solved the issue of forgetting changelog entries by making the decision on changelog entry or not mandatory via GitHub Actions in https://github.com/urllib3/urllib3/pull/2662