### PR TITLE
Configure pytest, isort and mypy in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,3 +76,28 @@ include = [
   "/README.md",
   "/LICENSE.txt",
 ]
+
+[tool.pytest.ini_options]
+xfail_strict = true
+python_classes = ["Test", "*TestCase"]
+
+[tool.isort]
+profile = "black"
+
+[tool.mypy]
+mypy_path = "src"
+check_untyped_defs = true
+disallow_any_generics = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+no_implicit_optional = true
+no_implicit_reexport = true
+show_error_codes = true
+strict_equality = true
+warn_redundant_casts = true
+warn_return_any = true
+warn_unused_configs = true
+warn_unused_ignores = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,28 +2,3 @@
 ignore = E501, E203, W503, W504
 exclude=./docs/conf.py
 max-line-length=99
-
-[tool:pytest]
-xfail_strict = true
-python_classes = Test *TestCase
-
-[isort]
-profile=black
-
-[mypy]
-mypy_path = src
-check_untyped_defs = True
-disallow_any_generics = True
-disallow_incomplete_defs = True
-disallow_subclassing_any = True
-disallow_untyped_calls = True
-disallow_untyped_decorators = True
-disallow_untyped_defs = True
-no_implicit_optional = True
-no_implicit_reexport = True
-show_error_codes = True
-strict_equality = True
-warn_redundant_casts = True
-warn_return_any = True
-warn_unused_configs = True
-warn_unused_ignores = True


### PR DESCRIPTION
So this was a contributor friendly issue but #2780 and #2784 both got confused about this, adding settings in pyproject.toml for pytest and isort respectively, so I've decided to just do it myself to avoid more problems with this in the future.

Closes #2773