### PR TITLE
Support cryptography 39

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -12,7 +12,7 @@ pytest-freezegun==0.4.2
 flaky==3.7.0
 trustme==0.7.0
 cryptography==3.2.1;python_version<"3.6"
-cryptography==3.4.7;python_version>="3.6"
+cryptography==38.0.3;python_version>="3.6"
 python-dateutil==2.8.1
 
 # https://github.com/GrahamDumpleton/wrapt/issues/189

--- a/src/urllib3/contrib/pyopenssl.py
+++ b/src/urllib3/contrib/pyopenssl.py
@@ -47,10 +47,10 @@ compression in Python 2 (see `CRIME attack`_).
 """
 from __future__ import absolute_import
 
+import OpenSSL.crypto
 import OpenSSL.SSL
 from cryptography import x509
 from cryptography.hazmat.backends.openssl import backend as openssl_backend
-from cryptography.hazmat.backends.openssl.x509 import _Certificate
 
 try:
     from cryptography.x509 import UnsupportedExtension
@@ -228,9 +228,8 @@ def get_subj_alt_name(peer_cert):
     if hasattr(peer_cert, "to_cryptography"):
         cert = peer_cert.to_cryptography()
     else:
-        # This is technically using private APIs, but should work across all
-        # relevant versions before PyOpenSSL got a proper API for this.
-        cert = _Certificate(openssl_backend, peer_cert._x509)
+        der = OpenSSL.crypto.dump_certificate(OpenSSL.crypto.FILETYPE_ASN1, peer_cert)
+        cert = x509.load_der_x509_certificate(der, openssl_backend)
 
     # We want to find the SAN extension. Ask Cryptography to locate it (it's
     # faster than looping in Python)


### PR DESCRIPTION
Looking at the build in https://github.com/urllib3/urllib3/pull/2827, I noticed the following warning:

> /home/docs/checkouts/readthedocs.org/user_builds/urllib3/envs/2827/lib/python3.7/site-packages/cryptography/hazmat/backends/openssl/x509.py:17: CryptographyDeprecationWarning: This version of cryptography contains a temporary pyOpenSSL fallback path. Upgrade pyOpenSSL now.
  utils.DeprecatedIn35,

This is because our pyOpenSSL backend does `from cryptography.hazmat.backends.openssl.x509 import _Certificate`. It will be gone in the next version of cryptography. And people could blame pyOpenSSL, when we are the one to blame.

The fix is to use the current implementation of `to_cryptography`, which was added five years ago in 2017, but using APIs that were available in 2014, which means we don't have to upgrade our cryptography and pyopenssl pins.