### PR TITLE
[1.26] Speed up Python 3.11 CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,10 +70,10 @@ jobs:
             os: ubuntu-latest
             experimental: false
             nox-session: google_brotli-2.7
-          - python-version: "3.10"
+          - python-version: "3.x"
             os: ubuntu-latest
             experimental: false
-            nox-session: google_brotli-3.10
+            nox-session: google_brotli-3
           - python-version: "2.7"
             os: ubuntu-latest
             experimental: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,10 +70,10 @@ jobs:
             os: ubuntu-latest
             experimental: false
             nox-session: google_brotli-2.7
-          - python-version: "3.9"
+          - python-version: "3.10"
             os: ubuntu-latest
             experimental: false
-            nox-session: google_brotli-3.9
+            nox-session: google_brotli-3.10
           - python-version: "2.7"
             os: ubuntu-latest
             experimental: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,11 +69,11 @@ jobs:
           - python-version: "2.7"
             os: ubuntu-latest
             experimental: false
-            nox-session: google_brotli-2
+            nox-session: google_brotli-2.7
           - python-version: "3.9"
             os: ubuntu-latest
             experimental: false
-            nox-session: google_brotli-3
+            nox-session: google_brotli-3.9
           - python-version: "2.7"
             os: ubuntu-latest
             experimental: false

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,7 +1,8 @@
 mock==3.0.5
-coverage~=5.0
+coverage~=5.0;python_version<="2.7"
+coverage=6.0;python_version>="3.6"
 tornado==5.1.1;python_version<="2.7"
-tornado==6.1.0;python_version>"3.5"
+tornado==6.1.0;python_version>="3.6"
 PySocks==1.7.1
 # https://github.com/Anorov/PySocks/issues/131
 win-inet-pton==1.1.0

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,6 @@
 mock==3.0.5
 coverage~=5.0;python_version<="2.7"
-coverage=6.0;python_version>="3.6"
+coverage~=6.0;python_version>="3.6"
 tornado==5.1.1;python_version<="2.7"
 tornado==6.1.0;python_version>="3.6"
 PySocks==1.7.1

--- a/noxfile.py
+++ b/noxfile.py
@@ -50,7 +50,7 @@ def test(session):
     tests_impl(session)
 
 
-@nox.session(python=["2.7", "3.10"])
+@nox.session(python=["2.7", "3"])
 def google_brotli(session):
     # https://pypi.org/project/Brotli/ is the Google version of brotli, so
     # install it separately and don't install our brotli extra (which installs

--- a/noxfile.py
+++ b/noxfile.py
@@ -50,7 +50,7 @@ def test(session):
     tests_impl(session)
 
 
-@nox.session(python=["2", "3"])
+@nox.session(python=["2.7", "3.10"])
 def google_brotli(session):
     # https://pypi.org/project/Brotli/ is the Google version of brotli, so
     # install it separately and don't install our brotli extra (which installs


### PR DESCRIPTION
Python 3.11 runs test extremely slowly for now.