### PR TITLE
Pin all workflows to commit shas

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -12,13 +12,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - name: "Checkout repository"
+        uses: "actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b"
         with:
           # `towncrier check` runs `git diff --name-only origin/main...`, which
           # needs a non-shallow clone.
           fetch-depth: 0
 
-      - name: Check changelog
+      - name: "Check changelog"
         if: "!contains(github.event.pull_request.labels.*.name, 'Skip Changelog')"
         run: |
           if ! pipx run towncrier check --compare-with origin/${{ github.base_ref }}; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,19 +14,22 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v3
-      - name: Set up Python 3
-        uses: actions/setup-python@v4
+      - name: "Checkout repository"
+        uses: "actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b"
+
+      - name: "Setup Python"
+        uses: "actions/setup-python@d09bd5e6005b175076f227b13d9730d56e9dcfcb"
         with:
-          python-version: "3"
-          cache: pip
-      - name: Check packages
+          python-version: "3.x"
+          cache: "pip"
+
+      - name: "Check packages"
         run: |
-          python3 -m pip install -U pip setuptools wheel build twine rstcheck
-          python3 -m build
+          python -m pip install -U pip setuptools wheel build twine rstcheck
+          python -m build
           rstcheck CHANGES.rst
-          python3 -m twine check dist/*
+          python -m twine check dist/*
+
   test:
     env:
       SETUPTOOLS_USE_DISTUTILS: stdlib
@@ -84,39 +87,41 @@ jobs:
     continue-on-error: ${{ matrix.experimental }}
     timeout-minutes: 20
     steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v3
+      - name: "Checkout repository"
+        uses: "actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b"
 
-      - name: Set Up Python - ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+      - name: "Setup Python ${{ matrix.python-version }}"
+        uses: "actions/setup-python@d09bd5e6005b175076f227b13d9730d56e9dcfcb"
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Set Up Python (Development version) - ${{ matrix.python-version }}
-        uses: deadsnakes/action@v2.1.1
-        if: endsWith(matrix.python-version, '-dev')
+      # Use deadsnakes for development versions
+      - if: endsWith(matrix.python-version, '-dev')
+        name: "Setup Python ${{ matrix.python-version }}"
+        uses: deadsnakes/action@7ab8819e223c70d2bdedd692dfcea75824e0a617
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Set Up Python 3 to run nox on Python 2
-        if: matrix.python-version == '2.7'
-        uses: actions/setup-python@v4
+      # Setup Python 3.x to run nox on behalf of Python 2.7
+      - if: matrix.python-version == '2.7'
+        name: "Setup Python 3.x"
+        uses: "actions/setup-python@d09bd5e6005b175076f227b13d9730d56e9dcfcb"
         with:
-          python-version: "3"
-          cache: pip
+          python-version: "3.x"
+          cache: "pip"
 
-      - name: Install Dependencies
+      - name: "Install dependencies"
         run: python -m pip install --upgrade pip setuptools nox
 
-      - name: Run Tests
+      - name: "Run tests"
         run: ./ci/run_tests.sh
         env:
           PYTHON_VERSION: ${{ matrix.python-version }}
           NOX_SESSION: ${{ matrix.nox-session }}
 
-      - name: Upload Coverage
-        if: ${{ matrix.nox-session != 'unsupported_setup_py' }}
-        uses: "actions/upload-artifact@v3"
+      - if: ${{ matrix.nox-session != 'unsupported_setup_py' }}
+        name: "Upload artifact"
+        uses: "actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8"
         with:
           name: coverage-data
           path: ".coverage.*"
@@ -127,17 +132,19 @@ jobs:
     runs-on: "ubuntu-latest"
     needs: test
     steps:
-      - uses: actions/checkout@v3
-      - name: "Use latest Python so it understands all syntax"
-        uses: actions/setup-python@v4
+      - name: "Checkout repository"
+        uses: "actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b"
+
+      - name: "Setup Python"
+        uses: "actions/setup-python@d09bd5e6005b175076f227b13d9730d56e9dcfcb"
         with:
-          python-version: "3.10"
+          python-version: "3.x"
 
       - name: "Install coverage"
         run: "python -m pip install --upgrade coverage"
 
-      - name: "Download coverage data"
-        uses: actions/download-artifact@v3
+      - name: "Download artifact"
+        uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741
         with:
           name: coverage-data
 
@@ -146,10 +153,10 @@ jobs:
           python -m coverage combine
           python -m coverage html --skip-covered --skip-empty
           python -m coverage report --ignore-errors --show-missing --fail-under=100
-      - name: "Upload report if check failed"
-        uses: actions/upload-artifact@v3
+
+      - if: ${{ failure() }}
+        name: "Upload report if check failed"
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8
         with:
           name: coverage-report
           path: htmlcov
-        if: ${{ failure() }}
-

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -14,15 +14,16 @@ jobs:
     timeout-minutes: 20
 
     steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v3
+      - name: "Checkout repository"
+        uses: "actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b"
 
-      - name: Set Up Python - ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+      - name: "Setup Python"
+        uses: "actions/setup-python@d09bd5e6005b175076f227b13d9730d56e9dcfcb"
         with:
-          python-version: "3.9"
+          python-version: "3.x"
 
-      - name: Install Dependencies
+      - name: "Install dependencies"
         run: python -m pip install --upgrade nox
-      - name: Run downstream tests
+
+      - name: "Run downstream tests"
         run: nox -s downstream_${{ matrix.downstream }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,16 +10,20 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v4
+      - name: "Checkout repository"
+        uses: "actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b"
+
+      - name: "Setup Python"
+        uses: "actions/setup-python@d09bd5e6005b175076f227b13d9730d56e9dcfcb"
         with:
-          python-version: "3.8"
+          python-version: "3.x"
           cache: pip
-      - name: Lint the code
-        uses: pre-commit/action@v3.0.0
-      - name: Install dependencies
-        run: python3.8 -m pip install nox
-      - name: Run mypy
+
+      - name: "Run pre-commit"
+        uses: pre-commit/action@646c83fcd040023954eafda54b4db0192ce70507
+
+      - name: "Install dependencies"
+        run: python -m pip install nox
+
+      - name: "Run mypy"
         run: nox -s mypy

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,9 +18,11 @@ jobs:
       name: "publish"
 
     steps:
-      - uses: "actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b"
+      - name: "Checkout repository"
+        uses: "actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b"
 
-      - uses: "actions/setup-python@d09bd5e6005b175076f227b13d9730d56e9dcfcb"
+      - name: "Setup Python"
+        uses: "actions/setup-python@d09bd5e6005b175076f227b13d9730d56e9dcfcb"
         with:
           python-version: "3.x"
 
@@ -54,13 +56,15 @@ jobs:
 
           done
 
-      - uses: "actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8"
+      - name: "Upload artifacts"
+        uses: "actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8"
         with:
           name: "sigstore-artifacts"
           path: "sigstore-artifacts/*"
           if-no-files-found: "error"
 
-      - uses: "pypa/gh-action-pypi-publish@37f50c210e3d2f9450da2cd423303d6a14a6e29f"
+      - name: "Publish to PyPI"
+        uses: "pypa/gh-action-pypi-publish@37f50c210e3d2f9450da2cd423303d6a14a6e29f"
         with:
           user: __token__
           password: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
Part of the OpenSSF scorecard for pinning dependencies is pinning all GitHub Actions to commit SHAs.

```
$ scorecard-linux-amd64 --local urllib3 --checks Pinned-Dependencies

Starting [Pinned-Dependencies]
Finished [Pinned-Dependencies]

RESULTS
-------
Aggregate score: 10.0 / 10

Check scores:
|---------|---------------------|-----------------------------|--------------------------------------------------------------------------------------------------------------------|
|  SCORE  |        NAME         |           REASON            |                                             DOCUMENTATION/REMEDIATION                                              |
|---------|---------------------|-----------------------------|--------------------------------------------------------------------------------------------------------------------|
| 10 / 10 | Pinned-Dependencies | all dependencies are pinned | https://github.com/ossf/scorecard/blob/e42af756609b2cde6d757fd45ea05ddf0016ff62/docs/checks.md#pinned-dependencies |
|---------|---------------------|-----------------------------|--------------------------------------------------------------------------------------------------------------------|
```