### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -86,7 +86,7 @@ After the ``--`` indicator, any arguments will be passed to pytest.
 To specify an exact test case the following syntax also works:
 ``test/dir/module_name.py::TestClassName::test_method_name``
 (eg.: ``test/with_dummyserver/test_https.py::TestHTTPS::test_simple``).
-The following argument is another valid example to pass to pytest: ``-k test_methode_name``.
+The following argument is another valid example to pass to pytest: ``-k test_method_name``.
 These are useful when developing new test cases and there is no point
 re-running the entire test suite every iteration. It is also possible to
 further parameterize pytest for local testing.

--- a/src/urllib3/contrib/securetransport.py
+++ b/src/urllib3/contrib/securetransport.py
@@ -406,7 +406,7 @@ class WrappedSocket:
         self.socket.sendall(rec)
         # close the connection immediately
         # l_onoff = 1, activate linger
-        # l_linger = 0, linger for 0 seoncds
+        # l_linger = 0, linger for 0 seconds
         opts = struct.pack("ii", 1, 0)
         self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_LINGER, opts)
         self.close()

--- a/test/test_collections.py
+++ b/test/test_collections.py
@@ -280,7 +280,7 @@ class TestHTTPHeaderDict:
         ]
 
         assert list(d.items()) == expected_results
-        # make sure the values persist over copys
+        # make sure the values persist over copies
         assert list(d.copy().items()) == expected_results
 
         other_dict = HTTPHeaderDict()

--- a/test/test_ssltransport.py
+++ b/test/test_ssltransport.py
@@ -272,7 +272,7 @@ class SocketProxyDummyServer(SocketDummyServerTestCase):
     def start_proxy_handler(self) -> None:
         """
         Socket handler for the proxy. Terminates the first TLS layer and tunnels
-        any bytes needed for client <-> server communicatin.
+        any bytes needed for client <-> server communication.
         """
 
         def proxy_handler(listener: socket.socket) -> None:


### PR DESCRIPTION
There are small typos in:
- docs/contributing.rst
- src/urllib3/contrib/securetransport.py
- test/test_collections.py
- test/test_ssltransport.py

Fixes:
- Should read `seconds` rather than `seoncds`.
- Should read `method` rather than `methode`.
- Should read `copies` rather than `copys`.
- Should read `communication` rather than `communicatin`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md