### PR TITLE
Replace flake8, isort, and pyupgrade with ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,23 +1,12 @@
 repos:
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.3.1
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: v0.0.263
     hooks:
-      - id: pyupgrade
-        args: ["--py37-plus"]
+      - id: ruff
+        # args: [ --fix, --exit-non-zero-on-fix ]
 
   - repo: https://github.com/psf/black
-    rev: 23.1.0
+    rev: 23.3.0
     hooks:
       - id: black
         args: ["--target-version", "py37"]
-
-  - repo: https://github.com/PyCQA/isort
-    rev: 5.12.0
-    hooks:
-      - id: isort
-
-  - repo: https://github.com/PyCQA/flake8
-    rev: 6.0.0
-    hooks:
-      - id: flake8
-        additional_dependencies: [flake8-2020]

--- a/changelog/3004.misc
+++ b/changelog/3004.misc
@@ -1,0 +1,1 @@
+Replaced flake8, isort, and pyupgrade with ruff

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -73,7 +73,7 @@ html_favicon = "images/favicon.png"
 html_static_path = ["_static"]
 html_theme_options = {
     "announcement": """
-        <a style=\"text-decoration: none; color: white;\" 
+        <a style=\"text-decoration: none; color: white;\"
            href=\"https://github.com/sponsors/urllib3\">
            <img src=\"/en/latest/_static/favicon.png\"/> Support urllib3 on GitHub Sponsors
         </a>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,10 +100,6 @@ filterwarnings = [
     '''default:ssl NPN is deprecated, use ALPN instead:DeprecationWarning''',
 ]
 
-[tool.isort]
-profile = "black"
-add_imports = "from __future__ import annotations"
-
 [tool.mypy]
 mypy_path = "src"
 check_untyped_defs = true
@@ -121,3 +117,86 @@ warn_redundant_casts = true
 warn_return_any = true
 warn_unused_configs = true
 warn_unused_ignores = true
+
+[tool.ruff]
+select = [
+  "C90",    # McCabe cyclomatic complexity
+  "E",      # pycodestyle
+  "EXE",    # flake8-executable
+  "F",      # Pyflakes
+  "G",      # flake8-logging-format
+  "I",      # isort
+  "ICN",    # flake8-import-conventions
+  "INP",    # flake8-no-pep420
+  "INT",    # flake8-gettext
+  "PIE",    # flake8-pie
+  "PL",     # Pylint
+  "PYI",    # flake8-pyi
+  "RSE",    # flake8-raise
+  "RUF",    # Ruff-specific rules
+  "T10",    # flake8-debugger
+  "TID",    # flake8-tidy-imports
+  "UP",     # pyupgrade
+  "W",      # pycodestyle
+  "YTT",    # flake8-2020
+  # "A",    # flake8-builtins
+  # "ANN",  # flake8-annotations
+  # "ARG",  # flake8-unused-arguments
+  # "B",    # flake8-bugbear
+  # "BLE",  # flake8-blind-except
+  # "C4",   # flake8-comprehensions
+  # "COM",  # flake8-commas
+  # "D",    # pydocstyle
+  # "DJ",   # flake8-django
+  # "DTZ",  # flake8-datetimez
+  # "EM",   # flake8-errmsg
+  # "ERA",  # eradicate
+  # "FBT",  # flake8-boolean-trap
+  # "ISC",  # flake8-implicit-str-concat
+  # "N",    # pep8-naming
+  # "NPY",  # NumPy-specific rules
+  # "PD",   # pandas-vet
+  # "PGH",  # pygrep-hooks
+  # "PT",   # flake8-pytest-style
+  # "PTH",  # flake8-use-pathlib
+  # "Q",    # flake8-quotes
+  # "RET",  # flake8-return
+  # "S",    # flake8-bandit
+  # "SIM",  # flake8-simplify
+  # "SLF",  # flake8-self
+  # "T20",  # flake8-print
+  # "TCH",  # flake8-type-checking
+  # "TRY",  # tryceratops
+]
+ignore = [
+  "PLC0414",
+  "PLC1901",
+  "PLR0402",
+  "PLR2004",
+  "PLR5501",
+  "PLW0603",
+  "PLW2901",
+  "RSE102",
+  "RUF001",
+  "RUF005",
+  "RUF100",
+  "TID252",
+]
+line-length = 301
+target-version = "py37"
+
+[tool.ruff.isort]
+known-first-party = ["urllib3"]
+required-imports = ["from __future__ import annotations"]
+
+[tool.ruff.mccabe]
+max-complexity = 25
+
+[tool.ruff.pylint]
+max-args = 19
+max-branches = 30
+max-statements = 90
+
+[tool.ruff.per-file-ignores]
+"docs/conf.py" = ["E402", "INP001"]
+"test/*" = ["S101"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,0 @@
-[flake8]
-ignore = E501, E203, W503, W504
-exclude=./docs/conf.py
-max-line-length=99

--- a/src/urllib3/_request_methods.py
+++ b/src/urllib3/_request_methods.py
@@ -96,7 +96,7 @@ class RequestMethods:
         if json is not None:
             if headers is None:
                 headers = self.headers.copy()  # type: ignore
-            if not ("content-type" in map(str.lower, headers.keys())):
+            if "content-type" not in map(str.lower, headers.keys()):
                 headers["Content-Type"] = "application/json"  # type: ignore
 
             body = _json.dumps(json, separators=(",", ":"), ensure_ascii=False).encode(

--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -45,9 +45,8 @@ from .util.request import _TYPE_BODY_POSITION, set_file_position
 from .util.retry import Retry
 from .util.ssl_match_hostname import CertificateError
 from .util.timeout import _DEFAULT_TIMEOUT, _TYPE_DEFAULT, Timeout
-from .util.url import Url, _encode_target
+from .util.url import Url, _encode_target, parse_url
 from .util.url import _normalize_host as normalize_host
-from .util.url import parse_url
 from .util.util import to_str
 
 if typing.TYPE_CHECKING:

--- a/src/urllib3/util/ssl_match_hostname.py
+++ b/src/urllib3/util/ssl_match_hostname.py
@@ -150,8 +150,10 @@ def match_hostname(
 
     if len(dnsnames) > 1:
         raise CertificateError(
-            "hostname %r "
-            "doesn't match either of %s" % (hostname, ", ".join(map(repr, dnsnames)))
+            "hostname {!r} "
+            "doesn't match either of {}".format(
+                hostname, ", ".join(map(repr, dnsnames))
+            )
         )
     elif len(dnsnames) == 1:
         raise CertificateError(f"hostname {hostname!r} doesn't match {dnsnames[0]!r}")

--- a/src/urllib3/util/timeout.py
+++ b/src/urllib3/util/timeout.py
@@ -154,21 +154,21 @@ class Timeout:
             float(value)
         except (TypeError, ValueError):
             raise ValueError(
-                "Timeout value %s was %s, but it must be an "
-                "int, float or None." % (name, value)
+                "Timeout value {} was {}, but it must be an "
+                "int, float or None.".format(name, value)
             ) from None
 
         try:
             if value <= 0:
                 raise ValueError(
-                    "Attempted to set %s timeout to %s, but the "
+                    "Attempted to set {} timeout to {}, but the "
                     "timeout cannot be set to a value less "
-                    "than or equal to 0." % (name, value)
+                    "than or equal to 0.".format(name, value)
                 )
         except TypeError:
             raise ValueError(
-                "Timeout value %s was %s, but it must be an "
-                "int, float or None." % (name, value)
+                "Timeout value {} was {}, but it must be an "
+                "int, float or None.".format(name, value)
             ) from None
 
         return value

--- a/src/urllib3/util/url.py
+++ b/src/urllib3/util/url.py
@@ -61,7 +61,7 @@ _IPV6_ADDRZ_RE = re.compile("^" + _IPV6_ADDRZ_PAT + "$")
 _BRACELESS_IPV6_ADDRZ_RE = re.compile("^" + _IPV6_ADDRZ_PAT[2:-2] + "$")
 _ZONE_ID_RE = re.compile("(" + _ZONE_ID_PAT + r")\]$")
 
-_HOST_PORT_PAT = ("^(%s|%s|%s)(?::0*?(|0|[1-9][0-9]{0,4}))?$") % (
+_HOST_PORT_PAT = ("^({}|{}|{})(?::0*?(|0|[1-9][0-9]{{0,4}}))?$").format(
     _REG_NAME_PAT,
     _IPV4_PAT,
     _IPV6_ADDRZ_PAT,

--- a/test/test_connectionpool.py
+++ b/test/test_connectionpool.py
@@ -304,7 +304,7 @@ class TestConnectionPool:
             "Max retries exceeded with url: Test. (Caused by None)"
         )
 
-        err = SocketError("Test")
+        err = OSError("Test")
 
         # using err.__class__ here, as socket.error is an alias for OSError
         # since Py3.3 and gets printed as this

--- a/test/test_exceptions.py
+++ b/test/test_exceptions.py
@@ -31,7 +31,7 @@ class TestPickle:
             LocationParseError(""),
             ConnectTimeoutError(None),
             HTTPError("foo"),
-            HTTPError("foo", IOError("foo")),
+            HTTPError("foo", OSError("foo")),
             MaxRetryError(HTTPConnectionPool("localhost"), "/", None),
             LocationParseError("fake location"),
             ClosedPoolError(HTTPConnectionPool("localhost"), ""),


### PR DESCRIPTION
<!---
Thanks for your contribution! ♥️

If this is your first PR to urllib3 please review the Contributing Guide:
https://urllib3.readthedocs.io/en/latest/contributing.html

Adhering to the Contributing Guide means we can review, merge, and release your change faster! :)
--->
[Ruff](https://beta.ruff.rs/) supports [over 500 lint rules](https://beta.ruff.rs/docs/rules) and can be used to replace [Flake8](https://pypi.org/project/flake8/) (plus dozens of plugins), [isort](https://pypi.org/project/isort/), [pydocstyle](https://pypi.org/project/pydocstyle/), [yesqa](https://github.com/asottile/yesqa), [eradicate](https://pypi.org/project/eradicate/), [pyupgrade](https://pypi.org/project/pyupgrade/), and [autoflake](https://pypi.org/project/autoflake/), all while executing (in Rust) tens or hundreds of times faster than any individual tool.