### PR TITLE
Capture debug logs in pytest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
             experimental: false
             nox-session: test-pypy
           - python-version: "2.7"
-            os: ubuntu-latest
+            os: ubuntu-20.04  # CPython 2.7 is not available for ubuntu-22.04
             experimental: false
             nox-session: unsupported_setup_py
           - python-version: "3.9"

--- a/changelog/2839.bugfix.rst
+++ b/changelog/2839.bugfix.rst
@@ -1,0 +1,1 @@
+Fix logging error when using ``add_stderr_logger``.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,7 @@ include = [
 xfail_strict = true
 python_classes = ["Test", "*TestCase"]
 markers = ["limit_memory"]
+log_level = "DEBUG"
 filterwarnings = [
     "error",
     '''default:'urllib3\[secure\]' extra is deprecated and will be removed in urllib3 v2\.1\.0.*:DeprecationWarning''',

--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -545,7 +545,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         response._pool = self  # type: ignore[attr-defined]
 
         log.debug(
-            '%s://%s:%s "%s %s %s" %s',
+            '%s://%s:%s "%s %s %s" %s %s',
             self.scheme,
             self.host,
             self.port,

--- a/test/with_dummyserver/test_connectionpool.py
+++ b/test/with_dummyserver/test_connectionpool.py
@@ -1,9 +1,7 @@
 from __future__ import annotations
 
 import io
-import logging
 import socket
-import sys
 import time
 import typing
 import warnings
@@ -38,10 +36,6 @@ from .. import INVALID_SOURCE_ADDRESSES, TARPIT_HOST, VALID_SOURCE_ADDRESSES
 from ..port_helpers import find_unused_port
 
 pytestmark = pytest.mark.flaky
-
-log = logging.getLogger("urllib3.connectionpool")
-log.setLevel(logging.NOTSET)
-log.addHandler(logging.StreamHandler(sys.stdout))
 
 
 def wait_for_socket(ready_event: Event) -> None:

--- a/test/with_dummyserver/test_https.py
+++ b/test/with_dummyserver/test_https.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import datetime
-import logging
 import os.path
 import shutil
 import ssl
@@ -50,11 +49,6 @@ from .. import has_alpn
 
 # Retry failed tests
 pytestmark = pytest.mark.flaky
-
-
-log = logging.getLogger("urllib3.connectionpool")
-log.setLevel(logging.NOTSET)
-log.addHandler(logging.StreamHandler(sys.stdout))
 
 
 TLSv1_CERTS = DEFAULT_CERTS.copy()


### PR DESCRIPTION
I've configured pytest to capture debug logs (the [default being warning logs](https://docs.pytest.org/en/7.1.x/how-to/logging.html#incompatible-changes-in-pytest-3-4)), which catches the bug found in https://github.com/urllib3/urllib3/issues/2839. Showing our actual debug logs in tests is an added bonus. I've also removed logging configuration in two tests as it [predates our use of pytest](https://github.com/urllib3/urllib3/commit/1a154eb9fc4216968f634368cc2ff9873265b1d5) and is no longer needed. 

Closes #2839 