### PR TITLE
Test brotli with Python 3.10, not 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
             os: ubuntu-20.04  # CPython 2.7 is not available for ubuntu-22.04
             experimental: false
             nox-session: unsupported_setup_py
-          - python-version: "3.9"
+          - python-version: "3.10"
             os: ubuntu-latest
             experimental: false
             nox-session: test_brotlipy

--- a/noxfile.py
+++ b/noxfile.py
@@ -84,7 +84,7 @@ def unsupported_setup_py(session: nox.Session) -> None:
     assert "Please use `python -m pip install .` instead." in process.stderr
 
 
-@nox.session(python=["3"])
+@nox.session(python=["3.10"])
 def test_brotlipy(session: nox.Session) -> None:
     """Check that if 'brotlipy' is installed instead of 'brotli' or
     'brotlicffi' that we still don't blow up.


### PR DESCRIPTION
Python 3.11 runs test extremely slowly for now.

This requires changing the required checks again sorry.