### PR TITLE
Fix HTTPResponse.read(0) as first read call

### DIFF
--- a/changelog/2998.bugfix.rst
+++ b/changelog/2998.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed ``HTTPResponse.read(0)`` call when underlying buffer is empty.

--- a/src/urllib3/response.py
+++ b/src/urllib3/response.py
@@ -244,7 +244,9 @@ class BytesQueueBuffer:
         self._size += len(data)
 
     def get(self, n: int) -> bytes:
-        if not self.buffer:
+        if n == 0:
+            return b""
+        elif not self.buffer:
             raise RuntimeError("buffer is empty")
         elif n < 0:
             raise ValueError("n should be > 0")

--- a/test/test_response.py
+++ b/test/test_response.py
@@ -44,6 +44,8 @@ class TestBytesQueueBuffer:
         with pytest.raises(RuntimeError, match="buffer is empty"):
             assert buffer.get(10)
 
+        assert buffer.get(0) == b""
+
         buffer.put(b"foo")
         with pytest.raises(ValueError, match="n should be > 0"):
             buffer.get(-1)
@@ -181,6 +183,7 @@ class TestResponse:
         fp = BytesIO(b"foo")
         r = HTTPResponse(fp, preload_content=False)
 
+        assert r.read(0) == b""
         assert r.read(1) == b"f"
         assert r.read(2) == b"oo"
         assert r.read() == b""


### PR DESCRIPTION
HTTPResponse uses a bytes buffer since https://github.com/urllib3/urllib3/pull/2798. This buffer fails if we call get(n) and the buffer is empty, but that means that if the first call to HTTPResponse.read(n) is done with n = 0, the read() call fails. I don't think there is a good reason to do that in practice, but requests-toolbelt has a unit test that does it, which currently fails with urllib3 2.0: https://github.com/requests/toolbelt/actions/runs/4834111890/jobs/8614945073?pr=356