### PR TITLE
[1.26] Fix `OverflowError` when SSL is used on some Python versions

### DIFF
--- a/src/urllib3/response.py
+++ b/src/urllib3/response.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 import io
 import logging
+import sys
 import zlib
 from contextlib import contextmanager
 from socket import error as SocketError
@@ -15,6 +16,7 @@ try:
 except ImportError:
     brotli = None
 
+from . import util
 from ._collections import HTTPHeaderDict
 from .connection import BaseSSLError, HTTPException
 from .exceptions import (
@@ -481,6 +483,54 @@ class HTTPResponse(io.IOBase):
             if self._original_response and self._original_response.isclosed():
                 self.release_conn()
 
+    def _fp_read(self, amt):
+        """
+        Read a response with the thought that reading the number of bytes
+        larger than can fit in a 32-bit int at a time via SSL in some
+        known cases leads to an overflow error that has to be prevented
+        if `amt` or `self.length_remaining` indicate that a problem may
+        happen.
+
+        The known cases:
+          * 3.8 <= CPython < 3.9.7 because of a bug
+            https://github.com/urllib3/urllib3/issues/2513#issuecomment-1152559900.
+          * urllib3 injected with pyOpenSSL-backed SSL-support.
+          * CPython < 3.10 only when `amt` does not fit 32-bit int.
+        """
+        assert self._fp
+        c_int_max = 2 ** 31 - 1
+        if (
+            (
+                (amt and amt > c_int_max)
+                or (self.length_remaining and self.length_remaining > c_int_max)
+            )
+            and not util.IS_SECURETRANSPORT
+            and (util.IS_PYOPENSSL or sys.version_info < (3, 10))
+        ):
+            buffer = io.BytesIO()
+            # Besides `max_chunk_amt` being a maximum chunk size, it
+            # affects memory overhead of reading a response by this
+            # method in CPython.
+            # `c_int_max` equal to 2 GiB - 1 byte is the actual maximum
+            # chunk size that does not lead to an overflow error, but
+            # 256 MiB is a compromise.
+            max_chunk_amt = 2 ** 28
+            while amt is None or amt != 0:
+                if amt is not None:
+                    chunk_amt = min(amt, max_chunk_amt)
+                    amt -= chunk_amt
+                else:
+                    chunk_amt = max_chunk_amt
+                data = self._fp.read(chunk_amt)
+                if not data:
+                    break
+                buffer.write(data)
+                del data  # to reduce peak memory usage by `max_chunk_amt`.
+            return buffer.getvalue()
+        else:
+            # StringIO doesn't like amt=None
+            return self._fp.read(amt) if amt is not None else self._fp.read()
+
     def read(self, amt=None, decode_content=None, cache_content=False):
         """
         Similar to :meth:`http.client.HTTPResponse.read`, but with two additional
@@ -513,13 +563,11 @@ class HTTPResponse(io.IOBase):
         fp_closed = getattr(self._fp, "closed", False)
 
         with self._error_catcher():
+            data = self._fp_read(amt) if not fp_closed else b""
             if amt is None:
-                # cStringIO doesn't like amt=None
-                data = self._fp.read() if not fp_closed else b""
                 flush_decoder = True
             else:
                 cache_content = False
-                data = self._fp.read(amt) if not fp_closed else b""
                 if (
                     amt != 0 and not data
                 ):  # Platform-specific: Buggy versions of Python.

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -35,6 +35,7 @@ except ImportError:
 
 import os
 import os.path
+import platform
 import select
 import shutil
 import socket
@@ -1497,6 +1498,61 @@ class TestSSL(SocketDummyServerTestCase):
             with pytest.raises(SSLError):
                 pool.request("GET", "/", retries=False, timeout=LONG_TIMEOUT)
         assert server_closed.wait(LONG_TIMEOUT), "The socket was not terminated"
+
+    # SecureTransport can read only small pieces of data at the moment.
+    # https://github.com/urllib3/urllib3/pull/2674
+    @notSecureTransport
+    @pytest.mark.skipif(
+        os.environ.get("CI") == "true" and platform.python_implementation() == "PyPy",
+        reason="too slow to run in CI",
+    )
+    @pytest.mark.parametrize(
+        "preload_content,read_amt", [(True, None), (False, None), (False, 2 ** 31)]
+    )
+    def test_requesting_large_resources_via_ssl(self, preload_content, read_amt):
+        """
+        Ensure that it is possible to read 2 GiB or more via an SSL
+        socket.
+        https://github.com/urllib3/urllib3/issues/2513
+        """
+        content_length = 2 ** 31  # (`int` max value in C) + 1.
+        ssl_ready = Event()
+
+        def socket_handler(listener):
+            sock = listener.accept()[0]
+            ssl_sock = ssl.wrap_socket(
+                sock,
+                server_side=True,
+                keyfile=DEFAULT_CERTS["keyfile"],
+                certfile=DEFAULT_CERTS["certfile"],
+                ca_certs=DEFAULT_CA,
+            )
+            ssl_ready.set()
+
+            while not ssl_sock.recv(65536).endswith(b"\r\n\r\n"):
+                continue
+
+            ssl_sock.send(
+                b"HTTP/1.1 200 OK\r\n"
+                b"Content-Type: text/plain\r\n"
+                b"Content-Length: %d\r\n\r\n" % content_length
+            )
+
+            chunks = 2
+            for i in range(chunks):
+                ssl_sock.sendall(b"0" * (content_length // chunks))
+
+            ssl_sock.close()
+            sock.close()
+
+        self._start_server(socket_handler)
+        ssl_ready.wait(5)
+        with HTTPSConnectionPool(
+            self.host, self.port, ca_certs=DEFAULT_CA, retries=False
+        ) as pool:
+            response = pool.request("GET", "/", preload_content=preload_content)
+            data = response.data if preload_content else response.read(read_amt)
+            assert len(data) == content_length
 
 
 class TestErrorWrapping(SocketDummyServerTestCase):


### PR DESCRIPTION
This is a backport of #2657 to `1.26.x`.