### PR TITLE
Keep hostname's trailing dot

### DIFF
--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -690,6 +690,7 @@ def _ssl_wrap_socket_and_match_hostname(
     either via hostname or fingerprint. This function exists to guarantee
     that both proxies and targets have the same behavior when connecting via TLS.
     """
+    server_hostname = server_hostname.rstrip(".")
     default_ssl_context = False
     if ssl_context is None:
         default_ssl_context = True
@@ -747,7 +748,7 @@ def _ssl_wrap_socket_and_match_hostname(
         ca_certs=ca_certs,
         ca_cert_dir=ca_cert_dir,
         ca_cert_data=ca_cert_data,
-        server_hostname=server_hostname.rstrip("."),
+        server_hostname=server_hostname,
         ssl_context=context,
         tls_in_tls=tls_in_tls,
     )

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -1714,7 +1714,7 @@ class TestHeaders(SocketDummyServerTestCase):
         with HTTPConnectionPool(self.host + ".", self.port, retries=False) as pool:
             pool.request("GET", "/")
             self.assert_header_received(
-                self.received_headers, "Host", f"{self.host}:{self.port}"
+                self.received_headers, "Host", f"{self.host}.:{self.port}"
             )
 
     def test_response_headers_are_returned_in_the_original_order(self) -> None:


### PR DESCRIPTION
## Summary
This resolves both #2244 and #2873. It follows the behavior of curl >= 7.83.1 (See [A tale of a trailing dot](https://daniel.haxx.se/blog/2022/05/12/a-tale-of-a-trailing-dot/) for details).

## TODO
- [ ] Add more tests