### PR TITLE
Fix the type hint of PoolKey.key_retries

### DIFF
--- a/changelog/2865.bugfix.rst
+++ b/changelog/2865.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed the type hint of ``PoolKey.key_retries`` by adding ``bool`` to the union.

--- a/changelog/2865.doc.rst
+++ b/changelog/2865.doc.rst
@@ -1,1 +1,0 @@
-Fixed the type hint of ``PoolKey.key_retries``.

--- a/changelog/2865.doc.rst
+++ b/changelog/2865.doc.rst
@@ -1,0 +1,1 @@
+Fixed the type hint of ``PoolKey.key_retries``.

--- a/src/urllib3/poolmanager.py
+++ b/src/urllib3/poolmanager.py
@@ -66,7 +66,7 @@ class PoolKey(typing.NamedTuple):
     key_host: str
     key_port: int | None
     key_timeout: Timeout | float | int | None
-    key_retries: Retry | int | None
+    key_retries: Retry | bool | int | None
     key_block: bool | None
     key_source_address: tuple[str, int] | None
     key_key_file: str | None


### PR DESCRIPTION
Thanks for maintaining this great project! Here is a simple patch to fix some type hints.

`key_retries` also accepts `bool` values: https://github.com/urllib3/urllib3/blob/6cfdca5825e3557f66fd00d0c2f4407c3e1e0d1e/src/urllib3/util/retry.py#L261