### PR TITLE
Fix reading pieces of data larger than 16 KiB on macOS

### DIFF
--- a/changelog/2674.bugfix.rst
+++ b/changelog/2674.bugfix.rst
@@ -1,1 +1,1 @@
-Fixed reading pieces of data larger than 16 KiB on macOS.
+Fixed incomplete reads of data by SecureTransport on macOS.

--- a/changelog/2674.bugfix.rst
+++ b/changelog/2674.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed reading pieces of data larger than 16 KiB on macOS.

--- a/src/urllib3/contrib/securetransport.py
+++ b/src/urllib3/contrib/securetransport.py
@@ -573,7 +573,7 @@ class WrappedSocket:
         processed_bytes = ctypes.c_size_t(0)
         processed_bytes_total = 0
 
-        while nbytes:
+        while nbytes > 0:
             buffer = (ctypes.c_char * nbytes).from_buffer(buffer, processed_bytes.value)
 
             with self._raise_on_error():

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -1502,6 +1502,7 @@ class TestSSL(SocketDummyServerTestCase):
         socket.
         """
         content_length = 16385  # 16 KiB + 1 byte.
+        content = os.urandom(content_length)
 
         def socket_handler(listener: socket.socket) -> None:
             sock = listener.accept()[0]
@@ -1521,7 +1522,7 @@ class TestSSL(SocketDummyServerTestCase):
                 b"Content-Type: text/plain\r\n"
                 b"Content-Length: %d\r\n\r\n" % content_length
             )
-            ssl_sock.sendall(bytes(content_length))
+            ssl_sock.sendall(content)
 
             ssl_sock.close()
             sock.close()
@@ -1530,7 +1531,7 @@ class TestSSL(SocketDummyServerTestCase):
         with HTTPSConnectionPool(self.host, self.port, ca_certs=DEFAULT_CA) as pool:
             response = pool.request("GET", "/", preload_content=preload_content)
             data = response.data if preload_content else response.read(read_amt)
-            assert len(data) == content_length
+            assert data == content
 
 
 class TestErrorWrapping(SocketDummyServerTestCase):


### PR DESCRIPTION
While I was working on #2657, I found that urllib3 injected with the `SecureTransport` integration fails to read the full response when the content length is more than 16 KiB.

A new test uncovers the problem too, the test has three variants.
All the variants failed on the CPython 3.8 and 3.10 runs, and only one variant failed on 3.7 and 3.9 runs. This happened because CPython 3.7 and 3.9 read desired amount of data in a loop. 3.8 and 3.10 did not do that. https://github.com/python/cpython/commit/153365d864c411f6fb523efa752ccb3497d815ca illustrates the difference in their code.

When I debugged the code, I found that `Security.SSLRead` reads only 16384 bytes even though `nbytes` and `buffer` are larger.
https://github.com/urllib3/urllib3/blob/72446d421c3b4faeaba392a3e2775c41dd25b7eb/src/urllib3/contrib/securetransport.py#L577-L579
Also, I checked `_read_callback` that is called by `Security.SSLRead`. The method read as much bytes from a socket as it was instructed, so I do not think it should be blamed.
I noticed that the socket was in the non-blocking mode in the callback, but changing the mode to blocking in `WrappedSocket` did not fix the problem.
https://github.com/urllib3/urllib3/blob/72446d421c3b4faeaba392a3e2775c41dd25b7eb/src/urllib3/contrib/securetransport.py#L204-L210

---

Calling `Security.SSLRead` in a loop until enough bytes are read looks to be a working solution.