### PR TITLE
Experimentation around support for HTTP/1.1, HTTP/2 and HTTP/3 outside of http.client

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,11 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    branch:
+      - main
+      - 1.26.x
+  pull_request:
 
 permissions: "read-all"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12-dev"]
         os:
-          - macos-11
+          - macos-latest
           - windows-latest
           - ubuntu-20.04  # OpenSSL 1.1.1
           - ubuntu-22.04  # OpenSSL 3.0
@@ -71,10 +71,10 @@ jobs:
             os: ubuntu-22.04
           # Testing with non-final CPython on macOS is too slow for CI.
           - python-version: "3.12-dev"
-            os: macos-11
+            os: macos-latest
 
     runs-on: ${{ matrix.os }}
-    name: ${{ fromJson('{"macos-11":"macOS","windows-latest":"Windows","ubuntu-latest":"Ubuntu","ubuntu-20.04":"Ubuntu 20.04 (OpenSSL 1.1.1)","ubuntu-22.04":"Ubuntu 22.04 (OpenSSL 3.0)"}')[matrix.os] }} ${{ matrix.python-version }} ${{ matrix.nox-session}}
+    name: ${{ fromJson('{"macos-latest":"macOS","windows-latest":"Windows","ubuntu-latest":"Ubuntu","ubuntu-20.04":"Ubuntu 20.04 (OpenSSL 1.1.1)","ubuntu-22.04":"Ubuntu 22.04 (OpenSSL 3.0)"}')[matrix.os] }} ${{ matrix.python-version }} ${{ matrix.nox-session}}
     continue-on-error: ${{ matrix.experimental }}
     timeout-minutes: 30
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,12 @@
 name: CI
 
-on:
-  push:
-    branch:
-      - main
-      - 1.26.x
-  pull_request:
+on: [push, pull_request]
 
 permissions: "read-all"
+
+concurrency:
+  group: ci-${{ github.ref_name }}
+  cancel-in-progress: true
 
 defaults:
   run:
@@ -41,13 +40,19 @@ jobs:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12-dev"]
         os:
-          - macos-latest
+          - macos-11
           - windows-latest
           - ubuntu-20.04  # OpenSSL 1.1.1
           - ubuntu-22.04  # OpenSSL 3.0
         nox-session: ['']
         include:
           - experimental: false
+            traefik-server: false
+          - python-version: "3.11"
+            os: ubuntu-latest
+            nox-session: test_h2n3
+            experimental: false
+            traefik-server: true
           - python-version: "pypy-3.7"
             os: ubuntu-latest
             experimental: false
@@ -76,15 +81,157 @@ jobs:
             os: ubuntu-22.04
           # Testing with non-final CPython on macOS is too slow for CI.
           - python-version: "3.12-dev"
-            os: macos-latest
+            os: macos-11
 
     runs-on: ${{ matrix.os }}
-    name: ${{ fromJson('{"macos-latest":"macOS","windows-latest":"Windows","ubuntu-latest":"Ubuntu","ubuntu-20.04":"Ubuntu 20.04 (OpenSSL 1.1.1)","ubuntu-22.04":"Ubuntu 22.04 (OpenSSL 3.0)"}')[matrix.os] }} ${{ matrix.python-version }} ${{ matrix.nox-session}}
+    name: ${{ fromJson('{"macos-11":"macOS","windows-latest":"Windows","ubuntu-latest":"Ubuntu","ubuntu-20.04":"Ubuntu 20.04 (OpenSSL 1.1.1)","ubuntu-22.04":"Ubuntu 22.04 (OpenSSL 3.0)"}')[matrix.os] }} ${{ matrix.python-version }} ${{ matrix.nox-session }}
     continue-on-error: ${{ matrix.experimental }}
-    timeout-minutes: 30
+    timeout-minutes: 40
     steps:
       - name: "Checkout repository"
         uses: "actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3"
+
+      - name: "Traefik: Fake CA and Domain"
+        if: ${{ matrix.traefik-server }}
+        run: |
+          wget https://github.com/FiloSottile/mkcert/releases/download/v1.4.4/mkcert-v1.4.4-linux-amd64
+          chmod +x mkcert-v1.4.4-linux-amd64
+          sudo cp mkcert-v1.4.4-linux-amd64 /usr/local/bin/mkcert
+          sudo apt install libnss3-tools
+          mkdir ./certs
+          mkcert -install
+          mkcert -cert-file ./certs/httpbin.local.pem -key-file ./certs/httpbin.local.key httpbin.local alt.httpbin.local
+          echo "127.0.0.1   httpbin.local alt.httpbin.local" | sudo tee -a /etc/hosts
+      - name: "Traefik: Produce Compose & Config"
+        if: ${{ matrix.traefik-server }}
+        env:
+          TRAEFIK_CERTIFICATE_TOML: |
+            [[tls.certificates]]
+              certFile = "/certs/httpbin.local.pem"
+              keyFile = "/certs/httpbin.local.key"
+          TRAEFIK_COMPOSE_SCHEMA: |
+            services:
+              proxy:
+                image: traefik:v2.10
+                restart: unless-stopped
+                healthcheck:
+                  test: [ "CMD", "traefik" ,"healthcheck", "--ping" ]
+                  interval: 3s
+                  timeout: 3s
+                  retries: 10
+                ports:
+                  - target: 8888
+                    published: 8888
+                    protocol: tcp
+                    mode: host
+                  - target: 4443
+                    published: 4443
+                    protocol: tcp
+                    mode: host
+                  - target: 4443
+                    published: 4443
+                    protocol: udp
+                    mode: host
+                volumes:
+                  - /var/run/docker.sock:/var/run/docker.sock
+                  - ./certs:/certs
+                command:
+                  # Enable Docker in Traefik, so that it reads labels from Docker services
+                  - --providers.docker
+                  # TLS providers
+                  - --providers.file.directory=/certs/
+                  # Auto discovery
+                  - --providers.file.watch=true
+                  # Do not expose all Docker services, only the ones explicitly exposed
+                  - --providers.docker.exposedbydefault=false
+                  # Create an entrypoint "http" listening on port 8080
+                  - --entrypoints.http.address=:8888
+                  # Create an entrypoint "https" listening on port 4443
+                  - --entrypoints.https.address=:4443
+                  # QUIC Related Configuration
+                  - --experimental.http3=true
+                  - --entrypoints.https.http3=true
+                  # Enable the access log, with HTTP requests
+                  - --accesslog
+                  # Enable the Traefik log, for configurations and errors
+                  - --log
+                  # Disable the Dashboard and API
+                  - --api.dashboard=false
+                  # Enable healthcheck
+                  - --ping
+                  - --log.level=DEBUG
+              
+              proxy_alt:
+                image: traefik:v2.10
+                restart: unless-stopped
+                healthcheck:
+                  test: [ "CMD", "traefik" ,"healthcheck", "--ping" ]
+                  interval: 3s
+                  timeout: 3s
+                  retries: 10
+                ports:
+                  - target: 9999
+                    published: 9999
+                    protocol: tcp
+                    mode: host
+                  - target: 8754
+                    published: 8754
+                    protocol: tcp
+                    mode: host
+                volumes:
+                  - /var/run/docker.sock:/var/run/docker.sock
+                  - ./certs:/certs
+                command:
+                  # Enable Docker in Traefik, so that it reads labels from Docker services
+                  - --providers.docker
+                  # TLS providers
+                  - --providers.file.directory=/certs/
+                  # Auto discovery
+                  - --providers.file.watch=true
+                  # Do not expose all Docker services, only the ones explicitly exposed
+                  - --providers.docker.exposedbydefault=false
+                  # Create an entrypoint "http" listening on port 9999
+                  - --entrypoints.http.address=:9999
+                  # Create an entrypoint "https" listening on port 8754
+                  - --entrypoints.https.address=:8754
+                  # Enable the access log, with HTTP requests
+                  - --accesslog
+                  # Enable the Traefik log, for configurations and errors
+                  - --log
+                  # Disable the Dashboard and API
+                  - --api.dashboard=false
+                  # Enable healthcheck
+                  - --ping
+              
+              httpbin:
+                image: mccutchen/go-httpbin:v2.8.0
+                restart: unless-stopped
+                depends_on:
+                  proxy:
+                    condition: service_healthy
+                labels:
+                  - traefik.enable=true
+                  - traefik.http.routers.httpbin-http.rule=Host(`httpbin.local`) || Host(`alt.httpbin.local`)
+                  - traefik.http.routers.httpbin-http.entrypoints=http
+                  - traefik.http.routers.httpbin-https.rule=Host(`httpbin.local`) || Host(`alt.httpbin.local`)
+                  - traefik.http.routers.httpbin-https.entrypoints=https
+                  - traefik.http.routers.httpbin-https.tls=true
+                  - traefik.http.services.httpbin.loadbalancer.server.port=8080
+        run: |
+          echo "$TRAEFIK_COMPOSE_SCHEMA" > ./docker-compose.yaml
+          echo "$TRAEFIK_CERTIFICATE_TOML" > ./certs/certificate.toml
+
+      - name: "Traefik: Start stack"
+        if: ${{ matrix.traefik-server }}
+        run: docker compose up -d
+
+      - name: "Traefik: Wait for service"
+        if: ${{ matrix.traefik-server }}
+        run: curl --retry 30 --retry-max-time 120 --fail --retry-all-errors https://httpbin.local:4443/get
+
+      - name: "mkcert: export MKCERT_CA_ROOT"
+        if: ${{ matrix.traefik-server }}
+        run: export MKCERT_CA_ROOT=`mkcert -CAROOT`
 
       - name: "Setup Python ${{ matrix.python-version }}"
         uses: "actions/setup-python@57ded4d7d5e986d7296eab16560982c6dd7c923b"

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        downstream: [botocore, requests]
+        downstream: [botocore, requests, requests_h2n3]
     runs-on: ubuntu-22.04
     timeout-minutes: 30
 

--- a/README.md
+++ b/README.md
@@ -27,18 +27,21 @@ standard libraries:
 - File uploads with multipart encoding.
 - Helpers for retrying requests and dealing with HTTP redirects.
 - Support for gzip, deflate, brotli, and zstd encoding.
+- HTTP/1.1, HTTP/2 and HTTP/3 support.
 - Proxy support for HTTP and SOCKS.
 - 100% test coverage.
 
 urllib3 is powerful and easy to use:
 
-```python3
+```python
 >>> import urllib3
->>> resp = urllib3.request("GET", "http://httpbin.org/robots.txt")
+>>> resp = urllib3.request("GET", "https://httpbin.org/robots.txt")
 >>> resp.status
 200
 >>> resp.data
 b"User-agent: *\nDisallow: /deny\n"
+>>> resp.version
+20
 ```
 
 ## Installing
@@ -49,6 +52,10 @@ urllib3 can be installed with [pip](https://pip.pypa.io):
 $ python -m pip install urllib3
 ```
 
+to (experimentally) enable HTTP/2, HTTP/3 (and detach yourself from the legacy http.client for HTTP/1.1) you must install urllib3 with:
+```bash
+$ python -m pip install urllib3[h2n3]
+```
 Alternatively, you can grab the latest source code from [GitHub](https://github.com/urllib3/urllib3):
 
 ```bash

--- a/changelog/3000.feature.rst
+++ b/changelog/3000.feature.rst
@@ -1,0 +1,26 @@
+Added experimental support for HTTP/1.1, HTTP/2 and HTTP/3 independently of httplib.
+
+Currently urllib3 does not offer async http request and the backend is the http.client package
+shipped alongside Python. This implementation is not scheduled to improve, even less to support latest
+protocol.
+
+Without proxies, the negotiation is as follow:
+
+- http requests are always made using HTTP/1.1.
+- https requests are made with HTTP/2 if TLS-ALPN yield its support otherwise HTTP/1.1.
+
+- https requests may upgrade to HTTP/3 if latest response contain a valid Alt-Svc header.
+
+With proxies:
+
+- The initial proxy request is always issued using HTTP/1.1 regardless if its http or https.
+- Subsequents requests follow the previous section (Without proxies) at the sole exception that HTTP/3 upgrade is disabled.
+
+You may explicitly disable HTTP/2 or, and, HTTP/3 by passing ``disabled_svn={HttpVersion.h2}`` to your ``BaseHttpConnection`` instance.
+Disabling HTTP/1.1 is forbidden and raise an error.
+
+Note that a valid or accepted Alt-Svc header in urllib3 means looking for the "h3" (final specification) protocol and disallow switching hostname for security
+reasons.
+
+Starting now, users may start to experiment detaching themselves from it by installing urllib
+as follow ``pip install urllib3[h2n3]``.

--- a/ci/0002-Requests-Hface.patch
+++ b/ci/0002-Requests-Hface.patch
@@ -1,0 +1,13 @@
+diff --git a/tests/test_lowlevel.py b/tests/test_lowlevel.py
+index 859d07e8..024723e0 100644
+--- a/tests/test_lowlevel.py
++++ b/tests/test_lowlevel.py
+@@ -55,7 +55,7 @@ def test_chunked_encoding_error():
+
+     with server as (host, port):
+         url = f"http://{host}:{port}/"
+-        with pytest.raises(requests.exceptions.ChunkedEncodingError):
++        with pytest.raises(requests.exceptions.ConnectionError):
+             requests.get(url)
+         close_server.set()  # release server block
+

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -124,4 +124,8 @@ nitpick_ignore = [
     ("py:class", "urllib3.contrib.socks._TYPE_SOCKS_OPTIONS"),
     ("py:class", "urllib3.util.timeout._TYPE_DEFAULT"),
     ("py:class", "BaseHTTPConnection"),
+    ("py:class", "connection._TYPE_SOCKET_OPTIONS"),
+    ("py:class", "urllib3.backend.httplib._PatchedHTTPConnection"),
+    ("py:class", "urllib3.backend._base.ProxyHttpLibResponse"),
+    ("py:class", "QuicPreemptiveCacheType"),
 ]

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -27,6 +27,7 @@ standard libraries:
 - File uploads with multipart encoding.
 - Helpers for retrying requests and dealing with HTTP redirects.
 - Support for gzip, deflate, brotli, and zstd encoding.
+- HTTP/1.1, HTTP/2 and HTTP/3 support.
 - Proxy support for HTTP and SOCKS.
 - 100% test coverage.
 
@@ -81,6 +82,12 @@ urllib3 can be installed with `pip <https://pip.pypa.io>`_
 .. code-block:: bash
 
   $ python -m pip install urllib3
+
+To (experimentally) enable HTTP/2 and HTTP/3 you must install urllib3 with:
+
+.. code-block:: bash
+
+  $ python -m pip install urllib3[h2n3]
 
 Alternatively, you can grab the latest source code from `GitHub <https://github.com/urllib3/urllib3>`_:
 

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -11,4 +11,5 @@ API Reference
    urllib3.response
    urllib3.fields
    urllib3.util
+   urllib3.backend
    contrib/index

--- a/docs/reference/urllib3.backend.rst
+++ b/docs/reference/urllib3.backend.rst
@@ -1,0 +1,21 @@
+Backends
+========
+
+.. automodule:: urllib3.backend
+
+.. autoclass:: urllib3.backend.BaseBackend
+    :members:
+    :show-inheritance:
+
+.. autoclass:: urllib3.backend.hface.HfaceBackend
+    :members:
+    :show-inheritance:
+
+.. autoclass:: urllib3.backend.httplib.LegacyBackend
+    :members:
+    :show-inheritance:
+
+.. autoclass:: urllib3.backend.HttpVersion
+    :members:
+
+.. autoclass:: urllib3.backend.QuicPreemptiveCacheType

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,4 +3,5 @@ sphinx>3.0.0
 requests
 furo
 sphinx-copybutton
+urllib3-ext-hface>=0.3.0,<0.4.0
 sphinxext-opengraph

--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -13,6 +13,17 @@ urllib3 can be installed with `pip <https://pip.pypa.io>`_
   $ python -m pip install urllib3
 
 
+HTTP/2 and HTTP/3 support
+-------------------------
+
+If you want to support more HTTP protocols like HTTP/2 and HTTP/3 over QUIC, install urllib3 with
+
+.. code-block:: bash
+
+  $ python -m pip install urllib3[h2n3]
+
+This will detach urllib3 from the legacy http.client package, even for HTTP/1.1 requests.
+
 Making Requests
 ---------------
 
@@ -98,6 +109,8 @@ The :class:`~response.HTTPResponse` object provides
     # b"{\n  "origin": "104.232.115.37"\n}\n"
     print(resp.headers)
     # HTTPHeaderDict({"Content-Length": "32", ...})
+    print(resp.version)
+    # 20
 
 JSON Content
 ~~~~~~~~~~~~

--- a/mypy-requirements.txt
+++ b/mypy-requirements.txt
@@ -7,3 +7,4 @@ trustme==0.9.0
 types-backports
 types-requests
 nox
+urllib3-ext-hface>=0.3.0,<0.4.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,9 @@ secure = [
 socks = [
   "PySocks>=1.5.6,<2.0,!=1.5.7",
 ]
+h2n3 = [
+  "urllib3-ext-hface>=0.3.4,<0.4.0",
+]
 
 [project.urls]
 "Changelog" = "https://github.com/urllib3/urllib3/blob/main/CHANGES.rst"

--- a/src/urllib3/__init__.py
+++ b/src/urllib3/__init__.py
@@ -14,6 +14,7 @@ from . import exceptions
 from ._base_connection import _TYPE_BODY
 from ._collections import HTTPHeaderDict
 from ._version import __version__
+from .backend import HttpVersion
 from .connectionpool import HTTPConnectionPool, HTTPSConnectionPool, connection_from_url
 from .filepost import _TYPE_FIELDS, encode_multipart_formdata
 from .poolmanager import PoolManager, ProxyManager, proxy_from_url
@@ -81,6 +82,7 @@ __all__ = (
     "make_headers",
     "proxy_from_url",
     "request",
+    "HttpVersion",
 )
 
 logging.getLogger(__name__).addHandler(NullHandler())

--- a/src/urllib3/_version.py
+++ b/src/urllib3/_version.py
@@ -1,4 +1,4 @@
 # This file is protected via CODEOWNERS
 from __future__ import annotations
 
-__version__ = "2.0.3"
+__version__ = "2.0.931"

--- a/src/urllib3/backend/__init__.py
+++ b/src/urllib3/backend/__init__.py
@@ -1,0 +1,20 @@
+"""
+This is meant to support various HTTP version.
+
+    - (standard) http.client shipped within cpython distribution
+    - (experimental) hface shipped by installing urllib3-ext-hface
+"""
+
+from __future__ import annotations
+
+from ._base import BaseBackend, HttpVersion, QuicPreemptiveCacheType
+from .hface import HfaceBackend
+from .httplib import LegacyBackend
+
+__all__ = (
+    "BaseBackend",
+    "LegacyBackend",
+    "HfaceBackend",
+    "HttpVersion",
+    "QuicPreemptiveCacheType",
+)

--- a/src/urllib3/backend/_base.py
+++ b/src/urllib3/backend/_base.py
@@ -1,0 +1,271 @@
+from __future__ import annotations
+
+import enum
+import socket
+import typing
+
+if typing.TYPE_CHECKING:
+    from ssl import SSLSocket, SSLContext
+
+from .._collections import HTTPHeaderDict
+from ..util import connection
+
+
+class HttpVersion(str, enum.Enum):
+    """Describe possible SVN protocols that can be supported."""
+
+    h11 = "HTTP/1.1"
+    # we know that it is rather "HTTP/2" than "HTTP/2.0"
+    # it is this way to remain somewhat compatible with http.client
+    # http_svn (int). 9 -> 11 -> 20 -> 30
+    h2 = "HTTP/2.0"
+    h3 = "HTTP/3.0"
+
+
+class ProxyHttpLibResponse:
+    """Implemented for backward compatibility purposes. It is there to impose http.client like
+    basic response object. So that we don't have to change urllib3 tested behaviors."""
+
+    def __init__(
+        self,
+        status: int,
+        version: int,
+        reason: str,
+        headers: HTTPHeaderDict,
+        body: typing.Callable[[int | None], tuple[bytes, bool]] | None,
+        *,
+        method: str | None = None,
+        authority: str | None = None,
+        port: int | None = None,
+    ):
+        self.status = status
+        self.version = version
+        self.reason = reason
+        self.msg = headers
+        self._method = method
+
+        self.__internal_read_st = body
+        self.closed = True if self.__internal_read_st is None else False
+        self._eot = True if self.__internal_read_st is None else False
+
+        # is kept to determine if we can upgrade conn
+        self.authority = authority
+        self.port = port
+
+        self.__buffer_excess: bytes = b""
+
+    def isclosed(self) -> bool:
+        """Here we do not create a fp sock like http.client Response."""
+        return self.closed
+
+    def read(self, __size: int | None = None) -> bytes:
+        if self.closed is True or self.__internal_read_st is None:
+            # overly protective, just in case.
+            raise ValueError(
+                "I/O operation on closed file."
+            )  # Defensive: Should not be reachable in normal condition
+
+        if __size == 0:
+            return b""  # Defensive: This is unreachable, this case is already covered higher in the stack.
+
+        if self._eot is False:
+            data, self._eot = self.__internal_read_st(__size)
+
+            # that's awkward, but rather no choice. the state machine
+            # consume and render event regardless of your amt !
+            if self.__buffer_excess:
+                data = (  # Defensive: Difficult to put in place a scenario that verify this
+                    self.__buffer_excess + data
+                )
+                self.__buffer_excess = b""  # Defensive:
+        else:
+            if __size is None:
+                data = self.__buffer_excess
+            else:
+                data = self.__buffer_excess[:__size]
+                self.__buffer_excess = self.__buffer_excess[__size:]
+
+        if __size is not None and len(data) > __size:
+            self.__buffer_excess = data[__size:]
+            data = data[:__size]
+
+        if self._eot and len(self.__buffer_excess) == 0:
+            self.closed = True
+
+        return data
+
+    def close(self) -> None:
+        self.__internal_read_st = None
+        self.closed = True
+
+
+_HostPortType = typing.Tuple[str, int]
+QuicPreemptiveCacheType = typing.MutableMapping[
+    _HostPortType, typing.Optional[_HostPortType]
+]
+
+
+class BaseBackend:
+    """
+    The goal here is to detach ourselves from the http.client package.
+    At first, we'll strictly follow the methods in http.client.HTTPConnection. So that
+    we would be able to implement other backend without disrupting the actual code base.
+    Extend that base class in order to ship another backend with urllib3.
+    """
+
+    supported_svn: typing.ClassVar[list[HttpVersion] | None] = None
+    scheme: typing.ClassVar[str]
+
+    default_socket_kind: socket.SocketKind = socket.SOCK_STREAM
+    #: Disable Nagle's algorithm by default.
+    default_socket_options: typing.ClassVar[connection._TYPE_SOCKET_OPTIONS] = [
+        (socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+    ]
+
+    #: Whether this connection verifies the host's certificate.
+    is_verified: bool = False
+
+    #: Whether this proxy connection verified the proxy host's certificate.
+    # If no proxy is currently connected to the value will be ``None``.
+    proxy_is_verified: bool | None = None
+
+    def __init__(
+        self,
+        host: str,
+        port: int | None = None,
+        timeout: int = -1,
+        source_address: tuple[str, int] | None = None,
+        blocksize: int = 8192,
+        *,
+        socket_options: None
+        | (connection._TYPE_SOCKET_OPTIONS) = default_socket_options,
+        disabled_svn: set[HttpVersion] | None = None,
+        preemptive_quic_cache: QuicPreemptiveCacheType | None = None,
+    ):
+        self.host = host
+        self.port = port
+        self.timeout = timeout
+        self.source_address = source_address
+        self.blocksize = blocksize
+        self.socket_kind = BaseBackend.default_socket_kind
+        self.socket_options = socket_options
+        self.sock: socket.socket | SSLSocket | None = None
+
+        self._response: ProxyHttpLibResponse | None = None
+        # Set it as default
+        self._svn: HttpVersion | None = HttpVersion.h11
+
+        self._tunnel_host: str | None = None
+        self._tunnel_port: int | None = None
+        self._tunnel_scheme: str | None = None
+        self._tunnel_headers: typing.Mapping[str, str] = dict()
+
+        self._disabled_svn = disabled_svn or set()
+        self._preemptive_quic_cache = preemptive_quic_cache
+
+        if self._disabled_svn:
+            if HttpVersion.h11 in self._disabled_svn:
+                raise RuntimeError(
+                    "HTTP/1.1 cannot be disabled. It will be allowed in a future urllib3 version."
+                )
+
+    @property
+    def disabled_svn(self) -> set[HttpVersion]:
+        return self._disabled_svn
+
+    @property
+    def _http_vsn_str(self) -> str:
+        """Reimplemented for backward compatibility purposes."""
+        assert self._svn is not None
+        return self._svn.value
+
+    @property
+    def _http_vsn(self) -> int:
+        """Reimplemented for backward compatibility purposes."""
+        assert self._svn is not None
+        return int(self._svn.value.split("/")[-1].replace(".", ""))
+
+    def _upgrade(self) -> None:
+        """Upgrade conn from svn ver to max supported."""
+        raise NotImplementedError
+
+    def _tunnel(self) -> None:
+        """Emit proper CONNECT request to the http (server) intermediary."""
+        raise NotImplementedError
+
+    def _new_conn(self) -> socket.socket | None:
+        """Run protocol initialization from there. Return None to ensure that the child
+        class correctly create the socket / connection."""
+        raise NotImplementedError
+
+    def _post_conn(self) -> None:
+        """Should be called after _new_conn proceed as expected.
+        Expect protocol handshake to be done here."""
+        raise NotImplementedError
+
+    def _custom_tls(
+        self,
+        ssl_context: SSLContext | None = None,
+        ca_certs: str | None = None,
+        ca_cert_dir: str | None = None,
+        ca_cert_data: None | str | bytes = None,
+        ssl_minimum_version: int | None = None,
+        ssl_maximum_version: int | None = None,
+        cert_file: str | None = None,
+        key_file: str | None = None,
+        key_password: str | None = None,
+    ) -> None:
+        """This method serve as bypassing any default tls setup.
+        It is most useful when the encryption does not lie on the TCP layer. This method
+        WILL raise NotImplementedError if the connection is not concerned."""
+        raise NotImplementedError
+
+    def set_tunnel(
+        self,
+        host: str,
+        port: int | None = None,
+        headers: typing.Mapping[str, str] | None = None,
+        scheme: str = "http",
+    ) -> None:
+        """Prepare the connection to set up a tunnel. Does NOT actually do the socket and http connect.
+        Here host:port represent the target (final) server and not the intermediary."""
+        raise NotImplementedError
+
+    def putrequest(
+        self,
+        method: str,
+        url: str,
+        skip_host: bool = False,
+        skip_accept_encoding: bool = False,
+    ) -> None:
+        """It is the first method called, setting up the request initial context."""
+        raise NotImplementedError
+
+    def putheader(self, header: str, *values: str) -> None:
+        """For a single header name, assign one or multiple value. This method is called right after putrequest()
+        for each entries."""
+        raise NotImplementedError
+
+    def endheaders(
+        self, message_body: bytes | None = None, *, encode_chunked: bool = False
+    ) -> None:
+        """This method conclude the request context construction."""
+        raise NotImplementedError
+
+    def getresponse(self) -> ProxyHttpLibResponse:
+        """Fetch the HTTP response. You SHOULD not retrieve the body in that method, it SHOULD be done
+        in the ProxyHttpLibResponse, so it enable stream capabilities and remain efficient.
+        """
+        raise NotImplementedError
+
+    def close(self) -> None:
+        """End the connection, do some reinit, closing of fd, etc..."""
+        raise NotImplementedError
+
+    def send(
+        self,
+        data: (bytes | typing.IO[typing.Any] | typing.Iterable[bytes] | str),
+    ) -> None:
+        """The send() method SHOULD be invoked after calling endheaders() if and only if the request
+        context specify explicitly that a body is going to be sent."""
+        raise NotImplementedError

--- a/src/urllib3/backend/hface.py
+++ b/src/urllib3/backend/hface.py
@@ -1,0 +1,805 @@
+from __future__ import annotations
+
+import typing
+
+_BACKEND_AVAILABLE: bool
+
+try:
+    # purposely disable this backend if python not built with ssl
+    from ssl import CERT_NONE, SSLContext, SSLSocket
+
+    from urllib3_ext_hface import (
+        HTTP1Protocol,
+        HTTP2Protocol,
+        HTTP3Protocol,
+        HTTPOverQUICProtocol,
+        HTTPOverTCPProtocol,
+        HTTPProtocolFactory,
+        QuicTLSConfig,
+    )
+    from urllib3_ext_hface.events import (
+        ConnectionTerminated,
+        DataReceived,
+        Event,
+        HandshakeCompleted,
+        HeadersReceived,
+    )
+
+    _BACKEND_AVAILABLE = True
+except ImportError:
+    _BACKEND_AVAILABLE = False
+
+
+# Don't bother interpreting HfaceBackend if it is not available.
+if not _BACKEND_AVAILABLE:
+    HfaceBackend = NotImplemented
+else:
+    import sys
+    from http.client import ResponseNotReady, responses
+    from socket import SOCK_DGRAM, SOCK_STREAM
+
+    from .._collections import HTTPHeaderDict
+    from ..exceptions import InvalidHeader, ProtocolError, SSLError
+    from ..util import connection, parse_alt_svc
+    from ..util.ssltransport import SSLTransport
+    from ._base import (
+        BaseBackend,
+        HttpVersion,
+        ProxyHttpLibResponse,
+        QuicPreemptiveCacheType,
+    )
+
+    _HAS_SYS_AUDIT = hasattr(sys, "audit")
+
+    class HfaceBackend(BaseBackend):  # type: ignore[no-redef]
+        supported_svn = [HttpVersion.h11, HttpVersion.h2, HttpVersion.h3]
+
+        def __init__(
+            self,
+            host: str,
+            port: int | None = None,
+            timeout: int = -1,
+            source_address: tuple[str, int] | None = None,
+            blocksize: int = 8192,
+            *,
+            socket_options: None
+            | (connection._TYPE_SOCKET_OPTIONS) = BaseBackend.default_socket_options,
+            disabled_svn: set[HttpVersion] | None = None,
+            preemptive_quic_cache: QuicPreemptiveCacheType | None = None,
+        ):
+            super().__init__(
+                host,
+                port,
+                timeout,
+                source_address,
+                blocksize,
+                socket_options=socket_options,
+                disabled_svn=disabled_svn,
+                preemptive_quic_cache=preemptive_quic_cache,
+            )
+
+            self._protocol: HTTPOverQUICProtocol | HTTPOverTCPProtocol | None = None
+            self._svn = None
+
+            self._stream_id: int | None = None
+
+            # prep buffer, internal usage only.
+            # not suited for HTTPHeaderDict
+            self.__headers: list[tuple[bytes, bytes]] = []
+            self.__expected_body_length: int | None = None
+            self.__remaining_body_length: int | None = None
+
+            # h3 specifics
+            self.__custom_tls_settings: QuicTLSConfig | None = None
+            self.__alt_authority: tuple[str, int] | None = None
+            self.__session_ticket: typing.Any | None = None
+            # we may switch from STREAM (TCP) to DGRAM (UDP)
+            # options may not work as intended, we keep tcp options in there
+            self.__backup_socket_options: None | (
+                connection._TYPE_SOCKET_OPTIONS
+            ) = None
+
+        def _new_conn(self) -> None:
+            # handle if set up, quic cache capability. thus avoiding first TCP request prior to upgrade.
+            if (
+                self._svn is None
+                and HttpVersion.h3 not in self._disabled_svn
+                and self.scheme == "https"
+            ):
+                if (
+                    self._preemptive_quic_cache
+                    and (self.host, self.port) in self._preemptive_quic_cache
+                ):
+                    self.__alt_authority = self._preemptive_quic_cache[
+                        (self.host, self.port or 443)
+                    ]
+                    if self.__alt_authority:
+                        self._svn = HttpVersion.h3
+                        # we ignore alt-host as we do not trust cache security
+                        self.port = self.__alt_authority[1]
+
+            if self._svn == HttpVersion.h3:
+                if self.__backup_socket_options is None:
+                    self.__backup_socket_options = self.socket_options
+
+                # ensure no opt are set for QUIC/UDP socket
+                self.socket_options = []
+                self.socket_kind = SOCK_DGRAM
+
+                # undo local memory on whether conn supposedly support quic/h3
+                # if conn target another host.
+                if self._response and self._response.authority != self.host:
+                    self._svn = None
+                    self._new_conn()  # restore socket defaults
+            else:
+                if self.__backup_socket_options is not None:
+                    self.socket_options = self.__backup_socket_options
+                    self.__backup_socket_options = None
+                self.socket_kind = SOCK_STREAM
+
+        def _upgrade(self) -> None:
+            assert (
+                self._response is not None
+            ), "attempt to call _upgrade() prior to successful getresponse()"
+
+            if self._svn == HttpVersion.h3:
+                return
+            if HttpVersion.h3 in self._disabled_svn:
+                return
+
+            self.__alt_authority = self.__h3_probe()
+
+            if self.__alt_authority:
+                if self._preemptive_quic_cache is not None:
+                    self._preemptive_quic_cache[
+                        (self.host, self.port or 443)
+                    ] = self.__alt_authority
+                self._svn = HttpVersion.h3
+                # We purposely ignore setting the Hostname. Avoid MITM attack from local cache attack.
+                self.port = self.__alt_authority[1]
+                self.close()
+
+        def _custom_tls(
+            self,
+            ssl_context: SSLContext | None = None,
+            ca_certs: str | None = None,
+            ca_cert_dir: str | None = None,
+            ca_cert_data: None | str | bytes = None,
+            ssl_minimum_version: int | None = None,
+            ssl_maximum_version: int | None = None,
+            cert_file: str | None = None,
+            key_file: str | None = None,
+            key_password: str | None = None,
+        ) -> None:
+            """Meant to support TLS over QUIC meanwhile cpython does not ship with its native implementation."""
+            if self._svn != HttpVersion.h3:
+                raise NotImplementedError
+
+            self.__custom_tls_settings = QuicTLSConfig(
+                insecure=ssl_context.verify_mode == CERT_NONE if ssl_context else False,
+                cafile=ca_certs,
+                capath=ca_cert_dir,
+                cadata=ca_cert_data.encode()
+                if isinstance(ca_cert_data, str)
+                else ca_cert_data,
+                session_ticket=self.__session_ticket,  # going to be set after first successful quic handshake
+                certfile=cert_file,
+                keyfile=key_file,
+                keypassword=key_password,
+            )
+
+            self.is_verified = not self.__custom_tls_settings.insecure
+
+        def __h3_probe(self) -> tuple[str, int] | None:
+            """Determine if remote is capable of operating through the http/3 protocol over QUIC."""
+            # need at least first request being made
+            assert self._svn is not None
+            assert self._response is not None
+
+            # do not upgrade if not coming from TLS already.
+            # we exclude SSLTransport, HTTP/3 is not supported in that condition anyway.
+            if not isinstance(self.sock, SSLSocket):
+                return None
+
+            for alt_svc in self._response.msg.getlist("alt-svc"):
+                for protocol, alt_authority in parse_alt_svc(alt_svc):
+                    # Looking for final specification of HTTP/3 over QUIC.
+                    if protocol != "h3":
+                        continue
+
+                    server, port = alt_authority.split(":")
+
+                    # Security: We don't accept Alt-Svc with switching Host
+                    # It's up to consideration, can be a security risk.
+                    if server and server != self.host:
+                        continue
+
+                    return server, int(port)
+
+            return None
+
+        def _post_conn(self) -> None:
+            if self._tunnel_host is None:
+                assert (
+                    self._protocol is None
+                ), "_post_conn() must be called when socket is closed or unset"
+            assert (
+                self.sock is not None
+            ), "probable attempt to call _post_conn() prior to successful _new_conn()"
+
+            # first request was not made yet
+            if self._svn is None:
+                if isinstance(self.sock, (SSLSocket, SSLTransport)):
+                    alpn: str | None = (
+                        self.sock.selected_alpn_protocol()
+                        if isinstance(self.sock, SSLSocket)
+                        else self.sock.sslobj.selected_alpn_protocol()  # type: ignore[attr-defined]
+                    )
+
+                    if alpn is not None:
+                        if alpn == "h2":
+                            self._protocol = HTTPProtocolFactory.new(HTTP2Protocol)  # type: ignore[type-abstract]
+                            self._svn = HttpVersion.h2
+                        elif alpn != "http/1.1":
+                            raise ProtocolError(  # Defensive: This should be unreachable as ALPN is explicit higher in the stack.
+                                f"Unsupported ALPN '{alpn}' during handshake"
+                            )
+            else:
+                if self._svn == HttpVersion.h2:
+                    self._protocol = HTTPProtocolFactory.new(HTTP2Protocol)  # type: ignore[type-abstract]
+                elif self._svn == HttpVersion.h3:
+                    assert self.__custom_tls_settings is not None
+                    assert self.__alt_authority is not None
+
+                    server, port = self.__alt_authority
+
+                    self._protocol = HTTPProtocolFactory.new(
+                        HTTP3Protocol,  # type: ignore[type-abstract]
+                        remote_address=(self.host, int(port)),
+                        server_name=self.host,
+                        tls_config=self.__custom_tls_settings,
+                    )
+
+            # fallback to http/1.1
+            if self._protocol is None or self._svn == HttpVersion.h11:
+                self._protocol = HTTPProtocolFactory.new(HTTP1Protocol)  # type: ignore[type-abstract]
+                self._svn = HttpVersion.h11
+
+                return
+
+            # it may be required to send some initial data, aka. magic header (PRI * HTTP/2..)
+            self.__exchange_until(
+                HandshakeCompleted,
+                receive_first=False,
+            )
+
+        def set_tunnel(
+            self,
+            host: str,
+            port: int | None = None,
+            headers: typing.Mapping[str, str] | None = None,
+            scheme: str = "http",
+        ) -> None:
+            if self.sock:
+                # overly protective, checks are made higher, this is unreachable.
+                raise RuntimeError(  # Defensive: mimic HttpConnection from http.client
+                    "Can't set up tunnel for established connection"
+                )
+
+            # We either support tunneling or http/3. Need complex developments.
+            if HttpVersion.h3 not in self._disabled_svn:
+                self._disabled_svn.add(HttpVersion.h3)
+
+            self._tunnel_host = host
+            self._tunnel_port = port
+
+            if headers:
+                self._tunnel_headers = headers
+            else:
+                self._tunnel_headers = {}
+
+        def _tunnel(self) -> None:
+            assert self._protocol is not None
+            assert self.sock is not None
+            assert self._tunnel_host is not None
+            assert self._tunnel_port is not None
+
+            if self._svn != HttpVersion.h11:
+                raise NotImplementedError(
+                    """Unable to establish a tunnel using other than HTTP/1.1."""
+                )
+
+            self._stream_id = self._protocol.get_available_stream_id()
+
+            req_context = [
+                (
+                    b":authority",
+                    f"{self._tunnel_host}:{self._tunnel_port}".encode("ascii"),
+                ),
+                (b":method", b"CONNECT"),
+            ]
+
+            for header, value in self._tunnel_headers.items():
+                req_context.append(
+                    (header.lower().encode(), value.encode("iso-8859-1"))
+                )
+
+            self._protocol.submit_headers(
+                self._stream_id,
+                req_context,
+                True,
+            )
+
+            events = self.__exchange_until(
+                HeadersReceived,
+                receive_first=False,
+                event_type_collectable=(HeadersReceived,),
+                # special case for CONNECT
+                respect_end_stream_signal=False,
+            )
+
+            status: int | None = None
+
+            for event in events:
+                if isinstance(event, HeadersReceived):
+                    for raw_header, raw_value in event.headers:
+                        if raw_header == b":status":
+                            status = int(raw_value.decode())
+                            break
+
+            tunnel_accepted: bool = status is not None and (200 <= status < 300)
+
+            if not tunnel_accepted:
+                self.close()
+                message: str = responses[status] if status in responses else "UNKNOWN"
+                raise OSError(f"Tunnel connection failed: {status} {message}")
+
+            # We will re-initialize those afterward
+            # to be in phase with Us --> NotIntermediary
+            self._svn = None
+            self._protocol = None
+            self._protocol_factory = None
+
+        def __exchange_until(
+            self,
+            event_type: type[Event] | tuple[type[Event], ...],
+            *,
+            receive_first: bool = False,
+            event_type_collectable: type[Event] | tuple[type[Event], ...] | None = None,
+            respect_end_stream_signal: bool = True,
+            maximal_data_in_read: int | None = None,
+            data_in_len_from: typing.Callable[[Event], int] | None = None,
+        ) -> list[Event]:
+            """This method simplify socket exchange in/out based on what the protocol state machine orders.
+            Can be used for the initial handshake for instance."""
+            assert self._protocol is not None
+            assert self.sock is not None
+            assert (maximal_data_in_read is not None and maximal_data_in_read >= 0) or (
+                maximal_data_in_read is None
+            )
+
+            data_out: bytes
+            data_in: bytes
+
+            data_in_len: int = 0
+
+            events: list[Event] = []
+
+            if maximal_data_in_read == 0:
+                # The '0' case amt is handled higher in the stack.
+                return events  # Defensive: This should be unreachable in the current project state.
+
+            while True:
+                if not self._protocol.has_pending_event():
+                    if receive_first is False:
+                        data_out = self._protocol.bytes_to_send()
+
+                        if data_out:
+                            self.sock.sendall(data_out)
+                        else:  # nothing to send out...? immediately exit.
+                            return events  # Defensive: This should be unreachable in the current project state.
+
+                    data_in = self.sock.recv(maximal_data_in_read or self.blocksize)
+
+                    if not data_in:
+                        # in some cases (merely http/1 legacy)
+                        # server can signify "end-of-transmission" by simply closing the socket.
+                        # pretty much dirty.
+
+                        # must have at least one event received, otherwise we can't declare a proper eof.
+                        if (events or self._response is not None) and hasattr(
+                            self._protocol, "eof_received"
+                        ):
+                            try:
+                                self._protocol.eof_received()
+                            except self._protocol.exceptions() as e:  # Defensive:
+                                # overly protective, we hide exception that are behind urllib3.
+                                # should not happen, but one truly never known.
+                                raise ProtocolError(e) from e  # Defensive:
+                        else:
+                            raise ProtocolError(
+                                "server unexpectedly closed the connection in-flight (prior-to-response)"
+                            )
+                    else:
+                        if data_in_len_from is None:
+                            data_in_len += len(data_in)
+
+                        try:
+                            self._protocol.bytes_received(data_in)
+                        except self._protocol.exceptions() as e:
+                            raise ProtocolError(e) from e  # Defensive:
+
+                    if receive_first is True:
+                        data_out = self._protocol.bytes_to_send()
+
+                        if data_out:
+                            self.sock.sendall(data_out)
+
+                for event in iter(self._protocol.next_event, None):  # type: Event
+                    if isinstance(event, ConnectionTerminated):
+                        if (
+                            event.error_code == 400
+                            and event.message
+                            and "header" in event.message
+                        ):
+                            raise InvalidHeader(event.message)
+                        # QUIC operate TLS verification outside native capabilities
+                        # We have to forward the error so that users aren't caught off guard when the connection
+                        # unexpectedly close.
+                        elif event.error_code == 298 and self._svn == HttpVersion.h3:
+                            raise SSLError(
+                                "TLS over QUIC did not succeed (Error 298). Chain certificate verification failed."
+                            )
+
+                        raise ProtocolError(event.message)
+
+                    if data_in_len_from:
+                        data_in_len += data_in_len_from(event)
+
+                    if not event_type_collectable:
+                        events.append(event)
+                    else:
+                        if isinstance(event, event_type_collectable):
+                            events.append(event)
+
+                    if (event_type and isinstance(event, event_type)) or (
+                        maximal_data_in_read and data_in_len >= maximal_data_in_read
+                    ):
+                        # if event type match, make sure it is the latest one
+                        # simply put, end_stream should be True.
+                        if respect_end_stream_signal and hasattr(event, "end_stream"):
+                            if event.end_stream is True:
+                                return events
+                            continue
+
+                        return events
+
+        def putrequest(
+            self,
+            method: str,
+            url: str,
+            skip_host: bool = False,
+            skip_accept_encoding: bool = False,
+        ) -> None:
+            """Internally fhace translate this into what putrequest does. e.g. initial trame."""
+            self.__headers = []
+            self.__expected_body_length = None
+            self.__remaining_body_length = None
+
+            if self._tunnel_host is not None:
+                host, port = self._tunnel_host, self._tunnel_port
+            else:
+                host, port = self.host, self.port
+
+            authority: bytes = host.encode("idna")
+
+            self.__headers = [
+                (b":method", method.encode("ascii")),
+                (
+                    b":scheme",
+                    self.scheme.encode("ascii"),
+                ),
+                (b":path", url.encode("ascii")),
+            ]
+
+            if not skip_host:
+                self.__headers.append(
+                    (
+                        b":authority",
+                        authority
+                        if port == self.default_port  # type: ignore[attr-defined]
+                        else authority + f":{port}".encode(),
+                    ),
+                )
+
+            if not skip_accept_encoding:
+                self.putheader("Accept-Encoding", "identity")
+
+        def putheader(self, header: str, *values: str) -> None:
+            # note: requests allow passing headers as bytes (seen in requests/tests)
+            # warn: always lowercase header names, quic transport crash if not lowercase.
+            header = header.lower()
+
+            encoded_header = (
+                header.encode("ascii") if isinstance(header, str) else header
+            )
+
+            for value in values:
+                self.__headers.append(
+                    (
+                        encoded_header,
+                        value.encode("iso-8859-1") if isinstance(value, str) else value,
+                    )
+                )
+
+        def endheaders(
+            self, message_body: bytes | None = None, *, encode_chunked: bool = False
+        ) -> None:
+            # only the case when it is plain http
+            if self.sock is None:
+                self.connect()  # type: ignore[attr-defined]
+
+            assert self.sock is not None
+            assert self._protocol is not None
+
+            # only h2 and h3 support streams, it is faked/simulated for h1.
+            self._stream_id = self._protocol.get_available_stream_id()
+
+            # unless anything hint the opposite, the request head frame is the end stream
+            should_end_stream: bool = True
+            # only h11 support chunked transfer encoding, we internally translate
+            # it to the right method for h2 and h3.
+            support_te_chunked: bool = self._svn == HttpVersion.h11
+
+            # determine if stream should end there (absent body case)
+            for raw_header, raw_value in self.__headers:
+                header: str = raw_header.decode("ascii").lower().replace("_", "-")
+                value: str = raw_value.decode("iso-8859-1")
+                if header.startswith(":"):
+                    continue
+                if header == "content-length":
+                    if value.isdigit():
+                        self.__expected_body_length = int(value)
+                    should_end_stream = not (
+                        self.__expected_body_length is not None and int(value) > 0
+                    )
+                    break
+                if header == "transfer-encoding" and value.lower() == "chunked":
+                    should_end_stream = False
+                    break
+
+            # handle cases where 'Host' header is set manually
+            if any(k == b":authority" for k, v in self.__headers) is False:
+                for raw_header, raw_value in self.__headers:
+                    header = raw_header.decode("ascii").lower().replace("_", "-")
+
+                    if header == "host":
+                        self.__headers.append((b":authority", raw_value))
+                        break
+            if any(k == b":authority" for k, v in self.__headers) is False:
+                raise ProtocolError(
+                    (
+                        "HfaceBackend do not support emitting HTTP requests without the `Host` header",
+                        "It was only permitted in HTTP/1.0 and prior. This implementation ship with HTTP/1.1+.",
+                    )
+                )
+
+            if not support_te_chunked:
+                # We MUST never use that header in h2 and h3 over quic.
+                # It may(should) break the connection.
+                intent_te_chunked: bool = False
+                try:
+                    self.__headers.remove((b"transfer-encoding", b"chunked"))
+                    intent_te_chunked = True
+                except ValueError:
+                    pass
+
+                # some quic/h3 implementation like quic-go skip reading the body
+                # if this indicator isn't present, equivalent to te: chunked but looking for stream FIN marker.
+                # officially, it should not be there. kept for compatibility.
+                if (
+                    intent_te_chunked
+                    and self._svn == HttpVersion.h3
+                    and self.__expected_body_length is None
+                ):
+                    self.__headers.append((b"content-length", b"-1"))
+
+            try:
+                self._protocol.submit_headers(
+                    self._stream_id,
+                    self.__headers,
+                    end_stream=should_end_stream,
+                )
+            except self._protocol.exceptions() as e:  # Defensive:
+                # overly protective, designed to avoid exception leak bellow urllib3.
+                raise ProtocolError(e) from e  # Defensive:
+
+            self.sock.sendall(self._protocol.bytes_to_send())
+
+        def __read_st(self, __amt: int | None = None) -> tuple[bytes, bool]:
+            """Allows us to defer the body loading after constructing the response object."""
+            eot = False
+
+            events: list[DataReceived] = self.__exchange_until(  # type: ignore[assignment]
+                DataReceived,
+                receive_first=True,
+                # we ignore Trailers even if provided in response.
+                event_type_collectable=(DataReceived, HeadersReceived),
+                maximal_data_in_read=__amt,
+                data_in_len_from=lambda x: len(x.data)
+                if isinstance(x, DataReceived)
+                else 0,
+            )
+
+            if events and events[-1].end_stream:
+                eot = True
+                # probe for h3/quic if available, and remember it.
+                self._upgrade()
+
+                # remote can refuse future inquiries, so no need to go further with this conn.
+                if self._protocol and self._protocol.has_expired():
+                    self.close()
+
+            return (
+                b"".join(
+                    e.data if isinstance(e, DataReceived) else b"" for e in events
+                ),
+                eot,
+            )
+
+        def getresponse(self) -> ProxyHttpLibResponse:
+            if self.sock is None or self._protocol is None or self._svn is None:
+                raise ResponseNotReady()  # Defensive: Comply with http.client, actually tested but not reported?
+
+            headers = HTTPHeaderDict()
+            status: int | None = None
+
+            events: list[HeadersReceived] = self.__exchange_until(  # type: ignore[assignment]
+                HeadersReceived,
+                receive_first=True,
+                event_type_collectable=(HeadersReceived,),
+                respect_end_stream_signal=False,
+            )
+
+            for event in events:
+                if isinstance(event, HeadersReceived):
+                    for raw_header, raw_value in event.headers:
+                        header: str = raw_header.decode("ascii")
+                        value: str = raw_value.decode("iso-8859-1")
+
+                        # special headers that represent (usually) the HTTP response status, version and reason.
+                        if header.startswith(":"):
+                            if header == ":status" and value.isdigit():
+                                status = int(value)
+                                continue
+                            # this should be unreachable.
+                            # it is designed to detect eventual changes lower in the stack.
+                            raise ProtocolError(
+                                f"Unhandled special header '{header}'"
+                            )  # Defensive:
+
+                        headers.add(header, value)
+
+            # this should be unreachable
+            if status is None:
+                raise ProtocolError(  # Defensive: This is unreachable, all three implementations crash before.
+                    "Got an HTTP response without a status code. This is a violation."
+                )
+
+            eot = events[-1].end_stream is True
+
+            response = ProxyHttpLibResponse(
+                status,
+                self._http_vsn,
+                responses[status] if status in responses else "UNKNOWN",
+                headers,
+                self.__read_st if not eot else None,
+                method=dict(self.__headers)[b":method"].decode("ascii"),
+                authority=self.host,
+                port=self.port,
+            )
+
+            # keep last response
+            self._response = response
+
+            # save the quic ticket for session resumption
+            if self._svn == HttpVersion.h3 and hasattr(
+                self._protocol, "session_ticket"
+            ):
+                self.__session_ticket = self._protocol.session_ticket
+
+            if eot:
+                self._upgrade()
+
+                # remote can refuse future inquiries, so no need to go further with this conn.
+                if self._protocol and self._protocol.has_expired():
+                    self.close()
+
+            return response
+
+        def send(
+            self,
+            data: (bytes | typing.IO[typing.Any] | typing.Iterable[bytes] | str),
+        ) -> None:
+            """We might be receiving a chunk constructed downstream"""
+            if self.sock is None or self._stream_id is None or self._protocol is None:
+                # this is unreachable in normal condition as urllib3
+                # is strict on his workflow.
+                raise RuntimeError(  # Defensive:
+                    "Trying to send data from a closed connection"
+                )
+
+            if (
+                self.__remaining_body_length is None
+                and self.__expected_body_length is not None
+            ):
+                self.__remaining_body_length = self.__expected_body_length
+
+            def unpack_chunk(possible_chunk: bytes) -> bytes:
+                """This hacky function is there because we won't alter the send() method signature.
+                Therefor cannot know intention prior to this. b"%x\r\n%b\r\n" % (len(chunk), chunk)
+                """
+                if (
+                    possible_chunk.endswith(b"\r\n")
+                    and possible_chunk.startswith(b"--") is False
+                ):
+                    _: list[bytes] = possible_chunk.split(b"\r\n", maxsplit=1)
+                    if len(_) != 2 or any(uc == b"" for uc in _):
+                        return possible_chunk
+                    return _[-1][:-2]
+                return possible_chunk
+
+            try:
+                if isinstance(
+                    data,
+                    (
+                        bytes,
+                        bytearray,
+                    ),
+                ):
+                    data_ = unpack_chunk(data)
+                    is_chunked = len(data_) != len(data)
+
+                    if self.__remaining_body_length:
+                        self.__remaining_body_length -= len(data_)
+
+                    self._protocol.submit_data(
+                        self._stream_id,
+                        data_,
+                        end_stream=(is_chunked and data_ == b"")
+                        or self.__remaining_body_length == 0,
+                    )
+                else:
+                    # urllib3 is supposed to handle every case
+                    # and pass down bytes only. This should be unreachable.
+                    raise OSError(  # Defensive:
+                        f"unhandled type '{type(data)}' in send method"
+                    )
+
+                if _HAS_SYS_AUDIT:
+                    sys.audit("http.client.send", self, data)
+
+                self.sock.sendall(self._protocol.bytes_to_send())
+            except self._protocol.exceptions() as e:
+                raise ProtocolError(  # Defensive: In the unlikely event that exception may leak from below
+                    e
+                ) from e
+
+        def close(self) -> None:
+            if self.sock:
+                if self._protocol is not None:
+                    try:
+                        self._protocol.submit_close()
+                    except self._protocol.exceptions() as e:  # Defensive:
+                        # overly protective, made in case of possible exception leak.
+                        raise ProtocolError(e) from e  # Defensive:
+
+                    goodbye_trame: bytes = self._protocol.bytes_to_send()
+
+                    if goodbye_trame:
+                        self.sock.sendall(goodbye_trame)
+
+                self.sock.close()
+
+            self._protocol = None
+            self._stream_id = None

--- a/src/urllib3/backend/httplib.py
+++ b/src/urllib3/backend/httplib.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import typing
+from http.client import HTTPConnection
+
+from ..util import connection
+from ._base import BaseBackend, HttpVersion, QuicPreemptiveCacheType
+
+
+class _PatchedHTTPConnection(HTTPConnection):
+    """Internal use only. Use to bypass limits from Python inheritance mechanism."""
+
+    def __init__(
+        self,
+        host: str,
+        port: int | None = None,
+        timeout: int = -1,
+        source_address: tuple[str, int] | None = None,
+        blocksize: int = 8192,
+        *,
+        socket_options: None
+        | (connection._TYPE_SOCKET_OPTIONS) = BaseBackend.default_socket_options,
+        disabled_svn: set[HttpVersion] | None = None,
+        preemptive_quic_cache: QuicPreemptiveCacheType | None = None,
+    ):
+        super().__init__(
+            host=host,
+            port=port,
+            timeout=timeout,
+            source_address=source_address,
+            blocksize=blocksize,
+        )
+
+        self.socket_kind = BaseBackend.default_socket_kind
+        self.socket_options = socket_options
+
+        self._tunnel_host: str | None = None
+        self._tunnel_port: int | None = None
+        self._tunnel_scheme: str | None = None
+        self._tunnel_headers: typing.Mapping[str, str] = dict()
+
+        # has no effect for httplib.
+        self._disabled_svn = disabled_svn or set()
+        self._preemptive_quic_cache = preemptive_quic_cache
+
+
+class LegacyBackend(_PatchedHTTPConnection, BaseBackend):  # type: ignore[misc]
+    """httplib (http.client) legacy backend. will remain the default until a future version."""
+
+    supported_svn = [HttpVersion.h11]
+
+    def _upgrade(self) -> None:
+        raise NotImplementedError
+
+    def _new_conn(self) -> None:
+        ...
+
+    def _post_conn(self) -> None:
+        ...

--- a/src/urllib3/response.py
+++ b/src/urllib3/response.py
@@ -788,7 +788,10 @@ class HTTPResponse(BaseHTTPResponse):
                     amt -= chunk_amt
                 else:
                     chunk_amt = max_chunk_amt
-                data = self._fp.read(chunk_amt)
+                try:
+                    data = self._fp.read(chunk_amt)
+                except ValueError:  # Defensive: overly protective
+                    break  # Defensive: can also be an indicator that read ended, should not happen.
                 if not data:
                     break
                 buffer.write(data)

--- a/src/urllib3/util/__init__.py
+++ b/src/urllib3/util/__init__.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from .connection import is_connection_dropped
 from .request import SKIP_HEADER, SKIPPABLE_HEADERS, make_headers
-from .response import is_fp_closed
+from .response import is_fp_closed, parse_alt_svc
 from .retry import Retry
 from .ssl_ import (
     ALPN_PROTOCOLS,
@@ -41,4 +41,5 @@ __all__ = (
     "wait_for_write",
     "SKIP_HEADER",
     "SKIPPABLE_HEADERS",
+    "parse_alt_svc",
 )

--- a/src/urllib3/util/connection.py
+++ b/src/urllib3/util/connection.py
@@ -29,6 +29,7 @@ def create_connection(
     timeout: _TYPE_TIMEOUT = _DEFAULT_TIMEOUT,
     source_address: tuple[str, int] | None = None,
     socket_options: _TYPE_SOCKET_OPTIONS | None = None,
+    socket_kind: socket.SocketKind = socket.SOCK_STREAM,
 ) -> socket.socket:
     """Connect to *address* and return the socket object.
 
@@ -57,7 +58,7 @@ def create_connection(
     except UnicodeError:
         raise LocationParseError(f"'{host}', label empty or too long") from None
 
-    for res in socket.getaddrinfo(host, port, family, socket.SOCK_STREAM):
+    for res in socket.getaddrinfo(host, port, family, socket_kind):
         af, socktype, proto, canonname, sa = res
         sock = None
         try:

--- a/src/urllib3/util/response.py
+++ b/src/urllib3/util/response.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import http.client as httplib
+import re
+import typing
 from email.errors import MultipartInvariantViolationDefect, StartBoundaryNotFoundDefect
 
 from ..exceptions import HeaderParsingError
@@ -99,3 +101,14 @@ def is_response_to_head(response: httplib.HTTPResponse) -> bool:
     # FIXME: Can we do this somehow without accessing private httplib _method?
     method_str = response._method  # type: str  # type: ignore[attr-defined]
     return method_str.upper() == "HEAD"
+
+
+def parse_alt_svc(value: str) -> typing.Iterable[tuple[str, str]]:
+    """Given an Alt-Svc value, extract from it the protocol-id and the alt-authority.
+    https://httpwg.org/specs/rfc7838.html#alt-svc"""
+    pattern = re.compile(
+        r"(h[0-9]{1,3}(?:[\-0-9]{0,5}))=(?:[\"\']?)([a-z0-9\-_:.]+)(?:[\"\']?)",
+        re.IGNORECASE,
+    )
+
+    yield from re.findall(pattern, value)

--- a/src/urllib3/util/ssl_.py
+++ b/src/urllib3/util/ssl_.py
@@ -369,6 +369,7 @@ def ssl_wrap_socket(
     key_password: str | None = ...,
     ca_cert_data: None | str | bytes = ...,
     tls_in_tls: Literal[False] = ...,
+    alpn_protocols: list[str] | None = ...,
 ) -> ssl.SSLSocket:
     ...
 
@@ -388,6 +389,7 @@ def ssl_wrap_socket(
     key_password: str | None = ...,
     ca_cert_data: None | str | bytes = ...,
     tls_in_tls: bool = ...,
+    alpn_protocols: list[str] | None = ...,
 ) -> ssl.SSLSocket | SSLTransportType:
     ...
 
@@ -406,6 +408,7 @@ def ssl_wrap_socket(
     key_password: str | None = None,
     ca_cert_data: None | str | bytes = None,
     tls_in_tls: bool = False,
+    alpn_protocols: list[str] | None = None,
 ) -> ssl.SSLSocket | SSLTransportType:
     """
     All arguments except for server_hostname, ssl_context, and ca_cert_dir have
@@ -429,6 +432,8 @@ def ssl_wrap_socket(
         passing as the cadata parameter to SSLContext.load_verify_locations()
     :param tls_in_tls:
         Use SSLTransport to wrap the existing socket.
+    :param alpn_protocols:
+        Manually specify other protocols to be announced during tls handshake.
     """
     context = ssl_context
     if context is None:
@@ -459,7 +464,7 @@ def ssl_wrap_socket(
             context.load_cert_chain(certfile, keyfile, key_password)
 
     try:
-        context.set_alpn_protocols(ALPN_PROTOCOLS)
+        context.set_alpn_protocols(alpn_protocols or ALPN_PROTOCOLS)
     except NotImplementedError:  # Defensive: in CI, we always have set_alpn_protocols
         pass
 

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -81,6 +81,11 @@ if os.environ.get("CI") or os.environ.get("GITHUB_ACTIONS") == "true":
 
 DUMMY_POOL = ConnectionPool("dummy")
 
+try:
+    _TRAEFIK_AVAILABLE = bool(socket.getaddrinfo("httpbin.local", 8888))
+except socket.gaierror:
+    _TRAEFIK_AVAILABLE = False
+
 
 def _can_resolve(host: str) -> bool:
     """Returns True if the system can resolve host to an address."""
@@ -154,6 +159,13 @@ def notZstd() -> typing.Callable[[_TestFuncT], _TestFuncT]:
     return pytest.mark.skipif(
         zstd is not None,
         reason="only run if a python-zstandard library is not installed",
+    )
+
+
+def requireTraefik() -> typing.Callable[[_TestFuncT], _TestFuncT]:
+    return pytest.mark.skipif(
+        _TRAEFIK_AVAILABLE is False,
+        reason="only run if the Traefik (golang) server is available",
     )
 
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -4,6 +4,7 @@ import asyncio
 import contextlib
 import socket
 import ssl
+import sys
 import typing
 from pathlib import Path
 
@@ -347,3 +348,17 @@ def requires_tlsv1_3(supported_tls_versions: typing.AbstractSet[str]) -> None:
         or "TLSv1.3" not in supported_tls_versions
     ):
         pytest.skip("Test requires TLSv1.3")
+
+
+@pytest.fixture(scope="function")
+def only_httplib() -> None:
+    """Disable this test while not using http.client backend"""
+    if "urllib3_ext_hface" in sys.modules:
+        pytest.skip("Test require httplib backend")
+
+
+@pytest.fixture(scope="function")
+def not_httplib() -> None:
+    """Disable this test while using http.client backend"""
+    if "urllib3_ext_hface" not in sys.modules:
+        pytest.skip("Test require hface backend")

--- a/test/test_connectionpool.py
+++ b/test/test_connectionpool.py
@@ -45,7 +45,7 @@ class HTTPUnixConnection(HTTPConnection):
         super().__init__("localhost")
         self.unix_socket = host
         self.timeout = timeout
-        self.sock = None
+        self.sock = None  # type: ignore[assignment]
 
 
 class HTTPUnixConnectionPool(HTTPConnectionPool):

--- a/test/with_dummyserver/test_chunked_transfer.py
+++ b/test/with_dummyserver/test_chunked_transfer.py
@@ -167,6 +167,7 @@ class TestChunkedTransfer(SocketDummyServerTestCase):
             te_headers = self._get_header_lines(b"transfer-encoding")
             assert len(te_headers) == 1
 
+    @pytest.mark.usefixtures("only_httplib")
     def test_preserve_transfer_encoding_header(self) -> None:
         self.start_chunked_handler()
         chunks = [b"foo", b"bar", b"", b"bazzzzzzzzzzzzzzzzzzzzzz"]
@@ -259,7 +260,7 @@ class TestChunkedTransfer(SocketDummyServerTestCase):
 
                 if i == 0:
                     # Bad HTTP version will trigger a connection close
-                    sock.sendall(b"HTTP/0.5 200 OK\r\n\r\n")
+                    sock.sendall(b"HTTP/9 200 OK\r\n\r\n")
                 else:
                     sock.sendall(b"HTTP/1.1 200 OK\r\n\r\n")
                 sock.close()

--- a/test/with_traefik/__init__.py
+++ b/test/with_traefik/__init__.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import threading
+import typing
+from os import environ, path
+
+from tornado import httpserver, ioloop, web
+
+from dummyserver.server import DEFAULT_CERTS, run_loop_in_thread, run_tornado_app
+from dummyserver.testcase import ProxyHandler  # type: ignore[attr-defined]
+
+from .. import requireTraefik
+
+
+@requireTraefik()
+class TraefikTestCase:
+    host: str = "httpbin.local"
+    alt_host: str = "alt.httpbin.local"
+
+    http_port: int = 8888
+    https_port: int = 4443
+
+    http_alt_port: int = 9999
+    https_alt_port: int = 8754
+
+    http_url: str = f"http://{host}:{http_port}"
+    https_url: str = f"https://{host}:{https_port}"
+
+    http_alt_url: str = f"http://{host}:{http_alt_port}"
+    https_alt_url: str = f"https://{host}:{https_alt_port}"
+
+    ca_mkcert: str | None = None
+
+    @classmethod
+    def setup_class(cls) -> None:
+        declared_ca_path: str | None = environ.get("MKCERT_CA_ROOT")
+
+        expected_ca_path = (
+            path.join(environ.get("HOME") or "/", ".local/share/mkcert/rootCA.pem")
+            if declared_ca_path is None
+            else declared_ca_path + "/rootCA.pem"
+        )
+
+        if path.exists(expected_ca_path):
+            cls.ca_mkcert = expected_ca_path
+        else:
+            raise OSError(
+                f"Did not found mkcert rootCA.pem, did you miss a step? '{expected_ca_path}'"
+            )
+
+
+@requireTraefik()
+class TraefikWithProxyTestCase(TraefikTestCase):
+    io_loop: typing.ClassVar[ioloop.IOLoop]
+
+    https_certs: typing.ClassVar[dict[str, typing.Any]] = DEFAULT_CERTS
+
+    proxy_host: typing.ClassVar[str] = "localhost"
+    proxy_host_alt: typing.ClassVar[str] = "127.0.0.1"
+    proxy_server: typing.ClassVar[httpserver.HTTPServer]
+    proxy_port: typing.ClassVar[int]
+    proxy_url: typing.ClassVar[str]
+
+    https_proxy_server: typing.ClassVar[httpserver.HTTPServer]
+    https_proxy_port: typing.ClassVar[int]
+    https_proxy_url: typing.ClassVar[str]
+
+    server_thread: typing.ClassVar[threading.Thread]
+    _stack: typing.ClassVar[contextlib.ExitStack]
+
+    @classmethod
+    def setup_class(cls) -> None:
+        super().setup_class()
+
+        with contextlib.ExitStack() as stack:
+            io_loop = stack.enter_context(run_loop_in_thread())
+
+            async def run_app() -> None:
+                app = web.Application([(r".*", ProxyHandler)])
+                cls.proxy_server, cls.proxy_port = run_tornado_app(
+                    app, None, "http", cls.proxy_host
+                )
+
+                upstream_ca_certs = cls.https_certs.get("ca_certs")
+
+                app = web.Application(
+                    [(r".*", ProxyHandler)], upstream_ca_certs=upstream_ca_certs
+                )
+                cls.https_proxy_server, cls.https_proxy_port = run_tornado_app(
+                    app, cls.https_certs, "https", cls.proxy_host
+                )
+
+            asyncio.run_coroutine_threadsafe(run_app(), io_loop.asyncio_loop).result()  # type: ignore[attr-defined]
+            cls._stack = stack.pop_all()
+
+    @classmethod
+    def teardown_class(cls) -> None:
+        cls._stack.close()

--- a/test/with_traefik/test_connection.py
+++ b/test/with_traefik/test_connection.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+from http.client import ResponseNotReady
+
+import pytest
+
+from urllib3 import HttpVersion
+from urllib3.connection import HTTPSConnection
+
+from . import TraefikTestCase
+
+
+class TestConnection(TraefikTestCase):
+    def test_h3_probe_after_close(self) -> None:
+        conn = HTTPSConnection(self.host, self.https_port, ca_certs=self.ca_mkcert)
+
+        conn.request("GET", "/get")
+
+        resp = conn.getresponse()
+
+        assert resp.version == 20
+
+        conn.close()
+
+        conn.connect()
+
+        conn.request("GET", "/get")
+
+        resp = conn.getresponse()
+
+        assert resp.version == 30
+
+        conn.close()
+
+    def test_h2_svn_conserved(self) -> None:
+        conn = HTTPSConnection(
+            self.host,
+            self.https_port,
+            ca_certs=self.ca_mkcert,
+            disabled_svn={HttpVersion.h3},
+        )
+
+        conn.request("GET", "/get")
+
+        resp = conn.getresponse()
+
+        assert resp.version == 20
+
+        conn.close()
+
+        assert hasattr(conn, "_http_vsn") and conn._http_vsn == 20
+
+        conn.connect()
+
+        conn.request("GET", "/get")
+
+        resp = conn.getresponse()
+
+        assert resp.version == 20
+
+    def test_getresponse_not_ready(self) -> None:
+        conn = HTTPSConnection(
+            self.host,
+            self.https_port,
+            ca_certs=self.ca_mkcert,
+        )
+
+        conn.close()
+
+        with pytest.raises(ResponseNotReady):
+            conn.getresponse()
+
+    def test_quic_cache_capable(self) -> None:
+        quic_cache_resumption: dict[tuple[str, int], tuple[str, int] | None] = {
+            (self.host, self.https_port): ("", self.https_port)
+        }
+
+        conn = HTTPSConnection(
+            self.host,
+            self.https_port,
+            ca_certs=self.ca_mkcert,
+            preemptive_quic_cache=quic_cache_resumption,
+        )
+
+        conn.request("GET", "/get")
+        resp = conn.getresponse()
+
+        assert resp.status == 200
+        assert resp.version == 30
+
+    def test_quic_cache_capable_but_disabled(self) -> None:
+        quic_cache_resumption: dict[tuple[str, int], tuple[str, int] | None] = {
+            (self.host, self.https_port): ("", self.https_port)
+        }
+
+        conn = HTTPSConnection(
+            self.host,
+            self.https_port,
+            ca_certs=self.ca_mkcert,
+            preemptive_quic_cache=quic_cache_resumption,
+            disabled_svn={HttpVersion.h3},
+        )
+
+        conn.request("GET", "/get")
+        resp = conn.getresponse()
+
+        assert resp.status == 200
+        assert resp.version == 20
+
+    def test_quic_cache_explicit_not_capable(self) -> None:
+        quic_cache_resumption: dict[tuple[str, int], tuple[str, int] | None] = {
+            (self.host, self.https_port): None
+        }
+
+        conn = HTTPSConnection(
+            self.host,
+            self.https_port,
+            ca_certs=self.ca_mkcert,
+            preemptive_quic_cache=quic_cache_resumption,
+        )
+
+        conn.request("GET", "/get")
+        resp = conn.getresponse()
+
+        assert resp.status == 200
+        assert resp.version == 20
+
+    def test_quic_cache_implicit_not_capable(self) -> None:
+        quic_cache_resumption: dict[tuple[str, int], tuple[str, int] | None] = dict()
+
+        conn = HTTPSConnection(
+            self.host,
+            self.https_port,
+            ca_certs=self.ca_mkcert,
+            preemptive_quic_cache=quic_cache_resumption,
+        )
+
+        conn.request("GET", "/get")
+        resp = conn.getresponse()
+
+        assert resp.status == 200
+        assert resp.version == 20
+
+        assert len(quic_cache_resumption.keys()) == 1
+        assert (self.host, self.https_port) in quic_cache_resumption

--- a/test/with_traefik/test_protolevel.py
+++ b/test/with_traefik/test_protolevel.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import pytest
+
+from urllib3 import HTTPHeaderDict, HTTPSConnectionPool, request
+from urllib3.exceptions import ProtocolError
+from urllib3.util.request import SKIP_HEADER
+
+from . import TraefikTestCase
+
+
+class TestProtocolLevel(TraefikTestCase):
+    def test_forbid_request_without_authority(self) -> None:
+        with pytest.raises(
+            ProtocolError,
+            match="do not support emitting HTTP requests without the `Host` header",
+        ):
+            request(
+                "GET",
+                f"{self.https_url}/get",
+                headers={"Host": SKIP_HEADER},
+                retries=False,
+            )
+
+    @pytest.mark.parametrize(
+        "headers",
+        [
+            [(f"x-urllib3-{p}", str(p)) for p in range(8)],
+            [(f"x-urllib3-{p}", str(p)) for p in range(8)]
+            + [(f"x-urllib3-{p}", str(p)) for p in range(16)],
+            [("x-www-not-standard", "hello!world!")],
+        ],
+    )
+    def test_headers(self, headers: list[tuple[str, str]]) -> None:
+        dict_headers = dict(headers)
+
+        with HTTPSConnectionPool(
+            self.host, self.https_port, ca_certs=self.ca_mkcert
+        ) as p:
+            resp = p.request(
+                "GET",
+                f"{self.https_url}/headers",
+                headers=dict_headers,
+                retries=False,
+            )
+
+            assert resp.status == 200
+
+            temoin = HTTPHeaderDict(dict_headers)
+            payload = resp.json()
+
+            seen = []
+
+            for key, value in payload["headers"].items():
+                if key in temoin:
+                    seen.append(key)
+                    assert temoin.get(key) in value
+
+            assert len(seen) == len(dict_headers.keys())

--- a/test/with_traefik/test_proxy.py
+++ b/test/with_traefik/test_proxy.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import pytest
+
+from dummyserver.server import DEFAULT_CA
+from urllib3 import HttpVersion, proxy_from_url
+
+from . import TraefikWithProxyTestCase
+
+
+class TestProxyToTraefik(TraefikWithProxyTestCase):
+    @classmethod
+    def setup_class(cls) -> None:
+        super().setup_class()
+
+        cls.proxy_url = f"http://{cls.proxy_host}:{int(cls.proxy_port)}"
+        cls.https_proxy_url = f"https://{cls.proxy_host}:{int(cls.https_proxy_port)}"
+
+        if not cls.ca_mkcert:
+            raise OSError("missing mkcert ca")
+
+        with open(cls.ca_mkcert, "rb") as fp:
+            mkcert_ca = fp.read()
+
+        with open(DEFAULT_CA, "rb") as fp:
+            trustme_ca = fp.read()
+
+        if mkcert_ca not in trustme_ca:
+            with open(DEFAULT_CA, "wb") as fp:
+                fp.write(trustme_ca)
+                fp.write(mkcert_ca)
+
+    @classmethod
+    def teardown_class(cls) -> None:
+        super().teardown_class()
+
+    @pytest.mark.parametrize(
+        "proxy_url, destination_host, expected_max_svn, disabled_svn",
+        [
+            (
+                "https_proxy_url",
+                "http_url",
+                HttpVersion.h11,
+                None,
+            ),
+            (
+                "https_proxy_url",
+                "https_url",
+                HttpVersion.h2,
+                None,
+            ),
+            (
+                "proxy_url",
+                "http_url",
+                HttpVersion.h11,
+                None,
+            ),
+            (
+                "proxy_url",
+                "https_url",
+                HttpVersion.h2,
+                None,
+            ),
+            (
+                "proxy_url",
+                "https_url",
+                HttpVersion.h11,
+                HttpVersion.h2,
+            ),
+            (
+                "https_proxy_url",
+                "https_url",
+                HttpVersion.h11,
+                HttpVersion.h2,
+            ),
+        ],
+    )
+    def test_simple_proxy_get(
+        self,
+        proxy_url: str,
+        destination_host: str,
+        expected_max_svn: HttpVersion,
+        disabled_svn: HttpVersion | None,
+    ) -> None:
+        with proxy_from_url(
+            getattr(self, proxy_url), ca_certs=DEFAULT_CA, disabled_svn={disabled_svn}
+        ) as http:
+            svn_history = []
+
+            for i in range(3):
+                resp = http.request(
+                    "GET", f"{getattr(self, destination_host)}/get", retries=False
+                )
+
+                assert resp.status == 200
+                svn_history.append(resp.version)
+
+            assert svn_history[-1] == int(
+                expected_max_svn.value.split("/")[-1].replace(".", "")
+            )

--- a/test/with_traefik/test_send_data.py
+++ b/test/with_traefik/test_send_data.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from base64 import b64decode
+from io import BytesIO
+
+import pytest
+
+from urllib3 import HTTPSConnectionPool
+
+from . import TraefikTestCase
+
+
+class TestPostBody(TraefikTestCase):
+    def test_overrule_unicode_content_length(self) -> None:
+        with HTTPSConnectionPool(
+            self.host, self.https_port, ca_certs=self.ca_mkcert
+        ) as p:
+            resp = p.request("POST", "/post", body="🚀", headers={"Content-Length": "1"})
+
+            assert resp.status == 200
+            assert "Content-Length" in resp.json()["headers"]
+            assert resp.json()["headers"]["Content-Length"][0] == "4"
+
+    @pytest.mark.parametrize(
+        "method",
+        [
+            "POST",
+            "PUT",
+            "PATCH",
+        ],
+    )
+    @pytest.mark.parametrize(
+        "body",
+        [
+            "This is a rocket 🚀!",
+            "This is a rocket 🚀!".encode(),
+            BytesIO(b"foo" * 100),
+            b"x" * 10,
+            BytesIO(b"x" * 64),
+            b"foo\r\n",  # meant to verify that function unpack_chunk() in method send() work in edge cases
+            BytesIO(b"foo\r\n"),
+        ],
+    )
+    def test_h2n3_data(self, method: str, body: bytes | str | BytesIO) -> None:
+        with HTTPSConnectionPool(
+            self.host, self.https_port, ca_certs=self.ca_mkcert
+        ) as p:
+            for i in range(3):
+                if isinstance(body, BytesIO):
+                    body.seek(0, 0)
+
+                resp = p.request(method, f"/{method.lower()}", body=body)
+
+                assert resp.status == 200
+                assert resp.version == (20 if i == 0 else 30)
+
+                print(resp.json()["data"])
+
+                payload_seen_by_server: bytes = b64decode(resp.json()["data"][37:])
+
+                if isinstance(body, str):
+                    assert payload_seen_by_server == body.encode(
+                        "utf-8"
+                    ), f"HTTP/{resp.version/10} POST body failure: str"
+                elif isinstance(body, bytes):
+                    assert (
+                        payload_seen_by_server == body
+                    ), f"HTTP/{resp.version/10} POST body failure: bytes"
+                else:
+                    body.seek(0, 0)
+                    assert (
+                        payload_seen_by_server == body.read()
+                    ), f"HTTP/{resp.version/10} POST body failure: BytesIO"
+
+    @pytest.mark.parametrize(
+        "method",
+        [
+            "POST",
+            "PUT",
+            "PATCH",
+        ],
+    )
+    @pytest.mark.parametrize(
+        "fields",
+        [
+            {"a": "c", "d": "f", "foo": "bar"},
+            {"bobaaz": "really confident"},
+            {"z": "", "o": "klm"},
+        ],
+    )
+    def test_h2n3_form_field(self, method: str, fields: dict[str, str]) -> None:
+        with HTTPSConnectionPool(
+            self.host, self.https_port, ca_certs=self.ca_mkcert
+        ) as p:
+            for i in range(2):
+                resp = p.request(method, f"/{method.lower()}", fields=fields)
+
+                assert resp.status == 200
+                assert resp.version == (20 if i == 0 else 30)
+
+                payload = resp.json()
+
+                for key in fields:
+                    assert key in payload["form"]
+                    assert fields[key] in payload["form"][key]

--- a/test/with_traefik/test_ssl.py
+++ b/test/with_traefik/test_ssl.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import pytest
+
+from urllib3 import HTTPSConnectionPool
+from urllib3.exceptions import SSLError
+
+from . import TraefikTestCase
+
+
+class TestSsl(TraefikTestCase):
+    def test_h3_no_ca_cert(self) -> None:
+        """This case need a bit of explanations. urllib3 default tls context load default (ca) certificates
+        whereas aioquic does not. This cause that strange situation where TCP/TLS works but UDP/TLS does not.
+        """
+
+        with HTTPSConnectionPool(self.host, self.https_port, retries=False) as p:
+            for i in range(2):
+                if i == 0:
+                    resp = p.request("GET", "/get")
+                    assert resp.version == 20
+
+                    continue
+
+                with pytest.raises(SSLError, match="TLS over QUIC did not succeed"):
+                    p.request("GET", "/get")

--- a/test/with_traefik/test_stream.py
+++ b/test/with_traefik/test_stream.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from json import JSONDecodeError, loads
+
+import pytest
+
+from urllib3 import HTTPSConnectionPool
+
+from . import TraefikTestCase
+
+
+class TestStreamResponse(TraefikTestCase):
+    @pytest.mark.parametrize(
+        "amt",
+        [
+            None,
+            1,
+            3,
+            5,
+            16,
+            64,
+            1024,
+            16544,
+        ],
+    )
+    def test_h2n3_stream(self, amt: int | None) -> None:
+        with HTTPSConnectionPool(
+            self.host, self.https_port, ca_certs=self.ca_mkcert
+        ) as p:
+            for i in range(3):
+                resp = p.request("GET", "/get", preload_content=False)
+
+                assert resp.status == 200
+                assert resp.version == (20 if i == 0 else 30)
+
+                chunks = []
+
+                for chunk in resp.stream(amt):
+                    chunks.append(chunk)
+
+                try:
+                    payload_reconstructed = loads(b"".join(chunks))
+                except JSONDecodeError as e:
+                    print(e)
+                    payload_reconstructed = None
+
+                assert (
+                    payload_reconstructed is not None
+                ), f"HTTP/{resp.version/10} stream failure"
+                assert (
+                    "args" in payload_reconstructed
+                ), f"HTTP/{resp.version/10} stream failure"
+
+    def test_read_zero(self) -> None:
+        with HTTPSConnectionPool(
+            self.host, self.https_port, ca_certs=self.ca_mkcert
+        ) as p:
+            resp = p.request("GET", "/get", preload_content=False)
+            assert resp.status == 200
+
+            assert resp.read(0) == b""
+
+            for i in range(5):
+                assert len(resp.read(1)) == 1
+
+            assert resp.read(0) == b""
+            assert len(resp.read()) > 0

--- a/test/with_traefik/test_svn.py
+++ b/test/with_traefik/test_svn.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+import pytest
+
+from urllib3 import HTTPConnectionPool, HTTPSConnectionPool, HttpVersion, PoolManager
+from urllib3.connection import HTTPSConnection
+
+from . import TraefikTestCase
+
+
+class TestSvnCapability(TraefikTestCase):
+    def test_h11_only(self) -> None:
+        with HTTPConnectionPool(self.host, self.http_port) as p:
+            resp = p.request("GET", "/get")
+            assert resp.version == 11
+
+    def test_h11_no_upgrade(self) -> None:
+        with HTTPConnectionPool(host="httpbin.local", port=8888) as p:
+            for i in range(3):
+                resp = p.request("GET", "/get")
+
+                assert resp.version == 11
+
+    def test_alpn_h2_default(self) -> None:
+        with HTTPSConnectionPool(
+            self.host, self.https_port, ca_certs=self.ca_mkcert
+        ) as p:
+            resp = p.request("GET", "/get")
+
+            assert resp.version == 20
+
+    def test_upgrade_h3(self) -> None:
+        with HTTPSConnectionPool(
+            self.host, self.https_port, timeout=1, retries=0, ca_certs=self.ca_mkcert
+        ) as p:
+            for i in range(3):
+                resp = p.request("GET", "/get")
+                assert resp.version == (20 if i == 0 else 30)
+
+    def test_explicitly_disable_h3(self) -> None:
+        with HTTPSConnectionPool(
+            self.host,
+            self.https_port,
+            timeout=1,
+            retries=0,
+            ca_certs=self.ca_mkcert,
+            disabled_svn={HttpVersion.h3},
+        ) as p:
+            for i in range(3):
+                resp = p.request("GET", "/get")
+                assert resp.version == 20
+
+    def test_explicitly_disable_h2(self) -> None:
+        with HTTPSConnectionPool(
+            self.host,
+            self.https_port,
+            timeout=1,
+            retries=0,
+            ca_certs=self.ca_mkcert,
+            disabled_svn={HttpVersion.h2},
+        ) as p:
+            for i in range(3):
+                resp = p.request("GET", "/get")
+                assert resp.version == (11 if i == 0 else 30)
+
+    def test_cannot_disable_h11(self) -> None:
+        with pytest.raises(RuntimeError):
+            p = HTTPSConnectionPool(
+                self.host,
+                self.https_port,
+                timeout=1,
+                retries=0,
+                ca_certs=self.ca_mkcert,
+                disabled_svn={HttpVersion.h11},
+            )
+
+            p.request("GET", "/get")
+
+    def test_cant_upgrade_h3(self) -> None:
+        with HTTPSConnectionPool(
+            self.host,
+            self.https_alt_port,
+            timeout=1,
+            retries=False,
+            ca_certs=self.ca_mkcert,
+        ) as p:
+            for i in range(3):
+                resp = p.request(
+                    "GET",
+                    "/response-headers?Alt-Svc=h3-25%3D%22%3A443%22%3B%20ma%3D3600%2C%20h2%3D%22%3A443%22%3B%20ma%3D3600",
+                )
+
+                assert resp.version == 20
+                assert "Alt-Svc" in resp.headers
+                assert (
+                    resp.headers.get("Alt-Svc")
+                    == 'h3-25=":443"; ma=3600, h2=":443"; ma=3600'
+                )
+
+    def test_illegal_upgrade_h3(self) -> None:
+        with HTTPSConnectionPool(
+            self.host,
+            self.https_alt_port,
+            timeout=1,
+            retries=False,
+            ca_certs=self.ca_mkcert,
+        ) as p:
+            for i in range(3):
+                resp = p.request(
+                    "GET",
+                    "/response-headers?Alt-Svc=h3-25%3D%22%3A443%22%3B%20ma%3D3600%2C%20h3%3D%22evil.httpbin.local%3A443%22%3B%20ma%3D3600",
+                )
+
+                assert resp.version == 20
+                assert "Alt-Svc" in resp.headers
+                assert (
+                    resp.headers.get("Alt-Svc")
+                    == 'h3-25=":443"; ma=3600, h3="evil.httpbin.local:443"; ma=3600'
+                )
+
+    def test_other_port_upgrade_h3(self) -> None:
+        with HTTPSConnectionPool(
+            self.host,
+            self.https_alt_port,
+            timeout=1,
+            retries=False,
+            ca_certs=self.ca_mkcert,
+        ) as p:
+            for i in range(3):
+                resp = p.request(
+                    "GET",
+                    f"/response-headers?Alt-Svc=h3-25%3D%22%3A443%22%3B%20ma%3D3600%2C%20h3%3D%22%3A{self.https_port}%22%3B%20ma%3D3600",
+                )
+
+                assert resp.version == (20 if i == 0 else 30)
+                assert "Alt-Svc" in resp.headers
+                assert (
+                    resp.headers.get("Alt-Svc")
+                    == f'h3-25=":443"; ma=3600, h3=":{self.https_port}"; ma=3600'
+                )
+
+    def test_drop_h3_upgrade(self) -> None:
+        conn = HTTPSConnection(self.host, self.https_port, ca_certs=self.ca_mkcert)
+
+        conn.request("GET", "/get")
+        resp = conn.getresponse()
+
+        assert resp.version == 20
+        assert resp.status == 200
+        conn.close()
+
+        conn.host = self.alt_host
+        conn.port = self.https_alt_port
+
+        conn.connect()
+        conn.request("GET", "/get")
+        resp = conn.getresponse()
+
+        assert resp.version == 20
+        assert resp.status == 200
+
+    def test_drop_post_established_h3(self) -> None:
+        conn = HTTPSConnection(self.host, self.https_port, ca_certs=self.ca_mkcert)
+
+        conn.request("GET", "/get")
+        resp = conn.getresponse()
+
+        assert resp.version == 20
+        assert resp.status == 200
+
+        conn.request("GET", "/get")
+        resp = conn.getresponse()
+
+        assert resp.version == 30
+        assert resp.status == 200
+
+        conn.close()
+
+        conn.host = self.alt_host
+        conn.port = self.https_alt_port
+
+        conn.connect()
+        conn.request("GET", "/get")
+        resp = conn.getresponse()
+
+        assert resp.version == 20
+        assert resp.status == 200
+
+    def test_pool_manager_quic_cache(self) -> None:
+        dumb_cache: dict[tuple[str, int], tuple[str, int] | None] = dict()
+        pm = PoolManager(ca_certs=self.ca_mkcert, preemptive_quic_cache=dumb_cache)
+
+        conn = pm.connection_from_url(self.https_url)
+
+        resp = conn.urlopen("GET", "/get")
+
+        assert resp.status == 200
+        assert resp.version == 20
+
+        assert len(dumb_cache.keys()) == 1
+
+        conn.close()
+
+        pm = PoolManager(ca_certs=self.ca_mkcert, preemptive_quic_cache=dumb_cache)
+        conn = pm.connection_from_url(self.https_url)
+
+        resp = conn.urlopen("GET", "/get")
+
+        assert resp.status == 200
+        assert resp.version == 30
+
+        assert len(dumb_cache.keys()) == 1


### PR DESCRIPTION
**Disclaimer:**
- ⚠️While usable, it is not sufficiently battle-tested. Use at your own risk as support is not provided. ⚠️ 

**Introduction**
This PR experiment the possibility for urllib3 to allow detaching ourselves from the `http.client` package.
The following add support to the final specification (RFCs) of HTTP/1.1, HTTP/2, and HTTP/3 over QUIC.

Are you curious about the results? Install that experimental patch by doing the following:

```
pip install git+https://github.com/Ousret/urllib3.git@experimental-h2n3 urllib3-ext-hface -U
```

**The how**
I felt it is time to try moving away from the `httplib` while remaining the default.

I know that `async` has a certain appeal and usefulness. But let's face it, sync libs are here to stay (numbers speak for themselves _github depends_, _stats google dataset_, etc..), so we might as well
implementing the newest protocol in the sync enclosure.

I saw the attraction around the `hface` library posted on the Akamai GH organization and saw an opportunity.
Immediately I decided to fork the project because:

- Make sure that having the _extra_ lib is recognized as the _user willing to use the experimental feature_
- There were a lot of server and network stuff that are not needed for our purpose.
- The project seems unmaintained.

So the project name is `urllib3-ext-hface` and is located at https://github.com/Ousret/urllib3-ext-hface (for now)

```mermaid
  graph TD;
      urllib3-->urllib3-ext-hface;
      urllib3-ext-hface-->h11;
      urllib3-ext-hface-->h2;
      urllib3-ext-hface-->aioquic;
      aioquic-->pylsqpack;
      aioquic-->pyopenssl;
      pyopenssl-->cryptography;
      aioquic-->certifi;
      cryptography-->cffi;
      cffi-->pycparser;
      h2-->hyperframe;
      h2-->hpack;
```

**Backward compatibility**

Initially seeing the current implementation that relies on `http.client` was scary. I decided to make the alternative implementation follow as closely as possible the HttpConnection behavior so that the rest of the library would remain stable.

**Protocol upgrade**

For the time being, this implementation act as follow:

- _Is HTTP_? Initiate an HTTP/1.1 connection only.
- _Is HTTPS_? Initiate an HTTP/2.0 if and only if ALPN/TLS ends on specifying `h2`, otherwise HTTP/1.1

**And for HTTP/3?**

- Must be on HTTPS connection, regardless of HTTP/1.1 or HTTP/2, and the last response (in cursor conn) must include the Alt-Svc headers.

⚠️Only the non-draft version is supported (final spec) of h3 over QUIC.

**Remaining tasks**

- [x] Tunnelling (Proxy) ~raising NotImplementedError~
- [x] Having a reliable parsing solution for Alt-Svc (in utils)
- [x] Extend the tests (add nox session+experimental)
- [x] Identify unit tests that should be skipped (e.g. not applicable to newer protocols)
- [x] Mypy errors
- [x] Unify the manual sock conn creation for DTLS and TLS
- [x] ~Migrate ciphers TLS to DTLS if supported~
- [x] ~Making aioquic optional?~ no need in that experiment
- [x] Ensure downstream test passes, e.g. requests.
- [x] Learn things around that experimentation
- [x] Massively test this continuously on real-world servers (and not only the best-behaved ones)
- [x] Support QUIC session resumption/ticket
- [x] Investigate, and monitor: Memory usage, and performance across state machines (h11, h2, and h3)

**Glimpses**

from _urllib3_

```python
from urllib3 import request
from time import time_ns

if __name__ == "__main__":

    for i in range(3):
        before_ns = time_ns()
        resp = request("GET", "https://www.cloudflare.com/img/nav/globe-lang-select-dark.svg", retries=1, timeout=1)
        print(round((time_ns() - before_ns) / 10e5), 'ms')

        print(
            'content-length:', resp.headers.get('content-length')
        )

        print(
            f"h{resp.version}"
        )

        print(
            type(resp.data), len(resp.data), f"{resp.status=} {resp.reason=}"
        )

        print("==================================================================")
```

```
93 ms
content-length: 1840
h2
<class 'bytes'> 1840 resp.status=200 resp.reason='OK'
==================================================================
82 ms
content-length: 1840
h3
<class 'bytes'> 1840 resp.status=200 resp.reason='OK'
==================================================================
29 ms
content-length: 1840
h3
<class 'bytes'> 1840 resp.status=200 resp.reason='OK'
==================================================================
```

