### PR TITLE
Change the pip install for 2.0 to a working example

### DIFF
--- a/docs/v2-migration-guide.rst
+++ b/docs/v2-migration-guide.rst
@@ -89,7 +89,7 @@ Next you should try installing urllib3 v2.0 locally and run your test suite.
 
 .. code-block:: bash
 
-  $ python -m pip install -U --pre 'urllib3>2'
+  $ python -m pip install -U --pre 'urllib3>=2.0.0a1'
 
 
 Because there are many ``DeprecationWarnings`` you should ensure that you're


### PR DESCRIPTION
The installation example shown in docs [_Migrating as a package maintainer?_](https://urllib3.readthedocs.io/en/v2.0.0a3/v2-migration-guide.html#migrating-as-a-package-maintainer) doesn't actually work:

```
$ python -m pip install -U --pre 'urllib3>2'
ERROR: Could not find a version that satisfies the requirement urllib3>2 (from versions: 0.3, 1.0, 1.0.1, 1.0.2, 1.1, 1.2, 1.2.1, 1.2.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.7.1, 1.8, 1.8.2, 1.8.3, 1.9, 1.9.1, 1.10, 1.10.1, 1.10.2, 1.10.3, 1.10.4, 1.11, 1.12, 1.13, 1.13.1, 1.14, 1.15, 1.15.1, 1.16, 1.17, 1.18, 1.18.1, 1.19, 1.19.1, 1.20, 1.21, 1.21.1, 1.22, 1.23, 1.24, 1.24.1, 1.24.2, 1.24.3, 1.25, 1.25.1, 1.25.2, 1.25.3, 1.25.4, 1.25.5, 1.25.6, 1.25.7, 1.25.8, 1.25.9, 1.25.10, 1.25.11, 1.26.0, 1.26.1, 1.26.2, 1.26.3, 1.26.4, 1.26.5, 1.26.6, 1.26.7, 1.26.8, 1.26.9, 1.26.10, 1.26.11, 1.26.12, 1.26.13, 1.26.14, 1.26.15, 2.0.0a1, 2.0.0a2, 2.0.0a3)
ERROR: No matching distribution found for urllib3>2
```

Simply changing it to `>=2` won't work either, even with the `--pre` option, because the alpha releases are not considered as greater-or-equal to a (not yet existing) 2.0.0 final.

I'll assume you do want to allow prereleases in this part of the docs, since the `--pre` option was provided. If not, then we should instead use:

```
$ python -m pip install -U 'urllib3>=2'
```