### PR TITLE
Added deprecation warning for urllib3.contrib.securetransport

### DIFF
--- a/changelog/2692.removal.rst
+++ b/changelog/2692.removal.rst
@@ -1,0 +1,1 @@
+Deprecated ``urllib3.contrib.securetransport`` module which will be removed in future urllib3 v2.x release.

--- a/docs/reference/contrib/securetransport.rst
+++ b/docs/reference/contrib/securetransport.rst
@@ -2,6 +2,7 @@ macOS SecureTransport
 =====================
 .. warning::
     DEPRECATED: This module is deprecated and will be removed in a future 2.x release.
+    Read more in this `issue <https://github.com/urllib3/urllib3/issues/2681>`_.
 
 `SecureTranport <https://developer.apple.com/documentation/security/secure_transport>`_
 support for urllib3 via ctypes.

--- a/docs/reference/contrib/securetransport.rst
+++ b/docs/reference/contrib/securetransport.rst
@@ -1,5 +1,7 @@
 macOS SecureTransport
 =====================
+.. warning::
+    DEPRECATED: This module is deprecated and will be removed in a future 2.x release.
 
 `SecureTranport <https://developer.apple.com/documentation/security/secure_transport>`_
 support for urllib3 via ctypes.

--- a/src/urllib3/contrib/securetransport.py
+++ b/src/urllib3/contrib/securetransport.py
@@ -93,10 +93,10 @@ from ._securetransport.low_level import (
 )
 
 warnings.warn(
-    "'securetransport' module is deprecated and will be removed "
-    "in a future release of urllib3 2.x. Read more in doc: "
-    "https://urllib3.readthedocs.io/en/stable/reference/contrib/securetransport.html",
-    DeprecationWarning,
+    "'urllib3.contrib.securetransport' module is deprecated and will be removed "
+    "in a future release of urllib3 2.x. Read more in this issue: "
+    "https://github.com/urllib3/urllib3/issues/2681",
+    category=DeprecationWarning,
     stacklevel=2,
 )
 

--- a/src/urllib3/contrib/securetransport.py
+++ b/src/urllib3/contrib/securetransport.py
@@ -93,11 +93,11 @@ from ._securetransport.low_level import (
 )
 
 warnings.warn(
-        "'securetransport' module is deprecated and will be removed "
-        "in a future release of urllib3 2.x. Read more in doc: "
-        "https://urllib3.readthedocs.io/en/stable/reference/contrib/securetransport.html",
-        DeprecationWarning,
-        stacklevel=2,
+    "'securetransport' module is deprecated and will be removed "
+    "in a future release of urllib3 2.x. Read more in doc: "
+    "https://urllib3.readthedocs.io/en/stable/reference/contrib/securetransport.html",
+    DeprecationWarning,
+    stacklevel=2,
 )
 
 if TYPE_CHECKING:

--- a/src/urllib3/contrib/securetransport.py
+++ b/src/urllib3/contrib/securetransport.py
@@ -61,6 +61,7 @@ import socket
 import ssl
 import struct
 import threading
+import warnings
 import weakref
 from socket import socket as socket_cls
 from typing import (
@@ -89,6 +90,14 @@ from ._securetransport.low_level import (
     _create_cfstring_array,
     _load_client_cert_chain,
     _temporary_keychain,
+)
+
+warnings.warn(
+        "'securetransport' module is deprecated and will be removed "
+        "in a future release of urllib3 2.x. Read more in doc: "
+        "https://urllib3.readthedocs.io/en/stable/reference/contrib/securetransport.html",
+        DeprecationWarning,
+        stacklevel=2,
 )
 
 if TYPE_CHECKING:


### PR DESCRIPTION
This PR is to address issue #2692 