### PR TITLE
[1.26] Stop relying on distutils from standard library

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,6 @@ jobs:
           rstcheck README.rst CHANGES.rst
           python3.7 -m twine check dist/*
   test:
-    env:
-      SETUPTOOLS_USE_DISTUTILS: stdlib
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Python 3.12 no longer includes distutils and we have a recent enough setuptools for this to work, even on Python 2.7.