### PR TITLE
Fix multi-frame Zstandard response decoding

### DIFF
--- a/changelog/3008.bugfix.rst
+++ b/changelog/3008.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed response decoding with Zstandard when compressed data is made of several frames.


### PR DESCRIPTION
Fixes #3008.

## Background on Zstandard

Data compressed with Zstandard is a sequence of frames. A frame can be of two kinds:
- Zstandard frame, containing compressed data
- Skippable frame, to be ignored by the decompressor

When decompressing some data, data from each frame should be concatenated.

[Link to the Zstandard specification](https://github.com/facebook/zstd/blob/dev/doc/zstd_compression_format.md)

## Multi-frame with python-zstandard

The [python-zstandard](https://python-zstandard.readthedocs.org) library used to decompress the data currently stops after the first frame. As a result, if several frames are chained in the response, the decompressed response will be partial.

This seems to be a temporary state of affairs as the author's library wants to introduce a `read_across_frames` parameter to their decompress APIs, which would default to `False` for some time before defaulting to `True`.

With the current version, I relied of the `unused_data` attribute of the `ZstdDecompressionObj` when `eof` is reached to continue with the next frame. This behaviour is specified [in the documentation](https://python-zstandard.readthedocs.io/en/latest/decompressor.html#zstddecompressionobj).
