### PR TITLE
Use the default attestation name

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -58,7 +58,6 @@ jobs:
     uses: "slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.4.0"
     with:
       base64-subjects: "${{ needs.build.outputs.hashes }}"
-      attestation-name: "urllib3.intoto.jsonl"
       upload-assets: true
       compile-generator: true # Workaround for https://github.com/slsa-framework/slsa-github-generator/issues/1163
 


### PR DESCRIPTION
Instead of providing a name we should use the default `multiple.intoto.jsonl`. After this is approved I'll rename all the existing released filenames to match so we can document a strategy for verifying provenance across all releases.