### PR TITLE
Allow alternative SSL libaries with a warning

### DIFF
--- a/.github/ISSUE_TEMPLATE/02_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/02_bug_report.md
@@ -14,10 +14,12 @@ At least, paste here the output of:
 
 ```python
 import platform
+import ssl
 import urllib3
 
 print("OS", platform.platform())
 print("Python", platform.python_version())
+print(ssl.OPENSSL_VERSION)
 print("urllib3", urllib3.__version__)
 ```
 

--- a/changelog/3020.bugfix.rst
+++ b/changelog/3020.bugfix.rst
@@ -1,0 +1,1 @@
+Allowed alternative SSL libraries such as LibreSSL, while still issuing a warning as we cannot help users facing issues with implementations other than OpenSSL.

--- a/docs/v2-migration-guide.rst
+++ b/docs/v2-migration-guide.rst
@@ -187,7 +187,7 @@ ssl module is compiled with OpenSSL 1.0.2.k-fips
 
 .. code-block:: text
 
-  ImportError: urllib3 v2.0 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled with OpenSSL 1.0.2k-fips  26 Jan 2017.
+  ImportError: urllib3 v2.0 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled with 'OpenSSL 1.0.2k-fips  26 Jan 2017'.
   See: https://github.com/urllib3/urllib3/issues/2168
 
 Remediation depends on your system:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,7 @@ markers = ["limit_memory"]
 log_level = "DEBUG"
 filterwarnings = [
     "error",
+    '''default:urllib3 v2.0 only supports OpenSSL 1.1.1+.*''',
     '''default:'urllib3\[secure\]' extra is deprecated and will be removed in urllib3 v2\.1\.0.*:DeprecationWarning''',
     '''default:'urllib3\.contrib\.pyopenssl' module is deprecated and will be removed in urllib3 v2\.1\.0.*:DeprecationWarning''',
     '''default:'urllib3\.contrib\.securetransport' module is deprecated and will be removed in urllib3 v2\.1\.0.*:DeprecationWarning''',

--- a/src/urllib3/__init__.py
+++ b/src/urllib3/__init__.py
@@ -30,17 +30,18 @@ try:
 except ImportError:
     pass
 else:
-    # fmt: off
-    if (
-        not ssl.OPENSSL_VERSION.startswith("OpenSSL ")
-        or ssl.OPENSSL_VERSION_INFO < (1, 1, 1)
-    ):  # Defensive:
+    if not ssl.OPENSSL_VERSION.startswith("OpenSSL "):  # Defensive
+        raise exceptions.NotOpenSSLWarning(
+            "urllib3 v2.0 only supports OpenSSL 1.1.1+, currently "
+            f"the 'ssl' module is compiled with {ssl.OPENSSL_VERSION}. "
+            "See: https://github.com/urllib3/urllib3/issues/3020"
+        )
+    elif ssl.OPENSSL_VERSION_INFO < (1, 1, 1):  # Defensive:
         raise ImportError(
             "urllib3 v2.0 only supports OpenSSL 1.1.1+, currently "
             f"the 'ssl' module is compiled with {ssl.OPENSSL_VERSION}. "
             "See: https://github.com/urllib3/urllib3/issues/2168"
         )
-    # fmt: on
 
 # === NOTE TO REPACKAGERS AND VENDORS ===
 # Please delete this block, this logic is only

--- a/src/urllib3/__init__.py
+++ b/src/urllib3/__init__.py
@@ -30,7 +30,7 @@ try:
 except ImportError:
     pass
 else:
-    if not ssl.OPENSSL_VERSION.startswith("OpenSSL "):  # Defensive
+    if not ssl.OPENSSL_VERSION.startswith("OpenSSL "):  # Defensive:
         warnings.warn(
             "urllib3 v2.0 only supports OpenSSL 1.1.1+, currently "
             f"the 'ssl' module is compiled with {ssl.OPENSSL_VERSION}. "

--- a/src/urllib3/__init__.py
+++ b/src/urllib3/__init__.py
@@ -33,14 +33,14 @@ else:
     if not ssl.OPENSSL_VERSION.startswith("OpenSSL "):  # Defensive:
         warnings.warn(
             "urllib3 v2.0 only supports OpenSSL 1.1.1+, currently "
-            f"the 'ssl' module is compiled with {ssl.OPENSSL_VERSION}. "
+            f"the 'ssl' module is compiled with {ssl.OPENSSL_VERSION!r}. "
             "See: https://github.com/urllib3/urllib3/issues/3020",
             exceptions.NotOpenSSLWarning,
         )
     elif ssl.OPENSSL_VERSION_INFO < (1, 1, 1):  # Defensive:
         raise ImportError(
             "urllib3 v2.0 only supports OpenSSL 1.1.1+, currently "
-            f"the 'ssl' module is compiled with {ssl.OPENSSL_VERSION}. "
+            f"the 'ssl' module is compiled with {ssl.OPENSSL_VERSION!r}. "
             "See: https://github.com/urllib3/urllib3/issues/2168"
         )
 

--- a/src/urllib3/__init__.py
+++ b/src/urllib3/__init__.py
@@ -31,10 +31,11 @@ except ImportError:
     pass
 else:
     if not ssl.OPENSSL_VERSION.startswith("OpenSSL "):  # Defensive
-        raise exceptions.NotOpenSSLWarning(
+        warnings.warn(
             "urllib3 v2.0 only supports OpenSSL 1.1.1+, currently "
             f"the 'ssl' module is compiled with {ssl.OPENSSL_VERSION}. "
-            "See: https://github.com/urllib3/urllib3/issues/3020"
+            "See: https://github.com/urllib3/urllib3/issues/3020",
+            exceptions.NotOpenSSLWarning,
         )
     elif ssl.OPENSSL_VERSION_INFO < (1, 1, 1):  # Defensive:
         raise ImportError(

--- a/src/urllib3/exceptions.py
+++ b/src/urllib3/exceptions.py
@@ -214,6 +214,10 @@ class InsecureRequestWarning(SecurityWarning):
     """Warned when making an unverified HTTPS request."""
 
 
+class NotOpenSSLWarning(SecurityWarning):
+    """Warned when using unsupported SSL library"""
+
+
 class SystemTimeWarning(SecurityWarning):
     """Warned when system time is suspected to be wrong"""
 

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -1068,21 +1068,24 @@ class TestUtilSSL:
         warn.assert_not_called()
 
     @pytest.mark.parametrize(
-        "openssl_version_number, implementation_name, version_info, reliable",
+        "openssl_version, openssl_version_number, implementation_name, version_info, reliable",
         [
             # OpenSSL and Python OK -> reliable
-            (0x101010CF, "cpython", (3, 9, 3), True),
+            ("OpenSSL 1.1.1", 0x101010CF, "cpython", (3, 9, 3), True),
             # Python OK -> reliable
-            (0x10101000, "cpython", (3, 9, 3), True),
-            (0x10101000, "pypy", (3, 6, 9), False),
+            ("OpenSSL 1.1.1", 0x10101000, "cpython", (3, 9, 3), True),
+            ("OpenSSL 1.1.1", 0x10101000, "pypy", (3, 6, 9), False),
             # OpenSSL OK -> reliable
-            (0x101010CF, "cpython", (3, 9, 2), True),
-            # unreliable
-            (0x10101000, "cpython", (3, 9, 2), False),
+            ("OpenSSL 1.1.1", 0x101010CF, "cpython", (3, 9, 2), True),
+            # not OpenSSSL -> unreliable
+            ("LibreSSL 2.8.3", 0x101010CF, "cpython", (3, 10, 0), False),
+            # old OpenSSL and old Python, unreliable
+            ("OpenSSL 1.1.0", 0x10101000, "cpython", (3, 9, 2), False),
         ],
     )
     def test_is_has_never_check_common_name_reliable(
         self,
+        openssl_version: str,
         openssl_version_number: int,
         implementation_name: str,
         version_info: _TYPE_VERSION_INFO,
@@ -1090,6 +1093,7 @@ class TestUtilSSL:
     ) -> None:
         assert (
             _is_has_never_check_common_name_reliable(
+                openssl_version,
                 openssl_version_number,
                 implementation_name,
                 version_info,


### PR DESCRIPTION
Closes https://github.com/urllib3/urllib3/issues/3020

I'll have to run those two tests manually since the test suite does not cover them:

- [x] LibreSSL
- [x] OpenSSL 1.0.2