### PR TITLE
Run coverage step even if some jobs have failed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,7 @@ jobs:
 
 
   coverage:
+    if: always()
     runs-on: "ubuntu-latest"
     needs: test
     steps:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,8 +1,0 @@
-coverage:
-    status:
-        patch:
-            default:
-                target: '100'
-        project:
-            default:
-                target: '100'


### PR DESCRIPTION
We often have transient failures that don't affect coverage, and knowing the current coverage even with failures is useful.

We also removed an unused codecov.yml file.
