### PR TITLE
Switch build backend to Hatchling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,8 @@
 # This file is protected via CODEOWNERS
 
 [build-system]
-requires = ["flit_core >=3.2,<4"]
-build-backend = "flit_core.buildapi"
+requires = ["hatchling>=1.6.0"]
+build-backend = "hatchling.build"
 
 [project]
 name = "urllib3"
@@ -60,3 +60,6 @@ socks = [
 "Documentation" = "https://urllib3.readthedocs.io"
 "Code" = "https://github.com/urllib3/urllib3"
 "Issue tracker" = "https://github.com/urllib3/urllib3/issues"
+
+[tool.hatch.version]
+path = "src/urllib3/_version.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 # This file is protected via CODEOWNERS
 
 [build-system]
-requires = ["hatchling~=1.6"]
+requires = ["hatchling>=1.6.0,<2"]
 build-backend = "hatchling.build"
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 # This file is protected via CODEOWNERS
 
 [build-system]
-requires = ["hatchling>=1.6.0"]
+requires = ["hatchling~=1.6"]
 build-backend = "hatchling.build"
 
 [project]
@@ -34,7 +34,7 @@ classifiers = [
   "Topic :: Internet :: WWW/HTTP",
   "Topic :: Software Development :: Libraries",
 ]
-requires-python = ">=3.7, <4"
+requires-python = ">=3.7"
 dynamic = ["version"]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Description

This switches the build backend to `hatchling` (of which I am a maintainer in the [PyPA](https://github.com/pypa)) as that is the default in the official [Python packaging tutorial](https://packaging.python.org/en/latest/tutorials/packaging-projects/). Hatchling is available on all the major distribution channels such as [Debian](https://salsa.debian.org/python-team/packages/hatchling), [Fedora](https://src.fedoraproject.org/rpms/python-hatchling), [Arch Linux](https://archlinux.org/packages/community/any/python-hatchling/), [conda-forge](https://anaconda.org/conda-forge/hatchling), [Nixpkgs](https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/python-modules/hatchling/default.nix), [Alpine Linux](https://github.com/alpinelinux/aports/blob/master/community/py3-hatchling/APKBUILD), [FreeBSD](https://github.com/freebsd/freebsd-ports/blob/main/devel/py-hatchling/Makefile), [Gentoo Linux](https://github.com/gentoo/gentoo/tree/master/dev-python/hatchling), [MacPorts](https://github.com/macports/macports-ports/blob/master/python/py-hatchling/Portfile), [OpenEmbedded](https://github.com/openembedded/openembedded-core/commit/846e806181f1349be29cbce78c5041735dfd7e6f), [Spack](https://github.com/spack/spack/blob/develop/var/spack/repos/builtin/packages/py-hatchling/package.py), etc.

This unlocks the ability to use plugins that would allow us to [source the version](https://github.com/ofek/hatch-vcs) from Git, ship optional wheels compiled with [Mypyc](https://github.com/ofek/hatch-mypyc), make a [fancy PyPI readme](https://github.com/hynek/hatch-fancy-pypi-readme), etc.

## Future

- Use Mypyc 😄 
- We should probably remove the Python upper bound constraint as upper bounds for libraries are heavily discouraged by the community, see https://iscinumpy.dev/post/bound-version-constraints/