### PR TITLE
Set correct workflow permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,6 +62,8 @@ jobs:
       upload-assets: true
 
   publish:
+    permissions:
+      contents: write # for gh release upload
     name: "Publish"
     if: startsWith(github.ref, 'refs/tags/')
     needs: ["build", "provenance"]

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,11 +62,11 @@ jobs:
       upload-assets: true
 
   publish:
-    permissions:
-      contents: write # for gh release upload
     name: "Publish"
     if: startsWith(github.ref, 'refs/tags/')
     needs: ["build", "provenance"]
+    permissions:
+      contents: write
     runs-on: "ubuntu-latest"
 
     steps:

--- a/changelog/2740.bugfix.rst
+++ b/changelog/2740.bugfix.rst
@@ -1,1 +1,0 @@
-Fixed the failing Publish workflow.

--- a/changelog/2740.bugfix.rst
+++ b/changelog/2740.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed the failing Publish workflow.


### PR DESCRIPTION
This fixes the Publish workflow failure.