### PR TITLE
Set GHA token permissions to be read-only

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     types: [labeled, unlabeled, opened, reopened, synchronize]
 
+permissions: "read-all"
+
 jobs:
   check-changelog-entry:
     name: changelog entry

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: CI
 
 on: [push, pull_request]
 
+permissions: "read-all"
+
 defaults:
   run:
     shell: bash

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -2,6 +2,8 @@ name: Downstream
 
 on: [push, pull_request]
 
+permissions: "read-all"
+
 jobs:
   integration:
     strategy:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,8 @@ name: lint
 
 on: [push, pull_request]
 
+permissions: "read-all"
+
 jobs:
   lint:
     runs-on: ubuntu-20.04

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,7 @@ on:
       - "*"
 
 permissions:
+  contents: "read"
   # Needed to access the workflow's OIDC identity.
   id-token: "write"
 


### PR DESCRIPTION
Complies with the [OpenSSF Token-Permissions check](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) by making all permissions as restricted as possible.