### PR TITLE
Added support for union operators to ``HTTPHeaderDict``

### DIFF
--- a/changelog/2254.feature.rst
+++ b/changelog/2254.feature.rst
@@ -1,0 +1,3 @@
+Added support for union operators to ``HTTPHeaderDict``
+
+This allows a simple way to merge headers provided in a request with the ``PoolManager`` headers, rather than replace them.

--- a/src/urllib3/_collections.py
+++ b/src/urllib3/_collections.py
@@ -432,3 +432,24 @@ class HTTPHeaderDict(typing.MutableMapping[str, str]):
         if header_name in self:
             return potential_value in self._container[header_name.lower()][1:]
         return False
+
+    def __ior__(self, other: object) -> HTTPHeaderDict:
+        # Supports extending a header dict in-place using operator |=
+        # combining items with add instead of __setitem__
+        maybe_constructable = ensure_can_construct_http_header_dict(other)
+        if maybe_constructable is None:
+            return NotImplemented
+        other_as_http_header_dict = type(self)(maybe_constructable)
+        self.extend(other_as_http_header_dict)
+        return self
+
+    def __or__(self, other: object) -> HTTPHeaderDict:
+        # Supports merging header dicts using operator |
+        # combining items with add instead of __setitem__
+        maybe_constructable = ensure_can_construct_http_header_dict(other)
+        if maybe_constructable is None:
+            return NotImplemented
+        result = self.copy()
+        other_as_http_header_dict = type(self)(maybe_constructable)
+        result.extend(other_as_http_header_dict)
+        return result

--- a/src/urllib3/_collections.py
+++ b/src/urllib3/_collections.py
@@ -453,3 +453,13 @@ class HTTPHeaderDict(typing.MutableMapping[str, str]):
         other_as_http_header_dict = type(self)(maybe_constructable)
         result.extend(other_as_http_header_dict)
         return result
+
+    def __ror__(self, other: object) -> HTTPHeaderDict:
+        # Supports merging header dicts using operator | when other is on left side
+        # combining items with add instead of __setitem__
+        maybe_constructable = ensure_can_construct_http_header_dict(other)
+        if maybe_constructable is None:
+            return NotImplemented
+        result = type(self)(maybe_constructable)
+        result.extend(self)
+        return result

--- a/src/urllib3/_collections.py
+++ b/src/urllib3/_collections.py
@@ -439,8 +439,7 @@ class HTTPHeaderDict(typing.MutableMapping[str, str]):
         maybe_constructable = ensure_can_construct_http_header_dict(other)
         if maybe_constructable is None:
             return NotImplemented
-        other_as_http_header_dict = type(self)(maybe_constructable)
-        self.extend(other_as_http_header_dict)
+        self.extend(maybe_constructable)
         return self
 
     def __or__(self, other: object) -> HTTPHeaderDict:
@@ -450,8 +449,7 @@ class HTTPHeaderDict(typing.MutableMapping[str, str]):
         if maybe_constructable is None:
             return NotImplemented
         result = self.copy()
-        other_as_http_header_dict = type(self)(maybe_constructable)
-        result.extend(other_as_http_header_dict)
+        result.extend(maybe_constructable)
         return result
 
     def __ror__(self, other: object) -> HTTPHeaderDict:

--- a/test/test_collections.py
+++ b/test/test_collections.py
@@ -446,6 +446,8 @@ class TestHTTPHeaderDict:
     def test_union_with_unsupported_type(self, d: HTTPHeaderDict) -> None:
         with pytest.raises(TypeError, match="unsupported operand type.*'int'"):
             d | 42
+        with pytest.raises(TypeError, match="unsupported operand type.*'float'"):
+            3.14 | d
 
     def test_inplace_union_with_unsupported_type(self, d: HTTPHeaderDict) -> None:
         with pytest.raises(TypeError, match="unsupported operand type.*'NoneType'"):

--- a/test/test_collections.py
+++ b/test/test_collections.py
@@ -423,3 +423,23 @@ class TestHTTPHeaderDict:
         d._container[marker] = ["some", "strings"]  # type: ignore[index]
         assert marker not in d
         assert marker in d._container
+
+    def test_union(self, d: HTTPHeaderDict) -> None:
+        to_merge = {"Cookie": "tim-tam"}
+        result = d | to_merge
+        assert result == HTTPHeaderDict({"Cookie": "foo, bar, tim-tam"})
+        assert to_merge == {"Cookie": "tim-tam"}
+        assert d == HTTPHeaderDict({"Cookie": "foo, bar"})
+
+    def test_inplace_union(self, d: HTTPHeaderDict) -> None:
+        to_merge = {"Cookie": "tim-tam"}
+        d |= to_merge
+        assert d == HTTPHeaderDict({"Cookie": "foo, bar, tim-tam"})
+
+    def test_union_with_unsupported_type(self, d: HTTPHeaderDict) -> None:
+        with pytest.raises(TypeError, match="unsupported operand type.*'int'"):
+            d | 42
+
+    def test_inplace_union_with_unsupported_type(self, d: HTTPHeaderDict) -> None:
+        with pytest.raises(TypeError, match="unsupported operand type.*'NoneType'"):
+            d |= None

--- a/test/test_collections.py
+++ b/test/test_collections.py
@@ -431,6 +431,13 @@ class TestHTTPHeaderDict:
         assert to_merge == {"Cookie": "tim-tam"}
         assert d == HTTPHeaderDict({"Cookie": "foo, bar"})
 
+    def test_union_rhs(self, d: HTTPHeaderDict) -> None:
+        to_merge = {"Cookie": "tim-tam"}
+        result = to_merge | d
+        assert result == HTTPHeaderDict({"Cookie": "tim-tam, foo, bar"})
+        assert to_merge == {"Cookie": "tim-tam"}
+        assert d == HTTPHeaderDict({"Cookie": "foo, bar"})
+
     def test_inplace_union(self, d: HTTPHeaderDict) -> None:
         to_merge = {"Cookie": "tim-tam"}
         d |= to_merge

--- a/test/with_dummyserver/test_poolmanager.py
+++ b/test/with_dummyserver/test_poolmanager.py
@@ -379,6 +379,28 @@ class TestPoolManager(HTTPDummyServerTestCase):
                 ["Extra", "extra"],
             ]
 
+    def test_merge_headers_with_pool_manager_headers(self) -> None:
+        headers = HTTPHeaderDict()
+        headers.add("Cookie", "choc-chip")
+        headers.add("Cookie", "oatmeal-raisin")
+        orig = headers.copy()
+        added_headers = {"Cookie": "tim-tam"}
+
+        with PoolManager(headers=headers) as http:
+            r = http.request(
+                "GET",
+                f"{self.base_url}/multi_headers",
+                headers=http.headers | added_headers,
+            )
+            returned_headers = r.json()["headers"]
+            assert returned_headers[-3:] == [
+                ["Cookie", "choc-chip"],
+                ["Cookie", "oatmeal-raisin"],
+                ["Cookie", "tim-tam"],
+            ]
+            # make sure the pool headers weren't modified
+            assert http.headers == orig
+
     def test_headers_http_multi_header_multipart(self) -> None:
         headers = HTTPHeaderDict()
         headers.add("Multi", "1")

--- a/test/with_dummyserver/test_poolmanager.py
+++ b/test/with_dummyserver/test_poolmanager.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import gzip
+import typing
 from test import LONG_TIMEOUT
 from unittest import mock
 
@@ -390,7 +391,7 @@ class TestPoolManager(HTTPDummyServerTestCase):
             r = http.request(
                 "GET",
                 f"{self.base_url}/multi_headers",
-                headers=http.headers | added_headers,
+                headers=typing.cast(HTTPHeaderDict, http.headers) | added_headers,
             )
             returned_headers = r.json()["headers"]
             assert returned_headers[-3:] == [


### PR DESCRIPTION
This allows a simple way to merge headers provided in a request with the ``PoolManager`` headers, rather than replace them.

Related issue: https://github.com/urllib3/urllib3/issues/2254

I was inspired by Ran's example there:

```
pm.request('POST', 'https://foo.bar', headers={
    **pm.headers,
    'Content-Type': 'application/json',
}, ...)
```

The basic usage was also tested [here](https://github.com/urllib3/urllib3/pull/2274/files). However this approach has limitations - the return type is always a dict, and that happens at the Python level so there isn't much flexibility using that operation if you want to merge a `HTTPHeaderDict` instance either from the pool manager or from the request. The standard dict must have unique keys, so no merging of existing keys is possible, only overwriting.

```
>>> pm = urllib3.PoolManager(headers=HTTPHeaderDict({"k1": "v1"}))
>>> pm.headers
HTTPHeaderDict({'k1': 'v1'})
>>> {**pm.headers, "k2": "v2"}
{'k1': 'v1', 'k2': 'v2'}
>>> {**pm.headers, "k1": "v2"}  # uh-oh, we lost "v1"
{'k1': 'v2'}
```

My proposal would allow:

```
pm.request('POST', 'https://foo.bar', headers=pm.headers | more_headers, ...)
```

Which can merge, on either side, as expected:

```
>>> pm.headers | {"k1": "v2"}
HTTPHeaderDict({'k1': 'v1, v2'})
>>> {"k1": "v2", "k3": "v3"} | pm.headers
HTTPHeaderDict({'k1': 'v2, v1', 'k3': 'v3'})
```

Standard dicts support unions since Python 3.9 (see [_PEP 584 – Add Union Operators To dict_](https://peps.python.org/pep-0584/)) so I've tried to make the `HTTPHeaderDict` quack in that way.