### PR TITLE
Speed up Python 3.11 CI

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,16 +3,10 @@ source =
     urllib3
 
 omit =
-    *urllib3/packages/*
-    *urllib3/contrib/pyopenssl.py
-    *urllib3/contrib/securetransport.py
-    *urllib3/contrib/_securetransport/*
-
-[paths]
-source =
-    src/urllib3
-    */urllib3
-    *\urllib3
+    src/urllib3/packages/**
+    src/urllib3/contrib/pyopenssl.py
+    src/urllib3/contrib/securetransport.py
+    src/urllib3/contrib/_securetransport/*
 
 [report]
 exclude_lines =

--- a/.coveragerc
+++ b/.coveragerc
@@ -8,6 +8,12 @@ omit =
     src/urllib3/contrib/securetransport.py
     src/urllib3/contrib/_securetransport/*
 
+[paths]
+source =
+    src/urllib3
+    */urllib3
+    *\urllib3
+
 [report]
 exclude_lines =
     except ModuleNotFoundError:

--- a/.coveragerc
+++ b/.coveragerc
@@ -2,12 +2,6 @@
 source =
     urllib3
 
-omit =
-    src/urllib3/packages/**
-    src/urllib3/contrib/pyopenssl.py
-    src/urllib3/contrib/securetransport.py
-    src/urllib3/contrib/_securetransport/*
-
 [paths]
 source =
     src/urllib3
@@ -15,6 +9,11 @@ source =
     *\urllib3
 
 [report]
+omit =
+    src/urllib3/contrib/pyopenssl.py
+    src/urllib3/contrib/securetransport.py
+    src/urllib3/contrib/_securetransport/*
+
 exclude_lines =
     except ModuleNotFoundError:
     except ImportError:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
             os: ubuntu-20.04  # CPython 2.7 is not available for ubuntu-22.04
             experimental: false
             nox-session: unsupported_setup_py
-          - python-version: "3.9"
+          - python-version: "3.x"
             os: ubuntu-latest
             experimental: false
             nox-session: test_brotlipy

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,4 @@
-coverage==6.4
+coverage==7.0.4
 tornado==6.2
 PySocks==1.7.1
 pytest==7.2.0
@@ -6,7 +6,7 @@ pytest-timeout==2.1.0
 pytest-freezegun==0.4.2
 flaky==3.7.0
 trustme==0.9.0
-cryptography==37.0.2
+cryptography==39.0.0
 backports.zoneinfo==0.2.1;python_version<"3.9"
 towncrier==21.9.0
-pytest-memray==1.3.1;python_version>="3.8" and sys_platform!="win32" and implementation_name=="cpython"
+pytest-memray==1.4.0;python_version>="3.8" and sys_platform!="win32" and implementation_name=="cpython"


### PR DESCRIPTION
This will use a wheel for coverage and include a few performance coverage improvements that help on PyPy and CPython 3.11.

coverage 7.0.0 improved coverage combine but broke the .coveragerc configuration, let's see if I can figure out a config that works.