### PR TITLE
Fixed coverage regression when zstd >= 0.20 is installed

### DIFF
--- a/test/test_response.py
+++ b/test/test_response.py
@@ -349,13 +349,11 @@ class TestResponse:
     @onlyZstd()
     @pytest.mark.parametrize("data", [b"foo", b"x" * 100])
     def test_decode_zstd_error(self, data: bytes) -> None:
-        fp = BytesIO(data)
+        data = zstd.compress(data)
+        fp = BytesIO(data[:-1])  # purposely use incomplete frame
 
         with pytest.raises(DecodeError):
-            r = HTTPResponse(
-                fp, headers={"content-encoding": "zstd"}, preload_content=False
-            )
-            r.read()
+            HTTPResponse(fp, headers={"content-encoding": "zstd"})
 
     def test_multi_decoding_deflate_deflate(self) -> None:
         data = zlib.compress(zlib.compress(b"foo"))

--- a/test/test_response.py
+++ b/test/test_response.py
@@ -352,7 +352,10 @@ class TestResponse:
         fp = BytesIO(data)
 
         with pytest.raises(DecodeError):
-            HTTPResponse(fp, headers={"content-encoding": "zstd"})
+            r = HTTPResponse(
+                fp, headers={"content-encoding": "zstd"}, preload_content=False
+            )
+            r.read()
 
     def test_multi_decoding_deflate_deflate(self) -> None:
         data = zlib.compress(zlib.compress(b"foo"))

--- a/test/test_response.py
+++ b/test/test_response.py
@@ -349,8 +349,16 @@ class TestResponse:
     @onlyZstd()
     @pytest.mark.parametrize("data", [b"foo", b"x" * 100])
     def test_decode_zstd_error(self, data: bytes) -> None:
+        fp = BytesIO(data)
+
+        with pytest.raises(DecodeError):
+            HTTPResponse(fp, headers={"content-encoding": "zstd"})
+
+    @onlyZstd()
+    @pytest.mark.parametrize("data", [b"foo", b"x" * 100])
+    def test_decode_zstd_incomplete(self, data: bytes) -> None:
         data = zstd.compress(data)
-        fp = BytesIO(data[:-1])  # purposely use incomplete frame
+        fp = BytesIO(data[:-1])
 
         with pytest.raises(DecodeError):
             HTTPResponse(fp, headers={"content-encoding": "zstd"})


### PR DESCRIPTION
Hello,

Fix the coverage regression seen recently and reported by #2941
I confirm that this _regression_ appears once python-zstd 0.20 is installed no matter the interpreter version.

The unit test that is responsible for the missing coverage is:

```python
@onlyZstd()
@pytest.mark.parametrize("data", [b"foo", b"x" * 100])
def test_decode_zstd_error(self, data: bytes) -> None:
    ...
```

The dependency (not the Python interface but rather the native decoder) recently brought changes that make the decoding stricter. And that is good news. 

See attached traceback from before (<0.20)

```
Traceback (most recent call last):
  File "/home/ahmed/PycharmProjects/urllib3/test/test_response.py", line 354, in test_decode_zstd_error
    HTTPResponse(fp, headers={"content-encoding": "zstd"}, preload_content=False).read()
  File "/home/ahmed/PycharmProjects/urllib3/.nox/test-3-8/lib/python3.8/site-packages/urllib3/response.py", line 884, in read
    data = self._decode(data, decode_content, flush_decoder)
  File "/home/ahmed/PycharmProjects/urllib3/.nox/test-3-8/lib/python3.8/site-packages/urllib3/response.py", line 448, in _decode
    data += self._flush_decoder()
  File "/home/ahmed/PycharmProjects/urllib3/.nox/test-3-8/lib/python3.8/site-packages/urllib3/response.py", line 458, in _flush_decoder
    return self._decoder.decompress(b"") + self._decoder.flush()
  File "/home/ahmed/PycharmProjects/urllib3/.nox/test-3-8/lib/python3.8/site-packages/urllib3/response.py", line 177, in flush
    raise DecodeError("Zstandard data is incomplete")
urllib3.exceptions.DecodeError: Zstandard data is incomplete
```

and after (>=0.20)

```
Traceback (most recent call last):
  File "/home/ahmed/PycharmProjects/urllib3/.nox/test-3-8/lib/python3.8/site-packages/urllib3/response.py", line 438, in _decode
    data = self._decoder.decompress(data)
  File "/home/ahmed/PycharmProjects/urllib3/.nox/test-3-8/lib/python3.8/site-packages/urllib3/response.py", line 172, in decompress
    return self._obj.decompress(data)  # type: ignore[no-any-return]
zstd.ZstdError: zstd decompressor error: Unknown frame descriptor

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/ahmed/PycharmProjects/urllib3/test/test_response.py", line 354, in test_decode_zstd_error
    HTTPResponse(fp, headers={"content-encoding": "zstd"}, preload_content=False).read()
  File "/home/ahmed/PycharmProjects/urllib3/.nox/test-3-8/lib/python3.8/site-packages/urllib3/response.py", line 884, in read
    data = self._decode(data, decode_content, flush_decoder)
  File "/home/ahmed/PycharmProjects/urllib3/.nox/test-3-8/lib/python3.8/site-packages/urllib3/response.py", line 442, in _decode
    raise DecodeError(
urllib3.exceptions.DecodeError: ('Received response with content-encoding: zstd, but failed to decode it.', ZstdError('zstd decompressor error: Unknown frame descriptor'))
```

The test actually passed because we are looking for `DecodeError` and not for `ZstdError` raised in `.../urllib3/response.py", line 172`.

So now without `preload_content=False` in the Response instance, the decoding fail early in the process, thus the missing coverage line.

I looked at other (_similar_) PR and I purposely did not add a news fragment.

Finally, regarding the last point in the issue:

> Potentially report back to the zstandard package if necessary

I could be mistaken but, I think that is not necessary as it makes more sense for it to fail there instead of later. It feels safer that way.

I hope I was clear enough in this investigation.
Regards,