### PR TITLE
Backport publish workflow and process

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,9 @@
 # Restrict all files related to deploying to
 # require lead maintainer approval.
 
-.github/CODEOWNERS          @sethmlarson @shazow
-src/urllib3/_version.py     @sethmlarson @shazow
-setup.py                    @sethmlarson @shazow
-ci/                         @sethmlarson @shazow
-.travis.yml                 @sethmlarson @shazow
+.github/workflows/          @sethmlarson @pquentin @shazow
+.github/CODEOWNERS          @sethmlarson @pquentin @shazow
+src/urllib3/_version.py     @sethmlarson @pquentin @shazow
+setup.py                    @sethmlarson @pquentin @shazow
+pyproject.toml              @sethmlarson @pquentin @shazow
+ci/                         @sethmlarson @pquentin @shazow

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,65 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - "*"
+
+permissions:
+  # Needed to access the workflow's OIDC identity.
+  id-token: "write"
+
+jobs:
+  publish:
+    name: "Publish to PyPI"
+    runs-on: "ubuntu-latest"
+    environment:
+      name: "publish"
+
+    steps:
+      - uses: "actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b"
+
+      - uses: "actions/setup-python@d09bd5e6005b175076f227b13d9730d56e9dcfcb"
+        with:
+          python-version: "3.x"
+
+      - name: "Install dependencies"
+        run: python -m pip install build==0.8.0 sigstore==0.6.2
+
+      - name: "Build dists"
+        run: |
+          SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct) \
+          python -m build
+
+      - name: "Sign dists"
+        run: |
+          mkdir -p sigstore-artifacts/
+
+          for dist in dist/*; do
+            dist_name=$(basename "${dist}")
+
+            # Sign the dists and then verify them immediately
+            # with the generated artifacts.
+            python -m \
+              sigstore sign "${dist}" \
+              --output-signature sigstore-artifacts/"${dist_name}.sig" \
+              --output-certificate sigstore-artifacts/"${dist_name}.crt"
+
+            python -m \
+              sigstore verify "${dist}" \
+              --cert "sigstore-artifacts/${dist_name}.crt" \
+              --signature "sigstore-artifacts/${dist_name}.sig" \
+              --cert-oidc-issuer https://token.actions.githubusercontent.com
+
+          done
+
+      - uses: "actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8"
+        with:
+          name: "sigstore-artifacts"
+          path: "sigstore-artifacts/*"
+          if-no-files-found: "error"
+
+      - uses: "pypa/gh-action-pypi-publish@717ba43cfbb0387f6ce311b169a825772f54d295"
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_TOKEN }}

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -24,7 +24,7 @@ Setting up your development environment
 In order to setup the development environment all that you need is
 `nox <https://nox.thea.codes/en/stable/index.html>`_ installed in your machine::
 
-  $ pip install --user --upgrade nox
+  $ python -m pip install --user --upgrade nox
 
 
 Running the tests
@@ -166,22 +166,12 @@ While writing documentation you should follow these guidelines:
 Releases
 --------
 
-A release candidate can be created by any contributor by creating a branch
-named ``release-x.x`` where ``x.x`` is the version of the proposed release.
+A release candidate can be created by any contributor.
 
-- Update ``CHANGES.rst`` and ``urllib3/__init__.py`` with the proper version number
-  and commit the changes to ``release-x.x``.
-- Open a pull request to merge the ``release-x.x`` branch into the ``master`` branch.
-- Integration tests are run against the release candidate on Travis. From here on all
-  the steps below will be handled by a maintainer so unless you receive review comments
-  you are done here.
-- Once the pull request is squash merged into master the merging maintainer
-  will tag the merge commit with the version number:
-
-  - ``git tag -a 1.24.1 [commit sha]``
-  - ``git push origin master --tags``
-
-- After the commit is tagged Travis will build the tagged commit and upload the sdist and wheel
-  to PyPI and create a draft release on GitHub for the tag. The merging maintainer will
-  ensure that the PyPI sdist and wheel are properly uploaded.
-- The merging maintainer will mark the draft release on GitHub as an approved release.
+- Announce intent to release on Discord, see if anyone wants to include last minute
+  changes.
+- Update ``urllib3/_version.py`` with the proper version number
+- Commit the changes to a ``release-X.Y.Z`` branch.
+- Create a pull request and append ``&expand=1&template=release.md`` to the URL before
+  submitting in order to include our release checklist in the pull request description.
+- Follow the checklist!


### PR DESCRIPTION
This backports our publishing workflow since the branch that a tag lands on must have the config included. Also backports CODEOWNER updates and docs on publishing to the branch.