### PR TITLE
[1.26] Remove timeout in test select.select calls

### DIFF
--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -776,7 +776,7 @@ class TestSocketClosing(SocketDummyServerTestCase):
             # leaking it. Because we don't want to hang this thread, we
             # actually use select.select to confirm that a new request is
             # coming in: this lets us time the thread out.
-            rlist, _, _ = select.select([listener], [], [], 1)
+            rlist, _, _ = select.select([listener], [], [])
             assert rlist
             new_sock = listener.accept()[0]
 
@@ -885,7 +885,7 @@ class TestSocketClosing(SocketDummyServerTestCase):
             # Expect a new request. Because we don't want to hang this thread,
             # we actually use select.select to confirm that a new request is
             # coming in: this lets us time the thread out.
-            rlist, _, _ = select.select([listener], [], [], 5)
+            rlist, _, _ = select.select([listener], [], [])
             assert rlist
             sock = listener.accept()[0]
             consume_socket(sock)


### PR DESCRIPTION
`TestSocketClosing.test_release_conn_param_is_respected_after_timeout_retry` is flaky. This was already investigated two years ago: https://github.com/urllib3/urllib3/issues/1838. But clearly that fix was not enough.

Here's the latest failure:

```python
__ TestSocketClosing.test_release_conn_param_is_respected_after_timeout_retry __
Traceback (most recent call last):
  File "/Users/runner/work/urllib3/urllib3/.nox/test-3-9/lib/python3.9/site-packages/urllib3/connectionpool.py", line 703, in urlopen
    httplib_response = self._make_request(
  File "/Users/runner/work/urllib3/urllib3/.nox/test-3-9/lib/python3.9/site-packages/urllib3/connectionpool.py", line 449, in _make_request
    six.raise_from(e, None)
  File "<string>", line 3, in raise_from
  File "/Users/runner/work/urllib3/urllib3/.nox/test-3-9/lib/python3.9/site-packages/urllib3/connectionpool.py", line 444, in _make_request
    httplib_response = conn.getresponse()
  File "/Users/runner/hostedtoolcache/Python/3.9.16/x64/lib/python3.9/http/client.py", line 1377, in getresponse
    response.begin()
  File "/Users/runner/hostedtoolcache/Python/3.9.16/x64/lib/python3.9/http/client.py", line 320, in begin
    version, status, reason = self._read_status()
  File "/Users/runner/hostedtoolcache/Python/3.9.16/x64/lib/python3.9/http/client.py", line 281, in _read_status
    line = str(self.fp.readline(_MAXLINE + 1), "iso-8859-1")
  File "/Users/runner/hostedtoolcache/Python/3.9.16/x64/lib/python3.9/socket.py", line 704, in readinto
    return self._sock.recv_into(b)
ConnectionResetError: [Errno 54] Connection reset by peer

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/runner/work/urllib3/urllib3/test/with_dummyserver/test_socketlevel.py", line 912, in test_release_conn_param_is_respected_after_timeout_retry
    response = pool.urlopen(
  File "/Users/runner/work/urllib3/urllib3/.nox/test-3-9/lib/python3.9/site-packages/urllib3/connectionpool.py", line 815, in urlopen
    return self.urlopen(
  File "/Users/runner/work/urllib3/urllib3/.nox/test-3-9/lib/python3.9/site-packages/urllib3/connectionpool.py", line 787, in urlopen
    retries = retries.increment(
  File "/Users/runner/work/urllib3/urllib3/.nox/test-3-9/lib/python3.9/site-packages/urllib3/util/retry.py", line 592, in increment
    raise MaxRetryError(_pool, url, error or ResponseError(cause))
urllib3.exceptions.MaxRetryError: HTTPConnectionPool(host='localhost', port=50018): Max retries exceeded with url: / (Caused by ProtocolError('Connection aborted.', ConnectionResetError(54, 'Connection reset by peer')))
----------------------------- Captured stdout call -----------------------------
Retrying (Retry(total=0, connect=None, read=None, redirect=None, status=None)) after connection broken by 'ProtocolError('Connection aborted.', RemoteDisconnected('Remote end closed connection without response'))': /
Retrying (Retry(total=0, connect=None, read=None, redirect=None, status=None)) after connection broken by 'ProtocolError('Connection aborted.', RemoteDisconnected('Remote end closed connection without response'))': /
----------------------------- Captured stderr call -----------------------------
Exception in thread Thread-91:
Traceback (most recent call last):
  File "/Users/runner/hostedtoolcache/Python/3.9.16/x64/lib/python3.9/threading.py", line 980, in _bootstrap_inner
    self.run()
  File "/Users/runner/work/urllib3/urllib3/dummyserver/server.py", line 134, in run
    self.server = self._start_server()
  File "/Users/runner/work/urllib3/urllib3/dummyserver/server.py", line 130, in _start_server
    self.socket_handler(sock)
  File "/Users/runner/work/urllib3/urllib3/test/with_dummyserver/test_socketlevel.py", line 889, in socket_handler
    assert rlist
AssertionError: assert []
------------------------------ Captured log call -------------------------------
WARNING  urllib3.connectionpool:connectionpool.py:812 Retrying (Retry(total=0, connect=None, read=None, redirect=None, status=None)) after connection broken by 'ProtocolError('Connection aborted.', RemoteDisconnected('Remote end closed connection without response'))': /
```

As you can see, `assert rlist` is failing in `test/with_dummyserver/test_socketlevel.py`. What happens here is that `select.select` times out after 5 seconds. (It's good to see that the failure is not a request timeout! So the previous fix did work)

Removing the timeout means this test could hang forever but it has never been an issue in `test/test_ssltransport.py` where we call `select.select` without a timeout so I'd like to try that. If we see hangs in the future, we can always revert and investigate more, maybe by exploring the selectors module instead.