### PR TITLE
Add SLSA generic generator to publish workflow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/release.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release.md
@@ -8,14 +8,12 @@
     git push <REMOTE> --tags
     ```
 * [ ]  Execute the `publish` GitHub workflow. This requires a review from a maintainer.
-* [ ]  Download the sdist and wheel files from PyPI. Attach these files to the GitHub release.
-* [ ]  Download the `.crt` and `.sig` files from the `sigstore-artifacts` artifact in the `publish` workflow execution. Attach these files to the GitHub release.
+* [ ]  Ensure that all expected artifacts are added to the new GitHub release. Should
+       be one `.whl`, one `.tar.gz`, and one `urllib3.intoto.jsonl`. Update the GitHub
+       release to have the content of the release's changelog.
 * [ ]  Announce on:
-  
-  * [ ]  GitHub releases
   * [ ]  Twitter
   * [ ]  Discord
   * [ ]  OpenCollective
-  * [ ]  GitCoin Grants
 * [ ]  Update Tidelift metadata
 * [ ]  If this was a 1.26.x release, add changelog to the `main` branch

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,8 +11,8 @@ permissions:
   id-token: "write"
 
 jobs:
-  publish:
-    name: "Publish to PyPI"
+  build:
+    name: "Build dists"
     runs-on: "ubuntu-latest"
     environment:
       name: "publish"
@@ -34,37 +34,52 @@ jobs:
           SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct) \
           python -m build
 
-      - name: "Sign dists"
+      - name: "Generate hashes"
+        id: hash
         run: |
-          mkdir -p sigstore-artifacts/
+          cd dist && echo "::set-output name=hashes::$(sha256sum * | base64 -w0)"
 
-          for dist in dist/*; do
-            dist_name=$(basename "${dist}")
-
-            # Sign the dists and then verify them immediately
-            # with the generated artifacts.
-            python -m \
-              sigstore sign "${dist}" \
-              --output-signature sigstore-artifacts/"${dist_name}.sig" \
-              --output-certificate sigstore-artifacts/"${dist_name}.crt"
-
-            python -m \
-              sigstore verify "${dist}" \
-              --cert "sigstore-artifacts/${dist_name}.crt" \
-              --signature "sigstore-artifacts/${dist_name}.sig" \
-              --cert-oidc-issuer https://token.actions.githubusercontent.com
-
-          done
-
-      - name: "Upload artifacts"
+      - name: "Upload dists"
         uses: "actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8"
         with:
-          name: "sigstore-artifacts"
-          path: "sigstore-artifacts/*"
-          if-no-files-found: "error"
+          name: "dist"
+          path: "dist/"
+          if-no-files-found: error
+          retention-days: 5
 
-      - name: "Publish to PyPI"
-        uses: "pypa/gh-action-pypi-publish@37f50c210e3d2f9450da2cd423303d6a14a6e29f"
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_TOKEN }}
+  provenance:
+    needs: [build]
+    permissions:
+      actions: read
+      contents: write
+      id-token: write
+    uses: "slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.2.0"
+    with:
+      base64-subjects: "${{ needs.build.outputs.hashes }}"
+      attestation-name: "urllib3.intoto.jsonl"
+      upload-assets: true
+
+  publish:
+    name: "Publish"
+    if: startsWith(github.ref, 'refs/tags/')
+    needs: ["build", "provenance"]
+    runs-on: "ubuntu-latest"
+
+    steps:
+    - name: "Download dists"
+      uses: "actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741"
+      with:
+        name: "dist"
+        path: "dist/"
+
+    - name: "Upload dists to GitHub Release"
+      env:
+        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      run: |
+        gh release upload ${{ github.ref_name }} dist/* --repo ${{ github.repository }}
+
+    - name: "Publish dists to PyPI"
+      uses: "pypa/gh-action-pypi-publish@37f50c210e3d2f9450da2cd423303d6a14a6e29f"
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
Switches from Sigstore to SLSA for provenance attestation using GitHub OIDC. Allows users to verify that wheel and source distribution were built from our repository, workflow, and tag.

SLSA is also the new standard for a 10/10 on Scorecard: https://github.com/ossf/scorecard/pull/2144

Once the 1.26.12 release is live I'll do an E2E test, if that passes I will write documentation on how consumers can verify the wheels to close 

Tested that this setup works here:
- https://github.com/sethmlarson/python-slsa-release-test/releases/tag/0.1.14
- https://github.com/sethmlarson/python-slsa-release-test/blob/0.1.14/.github/workflows/release.yml

(Ignore new failures on this repository, was testing more things)