### PR TITLE
Ignore Dependabot updates for patches

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      # Ignore all patch releases as we can manually
+      # upgrade if we run into a bug and need a fix.
+      - update-types: ["version-update:semver-patch"]


### PR DESCRIPTION
Dependabot is fairly disruptive to my notifications, so let's ignore patch releases since they're pretty useless to us. Security fixes are always opened by Dependabot so we shouldn't be worried about missing those.