### PR TITLE
[1.26] fix invalid test_ssl_failure_midway_through_conn

### DIFF
--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -1221,10 +1221,11 @@ class TestSSL(SocketDummyServerTestCase):
             ssl_sock.close()
 
         self._start_server(socket_handler)
-        with HTTPSConnectionPool(self.host, self.port) as pool:
-            with pytest.raises(MaxRetryError) as cm:
-                pool.request("GET", "/", retries=0)
-            assert isinstance(cm.value.reason, SSLError)
+        with HTTPSConnectionPool(self.host, self.port, ca_certs=DEFAULT_CA) as pool:
+            with pytest.raises(
+                SSLError, match=r"(wrong version number|record overflow)"
+            ):
+                pool.request("GET", "/", retries=False)
 
     @notSecureTransport
     def test_ssl_read_timeout(self):


### PR DESCRIPTION
this test was not failing on the urllib 1.26.x branch because PytestUnhandledThreadExceptionWarning were not being raised as errors

test_ssl_failure_midway_through_conn was failing intermittently on windows in the handshake with a ConnectionResetError rather than an ssl.SSLError
eg https://github.com/urllib3/urllib3/actions/runs/4805604022/jobs/8552185456#step:5:2826 however it should never have failed in the handshake! It was failing because of a missing ca_certs kwarg and so the test was invalid

<!---
Thanks for your contribution! ♥️

If this is your first PR to urllib3 please review the Contributing Guide:
https://urllib3.readthedocs.io/en/latest/contributing.html

Adhering to the Contributing Guide means we can review, merge, and release your change faster! :)
--->
