### PR TITLE
Add Scorecard GitHub Action

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -1,0 +1,33 @@
+name: "Scorecard"
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: "0 0 * * 0"
+  push:
+    branches: ["main", "1.26.x"]
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: "Scorecard"
+    runs-on: "ubuntu-latest"
+    permissions:
+      security-events: write
+      id-token: write
+      contents: read
+      actions: read
+    
+    steps:
+      - name: "Checkout repository"
+        uses: "actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846"
+        with:
+          persist-credentials: false
+
+      - name: "Run Scorecard"
+        uses: "ossf/scorecard-action@3e15ea8318eee9b333819ec77a36aca8d39df13e"
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          repo_token: ${{ secrets.SCORECARD_TOKEN }}
+          publish_results: true


### PR DESCRIPTION
Followed the steps here: https://github.com/ossf/scorecard-action

Created a Personal Access Token for my account according to their specifications and added it under `SCORECARD_TOKEN` so the complete set of Scorecard checks can run on the project.