### PR TITLE
Change reg-name pattern to match the RFC

### DIFF
--- a/src/urllib3/util/url.py
+++ b/src/urllib3/util/url.py
@@ -52,7 +52,13 @@ _UNRESERVED_PAT = (
 _IPV6_PAT = "(?:" + "|".join([x % _subs for x in _variations]) + ")"
 _ZONE_ID_PAT = "(?:%25|%)(?:[" + _UNRESERVED_PAT + "]|%[a-fA-F0-9]{2})+"
 _IPV6_ADDRZ_PAT = r"\[" + _IPV6_PAT + r"(?:" + _ZONE_ID_PAT + r")?\]"
-_REG_NAME_PAT = r"(?:[^\[\]%:/?#]|%[a-fA-F0-9]{2})*"
+_PCT_ENCODED_PAT = r"%[a-fA-F0-9]{2}"
+_SUB_DELIMS_PAT = r"[!\$&'\(\)\*\+,;=]"
+_REG_NAME_PAT = r"(?:%s|%s|%s)*" % (
+    _UNRESERVED_PAT,
+    _PCT_ENCODED_PAT,
+    _SUB_DELIMS_PAT,
+)
 _TARGET_RE = re.compile(r"^(/[^?#]*)(?:\?([^#]*))?(?:#.*)?$")
 
 _IPV4_RE = re.compile("^" + _IPV4_PAT + "$")

--- a/src/urllib3/util/url.py
+++ b/src/urllib3/util/url.py
@@ -47,7 +47,7 @@ _variations = [
 ]
 
 _UNRESERVED_PAT = (
-    r"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789._!\-~"
+    r"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789._\-~"
 )
 _IPV6_PAT = "(?:" + "|".join([x % _subs for x in _variations]) + ")"
 _ZONE_ID_PAT = "(?:%25|%)(?:[" + _UNRESERVED_PAT + "]|%[a-fA-F0-9]{2})+"


### PR DESCRIPTION
(Fixes [#2802](https://github.com/urllib3/urllib3/issues/2802))
This patch makes it so that _REG_NAME_PAT matches RFC3986.
This fixes a bug, but it also introduces incompatibilities with Unicode.
I'd be happy to make this patch work with Unicode, but I wasn't sure if that's within the scope of this module.

Please let me know if I should add Unicode support, and then I'll add tests, autoformatting, etc.