### PR TITLE
remove leading '/' in relative paths.

### DIFF
--- a/src/urllib3/util/url.py
+++ b/src/urllib3/util/url.py
@@ -109,8 +109,7 @@ class Url(
         query: str | None = None,
         fragment: str | None = None,
     ):
-        if path and not path.startswith("/"):
-            path = "/" + path
+
         if scheme is not None:
             scheme = scheme.lower()
         return super().__new__(cls, scheme, auth, host, port, path, query, fragment)


### PR DESCRIPTION
### Remove leading '/' in relative paths.
Addresses #2903.

URLs like `a:b` should have path `b` instead of `/b`.