### PR TITLE
Fix type annotation for `pyopenssl.WrappedSocket.getpeercert`

### DIFF
--- a/src/urllib3/contrib/pyopenssl.py
+++ b/src/urllib3/contrib/pyopenssl.py
@@ -402,7 +402,7 @@ class WrappedSocket:
         else:
             self._io_refs -= 1
 
-    def getpeercert(self, binary_form: bool = False) -> Dict[str, List[Any]]:
+    def getpeercert(self, binary_form: bool = False) -> Optional[Dict[str, List[Any]]]:
         x509 = self.connection.get_peer_certificate()
 
         if not x509:


### PR DESCRIPTION
<!---
Thanks for your contribution! ♥️

If this is your first PR to urllib3 please review the Contributing Guide:
https://urllib3.readthedocs.io/en/latest/contributing.html

Adhering to the Contributing Guide means we can review, merge, and release your change faster! :)
--->

Hi! This return annotation seems incorrect, because you have [`no_implicit_optional = True`](https://github.com/urllib3/urllib3/blob/3951d3cf8f8c8119c455ce50c171dc0ca50cb130/setup.cfg#L22) and `get_peer_certificate()` [can return `None`](https://github.com/pyca/pyopenssl/blob/21.0.0/src/OpenSSL/SSL.py#L2185-L2194).

Refs https://github.com/python/typeshed/pull/8374