### PR TITLE
Do not mention deprecated urllib3[secure] as an option how to install certifi

### DIFF
--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -421,13 +421,6 @@ package which provides Mozilla's root certificate bundle:
 
     $ python -m pip install certifi
 
-You can also install certifi along with urllib3 by using the ``secure``
-extra:
-
-.. code-block:: bash
-
-    $ python -m pip install urllib3[secure]
-
 Once you have certificates, you can create a :class:`~poolmanager.PoolManager`
 that verifies certificates when making requests:
 


### PR DESCRIPTION
The example can be understood as recommending using urllib3[secure] to install certifi. For most cases, `python -m pip install certifi` should be OK.

Users can still learn about urllib3[secure] from the warning that immediately follows the removed example.