### PR TITLE
disable Nagle's algorithm in test_ssl_read_timeout

### DIFF
--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -1267,6 +1267,8 @@ class TestSSL(SocketDummyServerTestCase):
 
         def socket_handler(listener: socket.socket) -> None:
             sock = listener.accept()[0]
+            # disable Nagle's algorithm so there's no delay in sending a partial body
+            sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, True)
             ssl_sock = original_ssl_wrap_socket(
                 sock,
                 server_side=True,


### PR DESCRIPTION
it's possible that the `ssl_sock.send(` doesn't send enough data to satisfy Nagle's algorithm causing the kernel to wait over `LONG_TIMEOUT = 0.01` seconds before sending any data which causes read_headers to fail with a read timeout