### PR TITLE
Require pyOpenSSL 17.1.0+ to support cryptography 39+

### DIFF
--- a/changelog/2829.feature.rst
+++ b/changelog/2829.feature.rst
@@ -1,0 +1,1 @@
+Support cryptograph>=39 by requiring OpenSSL>=17.1.0.

--- a/changelog/2829.feature.rst
+++ b/changelog/2829.feature.rst
@@ -1,1 +1,1 @@
-Support cryptograph>=39 by requiring OpenSSL>=17.1.0.
+Support cryptography>=39 by requiring OpenSSL>=17.1.0 and cryptography>=1.9.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ zstd = [
 ]
 secure = [
   "pyOpenSSL>=17.1.0",
-  "cryptography>=1.3.4",
+  "cryptography>=1.9",
   "idna>=2.0.0",
   "certifi",
   "urllib3-secure-extra",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ zstd = [
   "zstandard>=0.18.0",
 ]
 secure = [
-  "pyOpenSSL>=0.14",
+  "pyOpenSSL>=17.1.0",
   "cryptography>=1.3.4",
   "idna>=2.0.0",
   "certifi",

--- a/src/urllib3/contrib/pyopenssl.py
+++ b/src/urllib3/contrib/pyopenssl.py
@@ -42,8 +42,6 @@ from __future__ import annotations
 
 import OpenSSL.SSL  # type: ignore[import]
 from cryptography import x509
-from cryptography.hazmat.backends.openssl import backend as openssl_backend
-from cryptography.hazmat.backends.openssl.x509 import _Certificate
 
 try:
     from cryptography.x509 import UnsupportedExtension  # type: ignore[attr-defined]
@@ -238,13 +236,7 @@ def get_subj_alt_name(peer_cert: X509) -> list[tuple[str, str]]:
     """
     Given an PyOpenSSL certificate, provides all the subject alternative names.
     """
-    # Pass the cert to cryptography, which has much better APIs for this.
-    if hasattr(peer_cert, "to_cryptography"):
-        cert = peer_cert.to_cryptography()
-    else:
-        # This is technically using private APIs, but should work across all
-        # relevant versions before PyOpenSSL got a proper API for this.
-        cert = _Certificate(openssl_backend, peer_cert._x509)
+    cert = peer_cert.to_cryptography()
 
     # We want to find the SAN extension. Ask Cryptography to locate it (it's
     # faster than looping in Python)


### PR DESCRIPTION
Looking at the build in https://github.com/urllib3/urllib3/pull/2827, I noticed the following warning:

> /home/docs/checkouts/readthedocs.org/user_builds/urllib3/envs/2827/lib/python3.7/site-packages/cryptography/hazmat/backends/openssl/x509.py:17: CryptographyDeprecationWarning: This version of cryptography contains a temporary pyOpenSSL fallback path. Upgrade pyOpenSSL now.
  utils.DeprecatedIn35,

This is because our pyOpenSSL backend does `from cryptography.hazmat.backends.openssl.x509 import _Certificate`. It will be gone in the next version of cryptography. And people could blame pyOpenSSL, when we are the one to blame. Since this was only in a fallback, I bumped the minimum pyOpenSSL version.