### PR TITLE
Add dependency-name: * to Dependabot ignore

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,4 +7,5 @@ updates:
     ignore:
       # Ignore all patch releases as we can manually
       # upgrade if we run into a bug and need a fix.
-      - update-types: ["version-update:semver-patch"]
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]


### PR DESCRIPTION
This may be why we're getting Dependabot updates for patch versions? [Docs](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#ignore) say:

> You can combine this with `dependency-name: "*"` to ignore particular update-types for all dependencies. Currently, `version-update:semver-major`, `version-update:semver-minor`, and `version-update:semver-patch` are the only supported options. Security updates are unaffected by this setting.