### PR TITLE
Change deprecation warnings to explicitly mention v2.1.0 for removals

### DIFF
--- a/docs/reference/contrib/pyopenssl.rst
+++ b/docs/reference/contrib/pyopenssl.rst
@@ -1,7 +1,7 @@
 PyOpenSSL
 =========
 .. warning::
-    DEPRECATED: This module is deprecated and will be removed in a future 2.x release.
+    DEPRECATED: This module is deprecated and will be removed in urllib3 v2.1.0.
     Read more in this `issue <https://github.com/urllib3/urllib3/issues/2680>`_.
 
 .. automodule:: urllib3.contrib.pyopenssl

--- a/docs/reference/contrib/securetransport.rst
+++ b/docs/reference/contrib/securetransport.rst
@@ -1,7 +1,7 @@
 macOS SecureTransport
 =====================
 .. warning::
-    DEPRECATED: This module is deprecated and will be removed in a future 2.x release.
+    DEPRECATED: This module is deprecated and will be removed in urllib3 v2.1.0.
     Read more in this `issue <https://github.com/urllib3/urllib3/issues/2681>`_.
 
 `SecureTranport <https://developer.apple.com/documentation/security/secure_transport>`_

--- a/src/urllib3/__init__.py
+++ b/src/urllib3/__init__.py
@@ -51,7 +51,7 @@ except ModuleNotFoundError:
 else:
     warnings.warn(
         "'urllib3[secure]' extra is deprecated and will be removed "
-        "in a future release of urllib3 2.x. Read more in this issue: "
+        "in urllib3 v2.1.0. Read more in this issue: "
         "https://github.com/urllib3/urllib3/issues/2680",
         category=DeprecationWarning,
         stacklevel=2,

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -422,8 +422,8 @@ class HTTPConnection(_HTTPConnection):
         body with chunked encoding and not as one block
         """
         warnings.warn(
-            "HTTPConnection.request_chunked() is deprecated and will be removed in a "
-            "future version. Instead use HTTPConnection.request(..., chunked=True).",
+            "HTTPConnection.request_chunked() is deprecated and will be removed "
+            "in urllib3 v2.1.0. Instead use HTTPConnection.request(..., chunked=True).",
             category=DeprecationWarning,
             stacklevel=2,
         )
@@ -580,9 +580,9 @@ class HTTPSConnection(HTTPConnection):
         This method should only be called once, before the connection is used.
         """
         warnings.warn(
-            "HTTPSConnection.set_cert() is deprecated and will be removed in a "
-            "future version. Instead provide the parameters to the HTTPSConnection "
-            "constructor.",
+            "HTTPSConnection.set_cert() is deprecated and will be removed "
+            "in urllib3 v2.1.0. Instead provide the parameters to the "
+            "HTTPSConnection constructor.",
             category=DeprecationWarning,
             stacklevel=2,
         )

--- a/src/urllib3/contrib/pyopenssl.py
+++ b/src/urllib3/contrib/pyopenssl.py
@@ -63,7 +63,7 @@ from .. import util
 
 warnings.warn(
     "'urllib3.contrib.pyopenssl' module is deprecated and will be removed "
-    "in a future release of urllib3 2.x. Read more in this issue: "
+    "in urllib3 v2.1.0. Read more in this issue: "
     "https://github.com/urllib3/urllib3/issues/2680",
     category=DeprecationWarning,
     stacklevel=2,

--- a/src/urllib3/contrib/securetransport.py
+++ b/src/urllib3/contrib/securetransport.py
@@ -94,7 +94,7 @@ from ._securetransport.low_level import (
 
 warnings.warn(
     "'urllib3.contrib.securetransport' module is deprecated and will be removed "
-    "in a future release of urllib3 2.x. Read more in this issue: "
+    "in urllib3 v2.1.0. Read more in this issue: "
     "https://github.com/urllib3/urllib3/issues/2681",
     category=DeprecationWarning,
     stacklevel=2,

--- a/src/urllib3/exceptions.py
+++ b/src/urllib3/exceptions.py
@@ -161,7 +161,7 @@ class NewConnectionError(ConnectTimeoutError, HTTPError):
     def pool(self) -> "HTTPConnection":
         warnings.warn(
             "The 'pool' property is deprecated and will be removed "
-            "in a later urllib3 v2.x release. use 'conn' instead.",
+            "in urllib3 v2.1.0. Use 'conn' instead.",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/src/urllib3/fields.py
+++ b/src/urllib3/fields.py
@@ -51,14 +51,14 @@ def format_header_param_rfc2231(name: str, value: _TYPE_FIELD_VALUE) -> str:
         An RFC-2231-formatted unicode string.
 
     .. deprecated:: 2.0.0
-        Will be removed in urllib3 v3.0.0. This is not valid for
+        Will be removed in urllib3 v2.1.0. This is not valid for
         ``multipart/form-data`` header parameters.
     """
     import warnings
 
     warnings.warn(
         "'format_header_param_rfc2231' is deprecated and will be "
-        "removed in urllib3 v3.0.0. This is not valid for "
+        "removed in urllib3 v2.1.0. This is not valid for "
         "multipart/form-data header parameters.",
         DeprecationWarning,
         stacklevel=2,
@@ -110,7 +110,7 @@ def format_multipart_header_param(name: str, value: _TYPE_FIELD_VALUE) -> str:
     .. versionchanged:: 2.0.0
         Renamed from ``format_header_param_html5`` and
         ``format_header_param``. The old names will be removed in
-        urllib3 v3.0.0.
+        urllib3 v2.1.0.
     """
     if isinstance(value, bytes):
         value = value.decode("utf-8")
@@ -124,14 +124,14 @@ def format_header_param_html5(name: str, value: _TYPE_FIELD_VALUE) -> str:
     """
     .. deprecated:: 2.0.0
         Renamed to :func:`format_multipart_header_param`. Will be
-        removed in urllib3 v3.0.0.
+        removed in urllib3 v2.1.0.
     """
     import warnings
 
     warnings.warn(
         "'format_header_param_html5' has been renamed to "
         "'format_multipart_header_param'. The old name will be "
-        "removed in urllib3 v3.0.0.",
+        "removed in urllib3 v2.1.0.",
         DeprecationWarning,
         stacklevel=2,
     )
@@ -142,14 +142,14 @@ def format_header_param(name: str, value: _TYPE_FIELD_VALUE) -> str:
     """
     .. deprecated:: 2.0.0
         Renamed to :func:`format_multipart_header_param`. Will be
-        removed in urllib3 v3.0.0.
+        removed in urllib3 v2.1.0.
     """
     import warnings
 
     warnings.warn(
         "'format_header_param' has been renamed to "
         "'format_multipart_header_param'. The old name will be "
-        "removed in urllib3 v3.0.0.",
+        "removed in urllib3 v2.1.0.",
         DeprecationWarning,
         stacklevel=2,
     )
@@ -171,8 +171,7 @@ class RequestField:
 
     .. versionchanged:: 2.0.0
         The ``header_formatter`` parameter is deprecated and will
-        be removed in urllib3 v3.0.0. Override :meth:`_render_part`
-        instead.
+        be removed in urllib3 v2.1.0.
     """
 
     def __init__(
@@ -195,8 +194,7 @@ class RequestField:
 
             warnings.warn(
                 "The 'header_formatter' parameter is deprecated and "
-                "will be removed in urllib3 v3.0.0. Override the "
-                "'_render_part' method instead.",
+                "will be removed in urllib3 v2.1.0.",
                 DeprecationWarning,
                 stacklevel=2,
             )

--- a/src/urllib3/util/ssl_.py
+++ b/src/urllib3/util/ssl_.py
@@ -281,8 +281,7 @@ def create_urllib3_context(
             # keep the maximum version to be it's default value: 'TLSVersion.MAXIMUM_SUPPORTED'
             warnings.warn(
                 "'ssl_version' option is deprecated and will be "
-                "removed in a future release of urllib3 2.x. Instead "
-                "use 'ssl_minimum_version'",
+                "removed in urllib3 v2.1.0. Instead use 'ssl_minimum_version'",
                 category=DeprecationWarning,
                 stacklevel=2,
             )

--- a/test/test_exceptions.py
+++ b/test/test_exceptions.py
@@ -60,7 +60,7 @@ class TestNewConnectionError:
         assert err.pool is err.conn
         msg = (
             "The 'pool' property is deprecated and will be removed "
-            "in a later urllib3 v2.x release. use 'conn' instead."
+            "in urllib3 v2.1.0. Use 'conn' instead."
         )
         record = records[0]
         assert isinstance(record.message, Warning)

--- a/test/test_fields.py
+++ b/test/test_fields.py
@@ -72,16 +72,16 @@ class TestRequestField:
     def test_format_header_param_rfc2231_deprecated(
         self, value: Union[bytes, str], expect: str
     ) -> None:
-        with pytest.deprecated_call(match=r"urllib3 v3\.0\.0"):
+        with pytest.deprecated_call(match=r"urllib3 v2\.1\.0"):
             param = format_header_param_rfc2231("filename", value)
 
         assert param == expect
 
     def test_format_header_param_html5_deprecated(self) -> None:
-        with pytest.deprecated_call(match=r"urllib3 v3\.0\.0"):
+        with pytest.deprecated_call(match=r"urllib3 v2\.1\.0"):
             param2 = format_header_param_html5("filename", "name")
 
-        with pytest.deprecated_call(match=r"urllib3 v3\.0\.0"):
+        with pytest.deprecated_call(match=r"urllib3 v2\.1\.0"):
             param1 = format_header_param("filename", "name")
 
         assert param1 == param2
@@ -111,7 +111,7 @@ class TestRequestField:
         assert cd == 'form-data; name="file"; filename="スキー旅行.txt"'
 
     def test_from_tuples_rfc2231(self) -> None:
-        with pytest.deprecated_call(match=r"urllib3 v3\.0\.0"):
+        with pytest.deprecated_call(match=r"urllib3 v2\.1\.0"):
             field = RequestField.from_tuples(
                 "file", ("näme", "data"), header_formatter=format_header_param_rfc2231
             )

--- a/test/with_dummyserver/test_connectionpool.py
+++ b/test/with_dummyserver/test_connectionpool.py
@@ -1016,7 +1016,7 @@ class TestConnectionPool(HTTPDummyServerTestCase):
             with pytest.warns(DeprecationWarning) as w:
                 conn.request_chunked("GET", "/headers")  # type: ignore[attr-defined]
             assert len(w) == 1 and str(w[0].message) == (
-                "HTTPConnection.request_chunked() is deprecated and will be removed in a future version. "
+                "HTTPConnection.request_chunked() is deprecated and will be removed in urllib3 v2.1.0. "
                 "Instead use HTTPConnection.request(..., chunked=True)."
             )
 

--- a/test/with_dummyserver/test_https.py
+++ b/test/with_dummyserver/test_https.py
@@ -767,7 +767,7 @@ class TestHTTPS(HTTPSDummyServerTestCase):
             conn.set_cert()
         assert conn.cert_reqs == ssl.CERT_REQUIRED
         assert len(w) == 1 and str(w[0].message) == (
-            "HTTPSConnection.set_cert() is deprecated and will be removed in a future version. "
+            "HTTPSConnection.set_cert() is deprecated and will be removed in urllib3 v2.1.0. "
             "Instead provide the parameters to the HTTPSConnection constructor."
         )
 
@@ -787,7 +787,7 @@ class TestHTTPS(HTTPSDummyServerTestCase):
             conn.ssl_context is not None and conn.ssl_context.verify_mode == verify_mode
         )
         assert len(w) == 1 and str(w[0].message) == (
-            "HTTPSConnection.set_cert() is deprecated and will be removed in a future version. "
+            "HTTPSConnection.set_cert() is deprecated and will be removed in urllib3 v2.1.0. "
             "Instead provide the parameters to the HTTPSConnection constructor."
         )
 
@@ -830,7 +830,7 @@ class TestHTTPS(HTTPSDummyServerTestCase):
             str(x.message)
             == (
                 "'ssl_version' option is deprecated and will be removed in "
-                "a future release of urllib3 2.x. Instead use 'ssl_minimum_version'"
+                "urllib3 v2.1.0. Instead use 'ssl_minimum_version'"
             )
             for x in w
         )


### PR DESCRIPTION
Plan between @pquentin and I is to release 2.0.0 pre-releases early next week, do a bunch of hardening and integration testing against existing packages, and then release 2.1.0 will the actual removals of deprecated features sometime in the summer of 2023.

Closes https://github.com/urllib3/urllib3/issues/2781