### PR TITLE
Remove workaround for old Python versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     name: ${{ fromJson('{"macos-latest":"macOS","windows-latest":"Windows","ubuntu-latest":"Ubuntu","ubuntu-20.04":"Ubuntu 20.04 (OpenSSL 1.1.1)","ubuntu-22.04":"Ubuntu 22.04 (OpenSSL 3.0)"}')[matrix.os] }} ${{ matrix.python-version }} ${{ matrix.nox-session}}
     continue-on-error: ${{ matrix.experimental }}
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       - name: "Checkout repository"
         uses: "actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b"

--- a/noxfile.py
+++ b/noxfile.py
@@ -42,6 +42,7 @@ def tests_impl(
         "--parallel-mode",
         "-m",
         "pytest",
+        "-v",
         "-r",
         "a",
         f"--color={'yes' if 'GITHUB_ACTIONS' in os.environ else 'auto'}",

--- a/src/urllib3/response.py
+++ b/src/urllib3/response.py
@@ -757,17 +757,7 @@ class HTTPResponse(BaseHTTPResponse):
                 flush_decoder = True
             else:
                 cache_content = False
-                if (
-                    amt != 0 and not data
-                ):  # Platform-specific: Buggy versions of Python.
-                    # Close the connection when no data is returned
-                    #
-                    # This is redundant to what httplib/http.client _should_
-                    # already do.  However, versions of python released before
-                    # December 15, 2012 (http://bugs.python.org/issue16298) do
-                    # not properly close the connection in all cases. There is
-                    # no harm in redundantly calling close.
-                    self._fp.close()
+                if amt != 0 and not data:
                     flush_decoder = True
                     if (
                         self.enforce_content_length


### PR DESCRIPTION
test_buggy_incomplete_read is still here to attest that the behavior did not change.
