### PR TITLE
More Delegation in PyOpenSSL Contrib Module

### DIFF
--- a/src/urllib3/contrib/pyopenssl.py
+++ b/src/urllib3/contrib/pyopenssl.py
@@ -295,6 +295,9 @@ class WrappedSocket:
         self._io_refs = 0
         self._closed = False
 
+    def __getattr__(self, name: str) -> typing.Any:
+        return getattr(self.connection, name)
+
     def fileno(self) -> int:
         return self.socket.fileno()
 
@@ -426,6 +429,9 @@ class PyOpenSSLContext:
         self.check_hostname = False
         self._minimum_version: int = ssl.TLSVersion.MINIMUM_SUPPORTED
         self._maximum_version: int = ssl.TLSVersion.MAXIMUM_SUPPORTED
+
+    def __getattr__(self, name: str) -> typing.Any:
+        return getattr(self._ctx, name)
 
     @property
     def options(self) -> int:


### PR DESCRIPTION
Hey All,

I was trying to use the PyOpenSSL module externally of urllib3 because it's a fantastic shim to make it act more like a stdlib ssl context. I ran into issues because WrappedSocket doesn't expose the "full" socket interface such as settimeout and do_handshake. This was an easy fix to just delegate to the PyOpenSSL Connection, which in turn delegates to the underlying socket.

Totally understand if this is rejected because its not needed by urllib3 and also because the contrib module seems soft deprecated  :-).