### PR TITLE
[1.26] Fix isort pre-commit installation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
         args: ["--target-version", "py27"]
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.9.3
+    rev: 5.12.0
     hooks:
       - id: isort
 


### PR DESCRIPTION
As noticed in https://github.com/urllib3/urllib3/actions/runs/4393994619/jobs/7694764541