### PR TITLE
Add official Hatch badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
   <a href="https://deps.dev/pypi/urllib3"><img alt="OpenSSF Scorecard" src="https://api.securityscorecards.dev/projects/github.com/urllib3/urllib3/badge" /></a>
   <a href="https://slsa.dev"><img alt="SLSA 3" src="https://slsa.dev/images/gh-badge-level3.svg" /></a>
   <a href="https://bestpractices.coreinfrastructure.org/projects/6227"><img alt="CII Best Practices" src="https://bestpractices.coreinfrastructure.org/projects/6227/badge" /></a>
+  <a href="https://github.com/pypa/hatch"><img alt="Hatch project" src="https://img.shields.io/badge/%F0%9F%A5%9A-Hatch-4051b5.svg" /></a>
 </p>
 
 urllib3 is a powerful, *user-friendly* HTTP client for Python. Much of the


### PR DESCRIPTION
If you want, we have a badge (and [logo](https://github.com/pypa/hatch/blob/master/docs/assets/images/logo.svg)) now 🙂 https://hatch.pypa.io/latest/next-steps/#community