### PR TITLE
[1.26] Fix socket timeout value when HTTPConnection is reused

### DIFF
--- a/changelog/2645.bugfix.rst
+++ b/changelog/2645.bugfix.rst
@@ -1,3 +1,0 @@
-Fixed an issue where an ``HTTPConnection`` instance would erroneously reuse the socket
-read timeout value from reading the previous response instead of a newly configured connect timeout.
-Instead now if ``HTTPConnection.timeout`` is updated before sending the next request the new timeout value will be used.

--- a/changelog/2645.bugfix.rst
+++ b/changelog/2645.bugfix.rst
@@ -1,0 +1,3 @@
+Fixed an issue where an ``HTTPConnection`` instance would erroneously reuse the socket
+read timeout value from reading the previous response instead of a newly configured connect timeout.
+Instead now if ``HTTPConnection.timeout`` is updated before sending the next request the new timeout value will be used.

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -229,6 +229,11 @@ class HTTPConnection(_HTTPConnection, object):
             )
 
     def request(self, method, url, body=None, headers=None):
+        # Update the inner socket's timeout value to send the request.
+        # This only triggers if the connection is re-used.
+        if self.sock is not None:
+            self.sock.settimeout(self.timeout)
+
         if headers is None:
             headers = {}
         else:

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -231,7 +231,7 @@ class HTTPConnection(_HTTPConnection, object):
     def request(self, method, url, body=None, headers=None):
         # Update the inner socket's timeout value to send the request.
         # This only triggers if the connection is re-used.
-        if self.sock is not None:
+        if getattr(self, "sock", None) is not None:
             self.sock.settimeout(self.timeout)
 
         if headers is None:

--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -379,7 +379,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
 
         timeout_obj = self._get_timeout(timeout)
         timeout_obj.start_connect()
-        conn.timeout = timeout_obj.connect_timeout
+        conn.timeout = Timeout.resolve_default_timeout(timeout_obj.connect_timeout)
 
         # Trigger any extra validation we need to do.
         try:

--- a/src/urllib3/util/timeout.py
+++ b/src/urllib3/util/timeout.py
@@ -2,9 +2,8 @@ from __future__ import absolute_import
 
 import time
 
-# The default socket timeout, used by httplib to indicate that no timeout was
-# specified by the user
-from socket import _GLOBAL_DEFAULT_TIMEOUT
+# The default socket timeout, used by httplib to indicate that no timeout was; specified by the user
+from socket import _GLOBAL_DEFAULT_TIMEOUT, getdefaulttimeout
 
 from ..exceptions import TimeoutStateError
 
@@ -115,6 +114,10 @@ class Timeout(object):
 
     # __str__ provided for backwards compatibility
     __str__ = __repr__
+
+    @classmethod
+    def resolve_default_timeout(cls, timeout):
+        return getdefaulttimeout() if timeout is cls.DEFAULT_TIMEOUT else timeout
 
     @classmethod
     def _validate_timeout(cls, value, name):


### PR DESCRIPTION
This is a backport of PR #2792, for the purposes of applying the fix for issue #2645 to the 1.26.x release stream.