### PR TITLE
Fix `_idna_encode`'s handling of `'\x80'`

### DIFF
--- a/changelog/2901.bugfix.rst
+++ b/changelog/2901.bugfix.rst
@@ -1,0 +1,1 @@
+Corrected a sign error in a check for whether a character is in the ASCII range.

--- a/src/urllib3/util/url.py
+++ b/src/urllib3/util/url.py
@@ -332,7 +332,7 @@ def _normalize_host(host: str | None, scheme: str | None) -> str | None:
 
 
 def _idna_encode(name: str) -> bytes:
-    if name and not name.isascii():
+    if not name.isascii():
         try:
             import idna
         except ImportError:

--- a/src/urllib3/util/url.py
+++ b/src/urllib3/util/url.py
@@ -332,7 +332,7 @@ def _normalize_host(host: str | None, scheme: str | None) -> str | None:
 
 
 def _idna_encode(name: str) -> bytes:
-    if name and any(not x.isascii() for x in name):
+    if name and not name.isascii():
         try:
             import idna
         except ImportError:

--- a/src/urllib3/util/url.py
+++ b/src/urllib3/util/url.py
@@ -332,7 +332,7 @@ def _normalize_host(host: str | None, scheme: str | None) -> str | None:
 
 
 def _idna_encode(name: str) -> bytes:
-    if name and any([ord(x) > 128 for x in name]):
+    if name and any(not x.isascii() for x in name):
         try:
             import idna
         except ImportError:


### PR DESCRIPTION
### Fix `_idna_encode`'s handling of `'\x80'`
Addresses #2901.

Also removes explicity code point comparisons in favor of `str.isascii`.