### PR TITLE
Use `_TYPE_FIELD_VALUE` for consistency

### DIFF
--- a/src/urllib3/fields.py
+++ b/src/urllib3/fields.py
@@ -34,7 +34,7 @@ def guess_content_type(
     return default
 
 
-def format_header_param_rfc2231(name: str, value: Union[str, bytes]) -> str:
+def format_header_param_rfc2231(name: str, value: _TYPE_FIELD_VALUE) -> str:
     """
     Helper function to format and quote a single header parameter using the
     strategy defined in RFC 2231.


### PR DESCRIPTION
This updates a leftover `Union[str, bytes]` for `_TYPE_FIELD_VALUE` for consistency.