### PR TITLE
Skip resource warnings in tests checking non-deprecated TLS versions

### DIFF
--- a/test/with_dummyserver/test_https.py
+++ b/test/with_dummyserver/test_https.py
@@ -847,7 +847,7 @@ class TestHTTPS(HTTPSDummyServerTestCase):
             finally:
                 conn.close()
 
-        assert [str(wm) for wm in w] == []
+        assert [str(wm) for wm in w if wm.category != ResourceWarning] == []
 
     def test_no_tls_version_deprecation_with_ssl_context(self) -> None:
         if self.tls_protocol_name is None:
@@ -868,7 +868,7 @@ class TestHTTPS(HTTPSDummyServerTestCase):
             finally:
                 conn.close()
 
-        assert [str(wm) for wm in w] == []
+        assert [str(wm) for wm in w if wm.category != ResourceWarning] == []
 
     def test_tls_version_maximum_and_minimum(self) -> None:
         if self.tls_protocol_name is None:


### PR DESCRIPTION
`test_ssl_version_with_protocol_tls_or_client_not_deprecated` and `test_no_tls_version_deprecation_with_ssl_context` have been too flaky recently because of catching some resource warnings. The warnings are unlikely relevant to the tests so skipping them may reduce the number of failed test runs.

```
FAILED test/with_dummyserver/test_https.py::TestHTTPS_TLSv1_2::test_ssl_version_with_protocol_tls_or_client_not_deprecated[16] - assert ['{message : ...line : None}'] == []
  Left contains 3 more items, first extra item: '{message : ResourceWarning("unclosed <ssl.SSLSocket fd=1728, family=23, type=1, proto=0, laddr=(\'::1\', 56171, 0, 0)...\\\\hostedtoolcache\\\\windows\\\\Python\\\\3.11.2\\\\x64\\\\Lib\\\\asyncio\\\\events.py\', lineno : 104, line : None}'
  Full diff:
    [
  -  ,
  +  '{message : ResourceWarning("unclosed <ssl.SSLSocket fd=1728, family=23, '
  +  "type=1, proto=0, laddr=('::1', 56171, 0, 0), raddr=('::1', 56138, 0, "
  +  '0)>"), category : \'ResourceWarning\', filename : '
  +  "'C:\\\\hostedtoolcache\\\\windows\\\\Python\\\\3.11.2\\\\x64\\\\Lib\\\\asyncio\\\\events.py', "
  +  'lineno : 104, line : None}',
  +  '{message : ResourceWarning("unclosed <ssl.SSLSocket fd=1676, family=23, '
  +  "type=1, proto=0, laddr=('::1', 56170, 0, 0), raddr=('::1', 56138, 0, "
  +  '0)>"), category : \'ResourceWarning\', filename : '
  +  "'C:\\\\hostedtoolcache\\\\windows\\\\Python\\\\3.11.2\\\\x64\\\\Lib\\\\asyncio\\\\events.py', "
  +  'lineno : 104, line : None}',
  +  '{message : ResourceWarning("unclosed <ssl.SSLSocket fd=1548, family=23, '
  +  "type=1, proto=0, laddr=('::1', 56172, 0, 0), raddr=('::1', 56138, 0, "
  +  '0)>"), category : \'ResourceWarning\', filename : '
  +  "'C:\\\\hostedtoolcache\\\\windows\\\\Python\\\\3.11.2\\\\x64\\\\Lib\\\\asyncio\\\\events.py', "
  +  'lineno : 104, line : None}',
    ]
```
```
FAILED test/with_dummyserver/test_https.py::TestHTTPS_TLSv1_3::test_no_tls_version_deprecation_with_ssl_context - assert ['{message : ...line : None}'] == []
  Left contains one more item: '{message : ResourceWarning("unclosed <ssl.SSLSocket fd=1520, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREA...stedtoolcache\\\\windows\\\\Python\\\\3.10.10\\\\x64\\\\lib\\\\asyncio\\\\base_events.py\', lineno : 438, line : None}'
  Full diff:
    [
  -  ,
  +  '{message : ResourceWarning("unclosed <ssl.SSLSocket fd=1520, '
  +  'family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, '
  +  'laddr=(\'127.0.0.1\', 50710), raddr=(\'127.0.0.1\', 50675)>"), category : '
  +  "'ResourceWarning', filename : "
  +  "'C:\\\\hostedtoolcache\\\\windows\\\\Python\\\\3.10.10\\\\x64\\\\lib\\\\asyncio\\\\base_events.py', "
  +  'lineno : 438, line : None}',
    ]
```