### PR TITLE
Fix reference to private urllib3.util.ssl_ module in custom context example

### DIFF
--- a/docs/advanced-usage.rst
+++ b/docs/advanced-usage.rst
@@ -619,7 +619,7 @@ flag that isn't set by default, and then makes a HTTPS request:
     import ssl
 
     from urllib3 import PoolManager
-    from urllib3.util.ssl_ import create_urllib3_context
+    from urllib3.util import create_urllib3_context
 
     ctx = create_urllib3_context()
     ctx.load_default_certs()


### PR DESCRIPTION
#2446 moved the `create_urllib3_context` function from the private `urllib3.util.ssl_` to the public `urllib3.util` module, but the code example (added by #2357) was not adjusted to no longer point at the private module.