### PR TITLE
Revert "Workaround GitHub not supporting Flit metadata"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,6 @@
 
 import sys
 
-from setuptools import setup
-
 sys.stderr.write(
     """
 ===============================
@@ -18,13 +16,3 @@ Please use `python -m pip install .` instead.
 """
 )
 sys.exit(1)
-
-
-# The below code will never execute, however GitHub is particularly
-# picky about where it finds Python packaging metadata.
-# See: https://github.com/github/feedback/discussions/6456
-
-setup(
-    name="urllib3",
-    requires=[],
-)


### PR DESCRIPTION
This reverts commit 954ff5989246e45ef2490d04d63d43c94f6d9bc2. GitHub's dependency graph now supports PEP 621.

https://github.blog/changelog/2023-02-13-dependency-graph-supports-the-python-pep-621-standard/

Thanks @ofek for the tip.