### PR TITLE
Add support for configuring header merging when using HTTPHeaderDict

### DIFF
--- a/changelog/2242.feature.rst
+++ b/changelog/2242.feature.rst
@@ -1,0 +1,6 @@
+Added support for configuring header merging behavior with HTTPHeaderDict
+
+When using a ``HTTPHeaderDict`` to provide headers for a request, by default duplicate
+header values will be repeated. But if ``combine=True`` is passed into a call to
+``HTTPHeaderDict.add``, then the added header value will be merged in with an existing
+value into a comma-separated list (``X-My-Header: foo, bar``).

--- a/src/urllib3/_collections.py
+++ b/src/urllib3/_collections.py
@@ -277,11 +277,7 @@ class HTTPHeaderDict(MutableMapping[str, str]):
         return False
 
     def setdefault(self, key: str, default: str = "") -> str:
-        if key in self:
-            return self[key]
-        else:
-            self[key] = default
-            return default
+        return super().setdefault(key, default)
 
     def __eq__(self, other: object) -> bool:
         maybe_constructable = ensure_can_construct_http_header_dict(other)

--- a/src/urllib3/_request_methods.py
+++ b/src/urllib3/_request_methods.py
@@ -2,6 +2,7 @@ import json as _json
 from typing import Any, Dict, Mapping, Optional, Sequence, Tuple, Union
 from urllib.parse import urlencode
 
+from ._collections import HTTPHeaderDict
 from .connection import _TYPE_BODY
 from .filepost import _TYPE_FIELDS, encode_multipart_formdata
 from .response import BaseHTTPResponse
@@ -188,7 +189,7 @@ class RequestMethods:
         if headers is None:
             headers = self.headers
 
-        extra_kw: Dict[str, Any] = {"headers": {}}
+        extra_kw: Dict[str, Any] = {"headers": HTTPHeaderDict(headers)}
         body: Union[bytes, str]
 
         if fields:
@@ -208,9 +209,8 @@ class RequestMethods:
                 )
 
             extra_kw["body"] = body
-            extra_kw["headers"] = {"Content-Type": content_type}
+            extra_kw["headers"].setdefault("Content-Type", content_type)
 
-        extra_kw["headers"].update(headers)
         extra_kw.update(urlopen_kw)
 
         return self.urlopen(method, url, **extra_kw)

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -73,7 +73,7 @@ port_by_scheme = {"http": 80, "https": 443}
 
 # When it comes time to update this value as a part of regular maintenance
 # (ie test_recent_date is failing) update it to ~6 months before the current date.
-RECENT_DATE = datetime.date(2020, 7, 1)
+RECENT_DATE = datetime.date(2022, 1, 1)
 
 _CONTAINS_CONTROL_CHAR_RE = re.compile(r"[^-!#$%&'*+.^_`|~0-9a-zA-Z]")
 

--- a/test/test_collections.py
+++ b/test/test_collections.py
@@ -155,6 +155,14 @@ class TestHTTPHeaderDict:
         assert len(h) == 4
         assert "ab" in h
 
+    def test_setdefault(self) -> None:
+        h = HTTPHeaderDict(a="1")
+        assert h.setdefault("A", "3") == "1"
+        assert h.setdefault("b", "2") == "2"
+        assert h.setdefault("c") == ""
+        assert h["c"] == ""
+        assert h["b"] == "2"
+
     def test_create_from_dict(self) -> None:
         h = HTTPHeaderDict(dict(ab="1", cd="2", ef="3", gh="4"))
         assert len(h) == 4
@@ -251,6 +259,34 @@ class TestHTTPHeaderDict:
         assert d["cookie"] == "foo, bar, foo"
         assert d["e"] == "foofoo"
         assert len(d) == 2
+
+    def test_header_repeat(self, d: HTTPHeaderDict) -> None:
+        d["other-header"] = "hello"
+        d.add("other-header", "world")
+
+        assert list(d.items()) == [
+            ("Cookie", "foo"),
+            ("Cookie", "bar"),
+            ("other-header", "hello"),
+            ("other-header", "world"),
+        ]
+
+        d.add("other-header", "!", combine=True)
+        expected_results = [
+            ("Cookie", "foo"),
+            ("Cookie", "bar"),
+            ("other-header", "hello"),
+            ("other-header", "world, !"),
+        ]
+
+        assert list(d.items()) == expected_results
+        # make sure the values persist over copys
+        assert list(d.copy().items()) == expected_results
+
+        other_dict = HTTPHeaderDict()
+        # we also need for extensions to properly maintain results
+        other_dict.extend(d)
+        assert list(other_dict.items()) == expected_results
 
     def test_extend_from_headerdict(self, d: HTTPHeaderDict) -> None:
         h = HTTPHeaderDict(Cookie="foo", e="foofoo")


### PR DESCRIPTION
This is a second attempt to resolve #2242, as an alternative to #2652.

 When passing in `combine=True` during calls to `add`, iteration over the `HTTPHeaderDict` will merge duplicate header values into one with a comma.

 This also resolves an issue where GET requests and POST requests using the same `HTTPHeaderDict` would exhibit different header merging behavior. Previously GET requests would repeat header values over multiple lines, while POST requests were instead merging them with a comma. Now both request methods match the same behavior.
