### PR TITLE
fixed issue with port "0" returning None

### DIFF
--- a/changelog/2850.bugfix.rst
+++ b/changelog/2850.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed parsing of port 0 (zero) returning None, instead of 0.

--- a/src/urllib3/util/url.py
+++ b/src/urllib3/util/url.py
@@ -63,7 +63,7 @@ _IPV6_ADDRZ_RE = re.compile("^" + _IPV6_ADDRZ_PAT + "$")
 _BRACELESS_IPV6_ADDRZ_RE = re.compile("^" + _IPV6_ADDRZ_PAT[2:-2] + "$")
 _ZONE_ID_RE = re.compile("(" + _ZONE_ID_PAT + r")\]$")
 
-_HOST_PORT_PAT = ("^(%s|%s|%s)(?::0*?(|0|[1-9][0-9]{0,5}))?$") % (
+_HOST_PORT_PAT = ("^(%s|%s|%s)(?::0*?(|0|[1-9][0-9]{0,4}))?$") % (
     _REG_NAME_PAT,
     _IPV4_PAT,
     _IPV6_ADDRZ_PAT,

--- a/src/urllib3/util/url.py
+++ b/src/urllib3/util/url.py
@@ -63,7 +63,7 @@ _IPV6_ADDRZ_RE = re.compile("^" + _IPV6_ADDRZ_PAT + "$")
 _BRACELESS_IPV6_ADDRZ_RE = re.compile("^" + _IPV6_ADDRZ_PAT[2:-2] + "$")
 _ZONE_ID_RE = re.compile("(" + _ZONE_ID_PAT + r")\]$")
 
-_HOST_PORT_PAT = ("^(%s|%s|%s)(?::0*([0-9]{0,5}))?$") % (
+_HOST_PORT_PAT = ("^(%s|%s|%s)(?::0*?(|0|[1-9][0-9]{0,5}))?$") % (
     _REG_NAME_PAT,
     _IPV4_PAT,
     _IPV6_ADDRZ_PAT,

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -352,6 +352,13 @@ class TestUtil:
         url = parse_url("https://example.com:0000000000080")
         assert url.port == 80
 
+    def test_parse_url_only_zeros(self) -> None:
+        url = parse_url("https://example.com:0")
+        assert url.port == 0
+
+        url = parse_url("https://example.com:000000000000")
+        assert url.port == 0
+
     def test_Url_str(self) -> None:
         U = Url("http", host="google.com")
         assert str(U) == U.url


### PR DESCRIPTION
since merging https://github.com/urllib3/urllib3/pull/2806 -- we report port "0" as None, although it should be "0". 

this pr fixes it and adds two tests for this case. thanks @sethmlarson for the magic regex :)

closes: #2850 