### PR TITLE
avoid distutils Version classes are deprecated warning by dropping pytest-freezegun

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,9 +1,9 @@
 coverage==7.0.4
+freezegun==1.2.2
 tornado==6.2
 PySocks==1.7.1
 pytest==7.2.0
 pytest-timeout==2.1.0
-pytest-freezegun==0.4.2
 trustme==0.9.0
 cryptography==39.0.1
 backports.zoneinfo==0.2.1;python_version<"3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,6 @@ filterwarnings = [
     '''default:'urllib3\[secure\]' extra is deprecated and will be removed in urllib3 v2\.1\.0.*:DeprecationWarning''',
     '''default:'urllib3\.contrib\.pyopenssl' module is deprecated and will be removed in urllib3 v2\.1\.0.*:DeprecationWarning''',
     '''default:'urllib3\.contrib\.securetransport' module is deprecated and will be removed in urllib3 v2\.1\.0.*:DeprecationWarning''',
-    '''default:distutils Version classes are deprecated\. Use packaging\.version instead\.:DeprecationWarning''',
     '''default:The 'pool' property is deprecated and will be removed in urllib3 v2\.1\.0\. use 'conn' instead:DeprecationWarning''',
     '''default:'ssl_version' option is deprecated and will be removed in urllib3 v2\.1\.0\. Instead use 'ssl_minimum_version':DeprecationWarning''',
     '''default:.*:urllib3.exceptions.InsecureRequestWarning''',

--- a/test/test_retry.py
+++ b/test/test_retry.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from test import DUMMY_POOL
 from unittest import mock
 
+import freezegun  # type: ignore[import]
 import pytest
 
 from urllib3.exceptions import (
@@ -332,7 +333,6 @@ class TestRetry:
         new_retry = retry.new()
         assert new_retry.respect_retry_after_header == respect_retry_after_header
 
-    @pytest.mark.freeze_time("2019-06-03 11:00:00", tz_offset=0)
     @pytest.mark.parametrize(
         "retry_after_header,respect_retry_after_header,sleep_duration",
         [
@@ -371,7 +371,9 @@ class TestRetry:
     ) -> None:
         retry = Retry(respect_retry_after_header=respect_retry_after_header)
 
-        with mock.patch("time.sleep") as sleep_mock:
+        with freezegun.freeze_time("2019-06-03 11:00:00", tz_offset=0), mock.patch(
+            "time.sleep"
+        ) as sleep_mock:
             # for the default behavior, it must be in RETRY_AFTER_STATUS_CODES
             response = HTTPResponse(
                 status=503, headers={"Retry-After": retry_after_header}


### PR DESCRIPTION
<!---
Thanks for your contribution! ♥️

If this is your first PR to urllib3 please review the Contributing Guide:
https://urllib3.readthedocs.io/en/latest/contributing.html

Adhering to the Contributing Guide means we can review, merge, and release your change faster! :)
--->
it looks like pytest-freezegun is unmaintained and it's only used in one test where it's cleaner to use freezegun directly