### PR TITLE
Use Ubuntu 20.04 to run CI for 2.7 and 3.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,11 +31,35 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["2.7", "3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
         os: [macos-11, windows-latest, ubuntu-latest]
         experimental: [false]
         nox-session: ['']
         include:
+          - python-version: "2.7"
+            os: macos-11
+            experimental: false
+            nox-session: ''
+          - python-version: "2.7"
+            os: windows-latest
+            experimental: false
+            nox-session: ''
+          - python-version: "2.7"
+            os: ubuntu-20.04
+            experimental: false
+            nox-session: ''
+          - python-version: "3.6"
+            os: macos-11
+            experimental: false
+            nox-session: ''
+          - python-version: "3.6"
+            os: windows-latest
+            experimental: false
+            nox-session: ''
+          - python-version: "3.6"
+            os: ubuntu-20.04
+            experimental: false
+            nox-session: ''
           - python-version: "pypy3"
             os: ubuntu-latest
             experimental: false


### PR DESCRIPTION
The ubuntu-latest tag no longer offers those EOL versions.