### PR TITLE
Reduce flakiness of dummyserver tests

### DIFF
--- a/changelog/2242.feature.rst
+++ b/changelog/2242.feature.rst
@@ -1,0 +1,6 @@
+Added support for configuring header merging behavior with HTTPHeaderDict
+
+When using a ``HTTPHeaderDict`` to provide headers for a request, by default duplicate
+header values will be repeated. But if ``combine=True`` is passed in a call to
+``HTTPHeaderDict.add``, then the added header value will be merged in with an existing
+value into a comma-separated list (``X-My-Header: foo, bar``).

--- a/src/urllib3/_collections.py
+++ b/src/urllib3/_collections.py
@@ -174,14 +174,17 @@ class HTTPHeaderDictItemView(Set[Tuple[str, str]]):
     >>> d['X-Header-Name']
     'Value1, Value2, Value3'
 
-    However, if we iterate over an HTTPHeaderDict's items, we want to get a
-    distinct item for every different value of a header:
+    However, if we iterate over an HTTPHeaderDict's items, we will optionally combine
+    these values based on whether combine=True was called when building up the dictionary
 
+    >>> d = HTTPHeaderDict({"A": "1", "B": "foo"})
+    >>> d.add("A", "2", combine=True)
+    >>> d.add("B", "bar")
     >>> list(d.items())
     [
-        ('X-Header-Name', 'Value1')
-        ('X-Header-Name', 'Value2')
-        ('X-Header-Name', 'Value3')
+        ('A', '1, 2'),
+        ('B', 'foo'),
+        ('B', 'bar'),
     ]
 
     This class conforms to the interface required by the MutableMapping ABC while
@@ -301,14 +304,24 @@ class HTTPHeaderDict(MutableMapping[str, str]):
         except KeyError:
             pass
 
-    def add(self, key: str, val: str) -> None:
+    def add(self, key: str, val: str, *, combine: bool = False) -> None:
         """Adds a (name, value) pair, doesn't overwrite the value if it already
         exists.
+
+        If this is called with combine=True, instead of adding a new header value
+        as a distinct item during iteration, this will instead append the value to
+        any existing header value with a comma. If no existing header value exists
+        for the key, then the value will simply be added, ignoring the combine parameter.
 
         >>> headers = HTTPHeaderDict(foo='bar')
         >>> headers.add('Foo', 'baz')
         >>> headers['foo']
         'bar, baz'
+        >>> list(headers.items())
+        [('foo', 'bar'), ('foo', 'baz')]
+        >>> headers.add('foo', 'quz', combine=True)
+        >>> list(headers.items())
+        [('foo', 'bar, baz, quz')]
         """
         # avoid a bytes/str comparison by decoding before httplib
         if isinstance(key, bytes):
@@ -318,7 +331,13 @@ class HTTPHeaderDict(MutableMapping[str, str]):
         # Keep the common case aka no item present as fast as possible
         vals = self._container.setdefault(key_lower, new_vals)
         if new_vals is not vals:
-            vals.append(val)
+            # if there are values here, then there is at least the initial
+            # key/value pair
+            assert len(vals) >= 2
+            if combine:
+                vals[-1] = vals[-1] + ", " + val
+            else:
+                vals.append(val)
 
     def extend(self, *args: ValidHTTPHeaderSource, **kwargs: str) -> None:
         """Generic import function for any type of header-like object.

--- a/src/urllib3/_request_methods.py
+++ b/src/urllib3/_request_methods.py
@@ -2,6 +2,7 @@ import json as _json
 from typing import Any, Dict, Mapping, Optional, Sequence, Tuple, Union
 from urllib.parse import urlencode
 
+from ._collections import HTTPHeaderDict
 from .connection import _TYPE_BODY
 from .filepost import _TYPE_FIELDS, encode_multipart_formdata
 from .response import BaseHTTPResponse
@@ -188,7 +189,7 @@ class RequestMethods:
         if headers is None:
             headers = self.headers
 
-        extra_kw: Dict[str, Any] = {"headers": {}}
+        extra_kw: Dict[str, Any] = {"headers": HTTPHeaderDict(headers)}
         body: Union[bytes, str]
 
         if fields:
@@ -208,9 +209,8 @@ class RequestMethods:
                 )
 
             extra_kw["body"] = body
-            extra_kw["headers"] = {"Content-Type": content_type}
+            extra_kw["headers"].add("Content-Type", content_type)
 
-        extra_kw["headers"].update(headers)
         extra_kw.update(urlopen_kw)
 
         return self.urlopen(method, url, **extra_kw)

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -73,7 +73,7 @@ port_by_scheme = {"http": 80, "https": 443}
 
 # When it comes time to update this value as a part of regular maintenance
 # (ie test_recent_date is failing) update it to ~6 months before the current date.
-RECENT_DATE = datetime.date(2020, 7, 1)
+RECENT_DATE = datetime.date(2022, 1, 1)
 
 _CONTAINS_CONTROL_CHAR_RE = re.compile(r"[^-!#$%&'*+.^_`|~0-9a-zA-Z]")
 

--- a/test/test_collections.py
+++ b/test/test_collections.py
@@ -252,6 +252,34 @@ class TestHTTPHeaderDict:
         assert d["e"] == "foofoo"
         assert len(d) == 2
 
+    def test_header_repeat(self, d: HTTPHeaderDict) -> None:
+        d["other-header"] = "hello"
+        d.add("other-header", "world")
+
+        assert list(d.items()) == [
+            ("Cookie", "foo"),
+            ("Cookie", "bar"),
+            ("other-header", "hello"),
+            ("other-header", "world"),
+        ]
+
+        d.add("other-header", "!", combine=True)
+        expected_results = [
+            ("Cookie", "foo"),
+            ("Cookie", "bar"),
+            ("other-header", "hello"),
+            ("other-header", "world, !"),
+        ]
+
+        assert list(d.items()) == expected_results
+        # make sure the values persist over copys
+        assert list(d.copy().items()) == expected_results
+
+        other_dict = HTTPHeaderDict()
+        # we also need for extensions to properly maintain results
+        other_dict.extend(d)
+        assert list(other_dict.items()) == expected_results
+
     def test_extend_from_headerdict(self, d: HTTPHeaderDict) -> None:
         h = HTTPHeaderDict(Cookie="foo", e="foofoo")
         d.extend(h)

--- a/test/utils.py
+++ b/test/utils.py
@@ -1,0 +1,71 @@
+import socket
+from typing import Optional
+
+
+def simple_read_http_request(sock: socket.socket) -> bytes:
+    """
+    Read in an HTTP Request from a socket, handling both content length and
+    chunked encoding.
+
+    This assumes that the request is well formed, and only supports either content length
+    or chunked encoding. This is only meant for use in tests!
+
+    Returns the bytes of the request
+    """
+    buf = b""
+    while b"\r\n\r\n" not in buf:
+        buf += sock.recv(65536)
+    # seperate the headers from the eventual body
+    header_buf, buf = buf.split(b"\r\n\r\n", maxsplit=1)
+    # check for any content
+    content_length: Optional[int] = None
+    chunked_content: bool = False
+    for header_line in header_buf.split(b"\r\n"):
+        if header_line.decode("ascii").lower().startswith("content-length"):
+            content_length = int(header_line.split(b":")[1].decode("ascii"))
+            break
+        if header_line.decode("ascii").lower().startswith("transfer-encoding"):
+            encoding = header_line.split(b":")[1].decode("ascii").strip()
+            if encoding != "chunked":
+                raise ValueError("Unsupported encoding")
+            chunked_content = True
+    if chunked_content:
+        final_content = b""
+        state = "read-length"
+        next_chunk_length: Optional[int] = None
+        while state != "done":
+            while state == "read-length":
+                maybe_split = buf.split(b"\r\n", maxsplit=1)
+                if len(maybe_split) == 2:
+                    # get the length
+                    len_str, buf = maybe_split
+                    final_content += len_str + b"\r\n"
+                    next_chunk_length = int(len_str, 16)
+                    state = "read-chunk"
+                else:
+                    buf += sock.recv(65536)
+            while state == "read-chunk":
+                if next_chunk_length == 0:
+                    # chunk of 0 length indicates being done
+                    # let's make sure to read in the remaining
+                    # buffer data though (at least the newline)
+                    while len(buf) < 2:
+                        buf += sock.recv(65536)
+                    final_content += buf
+                    state = "done"
+                    break
+                assert next_chunk_length is not None
+                while len(buf) < next_chunk_length + 2:
+                    buf += sock.recv(65536)
+                # we now have our chunk and the CRLF
+                final_content += buf[: next_chunk_length + 2]
+                # trim the CRLF as it's not part of the data
+                buf = buf[(next_chunk_length + 2) :]
+                next_chunk_length, state = None, "read-length"
+        # we are now done
+        return header_buf + b"\r\n\r\n" + final_content
+    else:
+        # read unchunked content
+        if content_length is not None and len(buf) < content_length:
+            buf += sock.recv(content_length - len(buf))
+        return header_buf + b"\r\n\r\n" + buf


### PR DESCRIPTION
(Includes #2669)

This replaces a handful of timeout-based dummyserver socket handlers with something that uses a simple HTTP-aware handler that looks for content lengths or chunked encoding.

Locally, at least, this caused otherwise flaky tests in this file to consistently pass.

I don't feel strongly about this being the right way forward for tests, but I had a hard time finding a way to reuse existing code to do this, and the flakiness locally was a bit frustrating.