### PR TITLE
feat: Remove id-token permission during build

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,9 +6,7 @@ on:
       - "*"
 
 permissions:
-  contents: "read"
-  # Needed to access the workflow's OIDC identity.
-  id-token: "write"
+  contents: read
 
 jobs:
   build:
@@ -54,7 +52,7 @@ jobs:
     permissions:
       actions: read
       contents: write
-      id-token: write
+      id-token: write # Needed to access the workflow's OIDC identity.
     uses: "slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.5.0"
     with:
       base64-subjects: "${{ needs.build.outputs.hashes }}"


### PR DESCRIPTION
Remove `id-token: write` permission for the build part. It is only needed for provenance signing.

<!---
Thanks for your contribution! ♥️

If this is your first PR to urllib3 please review the Contributing Guide:
https://urllib3.readthedocs.io/en/latest/contributing.html

Adhering to the Contributing Guide means we can review, merge, and release your change faster! :)
--->
