### PR TITLE
Restrict sdist files in Hatch

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,0 @@
-include README.md CHANGES.rst LICENSE.txt dev-requirements.txt Makefile src/urllib3/py.typed
-recursive-include dummyserver *
-recursive-include test *
-recursive-include docs *
-recursive-exclude docs/_build *

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,3 +64,15 @@ socks = [
 
 [tool.hatch.version]
 path = "src/urllib3/_version.py"
+
+[tool.hatch.build.targets.sdist]
+include = [
+  "/docs",
+  "/dummyserver",
+  "/src",
+  "/test",
+  "/dev-requirements.txt",
+  "/CHANGES.rst",
+  "/README.md",
+  "/LICENSE.txt",
+]


### PR DESCRIPTION
Hatch doesn't use MANIFEST.in so we should specify which files we want included in the sdist.