### PR TITLE
Provisional support for Python 3.12 with SSL/TLS breaking changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,16 +68,8 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v2
 
-      - if: ${{ !endsWith(matrix.python-version, '-dev') }}
-        name: "Setup Python ${{ matrix.python-version }}"
+      - name: "Setup Python ${{ matrix.python-version }}"
         uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      # Use deadsnakes for development versions
-      - if: endsWith(matrix.python-version, '-dev')
-        name: "Setup Python ${{ matrix.python-version }}"
-        uses: deadsnakes/action@v2.1.1
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["2.7", "3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["2.7", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
         os: [macos-latest, windows-latest, ubuntu-latest]
         experimental: [false]
         nox-session: ['']
@@ -56,10 +56,10 @@ jobs:
             os: ubuntu-latest
             experimental: false
             nox-session: app_engine
-          - python-version: 3.11-dev
+          - python-version: "3.12-dev"
             os: ubuntu-latest
             experimental: true
-            nox-session: test-3.11
+            nox-session: test-3.12
 
     runs-on: ${{ matrix.os }}
     name: ${{ fromJson('{"macos-latest":"macOS","windows-latest":"Windows","ubuntu-latest":"Ubuntu"}')[matrix.os] }} ${{ matrix.python-version }} ${{ matrix.nox-session}}
@@ -68,8 +68,16 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v2
 
-      - name: Set Up Python - ${{ matrix.python-version }}
+      - if: ${{ !endsWith(matrix.python-version, '-dev') }}
+        name: "Setup Python ${{ matrix.python-version }}"
         uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      # Use deadsnakes for development versions
+      - if: endsWith(matrix.python-version, '-dev')
+        name: "Setup Python ${{ matrix.python-version }}"
+        uses: deadsnakes/action@v2.1.1
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/changelog/2686.bugfix.rst
+++ b/changelog/2686.bugfix.rst
@@ -1,0 +1,1 @@
+Added provisional support for Python 3.12 with SSL/TLS breaking changes.

--- a/dummyserver/server.py
+++ b/dummyserver/server.py
@@ -37,7 +37,7 @@ DEFAULT_CERTS = {
 }
 DEFAULT_CA = os.path.join(CERTS_PATH, "cacert.pem")
 DEFAULT_CA_KEY = os.path.join(CERTS_PATH, "cacert.key")
-PROTOCOL_TLS_SERVER = ssl.PROTOCOL_SSLv23 if not hasattr(ssl, "PROTOCOL_TLS_SERVER") else ssl.PROTOCOL_TLS_SERVER
+PROTOCOL_TLS_SERVER = ssl.PROTOCOL_TLS if not hasattr(ssl, "PROTOCOL_TLS_SERVER") else ssl.PROTOCOL_TLS_SERVER
 
 
 def _resolves_to_ipv6(host):
@@ -149,13 +149,7 @@ def ssl_options_to_context(
     max_ssl_version=None,
 ):
     """Return an equivalent SSLContext based on ssl.wrap_socket args."""
-    # python 3.12+ specific
-    # fallback to PROTOCOL_TLS_CLIENT cause tornado to hang
-    if ssl_version is None and hasattr(ssl, "PROTOCOL_TLS_SERVER"):
-        ssl_version = ssl.PROTOCOL_TLS_SERVER
-    else:
-        ssl_version = resolve_ssl_version(ssl_version)
-
+    ssl_version = resolve_ssl_version(ssl_version, default=PROTOCOL_TLS_SERVER)
     cert_none = resolve_cert_reqs("CERT_NONE")
     if cert_reqs is None:
         cert_reqs = cert_none

--- a/dummyserver/server.py
+++ b/dummyserver/server.py
@@ -37,7 +37,11 @@ DEFAULT_CERTS = {
 }
 DEFAULT_CA = os.path.join(CERTS_PATH, "cacert.pem")
 DEFAULT_CA_KEY = os.path.join(CERTS_PATH, "cacert.key")
-PROTOCOL_TLS_SERVER = ssl.PROTOCOL_TLS if not hasattr(ssl, "PROTOCOL_TLS_SERVER") else ssl.PROTOCOL_TLS_SERVER
+PROTOCOL_TLS_SERVER = (
+    ssl.PROTOCOL_TLS
+    if not hasattr(ssl, "PROTOCOL_TLS_SERVER")
+    else ssl.PROTOCOL_TLS_SERVER
+)
 
 
 def _resolves_to_ipv6(host):

--- a/dummyserver/server.py
+++ b/dummyserver/server.py
@@ -37,6 +37,9 @@ DEFAULT_CERTS = {
 }
 DEFAULT_CA = os.path.join(CERTS_PATH, "cacert.pem")
 DEFAULT_CA_KEY = os.path.join(CERTS_PATH, "cacert.key")
+DEFAULT_SERVER_CONTEXT = ssl.SSLContext(
+    ssl.PROTOCOL_SSLv23 if not hasattr(ssl, "PROTOCOL_TLS_SERVER") else ssl.PROTOCOL_TLS_SERVER
+)
 
 
 def _resolves_to_ipv6(host):

--- a/dummyserver/server.py
+++ b/dummyserver/server.py
@@ -37,9 +37,7 @@ DEFAULT_CERTS = {
 }
 DEFAULT_CA = os.path.join(CERTS_PATH, "cacert.pem")
 DEFAULT_CA_KEY = os.path.join(CERTS_PATH, "cacert.key")
-DEFAULT_SERVER_CONTEXT = ssl.SSLContext(
-    ssl.PROTOCOL_SSLv23 if not hasattr(ssl, "PROTOCOL_TLS_SERVER") else ssl.PROTOCOL_TLS_SERVER
-)
+PROTOCOL_TLS_SERVER = ssl.PROTOCOL_SSLv23 if not hasattr(ssl, "PROTOCOL_TLS_SERVER") else ssl.PROTOCOL_TLS_SERVER
 
 
 def _resolves_to_ipv6(host):

--- a/noxfile.py
+++ b/noxfile.py
@@ -45,7 +45,7 @@ def tests_impl(session, extras="socks,secure,brotli"):
     )
 
 
-@nox.session(python=["2.7", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "pypy"])
+@nox.session(python=["2.7", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "pypy"])
 def test(session):
     tests_impl(session)
 

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -291,6 +291,7 @@ class HTTPSConnection(HTTPConnection):
     ca_cert_dir = None
     ca_cert_data = None
     ssl_version = None
+    max_ssl_version = None
     assert_fingerprint = None
     tls_in_tls_required = False
 
@@ -399,6 +400,8 @@ class HTTPSConnection(HTTPConnection):
 
         context = self.ssl_context
         context.verify_mode = resolve_cert_reqs(self.cert_reqs)
+        if self.max_ssl_version and hasattr(context, "maximum_version"):
+            context.maximum_version = self.max_ssl_version
 
         # Try to load OS default certs if none are given.
         # Works well on Windows (requires Python3.4+)

--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -932,6 +932,7 @@ class HTTPSConnectionPool(HTTPConnectionPool):
         assert_hostname=None,
         assert_fingerprint=None,
         ca_cert_dir=None,
+        max_ssl_version=None,
         **conn_kw
     ):
 
@@ -957,6 +958,7 @@ class HTTPSConnectionPool(HTTPConnectionPool):
         self.ca_certs = ca_certs
         self.ca_cert_dir = ca_cert_dir
         self.ssl_version = ssl_version
+        self.max_ssl_version = max_ssl_version
         self.assert_hostname = assert_hostname
         self.assert_fingerprint = assert_fingerprint
 
@@ -978,6 +980,7 @@ class HTTPSConnectionPool(HTTPConnectionPool):
                 assert_fingerprint=self.assert_fingerprint,
             )
             conn.ssl_version = self.ssl_version
+            conn.max_ssl_version = self.max_ssl_version
         return conn
 
     def _prepare_proxy(self, conn):

--- a/src/urllib3/contrib/pyopenssl.py
+++ b/src/urllib3/contrib/pyopenssl.py
@@ -96,8 +96,13 @@ HAS_SNI = True
 _openssl_versions = {
     util.PROTOCOL_TLS: OpenSSL.SSL.SSLv23_METHOD,
     PROTOCOL_TLS_CLIENT: OpenSSL.SSL.SSLv23_METHOD,
-    ssl.PROTOCOL_TLSv1: OpenSSL.SSL.TLSv1_METHOD,
 }
+
+if hasattr(ssl, "TLSVersion") and hasattr(ssl.TLSVersion, "TLSv1_3"):
+    _openssl_versions[ssl.TLSVersion.TLSv1_3] = OpenSSL.SSL.SSLv23_METHOD
+
+if hasattr(ssl, "PROTOCOL_TLSv1") and hasattr(OpenSSL.SSL, "TLSv1_METHOD"):
+    _openssl_versions[ssl.PROTOCOL_TLSv1] = OpenSSL.SSL.TLSv1_METHOD
 
 if hasattr(ssl, "PROTOCOL_SSLv3") and hasattr(OpenSSL.SSL, "SSLv3_METHOD"):
     _openssl_versions[ssl.PROTOCOL_SSLv3] = OpenSSL.SSL.SSLv3_METHOD
@@ -105,9 +110,11 @@ if hasattr(ssl, "PROTOCOL_SSLv3") and hasattr(OpenSSL.SSL, "SSLv3_METHOD"):
 if hasattr(ssl, "PROTOCOL_TLSv1_1") and hasattr(OpenSSL.SSL, "TLSv1_1_METHOD"):
     _openssl_versions[ssl.PROTOCOL_TLSv1_1] = OpenSSL.SSL.TLSv1_1_METHOD
 
-if hasattr(ssl, "PROTOCOL_TLSv1_2") and hasattr(OpenSSL.SSL, "TLSv1_2_METHOD"):
-    _openssl_versions[ssl.PROTOCOL_TLSv1_2] = OpenSSL.SSL.TLSv1_2_METHOD
-
+if hasattr(OpenSSL.SSL, "TLSv1_2_METHOD"):
+    if hasattr(ssl, "PROTOCOL_TLSv1_2"):
+        _openssl_versions[ssl.PROTOCOL_TLSv1_2] = OpenSSL.SSL.TLSv1_2_METHOD
+    elif hasattr(ssl, "TLSVersion") and hasattr(ssl.TLSVersion, "TLSv1_2"):
+        _openssl_versions[ssl.TLSVersion.TLSv1_2] = OpenSSL.SSL.TLSv1_2_METHOD
 
 _stdlib_to_openssl_verify = {
     ssl.CERT_NONE: OpenSSL.SSL.VERIFY_NONE,

--- a/src/urllib3/util/__init__.py
+++ b/src/urllib3/util/__init__.py
@@ -10,6 +10,7 @@ from .ssl_ import (
     HAS_SNI,
     IS_PYOPENSSL,
     IS_SECURETRANSPORT,
+    PROTOCOL_TLS,
     PROTOCOL_TLS_CLIENT,
     SSLContext,
     assert_fingerprint,
@@ -21,7 +22,8 @@ from .timeout import Timeout, current_time
 from .url import Url, get_host, parse_url, split_first
 from .wait import wait_for_read, wait_for_write
 
-PROTOCOL_TLS = PROTOCOL_TLS_CLIENT
+if PROTOCOL_TLS is NotImplemented:
+    PROTOCOL_TLS = PROTOCOL_TLS_CLIENT
 
 __all__ = (
     "HAS_SNI",

--- a/src/urllib3/util/__init__.py
+++ b/src/urllib3/util/__init__.py
@@ -10,7 +10,7 @@ from .ssl_ import (
     HAS_SNI,
     IS_PYOPENSSL,
     IS_SECURETRANSPORT,
-    PROTOCOL_TLS,
+    PROTOCOL_TLS_CLIENT,
     SSLContext,
     assert_fingerprint,
     resolve_cert_reqs,
@@ -20,6 +20,8 @@ from .ssl_ import (
 from .timeout import Timeout, current_time
 from .url import Url, get_host, parse_url, split_first
 from .wait import wait_for_read, wait_for_write
+
+PROTOCOL_TLS = PROTOCOL_TLS_CLIENT
 
 __all__ = (
     "HAS_SNI",

--- a/src/urllib3/util/ssl_.py
+++ b/src/urllib3/util/ssl_.py
@@ -231,12 +231,12 @@ def resolve_cert_reqs(candidate):
     return candidate
 
 
-def resolve_ssl_version(candidate):
+def resolve_ssl_version(candidate, default=PROTOCOL_TLS_CLIENT):
     """
     like resolve_cert_reqs
     """
     if candidate is None:
-        return PROTOCOL_TLS_CLIENT
+        return default
 
     if isinstance(candidate, str):
         res = getattr(ssl, candidate, None)

--- a/src/urllib3/util/ssl_.py
+++ b/src/urllib3/util/ssl_.py
@@ -236,7 +236,7 @@ def resolve_ssl_version(candidate):
     like resolve_cert_reqs
     """
     if candidate is None:
-        return PROTOCOL_TLS
+        return PROTOCOL_TLS_CLIENT
 
     if isinstance(candidate, str):
         res = getattr(ssl, candidate, None)

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -67,7 +67,7 @@ def _can_resolve(host):
 def has_alpn(ctx_cls=None):
     """Detect if ALPN support is enabled."""
     ctx_cls = ctx_cls or util.SSLContext
-    ctx = ctx_cls(protocol=ssl_.PROTOCOL_TLS)
+    ctx = ctx_cls(ssl_.PROTOCOL_TLS_CLIENT)
     try:
         if hasattr(ctx, "set_alpn_protocols"):
             ctx.set_alpn_protocols(ssl_.ALPN_PROTOCOLS)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -267,7 +267,9 @@ def requires_tlsv1_1(supported_tls_versions):
 @pytest.fixture(scope="function")
 def requires_tlsv1_2(supported_tls_versions):
     """Test requires TLSv1.2 available"""
-    if hasattr(ssl, "PROTOCOL_TLSv1_2") or (hasattr(ssl, "TLSVersion") and hasattr(ssl.TLSVersion, "TLSv1_2")):
+    if hasattr(ssl, "PROTOCOL_TLSv1_2") or (
+        hasattr(ssl, "TLSVersion") and hasattr(ssl.TLSVersion, "TLSv1_2")
+    ):
         return
     if "TLSv1.2" in supported_tls_versions:
         return
@@ -277,7 +279,9 @@ def requires_tlsv1_2(supported_tls_versions):
 @pytest.fixture(scope="function")
 def requires_tlsv1_3(supported_tls_versions):
     """Test requires TLSv1.3 available"""
-    if hasattr(ssl, "PROTOCOL_TLSv1_3") or (hasattr(ssl, "TLSVersion") and hasattr(ssl.TLSVersion, "TLSv1_3")):
+    if hasattr(ssl, "PROTOCOL_TLSv1_3") or (
+        hasattr(ssl, "TLSVersion") and hasattr(ssl.TLSVersion, "TLSv1_3")
+    ):
         return
     if "TLSv1.3" in supported_tls_versions or getattr(ssl, "HAS_TLSv1_3", False):
         return

--- a/test/contrib/test_socks.py
+++ b/test/contrib/test_socks.py
@@ -678,7 +678,11 @@ class TestSOCKSWithTLS(IPV4SocketDummyServerTestCase):
             handler.send(True)
 
             # Wrap in TLS
-            context = better_ssl.SSLContext(ssl.PROTOCOL_SSLv23 if not hasattr(ssl, "PROTOCOL_TLS_SERVER") else ssl.PROTOCOL_TLS_SERVER)
+            context = better_ssl.SSLContext(
+                ssl.PROTOCOL_SSLv23
+                if not hasattr(ssl, "PROTOCOL_TLS_SERVER")
+                else ssl.PROTOCOL_TLS_SERVER
+            )
             context.load_cert_chain(DEFAULT_CERTS["certfile"], DEFAULT_CERTS["keyfile"])
             tls = context.wrap_socket(sock, server_side=True)
             buf = b""

--- a/test/contrib/test_socks.py
+++ b/test/contrib/test_socks.py
@@ -678,7 +678,7 @@ class TestSOCKSWithTLS(IPV4SocketDummyServerTestCase):
             handler.send(True)
 
             # Wrap in TLS
-            context = better_ssl.SSLContext(ssl.PROTOCOL_SSLv23)
+            context = better_ssl.SSLContext(ssl.PROTOCOL_SSLv23 if not hasattr(ssl, "PROTOCOL_TLS_SERVER") else ssl.PROTOCOL_TLS_SERVER)
             context.load_cert_chain(DEFAULT_CERTS["certfile"], DEFAULT_CERTS["keyfile"])
             tls = context.wrap_socket(sock, server_side=True)
             buf = b""

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -877,7 +877,6 @@ class TestUtilSSL(object):
             ("PROTOCOL_TLSv1", "ssl.PROTOCOL_TLSv1"),
             ("TLSv1", "ssl.PROTOCOL_TLSv1"),
             ("ssl.PROTOCOL_SSLv23", "ssl.PROTOCOL_SSLv23"),
-            ("ssl.PROTOCOL_TLS", "ssl.PROTOCOL_TLS_CLIENT"),
             ("ssl.PROTOCOL_TLS_CLIENT", "ssl.PROTOCOL_TLS_CLIENT"),
             ("PROTOCOL_TLS_CLIENT", "ssl.PROTOCOL_TLS_CLIENT"),
         ],

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -873,13 +873,31 @@ class TestUtilSSL(object):
     @pytest.mark.parametrize(
         "candidate, version",
         [
-            (ssl.PROTOCOL_TLSv1, ssl.PROTOCOL_TLSv1),
-            ("PROTOCOL_TLSv1", ssl.PROTOCOL_TLSv1),
-            ("TLSv1", ssl.PROTOCOL_TLSv1),
-            (ssl.PROTOCOL_SSLv23, ssl.PROTOCOL_SSLv23),
+            ("ssl.PROTOCOL_TLSv1", "ssl.PROTOCOL_TLSv1"),
+            ("PROTOCOL_TLSv1", "ssl.PROTOCOL_TLSv1"),
+            ("TLSv1", "ssl.PROTOCOL_TLSv1"),
+            ("ssl.PROTOCOL_SSLv23", "ssl.PROTOCOL_SSLv23"),
+            ("ssl.PROTOCOL_TLS", "ssl.PROTOCOL_TLS_CLIENT"),
+            ("ssl.PROTOCOL_TLS_CLIENT", "ssl.PROTOCOL_TLS_CLIENT"),
+            ("PROTOCOL_TLS_CLIENT", "ssl.PROTOCOL_TLS_CLIENT"),
         ],
     )
     def test_resolve_ssl_version(self, candidate, version):
+        should_import_candidate = "ssl." in candidate
+        should_import_version = "ssl." in version
+
+        if should_import_candidate:
+            constant_name = candidate.replace('ssl.', '')
+            if not hasattr(ssl, constant_name):
+                pytest.skip('unavailable constant (candidate) ' + candidate)
+            candidate = getattr(ssl, constant_name)
+        if should_import_version:
+            constant_name = version.replace('ssl.', '')
+            if not hasattr(ssl, constant_name):
+                pytest.skip('unavailable constant (version) ' + version)
+            version = getattr(ssl, constant_name)
+        if candidate is NotImplemented or version is NotImplemented:
+            pytest.skip('deprecated/NotImplemented constants')
         assert resolve_ssl_version(candidate) == version
 
     def test_ssl_wrap_socket_loads_the_cert_chain(self):

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -887,17 +887,17 @@ class TestUtilSSL(object):
         should_import_version = "ssl." in version
 
         if should_import_candidate:
-            constant_name = candidate.replace('ssl.', '')
+            constant_name = candidate.replace("ssl.", "")
             if not hasattr(ssl, constant_name):
-                pytest.skip('unavailable constant (candidate) ' + candidate)
+                pytest.skip("unavailable constant (candidate) " + candidate)
             candidate = getattr(ssl, constant_name)
         if should_import_version:
-            constant_name = version.replace('ssl.', '')
+            constant_name = version.replace("ssl.", "")
             if not hasattr(ssl, constant_name):
-                pytest.skip('unavailable constant (version) ' + version)
+                pytest.skip("unavailable constant (version) " + version)
             version = getattr(ssl, constant_name)
         if candidate is NotImplemented or version is NotImplemented:
-            pytest.skip('deprecated/NotImplemented constants')
+            pytest.skip("deprecated/NotImplemented constants")
         assert resolve_ssl_version(candidate) == version
 
     def test_ssl_wrap_socket_loads_the_cert_chain(self):

--- a/test/with_dummyserver/test_https.py
+++ b/test/with_dummyserver/test_https.py
@@ -722,10 +722,15 @@ class TestHTTPS(HTTPSDummyServerTestCase):
         with HTTPSConnectionPool(
             self.host, self.port, ca_certs=DEFAULT_CA
         ) as https_pool:
-            if "max_ssl_version" in self.certs:
-                https_pool.ssl_version = self.certs["max_ssl_version"]
+            if (
+                hasattr(ssl, "PROTOCOL_TLS_SERVER")
+                and self.certs["ssl_version"] == ssl.PROTOCOL_TLS_SERVER
+            ):
+                https_pool.ssl_version = ssl.PROTOCOL_TLS_CLIENT
             else:
                 https_pool.ssl_version = self.certs["ssl_version"]
+            if "max_ssl_version" in self.certs:
+                https_pool.max_ssl_version = self.certs["max_ssl_version"]
             r = https_pool.request("GET", "/")
             assert r.status == 200, r.data
 

--- a/test/with_dummyserver/test_https.py
+++ b/test/with_dummyserver/test_https.py
@@ -67,7 +67,7 @@ TLSv1_1_CERTS["ssl_version"] = getattr(ssl, "PROTOCOL_TLSv1_1", None)
 
 TLSv1_2_CERTS = DEFAULT_CERTS.copy()
 # python 3.12+ specific
-if not hasattr(ssl, "PROTOCOL_TLSv1_2") and getattr(ssl, "HAS_TLSv1_2", False):
+if not hasattr(ssl, "PROTOCOL_TLSv1_2") and getattr(ssl, "HAS_TLSv1_2", False) and hasattr(ssl, "TLSVersion"):
     TLSv1_2_CERTS["ssl_version"] = getattr(ssl, "PROTOCOL_TLS_SERVER", None)
     TLSv1_2_CERTS["max_ssl_version"] = ssl.TLSVersion.TLSv1_2
 else:
@@ -75,7 +75,7 @@ else:
 
 TLSv1_3_CERTS = DEFAULT_CERTS.copy()
 # python 3.12+ specific
-if not hasattr(ssl, "PROTOCOL_TLSv1_3") and getattr(ssl, "HAS_TLSv1_3", False):
+if not hasattr(ssl, "PROTOCOL_TLSv1_3") and getattr(ssl, "HAS_TLSv1_3", False) and hasattr(ssl, "TLSVersion"):
     TLSv1_3_CERTS["ssl_version"] = getattr(ssl, "PROTOCOL_TLS_SERVER", None)
     TLSv1_3_CERTS["max_ssl_version"] = ssl.TLSVersion.TLSv1_3
 else:

--- a/test/with_dummyserver/test_https.py
+++ b/test/with_dummyserver/test_https.py
@@ -67,7 +67,11 @@ TLSv1_1_CERTS["ssl_version"] = getattr(ssl, "PROTOCOL_TLSv1_1", None)
 
 TLSv1_2_CERTS = DEFAULT_CERTS.copy()
 # python 3.12+ specific
-if not hasattr(ssl, "PROTOCOL_TLSv1_2") and getattr(ssl, "HAS_TLSv1_2", False) and hasattr(ssl, "TLSVersion"):
+if (
+    not hasattr(ssl, "PROTOCOL_TLSv1_2")
+    and getattr(ssl, "HAS_TLSv1_2", False)
+    and hasattr(ssl, "TLSVersion")
+):
     TLSv1_2_CERTS["ssl_version"] = getattr(ssl, "PROTOCOL_TLS_SERVER", None)
     TLSv1_2_CERTS["max_ssl_version"] = ssl.TLSVersion.TLSv1_2
 else:
@@ -75,7 +79,11 @@ else:
 
 TLSv1_3_CERTS = DEFAULT_CERTS.copy()
 # python 3.12+ specific
-if not hasattr(ssl, "PROTOCOL_TLSv1_3") and getattr(ssl, "HAS_TLSv1_3", False) and hasattr(ssl, "TLSVersion"):
+if (
+    not hasattr(ssl, "PROTOCOL_TLSv1_3")
+    and getattr(ssl, "HAS_TLSv1_3", False)
+    and hasattr(ssl, "TLSVersion")
+):
     TLSv1_3_CERTS["ssl_version"] = getattr(ssl, "PROTOCOL_TLS_SERVER", None)
     TLSv1_3_CERTS["max_ssl_version"] = ssl.TLSVersion.TLSv1_3
 else:

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -3,6 +3,7 @@
 from dummyserver.server import (
     DEFAULT_CA,
     DEFAULT_CERTS,
+    DEFAULT_SERVER_CONTEXT,
     encrypt_key_pem,
     get_unreachable_address,
 )
@@ -173,9 +174,8 @@ class TestClientCerts(SocketDummyServerTestCase):
         """
         Given a single socket, wraps it in TLS.
         """
-        return ssl.wrap_socket(
+        return DEFAULT_SERVER_CONTEXT.wrap_socket(
             sock,
-            ssl_version=ssl.PROTOCOL_SSLv23,
             cert_reqs=ssl.CERT_REQUIRED,
             ca_certs=self.ca_path,
             certfile=self.cert_path,
@@ -1076,7 +1076,7 @@ class TestProxyManager(SocketDummyServerTestCase):
                 return
 
             sock.send(("HTTP/1.1 200 Connection Established\r\n\r\n").encode("utf-8"))
-            ssl_sock = ssl.wrap_socket(
+            ssl_sock = DEFAULT_SERVER_CONTEXT.wrap_socket(
                 sock,
                 server_side=True,
                 keyfile=DEFAULT_CERTS["keyfile"],
@@ -1128,7 +1128,7 @@ class TestProxyManager(SocketDummyServerTestCase):
 
             if s.startswith("CONNECT [%s]:443" % (ipv6_addr,)):
                 sock.send(b"HTTP/1.1 200 Connection Established\r\n\r\n")
-                ssl_sock = ssl.wrap_socket(
+                ssl_sock = DEFAULT_SERVER_CONTEXT.wrap_socket(
                     sock,
                     server_side=True,
                     keyfile=DEFAULT_CERTS["keyfile"],
@@ -1195,7 +1195,7 @@ class TestSSL(SocketDummyServerTestCase):
         def socket_handler(listener):
             sock = listener.accept()[0]
             sock2 = sock.dup()
-            ssl_sock = ssl.wrap_socket(
+            ssl_sock = DEFAULT_SERVER_CONTEXT.wrap_socket(
                 sock,
                 server_side=True,
                 keyfile=DEFAULT_CERTS["keyfile"],
@@ -1232,7 +1232,7 @@ class TestSSL(SocketDummyServerTestCase):
 
         def socket_handler(listener):
             sock = listener.accept()[0]
-            ssl_sock = ssl.wrap_socket(
+            ssl_sock = DEFAULT_SERVER_CONTEXT.wrap_socket(
                 sock,
                 server_side=True,
                 keyfile=DEFAULT_CERTS["keyfile"],
@@ -1273,7 +1273,7 @@ class TestSSL(SocketDummyServerTestCase):
         def socket_handler(listener):
             for i in range(2):
                 sock = listener.accept()[0]
-                ssl_sock = ssl.wrap_socket(
+                ssl_sock = DEFAULT_SERVER_CONTEXT.wrap_socket(
                     sock,
                     server_side=True,
                     keyfile=DEFAULT_CERTS["keyfile"],
@@ -1320,7 +1320,7 @@ class TestSSL(SocketDummyServerTestCase):
             # first request, trigger an SSLError
             sock = listener.accept()[0]
             sock2 = sock.dup()
-            ssl_sock = ssl.wrap_socket(
+            ssl_sock = DEFAULT_SERVER_CONTEXT.wrap_socket(
                 sock,
                 server_side=True,
                 keyfile=DEFAULT_CERTS["keyfile"],
@@ -1345,7 +1345,7 @@ class TestSSL(SocketDummyServerTestCase):
 
             # retried request
             sock = listener.accept()[0]
-            ssl_sock = ssl.wrap_socket(
+            ssl_sock = DEFAULT_SERVER_CONTEXT.wrap_socket(
                 sock,
                 server_side=True,
                 keyfile=DEFAULT_CERTS["keyfile"],
@@ -1371,7 +1371,7 @@ class TestSSL(SocketDummyServerTestCase):
     def test_ssl_load_default_certs_when_empty(self):
         def socket_handler(listener):
             sock = listener.accept()[0]
-            ssl_sock = ssl.wrap_socket(
+            ssl_sock = DEFAULT_SERVER_CONTEXT.wrap_socket(
                 sock,
                 server_side=True,
                 keyfile=DEFAULT_CERTS["keyfile"],
@@ -1408,7 +1408,7 @@ class TestSSL(SocketDummyServerTestCase):
     def test_ssl_dont_load_default_certs_when_given(self):
         def socket_handler(listener):
             sock = listener.accept()[0]
-            ssl_sock = ssl.wrap_socket(
+            ssl_sock = DEFAULT_SERVER_CONTEXT.wrap_socket(
                 sock,
                 server_side=True,
                 keyfile=DEFAULT_CERTS["keyfile"],
@@ -1473,7 +1473,7 @@ class TestSSL(SocketDummyServerTestCase):
         def socket_handler(listener):
             sock = listener.accept()[0]
             try:
-                _ = ssl.wrap_socket(
+                _ = DEFAULT_SERVER_CONTEXT.wrap_socket(
                     sock,
                     server_side=True,
                     keyfile=DEFAULT_CERTS["keyfile"],
@@ -1520,7 +1520,7 @@ class TestSSL(SocketDummyServerTestCase):
 
         def socket_handler(listener):
             sock = listener.accept()[0]
-            ssl_sock = ssl.wrap_socket(
+            ssl_sock = DEFAULT_SERVER_CONTEXT.wrap_socket(
                 sock,
                 server_side=True,
                 keyfile=DEFAULT_CERTS["keyfile"],

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -1091,7 +1091,7 @@ class TestProxyManager(SocketDummyServerTestCase):
             ctx.load_cert_chain(
                 certfile=DEFAULT_CERTS["certfile"], keyfile=DEFAULT_CERTS["keyfile"]
             )
-            ctx.verify_mode = ssl.CERT_REQUIRED
+            ctx.verify_mode = ssl.CERT_NONE
             ctx.load_verify_locations(DEFAULT_CA)
 
             ssl_sock = ctx.wrap_socket(
@@ -1217,7 +1217,7 @@ class TestSSL(SocketDummyServerTestCase):
             ctx.load_cert_chain(
                 certfile=DEFAULT_CERTS["certfile"], keyfile=DEFAULT_CERTS["keyfile"]
             )
-            ctx.verify_mode = ssl.CERT_REQUIRED
+            ctx.verify_mode = ssl.CERT_NONE
             ctx.load_verify_locations(DEFAULT_CA)
 
             ssl_sock = ctx.wrap_socket(
@@ -1304,7 +1304,7 @@ class TestSSL(SocketDummyServerTestCase):
                 ctx.load_cert_chain(
                     certfile=DEFAULT_CERTS["certfile"], keyfile=DEFAULT_CERTS["keyfile"]
                 )
-                ctx.verify_mode = ssl.CERT_REQUIRED
+                ctx.verify_mode = ssl.CERT_NONE
                 ctx.load_verify_locations(DEFAULT_CA)
 
                 ssl_sock = ctx.wrap_socket(
@@ -1411,7 +1411,7 @@ class TestSSL(SocketDummyServerTestCase):
             ctx.load_cert_chain(
                 certfile=DEFAULT_CERTS["certfile"], keyfile=DEFAULT_CERTS["keyfile"]
             )
-            ctx.verify_mode = ssl.CERT_REQUIRED
+            ctx.verify_mode = ssl.CERT_NONE
             ctx.load_verify_locations(DEFAULT_CA)
 
             ssl_sock = ctx.wrap_socket(
@@ -1453,7 +1453,7 @@ class TestSSL(SocketDummyServerTestCase):
             ctx.load_cert_chain(
                 certfile=DEFAULT_CERTS["certfile"], keyfile=DEFAULT_CERTS["keyfile"]
             )
-            ctx.verify_mode = ssl.CERT_REQUIRED
+            ctx.verify_mode = ssl.CERT_NONE
             ctx.load_verify_locations(DEFAULT_CA)
 
             ssl_sock = ctx.wrap_socket(
@@ -1522,7 +1522,7 @@ class TestSSL(SocketDummyServerTestCase):
                 ctx.load_cert_chain(
                     certfile=DEFAULT_CERTS["certfile"], keyfile=DEFAULT_CERTS["keyfile"]
                 )
-                ctx.verify_mode = ssl.CERT_REQUIRED
+                ctx.verify_mode = ssl.CERT_NONE
                 ctx.load_verify_locations(DEFAULT_CA)
 
                 _ = ctx.wrap_socket(
@@ -1574,7 +1574,7 @@ class TestSSL(SocketDummyServerTestCase):
             ctx.load_cert_chain(
                 certfile=DEFAULT_CERTS["certfile"], keyfile=DEFAULT_CERTS["keyfile"]
             )
-            ctx.verify_mode = ssl.CERT_REQUIRED
+            ctx.verify_mode = ssl.CERT_NONE
             ctx.load_verify_locations(DEFAULT_CA)
 
             ssl_sock = ctx.wrap_socket(

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -1091,6 +1091,7 @@ class TestProxyManager(SocketDummyServerTestCase):
             ctx.load_cert_chain(
                 certfile=DEFAULT_CERTS["certfile"], keyfile=DEFAULT_CERTS["keyfile"]
             )
+            ctx.verify_mode = ssl.CERT_REQUIRED
             ctx.load_verify_locations(DEFAULT_CA)
 
             ssl_sock = ctx.wrap_socket(
@@ -1216,6 +1217,7 @@ class TestSSL(SocketDummyServerTestCase):
             ctx.load_cert_chain(
                 certfile=DEFAULT_CERTS["certfile"], keyfile=DEFAULT_CERTS["keyfile"]
             )
+            ctx.verify_mode = ssl.CERT_REQUIRED
             ctx.load_verify_locations(DEFAULT_CA)
 
             ssl_sock = ctx.wrap_socket(
@@ -1302,6 +1304,7 @@ class TestSSL(SocketDummyServerTestCase):
                 ctx.load_cert_chain(
                     certfile=DEFAULT_CERTS["certfile"], keyfile=DEFAULT_CERTS["keyfile"]
                 )
+                ctx.verify_mode = ssl.CERT_REQUIRED
                 ctx.load_verify_locations(DEFAULT_CA)
 
                 ssl_sock = ctx.wrap_socket(
@@ -1408,6 +1411,7 @@ class TestSSL(SocketDummyServerTestCase):
             ctx.load_cert_chain(
                 certfile=DEFAULT_CERTS["certfile"], keyfile=DEFAULT_CERTS["keyfile"]
             )
+            ctx.verify_mode = ssl.CERT_REQUIRED
             ctx.load_verify_locations(DEFAULT_CA)
 
             ssl_sock = ctx.wrap_socket(
@@ -1449,6 +1453,7 @@ class TestSSL(SocketDummyServerTestCase):
             ctx.load_cert_chain(
                 certfile=DEFAULT_CERTS["certfile"], keyfile=DEFAULT_CERTS["keyfile"]
             )
+            ctx.verify_mode = ssl.CERT_REQUIRED
             ctx.load_verify_locations(DEFAULT_CA)
 
             ssl_sock = ctx.wrap_socket(
@@ -1517,6 +1522,7 @@ class TestSSL(SocketDummyServerTestCase):
                 ctx.load_cert_chain(
                     certfile=DEFAULT_CERTS["certfile"], keyfile=DEFAULT_CERTS["keyfile"]
                 )
+                ctx.verify_mode = ssl.CERT_REQUIRED
                 ctx.load_verify_locations(DEFAULT_CA)
 
                 _ = ctx.wrap_socket(
@@ -1568,6 +1574,7 @@ class TestSSL(SocketDummyServerTestCase):
             ctx.load_cert_chain(
                 certfile=DEFAULT_CERTS["certfile"], keyfile=DEFAULT_CERTS["keyfile"]
             )
+            ctx.verify_mode = ssl.CERT_REQUIRED
             ctx.load_verify_locations(DEFAULT_CA)
 
             ssl_sock = ctx.wrap_socket(

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -336,7 +336,11 @@ class TestClientCerts(SocketDummyServerTestCase):
             sock.close()
 
         self._start_server(socket_handler)
-        ssl_context = ssl_.SSLContext(ssl_.PROTOCOL_TLS_CLIENT if ssl_.PROTOCOL_SSLv23 is NotImplemented else ssl_.PROTOCOL_SSLv23)
+        ssl_context = ssl_.SSLContext(
+            ssl_.PROTOCOL_TLS_CLIENT
+            if ssl_.PROTOCOL_SSLv23 is NotImplemented
+            else ssl_.PROTOCOL_SSLv23
+        )
         ssl_context.load_cert_chain(
             certfile=self.cert_path, keyfile=self.password_key_path, password=password
         )
@@ -355,7 +359,11 @@ class TestClientCerts(SocketDummyServerTestCase):
 
     @requires_ssl_context_keyfile_password
     def test_load_keyfile_with_invalid_password(self):
-        context = ssl_.SSLContext(ssl_.PROTOCOL_TLS_CLIENT if ssl_.PROTOCOL_SSLv23 is NotImplemented else ssl_.PROTOCOL_SSLv23)
+        context = ssl_.SSLContext(
+            ssl_.PROTOCOL_TLS_CLIENT
+            if ssl_.PROTOCOL_SSLv23 is NotImplemented
+            else ssl_.PROTOCOL_SSLv23
+        )
 
         # Different error is raised depending on context.
         if ssl_.IS_PYOPENSSL:
@@ -1080,7 +1088,9 @@ class TestProxyManager(SocketDummyServerTestCase):
             sock.send(("HTTP/1.1 200 Connection Established\r\n\r\n").encode("utf-8"))
 
             ctx = ssl.SSLContext(PROTOCOL_TLS_SERVER)
-            ctx.load_cert_chain(certfile=DEFAULT_CERTS["certfile"], keyfile=DEFAULT_CERTS["keyfile"])
+            ctx.load_cert_chain(
+                certfile=DEFAULT_CERTS["certfile"], keyfile=DEFAULT_CERTS["keyfile"]
+            )
             ctx.load_verify_locations(DEFAULT_CA)
 
             ssl_sock = ctx.wrap_socket(
@@ -1133,7 +1143,9 @@ class TestProxyManager(SocketDummyServerTestCase):
             if s.startswith("CONNECT [%s]:443" % (ipv6_addr,)):
                 sock.send(b"HTTP/1.1 200 Connection Established\r\n\r\n")
                 ctx = ssl.SSLContext(PROTOCOL_TLS_SERVER)
-                ctx.load_cert_chain(certfile=DEFAULT_CERTS["certfile"], keyfile=DEFAULT_CERTS["keyfile"])
+                ctx.load_cert_chain(
+                    certfile=DEFAULT_CERTS["certfile"], keyfile=DEFAULT_CERTS["keyfile"]
+                )
                 ssl_sock = ctx.wrap_socket(
                     sock,
                     server_side=True,
@@ -1201,7 +1213,9 @@ class TestSSL(SocketDummyServerTestCase):
             sock2 = sock.dup()
 
             ctx = ssl.SSLContext(PROTOCOL_TLS_SERVER)
-            ctx.load_cert_chain(certfile=DEFAULT_CERTS["certfile"], keyfile=DEFAULT_CERTS["keyfile"])
+            ctx.load_cert_chain(
+                certfile=DEFAULT_CERTS["certfile"], keyfile=DEFAULT_CERTS["keyfile"]
+            )
             ctx.load_verify_locations(DEFAULT_CA)
 
             ssl_sock = ctx.wrap_socket(
@@ -1240,7 +1254,9 @@ class TestSSL(SocketDummyServerTestCase):
             sock = listener.accept()[0]
 
             ctx = ssl.SSLContext(PROTOCOL_TLS_SERVER)
-            ctx.load_cert_chain(certfile=DEFAULT_CERTS["certfile"], keyfile=DEFAULT_CERTS["keyfile"])
+            ctx.load_cert_chain(
+                certfile=DEFAULT_CERTS["certfile"], keyfile=DEFAULT_CERTS["keyfile"]
+            )
 
             ssl_sock = ctx.wrap_socket(
                 sock,
@@ -1283,7 +1299,9 @@ class TestSSL(SocketDummyServerTestCase):
                 sock = listener.accept()[0]
 
                 ctx = ssl.SSLContext(PROTOCOL_TLS_SERVER)
-                ctx.load_cert_chain(certfile=DEFAULT_CERTS["certfile"], keyfile=DEFAULT_CERTS["keyfile"])
+                ctx.load_cert_chain(
+                    certfile=DEFAULT_CERTS["certfile"], keyfile=DEFAULT_CERTS["keyfile"]
+                )
                 ctx.load_verify_locations(DEFAULT_CA)
 
                 ssl_sock = ctx.wrap_socket(
@@ -1331,7 +1349,9 @@ class TestSSL(SocketDummyServerTestCase):
             sock = listener.accept()[0]
             sock2 = sock.dup()
             ctx = ssl.SSLContext(PROTOCOL_TLS_SERVER)
-            ctx.load_cert_chain(certfile=DEFAULT_CERTS["certfile"], keyfile=DEFAULT_CERTS["keyfile"])
+            ctx.load_cert_chain(
+                certfile=DEFAULT_CERTS["certfile"], keyfile=DEFAULT_CERTS["keyfile"]
+            )
             ssl_sock = ctx.wrap_socket(
                 sock,
                 server_side=True,
@@ -1356,7 +1376,9 @@ class TestSSL(SocketDummyServerTestCase):
             # retried request
             sock = listener.accept()[0]
             ctx = ssl.SSLContext(PROTOCOL_TLS_SERVER)
-            ctx.load_cert_chain(certfile=DEFAULT_CERTS["certfile"], keyfile=DEFAULT_CERTS["keyfile"])
+            ctx.load_cert_chain(
+                certfile=DEFAULT_CERTS["certfile"], keyfile=DEFAULT_CERTS["keyfile"]
+            )
             ssl_sock = ctx.wrap_socket(
                 sock,
                 server_side=True,
@@ -1383,7 +1405,9 @@ class TestSSL(SocketDummyServerTestCase):
             sock = listener.accept()[0]
 
             ctx = ssl.SSLContext(PROTOCOL_TLS_SERVER)
-            ctx.load_cert_chain(certfile=DEFAULT_CERTS["certfile"], keyfile=DEFAULT_CERTS["keyfile"])
+            ctx.load_cert_chain(
+                certfile=DEFAULT_CERTS["certfile"], keyfile=DEFAULT_CERTS["keyfile"]
+            )
             ctx.load_verify_locations(DEFAULT_CA)
 
             ssl_sock = ctx.wrap_socket(
@@ -1422,7 +1446,9 @@ class TestSSL(SocketDummyServerTestCase):
             sock = listener.accept()[0]
 
             ctx = ssl.SSLContext(PROTOCOL_TLS_SERVER)
-            ctx.load_cert_chain(certfile=DEFAULT_CERTS["certfile"], keyfile=DEFAULT_CERTS["keyfile"])
+            ctx.load_cert_chain(
+                certfile=DEFAULT_CERTS["certfile"], keyfile=DEFAULT_CERTS["keyfile"]
+            )
             ctx.load_verify_locations(DEFAULT_CA)
 
             ssl_sock = ctx.wrap_socket(
@@ -1488,7 +1514,9 @@ class TestSSL(SocketDummyServerTestCase):
             sock = listener.accept()[0]
             try:
                 ctx = ssl.SSLContext(PROTOCOL_TLS_SERVER)
-                ctx.load_cert_chain(certfile=DEFAULT_CERTS["certfile"], keyfile=DEFAULT_CERTS["keyfile"])
+                ctx.load_cert_chain(
+                    certfile=DEFAULT_CERTS["certfile"], keyfile=DEFAULT_CERTS["keyfile"]
+                )
                 ctx.load_verify_locations(DEFAULT_CA)
 
                 _ = ctx.wrap_socket(
@@ -1537,7 +1565,9 @@ class TestSSL(SocketDummyServerTestCase):
             sock = listener.accept()[0]
 
             ctx = ssl.SSLContext(PROTOCOL_TLS_SERVER)
-            ctx.load_cert_chain(certfile=DEFAULT_CERTS["certfile"], keyfile=DEFAULT_CERTS["keyfile"])
+            ctx.load_cert_chain(
+                certfile=DEFAULT_CERTS["certfile"], keyfile=DEFAULT_CERTS["keyfile"]
+            )
             ctx.load_verify_locations(DEFAULT_CA)
 
             ssl_sock = ctx.wrap_socket(


### PR DESCRIPTION
Fixes #2686 
First attempt to mitigate the planned changes in cpython:main.

**Immediately related:**
- https://github.com/python/cpython/pull/94599
- https://github.com/python/cpython/issues/94598
- https://github.com/python/cpython/issues/94199
- https://github.com/python/cpython/pull/94203

**Notes:**
The tracking issue was briefly attached to the v2 milestone and then removed. My understanding is that this patch is meant for v1.26.x branch.
The v2.x branch can benefit from a similar but highly simplified version of this patch. Thanks to the more lax constraint >= 3.7

**Main problems:**
- ssl.PROTOCOL_TLS is in fact deprecated but not yet removed. It is now worth `NotImplemented`.

```
DeprecationWarning: ssl.PROTOCOL_TLS is no longer supported. The constant will be removed in 3.13. Use ssl.PROTOCOL_TLS_CLIENT or ssl.PROTOCOL_TLS_SERVER instead.
```

urllib3 maintainers already took the time to support ssl.PROTOCOL_TLS_CLIENT in urllib3.utils._ssl, 
To avoid propagating PROTOCOL_TLS=NotImplemented, I made it so that it mirrors PROTOCOL_TLS_CLIENT instead in that precise case. (backward-compatibility purposes)

```
>>> from ssl import PROTOCOL_TLS, PROTOCOL_TLS_CLIENT
>>> PROTOCOL_TLS
<_SSLMethod.PROTOCOL_TLS: 2>
>>> PROTOCOL_TLS_CLIENT
<_SSLMethod.PROTOCOL_TLS_CLIENT: 16>
```

- In fact, we can no longer set protocols using their respective constants.

```python
ctx = ssl.SSLContext(ssl_version)
ctx.load_cert_chain(certfile, keyfile)
ctx.verify_mode = cert_reqs
ctx.maximum_version = max_ssl_version
```

Where `max_ssl_version` is one of `ssl.TLSVersion` IntEnum and `ssl_version` is either `ssl.PROTOCOL_TLS_CLIENT` or `ssl.PROTOCOL_TLS_SERVER`.

- gh-94598 is still a draft but I am confident that nothing will preclude this from working after further changes in the linked PR.

- 'urllib3.contrib.pyopenssl' module is deprecated but still there until v2, so we have to _slightly_ patch it in order to avoid a crash.

My understanding is that any protocol higher than TLSv1_2 is mapped to SSLv23_METHOD, so I acted accordingly.

- It is okay to use and map IntEnum protocol version when available? 

Like so `_openssl_versions[ssl.TLSVersion.TLSv1_2] = OpenSSL.SSL.TLSv1_2_METHOD`.

- SSLContext no longer accept default `protocol=None`, they decided to enforce the parameter rightfully.

I had to remove the positional parameter. Cf. gh-94598.

**Environment:**

I had no choice but to clone https://github.com/tiran/cpython/tree/py312_ssl_removal and build it locally then use it against the test suite.

There is no suitable python-version action available at the moment. cf.  gh-94598.

**Opening topics:**

- tornado dummy server hangs when `PROTOCOL_TLS_CLIENT` is passed

Make sense, so we fall back to PROTOCOL_TLS_SERVER instead, and everything goes well.

- I feel like we introduce some ambiguities about ssl_version and max_ssl_version.

ssl_version tends to not do what it seems like it is supposed to. Maybe a topic of discussion there.

Local run: https://github.com/Ousret/urllib3-experimental
