### PR TITLE
[1.26] Deprecate HTTPResponse.getheaders() and .getheader() methods

### DIFF
--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -862,7 +862,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
             )
 
         # Check if we should retry the HTTP response.
-        has_retry_after = bool(response.getheader("Retry-After"))
+        has_retry_after = bool(response.headers.get("Retry-After"))
         if retries.is_retry(method, response.status, has_retry_after):
             try:
                 retries = retries.increment(method, url, response=response, _pool=self)

--- a/src/urllib3/response.py
+++ b/src/urllib3/response.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 import io
 import logging
 import sys
+import warnings
 import zlib
 from contextlib import contextmanager
 from socket import error as SocketError
@@ -663,9 +664,21 @@ class HTTPResponse(io.IOBase):
 
     # Backwards-compatibility methods for http.client.HTTPResponse
     def getheaders(self):
+        warnings.warn(
+            "HTTPResponse.getheaders() is deprecated and will be removed "
+            "in urllib3 v2.1.0. Instead access HTTResponse.headers directly.",
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
         return self.headers
 
     def getheader(self, name, default=None):
+        warnings.warn(
+            "HTTPResponse.getheader() is deprecated and will be removed "
+            "in urllib3 v2.1.0. Instead use HTTResponse.headers.get(name, default).",
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
         return self.headers.get(name, default)
 
     # Backwards compatibility for http.cookiejar

--- a/src/urllib3/util/retry.py
+++ b/src/urllib3/util/retry.py
@@ -394,7 +394,7 @@ class Retry(object):
     def get_retry_after(self, response):
         """Get the value of Retry-After in seconds."""
 
-        retry_after = response.getheader("Retry-After")
+        retry_after = response.headers.get("Retry-After")
 
         if retry_after is None:
             return None

--- a/test/test_response.py
+++ b/test/test_response.py
@@ -13,6 +13,7 @@ import mock
 import pytest
 import six
 
+from urllib3._collections import HTTPHeaderDict
 from urllib3.exceptions import (
     DecodeError,
     IncompleteRead,
@@ -57,12 +58,20 @@ class TestLegacyResponse(object):
     def test_getheaders(self):
         headers = {"host": "example.com"}
         r = HTTPResponse(headers=headers)
-        assert r.getheaders() == headers
+        with pytest.warns(
+            DeprecationWarning,
+            match=r"HTTPResponse.getheaders\(\) is deprecated",
+        ):
+            assert r.getheaders() == HTTPHeaderDict(headers)
 
     def test_getheader(self):
         headers = {"host": "example.com"}
         r = HTTPResponse(headers=headers)
-        assert r.getheader("host") == "example.com"
+        with pytest.warns(
+            DeprecationWarning,
+            match=r"HTTPResponse.getheader\(\) is deprecated",
+        ):
+            assert r.getheader("host") == "example.com"
 
 
 class TestResponse(object):


### PR DESCRIPTION
Backports #2814 and and #2820
Closes #2819
