### PR TITLE
Add sigstore on publish for signing releases using GitHub OIDC

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/release.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release.md
@@ -7,9 +7,9 @@
     git tag -s -a '<VERSION>' -m 'Release: <VERSION>'
     git push <REMOTE> --tags
     ```
-* [ ]  Execute the `deploy` GitHub workflow.
-       This requires a review from a maintainer.
-* [ ]  Grab sdist and wheel from PyPI to attach to GitHub release
+* [ ]  Execute the `publish` GitHub workflow. This requires a review from a maintainer.
+* [ ]  Download the sdist and wheel files from PyPI. Attach these files to the GitHub release.
+* [ ]  Download the `.crt` and `.sig` files from the `sigstore-artifacts` artifact in the `publish` workflow execution. Attach these files to the GitHub release.
 * [ ]  Announce on:
   
   * [ ]  GitHub releases

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,10 @@ on:
     tags:
       - "*"
 
+permissions:
+  # Needed to access the workflow's OIDC identity.
+  id-token: "write"
+
 jobs:
   publish:
     name: "Publish to PyPI"
@@ -20,12 +24,40 @@ jobs:
           python-version: "3.x"
 
       - name: "Install dependencies"
-        run: python -m pip install build
+        run: python -m pip install build==0.8.0 sigstore==0.6.2
 
       - name: "Build dists"
         run: |
           SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct) \
           python -m build
+
+      - name: "Sign dists"
+        run: |
+          mkdir -p sigstore-artifacts/
+
+          for dist in dist/*; do
+            dist_name=$(basename "${dist}")
+
+            # Sign the dists and then verify them immediately
+            # with the generated artifacts.
+            python -m \
+              sigstore sign "${dist}" \
+              --output-signature sigstore-artifacts/"${dist_name}.sig" \
+              --output-certificate sigstore-artifacts/"${dist_name}.crt"
+
+            python -m \
+              sigstore verify "${dist}" \
+              --cert "sigstore-artifacts/${dist_name}.crt" \
+              --signature "sigstore-artifacts/${dist_name}.sig" \
+              --cert-oidc-issuer https://token.actions.githubusercontent.com
+
+          done
+
+      - uses: "actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8"
+        with:
+          name: "sigstore-artifacts"
+          path: "sigstore-artifacts/*"
+          if-no-files-found: "error"
 
       - uses: "pypa/gh-action-pypi-publish@717ba43cfbb0387f6ce311b169a825772f54d295"
         with:


### PR DESCRIPTION
- Adds sigstore signing step to the `publish` workflow. This was implemented and tested here: https://github.com/sethmlarson/secure-python-package-template/commit/3e634f05e7ef0e8c5cdcc1c876a34e976f58f773.
- Adds the step of downloading sigstore cert+signature files from the GitHub Action artifacts and attach to the GitHub release.
- Fixes a typo in the name of the `publish` workflow (was `deploy`)