### PR TITLE
Stop showing thousands of @ in test output

### DIFF
--- a/test/test_util.py
+++ b/test/test_util.py
@@ -486,14 +486,19 @@ class TestUtil:
             ),
         ),
         # Tons of '@' causing backtracking
-        ("https://" + ("@" * 10000) + "[", False),
-        (
+        pytest.param(
+            "https://" + ("@" * 10000) + "[",
+            False,
+            id="Tons of '@' causing backtracking 1",
+        ),
+        pytest.param(
             "https://user:" + ("@" * 10000) + "example.com",
             Url(
                 scheme="https",
                 auth="user:" + ("%40" * 9999),
                 host="example.com",
             ),
+            id="Tons of '@' causing backtracking 2",
         ),
     ]
 


### PR DESCRIPTION
As pointed out by @bluetech in https://github.com/urllib3/urllib3/pull/2810#issuecomment-1320334670.
