### PR TITLE
Stop considering LibreSSL for HAS_NEVER_CHECK_COMMON_NAME

### DIFF
--- a/test/test_util.py
+++ b/test/test_util.py
@@ -1059,12 +1059,10 @@ class TestUtilSSL:
             # Python OK -> reliable
             ("OpenSSL 1.1.1", 0x10101000, "cpython", (3, 9, 3), True),
             ("OpenSSL 1.1.1", 0x10101000, "pypy", (3, 6, 9), False),
-            ("LibreSSL 3.3.5", 0x101010CF, "pypy", (3, 6, 9), False),
             # OpenSSL OK -> reliable
             ("OpenSSL", 0x101010CF, "cpython", (3, 9, 2), True),
             # unreliable
             ("OpenSSL", 0x10101000, "cpython", (3, 9, 2), False),
-            ("LibreSSL", 0x101010CF, "cpython", (3, 9, 2), False),
         ],
     )
     def test_is_has_never_check_common_name_reliable(

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -1052,22 +1052,21 @@ class TestUtilSSL:
         warn.assert_not_called()
 
     @pytest.mark.parametrize(
-        "openssl_version, openssl_version_number, implementation_name, version_info, reliable",
+        "openssl_version_number, implementation_name, version_info, reliable",
         [
             # OpenSSL and Python OK -> reliable
-            ("OpenSSL 1.1.1l", 0x101010CF, "cpython", (3, 9, 3), True),
+            (0x101010CF, "cpython", (3, 9, 3), True),
             # Python OK -> reliable
-            ("OpenSSL 1.1.1", 0x10101000, "cpython", (3, 9, 3), True),
-            ("OpenSSL 1.1.1", 0x10101000, "pypy", (3, 6, 9), False),
+            (0x10101000, "cpython", (3, 9, 3), True),
+            (0x10101000, "pypy", (3, 6, 9), False),
             # OpenSSL OK -> reliable
-            ("OpenSSL", 0x101010CF, "cpython", (3, 9, 2), True),
+            (0x101010CF, "cpython", (3, 9, 2), True),
             # unreliable
-            ("OpenSSL", 0x10101000, "cpython", (3, 9, 2), False),
+            (0x10101000, "cpython", (3, 9, 2), False),
         ],
     )
     def test_is_has_never_check_common_name_reliable(
         self,
-        openssl_version: str,
         openssl_version_number: int,
         implementation_name: str,
         version_info: _TYPE_VERSION_INFO,
@@ -1075,7 +1074,6 @@ class TestUtilSSL:
     ) -> None:
         assert (
             _is_has_never_check_common_name_reliable(
-                openssl_version,
                 openssl_version_number,
                 implementation_name,
                 version_info,


### PR DESCRIPTION
We don't support LibreSSL at all since https://github.com/urllib3/urllib3/pull/2705.