### PR TITLE
Create a workflow for publishing to PyPI

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,9 @@
 # Restrict all files related to deploying to
 # require lead maintainer approval.
 
-.github/CODEOWNERS          @sethmlarson @shazow
-src/urllib3/_version.py     @sethmlarson @shazow
-setup.py                    @sethmlarson @shazow
-pyproject.toml              @sethmlarson @shazow
-ci/                         @sethmlarson @shazow
+.github/workflows/          @sethmlarson @pquentin @shazow
+.github/CODEOWNERS          @sethmlarson @pquentin @shazow
+src/urllib3/_version.py     @sethmlarson @pquentin @shazow
+setup.py                    @sethmlarson @pquentin @shazow
+pyproject.toml              @sethmlarson @pquentin @shazow
+ci/                         @sethmlarson @pquentin @shazow

--- a/.github/PULL_REQUEST_TEMPLATE/release.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release.md
@@ -4,32 +4,11 @@
 * [ ]  Tag with X.Y.Z, push tag on urllib3/urllib3 (not on your fork, update `<REMOTE>` accordingly)
   * Notice that the `<VERSION>` shouldn't have a `v` prefix (Use `1.26.6` instead of `v.1.26.6`)
   * ```
-    git tag -a '<VERSION>' -m 'Release: <VERSION>'
+    git tag -s -a '<VERSION>' -m 'Release: <VERSION>'
     git push <REMOTE> --tags
     ```
-* [ ]  Push to PyPI
-  * ```
-    cd /tmp
-    git clone ssh://git@github.com/urllib3/urllib3
-    cd urllib3
-    git checkout <TAG/VERSION>
-    python -m venv
-    source venv/bin/activate
-    python -m pip install -U pip
-    python -m pip install -U twine setuptools wheel build
-
-    # Set 'SOURCE_DATE_EPOCH' for build reproducibility.
-    export SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)
-    echo $SOURCE_DATE_EPOCH
-
-    python -m build
-
-    twine check dist/*
-    # Inspect the output to make sure it looks right
-    # Check versions, should be 1 wheel 1 sdist
-    
-    twine upload dist/*
-    ```
+* [ ]  Execute the `deploy` GitHub workflow.
+       This requires a review from a maintainer.
 * [ ]  Grab sdist and wheel from PyPI to attach to GitHub release
 * [ ]  Announce on:
   
@@ -39,4 +18,4 @@
   * [ ]  OpenCollective
   * [ ]  GitCoin Grants
 * [ ]  Update Tidelift metadata
-* [ ]  If this was a 1.26.x release, add changes to the `main` branch
+* [ ]  If this was a 1.26.x release, add changelog to the `main` branch

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,9 @@
 name: Publish to PyPI
 
 on:
-  tags:
-    - "*"
+  push:
+    tags:
+      - "*"
 
 jobs:
   publish:
@@ -15,6 +16,8 @@ jobs:
       - uses: "actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b"
 
       - uses: "actions/setup-python@d09bd5e6005b175076f227b13d9730d56e9dcfcb"
+        with:
+          python-version: "3.x"
 
       - name: "Install dependencies"
         run: python -m pip install build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,30 @@
+name: Publish to PyPI
+
+on:
+  tags:
+    - "*"
+
+jobs:
+  publish:
+    name: "Publish to PyPI"
+    runs-on: "ubuntu-latest"
+    environment:
+      name: "publish"
+
+    steps:
+      - uses: "actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b"
+
+      - uses: "actions/setup-python@d09bd5e6005b175076f227b13d9730d56e9dcfcb"
+
+      - name: "Install dependencies"
+        run: python -m pip install build
+
+      - name: "Build dists"
+        run: |
+          SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct) \
+          python -m build
+
+      - uses: "pypa/gh-action-pypi-publish@717ba43cfbb0387f6ce311b169a825772f54d295"
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
Security measures in place:
- Added the `.github/workflows` directory to `CODEOWNERS`
- Tags for the `*` pattern are protected to maintain/admin privileges
- The `publish` environment requires a review from @shazow, @pquentin, or I to execute
- The `publish` environment has a `PYPI_TOKEN` configured for only the urllib3 package
- Used commits instead of tags for GitHub actions we're using within the workflow

I've added @pquentin to our `CODEOWNERS` reviewers because there isn't any additional risk as you're already a release manager now with reviewer privileges of the `publish` environment and you can help with the reviewing load to `CODEOWNERS` protected files.