### PR TITLE
Drop support for OpenSSL <1.1.1

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: 3
+    python: "3"
 
 python:
   install:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,5 +1,10 @@
 version: 2
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: 3
+
 python:
   install:
     - requirements: docs/requirements.txt

--- a/changelog/2168.removal.rst
+++ b/changelog/2168.removal.rst
@@ -1,6 +1,9 @@
 Removed support for OpenSSL versions earlier than 1.1.1 or that don't have SNI support.
 When an incompatible OpenSSL version is detected an ``ImportError`` is raised.
 
+Removed support for Python with an ``ssl`` module compiled with LibreSSL, CiscoSSL,
+wolfSSL, and all other OpenSSL alternatives. Python is moving to require OpenSSL with PEP 644.
+
 Changed ``urllib3.util.create_urllib3_context`` to not override the system cipher suites with
 a default value. The new default will be cipher suites configured by the operating system.
 

--- a/changelog/2168.removal.rst
+++ b/changelog/2168.removal.rst
@@ -1,0 +1,9 @@
+Removed support for OpenSSL versions earlier than 1.1.1 or that don't have SNI support.
+When an incompatible OpenSSL version is detected an ``ImportError`` is raised.
+
+Changed ``urllib3.util.create_urllib3_context`` to not override the system cipher suites with
+a default value. The new default will be cipher suites configured by the operating system.
+
+Removed ``DEFAULT_CIPHERS``, ``HAS_SNI``, ``USE_DEFAULT_SSLCONTEXT_CIPHERS``, from the private module ``urllib3.util.ssl_``.
+
+Removed ``urllib3.exceptions.SNIMissingWarning``.

--- a/ci/0002-Stop-relying-on-removed-DEFAULT_CIPHERS.patch
+++ b/ci/0002-Stop-relying-on-removed-DEFAULT_CIPHERS.patch
@@ -1,0 +1,34 @@
+From dcc55a54fe2ba3b403923e95ab329009a9f430e2 Mon Sep 17 00:00:00 2001
+From: Quentin Pradet <quentin.pradet@gmail.com>
+Date: Fri, 19 Aug 2022 11:02:11 +0400
+Subject: [PATCH] Stop relying on removed DEFAULT_CIPHERS
+
+---
+ botocore/httpsession.py | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/botocore/httpsession.py b/botocore/httpsession.py
+index 29b210377..aaecb454b 100644
+--- a/botocore/httpsession.py
++++ b/botocore/httpsession.py
+@@ -19,7 +19,6 @@ from urllib3.exceptions import ReadTimeoutError as URLLib3ReadTimeoutError
+ from urllib3.exceptions import SSLError as URLLib3SSLError
+ from urllib3.util.retry import Retry
+ from urllib3.util.ssl_ import (
+-    DEFAULT_CIPHERS,
+     OP_NO_COMPRESSION,
+     PROTOCOL_TLS,
+     OP_NO_SSLv2,
+@@ -99,7 +98,8 @@ def create_urllib3_context(
+ 
+     context = SSLContext(ssl_version)
+ 
+-    context.set_ciphers(ciphers or DEFAULT_CIPHERS)
++    if ciphers:
++        context.set_ciphers(ciphers)
+ 
+     # Setting the default here, as we may have no ssl module on import
+     cert_reqs = ssl.CERT_REQUIRED if cert_reqs is None else cert_reqs
+-- 
+2.37.2
+

--- a/ci/requests.patch
+++ b/ci/requests.patch
@@ -1,8 +1,23 @@
+diff --git a/tests/__init__.py b/tests/__init__.py
+index 04385be1..e69de29b 100644
+--- a/tests/__init__.py
++++ b/tests/__init__.py
+@@ -1,10 +0,0 @@
+-"""Requests test package initialisation."""
+-
+-import warnings
+-
+-from urllib3.exceptions import SNIMissingWarning
+-
+-# urllib3 sets SNIMissingWarning to only go off once,
+-# while this test suite requires it to always fire
+-# so that it occurs during test_requests.test_https_warnings
+-warnings.simplefilter("always", SNIMissingWarning)
 diff --git a/tests/test_requests.py b/tests/test_requests.py
-index b77cba00..5a18d72c 100644
+index 5b4c3f53..2530b13b 100644
 --- a/tests/test_requests.py
 +++ b/tests/test_requests.py
-@@ -874,6 +874,7 @@ class TestRequests:
+@@ -974,6 +974,7 @@ class TestRequests:
          r = requests.get(httpbin(), cert=".")
          assert r.status_code == 200
  

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 -r ../dev-requirements.txt
 sphinx>3.0.0
-requests>=2,<2.16
+requests
 furo
 sphinx-copybutton

--- a/noxfile.py
+++ b/noxfile.py
@@ -92,12 +92,11 @@ def downstream_botocore(session: nox.Session) -> None:
     session.cd(tmp_dir)
     git_clone(session, "https://github.com/boto/botocore")
     session.chdir("botocore")
-    session.run(
-        "git",
-        "apply",
-        f"{root}/ci/0001-Mark-100-Continue-tests-as-failing.patch",
-        external=True,
-    )
+    for patch in [
+        "0001-Mark-100-Continue-tests-as-failing.patch",
+        "0002-Stop-relying-on-removed-DEFAULT_CIPHERS.patch",
+    ]:
+        session.run("git", "apply", f"{root}/ci/{patch}", external=True)
     session.run("git", "rev-parse", "HEAD", external=True)
     session.run("python", "scripts/ci/install")
 

--- a/src/urllib3/__init__.py
+++ b/src/urllib3/__init__.py
@@ -28,11 +28,17 @@ try:
 except ImportError:
     pass
 else:
-    if ssl.OPENSSL_VERSION_INFO < (1, 1, 1):  # Defensive:
+    # fmt: off
+    if (
+        not ssl.OPENSSL_VERSION.startswith("OpenSSL ")
+        or ssl.OPENSSL_VERSION_INFO < (1, 1, 1,)
+    ):  # Defensive:
         raise ImportError(
             "urllib3 v2.0 only supports OpenSSL 1.1.1+, currently "
-            f"the 'ssl' module is compiled with {ssl.OPENSSL_VERSION}."
+            f"the 'ssl' module is compiled with {ssl.OPENSSL_VERSION}. "
+            "See: https://github.com/urllib3/urllib3/issues/2168"
         )
+    # fmt: on
 
     # In theory OpenSSL 1.1.0 made SNI support required
     # but to be on the safe side we check to make sure.

--- a/src/urllib3/__init__.py
+++ b/src/urllib3/__init__.py
@@ -28,7 +28,7 @@ try:
 except ImportError:
     pass
 else:
-    if ssl.OPENSSL_VERSION_INFO < (1, 1, 1):
+    if ssl.OPENSSL_VERSION_INFO < (1, 1, 1):  # Defensive:
         raise ImportError(
             "urllib3 v2.0 only supports OpenSSL 1.1.1+, currently "
             f"the 'ssl' module is compiled with {ssl.OPENSSL_VERSION}."

--- a/src/urllib3/__init__.py
+++ b/src/urllib3/__init__.py
@@ -31,7 +31,7 @@ else:
     # fmt: off
     if (
         not ssl.OPENSSL_VERSION.startswith("OpenSSL ")
-        or ssl.OPENSSL_VERSION_INFO < (1, 1, 1,)
+        or ssl.OPENSSL_VERSION_INFO < (1, 1, 1)
     ):  # Defensive:
         raise ImportError(
             "urllib3 v2.0 only supports OpenSSL 1.1.1+, currently "
@@ -39,14 +39,6 @@ else:
             "See: https://github.com/urllib3/urllib3/issues/2168"
         )
     # fmt: on
-
-    # In theory OpenSSL 1.1.0 made SNI support required
-    # but to be on the safe side we check to make sure.
-    if not ssl.HAS_SNI:  # Defensive:
-        raise ImportError(
-            "urllib3 v2.0 only supports OpenSSL with SNI "
-            "(Server Name Identification) enabled."
-        )
 
 # === NOTE TO REPACKAGERS AND VENDORS ===
 # Please delete this block, this logic is only

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -616,6 +616,9 @@ def _ssl_wrap_socket_and_match_hostname(
         context.check_hostname = False
 
     # Try to load OS default certs if none are given.
+    # We need to do the hasattr() check for our custom
+    # pyOpenSSL and SecureTransport SSLContext objects
+    # because neither support load_default_certs().
     if (
         not ca_certs
         and not ca_cert_dir

--- a/src/urllib3/contrib/pyopenssl.py
+++ b/src/urllib3/contrib/pyopenssl.py
@@ -66,14 +66,6 @@ if TYPE_CHECKING:
 
 __all__ = ["inject_into_urllib3", "extract_from_urllib3"]
 
-# SNI always works.
-HAS_SNI = True
-
-# Use system TLS ciphers on OpenSSL 1.1.1+
-USE_DEFAULT_SSLCONTEXT_CIPHERS = util.ssl_._is_ge_openssl_v1_1_1(
-    openssl_backend.openssl_version_text(), openssl_backend.openssl_version_number()
-)
-
 # Map from urllib3 to PyOpenSSL compatible parameter-values.
 _openssl_versions = {
     util.ssl_.PROTOCOL_TLS: OpenSSL.SSL.SSLv23_METHOD,  # type: ignore[attr-defined]
@@ -138,9 +130,7 @@ _openssl_to_ssl_maximum_version: Dict[int, int] = {
 # OpenSSL will only write 16K at a time
 SSL_WRITE_BLOCKSIZE = 16384
 
-orig_util_HAS_SNI = util.HAS_SNI
 orig_util_SSLContext = util.ssl_.SSLContext
-orig_util_USE_SYSTEM_SSL_CIPHERS = util.ssl_.USE_DEFAULT_SSLCONTEXT_CIPHERS
 
 
 log = logging.getLogger(__name__)
@@ -153,11 +143,8 @@ def inject_into_urllib3() -> None:
 
     util.SSLContext = PyOpenSSLContext  # type: ignore[assignment]
     util.ssl_.SSLContext = PyOpenSSLContext  # type: ignore[assignment]
-    util.HAS_SNI = HAS_SNI
-    util.ssl_.HAS_SNI = HAS_SNI
     util.IS_PYOPENSSL = True
     util.ssl_.IS_PYOPENSSL = True
-    util.ssl_.USE_DEFAULT_SSLCONTEXT_CIPHERS = USE_DEFAULT_SSLCONTEXT_CIPHERS
 
 
 def extract_from_urllib3() -> None:
@@ -165,11 +152,8 @@ def extract_from_urllib3() -> None:
 
     util.SSLContext = orig_util_SSLContext
     util.ssl_.SSLContext = orig_util_SSLContext
-    util.HAS_SNI = orig_util_HAS_SNI
-    util.ssl_.HAS_SNI = orig_util_HAS_SNI
     util.IS_PYOPENSSL = False
     util.ssl_.IS_PYOPENSSL = False
-    util.ssl_.USE_DEFAULT_SSLCONTEXT_CIPHERS = orig_util_USE_SYSTEM_SSL_CIPHERS
 
 
 def _validate_dependencies_met() -> None:

--- a/src/urllib3/contrib/securetransport.py
+++ b/src/urllib3/contrib/securetransport.py
@@ -105,12 +105,7 @@ if TYPE_CHECKING:
 
 __all__ = ["inject_into_urllib3", "extract_from_urllib3"]
 
-# SNI always works
-HAS_SNI = True
-
-orig_util_HAS_SNI = util.HAS_SNI
 orig_util_SSLContext = util.ssl_.SSLContext
-orig_util_USE_SYSTEM_SSL_CIPHERS = util.ssl_.USE_DEFAULT_SSLCONTEXT_CIPHERS
 
 # This dictionary is used by the read callback to obtain a handle to the
 # calling wrapped socket. This is a pretty silly approach, but for now it'll
@@ -190,11 +185,8 @@ def inject_into_urllib3() -> None:
     """
     util.SSLContext = SecureTransportContext  # type: ignore[assignment]
     util.ssl_.SSLContext = SecureTransportContext  # type: ignore[assignment]
-    util.HAS_SNI = HAS_SNI
-    util.ssl_.HAS_SNI = HAS_SNI
     util.IS_SECURETRANSPORT = True
     util.ssl_.IS_SECURETRANSPORT = True
-    util.ssl_.USE_DEFAULT_SSLCONTEXT_CIPHERS = True
 
 
 def extract_from_urllib3() -> None:
@@ -203,11 +195,8 @@ def extract_from_urllib3() -> None:
     """
     util.SSLContext = orig_util_SSLContext
     util.ssl_.SSLContext = orig_util_SSLContext
-    util.HAS_SNI = orig_util_HAS_SNI
-    util.ssl_.HAS_SNI = orig_util_HAS_SNI
     util.IS_SECURETRANSPORT = False
     util.ssl_.IS_SECURETRANSPORT = False
-    util.ssl_.USE_DEFAULT_SSLCONTEXT_CIPHERS = orig_util_USE_SYSTEM_SSL_CIPHERS
 
 
 def _read_callback(

--- a/src/urllib3/exceptions.py
+++ b/src/urllib3/exceptions.py
@@ -252,12 +252,6 @@ class InsecurePlatformWarning(SecurityWarning):
     pass
 
 
-class SNIMissingWarning(HTTPWarning):
-    """Warned when making a HTTPS request without SNI available."""
-
-    pass
-
-
 class DependencyWarning(HTTPWarning):
     """
     Warned when an attempt is made to import a module with missing optional

--- a/src/urllib3/util/__init__.py
+++ b/src/urllib3/util/__init__.py
@@ -5,7 +5,6 @@ from .response import is_fp_closed
 from .retry import Retry
 from .ssl_ import (
     ALPN_PROTOCOLS,
-    HAS_SNI,
     IS_PYOPENSSL,
     IS_SECURETRANSPORT,
     SSLContext,
@@ -20,7 +19,6 @@ from .url import Url, parse_url
 from .wait import wait_for_read, wait_for_write
 
 __all__ = (
-    "HAS_SNI",
     "IS_PYOPENSSL",
     "IS_SECURETRANSPORT",
     "SSLContext",

--- a/test/test_ssl.py
+++ b/test/test_ssl.py
@@ -42,19 +42,12 @@ class TestSSL:
     def test_is_ipaddress_false(self, addr: Union[bytes, str]) -> None:
         assert not ssl_.is_ipaddress(addr)
 
-    @pytest.mark.parametrize(
-        ["ciphers", "expected_ciphers"],
-        [
-            ("ECDH+AESGCM:ECDH+CHACHA20", "ECDH+AESGCM:ECDH+CHACHA20"),
-        ],
-    )
     def test_create_urllib3_context_set_ciphers(
         self,
         monkeypatch: pytest.MonkeyPatch,
-        ciphers: Optional[str],
-        expected_ciphers: str,
     ) -> None:
 
+        ciphers = "ECDH+AESGCM:ECDH+CHACHA20"
         context = mock.create_autospec(ssl_.SSLContext)
         context.set_ciphers = mock.Mock()
         context.options = 0
@@ -63,7 +56,7 @@ class TestSSL:
         assert ssl_.create_urllib3_context(ciphers=ciphers) is context
 
         assert context.set_ciphers.call_count == 1
-        assert context.set_ciphers.call_args == mock.call(expected_ciphers)
+        assert context.set_ciphers.call_args == mock.call(ciphers)
 
     def test_create_urllib3_no_context(self) -> None:
         with mock.patch("urllib3.util.ssl_.SSLContext", None):
@@ -134,8 +127,7 @@ class TestSSL:
         assert context.post_handshake_auth == expected_pha
 
     def test_create_urllib3_context_default_ciphers(
-        self,
-        monkeypatch: pytest.MonkeyPatch,
+        self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         context = mock.create_autospec(ssl_.SSLContext)
         context.set_ciphers = mock.Mock()

--- a/test/test_ssl.py
+++ b/test/test_ssl.py
@@ -43,8 +43,7 @@ class TestSSL:
         assert not ssl_.is_ipaddress(addr)
 
     def test_create_urllib3_context_set_ciphers(
-        self,
-        monkeypatch: pytest.MonkeyPatch,
+        self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
 
         ciphers = "ECDH+AESGCM:ECDH+CHACHA20"

--- a/test/test_ssl.py
+++ b/test/test_ssl.py
@@ -4,7 +4,7 @@ from unittest import mock
 
 import pytest
 
-from urllib3.exceptions import ProxySchemeUnsupported, SNIMissingWarning, SSLError
+from urllib3.exceptions import ProxySchemeUnsupported, SSLError
 from urllib3.util import ssl_
 
 
@@ -43,44 +43,8 @@ class TestSSL:
         assert not ssl_.is_ipaddress(addr)
 
     @pytest.mark.parametrize(
-        ["has_sni", "server_hostname", "should_warn"],
-        [
-            (True, "www.google.com", False),
-            (True, "127.0.0.1", False),
-            (False, "127.0.0.1", False),
-            (False, "www.google.com", True),
-            (True, None, False),
-            (False, None, False),
-        ],
-    )
-    def test_sni_missing_warning_with_ip_addresses(
-        self,
-        monkeypatch: pytest.MonkeyPatch,
-        has_sni: bool,
-        server_hostname: Optional[str],
-        should_warn: bool,
-    ) -> None:
-        monkeypatch.setattr(ssl_, "HAS_SNI", has_sni)
-
-        sock = mock.Mock()
-        context = mock.create_autospec(ssl_.SSLContext)
-
-        with mock.patch("warnings.warn") as warn:
-            ssl_.ssl_wrap_socket(
-                sock, server_hostname=server_hostname, ssl_context=context
-            )
-
-        if should_warn:
-            assert warn.call_count >= 1
-            warnings = [call[0][1] for call in warn.call_args_list]
-            assert SNIMissingWarning in warnings
-        else:
-            assert warn.call_count == 0
-
-    @pytest.mark.parametrize(
         ["ciphers", "expected_ciphers"],
         [
-            (None, ssl_.DEFAULT_CIPHERS),
             ("ECDH+AESGCM:ECDH+CHACHA20", "ECDH+AESGCM:ECDH+CHACHA20"),
         ],
     )
@@ -98,11 +62,8 @@ class TestSSL:
 
         assert ssl_.create_urllib3_context(ciphers=ciphers) is context
 
-        if ciphers is None and ssl_.USE_DEFAULT_SSLCONTEXT_CIPHERS:
-            assert context.set_ciphers.call_count == 0
-        else:
-            assert context.set_ciphers.call_count == 1
-            assert context.set_ciphers.call_args == mock.call(expected_ciphers)
+        assert context.set_ciphers.call_count == 1
+        assert context.set_ciphers.call_args == mock.call(expected_ciphers)
 
     def test_create_urllib3_no_context(self) -> None:
         with mock.patch("urllib3.util.ssl_.SSLContext", None):
@@ -172,24 +133,18 @@ class TestSSL:
 
         assert context.post_handshake_auth == expected_pha
 
-    @pytest.mark.parametrize("use_default_sslcontext_ciphers", [True, False])
     def test_create_urllib3_context_default_ciphers(
-        self, monkeypatch: pytest.MonkeyPatch, use_default_sslcontext_ciphers: bool
+        self,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         context = mock.create_autospec(ssl_.SSLContext)
         context.set_ciphers = mock.Mock()
         context.options = 0
         monkeypatch.setattr(ssl_, "SSLContext", lambda *_, **__: context)
-        monkeypatch.setattr(
-            ssl_, "USE_DEFAULT_SSLCONTEXT_CIPHERS", use_default_sslcontext_ciphers
-        )
 
         ssl_.create_urllib3_context()
 
-        if use_default_sslcontext_ciphers:
-            context.set_ciphers.assert_not_called()
-        else:
-            context.set_ciphers.assert_called_with(ssl_.DEFAULT_CIPHERS)
+        context.set_ciphers.assert_not_called()
 
     @pytest.mark.parametrize(
         "kwargs",

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -13,12 +13,11 @@ from urllib.parse import urlparse
 
 import pytest
 
-from urllib3 import add_stderr_logger, disable_warnings, util
+from urllib3 import add_stderr_logger, disable_warnings
 from urllib3.connection import ProxyConfig
 from urllib3.exceptions import (
     InsecureRequestWarning,
     LocationParseError,
-    SNIMissingWarning,
     TimeoutStateError,
     UnrewindableBodyError,
 )
@@ -1027,21 +1026,6 @@ class TestUtilSSL:
                 server_hostname=server_hostname,
             )
         return mock_context, warn
-
-    def test_ssl_wrap_socket_sni_hostname_use_or_warn(self) -> None:
-        """Test that either an SNI hostname is used or a warning is made."""
-        sock = Mock()
-        context, warn = self._wrap_socket_and_mock_warn(sock, "www.google.com")
-        if util.HAS_SNI:
-            warn.assert_not_called()
-            context.wrap_socket.assert_called_once_with(
-                sock, server_hostname="www.google.com"
-            )
-        else:
-            assert warn.call_count >= 1
-            warnings = [call[0][1] for call in warn.call_args_list]
-            assert SNIMissingWarning in warnings
-            context.wrap_socket.assert_called_once_with(sock)
 
     def test_ssl_wrap_socket_sni_ip_address_no_warn(self) -> None:
         """Test that a warning is not made if server_hostname is an IP address."""

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -84,8 +84,6 @@ class TestCookies(SocketDummyServerTestCase):
 
 class TestSNI(SocketDummyServerTestCase):
     def test_hostname_in_first_request_packet(self) -> None:
-        if not util.HAS_SNI:
-            pytest.skip("SNI-support not available")
         done_receiving = Event()
         self.buf = b""
 


### PR DESCRIPTION
Closes https://github.com/urllib3/urllib3/issues/2168

From the original issue, decided to not to implement these:

- Didn't remove detection for SSLContext.minimum_version because it requires Python 3.8
- Didn't remove SSLKEYLOGFILE detection because it requires Python 3.8
- Didn't remove post_handshake_auth detection because it requires Python 3.8