### PR TITLE
Allow reuse of SSL sessions

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -6,6 +6,7 @@ max-line-length=99
 [tool:pytest]
 xfail_strict = true
 python_classes = Test *TestCase
+log_level = DEBUG
 
 [isort]
 profile=black

--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -942,6 +942,7 @@ class HTTPSConnectionPool(HTTPConnectionPool):
         assert_hostname: Optional[Union[str, "Literal[False]"]] = None,
         assert_fingerprint: Optional[str] = None,
         ca_cert_dir: Optional[str] = None,
+        reuse_ssl_sessions: bool = True,
         **conn_kw: Any,
     ) -> None:
 
@@ -969,6 +970,7 @@ class HTTPSConnectionPool(HTTPConnectionPool):
         self.ssl_maximum_version = ssl_maximum_version
         self.assert_hostname = assert_hostname
         self.assert_fingerprint = assert_fingerprint
+        self.reuse_ssl_sessions = reuse_ssl_sessions
 
     def _prepare_conn(self, conn: HTTPSConnection) -> HTTPConnection:
         """
@@ -1037,6 +1039,7 @@ class HTTPSConnectionPool(HTTPConnectionPool):
             cert_file=self.cert_file,
             key_file=self.key_file,
             key_password=self.key_password,
+            reuse_ssl_sessions=self.reuse_ssl_sessions,
             **self.conn_kw,
         )
 

--- a/src/urllib3/poolmanager.py
+++ b/src/urllib3/poolmanager.py
@@ -56,6 +56,7 @@ SSL_KEYWORDS = (
     "ssl_context",
     "key_password",
     "server_hostname",
+    "reuse_ssl_sessions",
 )
 # Default value for `blocksize` - a new parameter introduced to
 # http.client.HTTPConnection & http.client.HTTPSConnection in Python 3.7
@@ -100,6 +101,7 @@ class PoolKey(NamedTuple):
     key_assert_fingerprint: Optional[str]
     key_server_hostname: Optional[str]
     key_blocksize: Optional[int]
+    key_reuse_ssl_sessions: Optional[bool]
 
 
 def _default_key_normalizer(

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -617,6 +617,7 @@ class TestUtil:
 
         logger.debug("Testing add_stderr_logger")
         logger.removeHandler(handler)
+        logger.setLevel(logging.NOTSET)  # reset for other tests
 
     def test_disable_warnings(self) -> None:
         with warnings.catch_warnings(record=True) as w:

--- a/test/with_dummyserver/test_connectionpool.py
+++ b/test/with_dummyserver/test_connectionpool.py
@@ -1,7 +1,5 @@
 import io
-import logging
 import socket
-import sys
 import time
 import warnings
 from test import LONG_TIMEOUT, SHORT_TIMEOUT
@@ -36,10 +34,6 @@ from .. import INVALID_SOURCE_ADDRESSES, TARPIT_HOST, VALID_SOURCE_ADDRESSES
 from ..port_helpers import find_unused_port
 
 pytestmark = pytest.mark.flaky
-
-log = logging.getLogger("urllib3.connectionpool")
-log.setLevel(logging.NOTSET)
-log.addHandler(logging.StreamHandler(sys.stdout))
 
 
 def wait_for_socket(ready_event: Event) -> None:

--- a/test/with_dummyserver/test_https.py
+++ b/test/with_dummyserver/test_https.py
@@ -1,5 +1,4 @@
 import datetime
-import logging
 import os.path
 import shutil
 import ssl
@@ -49,11 +48,6 @@ from .. import has_alpn
 
 # Retry failed tests
 pytestmark = pytest.mark.flaky
-
-
-log = logging.getLogger("urllib3.connectionpool")
-log.setLevel(logging.NOTSET)
-log.addHandler(logging.StreamHandler(sys.stdout))
 
 
 TLSv1_CERTS = DEFAULT_CERTS.copy()


### PR DESCRIPTION
As discussed in #590, #604, #1886, and #1898. This PR borrows heavily from @PleasantMachine9's pr #1886.

The value seems to be primarily when connecting to a service that aggressively closes connections and also supports the abbreviated SSL handshake that's possible by reusing the SSL session.

~~I still need to add some restrictions to when urllib3 will allow the functionality to be enabled per the discussion in #1886~~ and I need to copy over the documentation.

Testing with standard integration tests that demonstrate the session reuse seems unlikely, so currently this is only confirming the debug log is hit. But I did confirm functionality against an HTTPS server that supports session resuming.