### PR TITLE
Bump Ubuntu version in integration tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         downstream: [botocore, requests]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 30
 
     steps:


### PR DESCRIPTION
Ubuntu 18.04 is gone: https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/
