### PR TITLE
Added OpenGraph information to the documentation configuration

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,10 +40,10 @@ extensions = [
 
 # Open Graph metadata
 ogp_title = "urllib3 documentation"
-ogp_site_url = "https://urllib3.readthedocs.io/en/stable/"
+ogp_site_url = "https://urllib3.readthedocs.io"
 ogp_type = "website"
 ogp_image = "https://github.com/urllib3/urllib3/raw/main/docs/_static/banner_github.svg"
-ogp_description = "Python HTTP library with thread-safe connection pooling, file post support, user friendly, and more."
+ogp_description = "urllib3 is a user-friendly HTTP client library for Python."
 
 # Test code blocks only when explicitly specified
 doctest_test_doctest_blocks = ""

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -35,7 +35,15 @@ extensions = [
     "sphinx_copybutton",
     "sphinx.ext.doctest",
     "sphinx.ext.intersphinx",
+    "sphinxext.opengraph",
 ]
+
+# Open Graph metadata
+ogp_title = "urllib3 documentation"
+ogp_site_url = "https://urllib3.readthedocs.io/en/stable/"
+ogp_type = "website"
+ogp_image = "https://github.com/urllib3/urllib3/raw/main/docs/_static/banner_github.svg"
+ogp_description = "Python HTTP library with thread-safe connection pooling, file post support, user friendly, and more."
 
 # Test code blocks only when explicitly specified
 doctest_test_doctest_blocks = ""

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,3 +3,4 @@ sphinx>3.0.0
 requests
 furo
 sphinx-copybutton
+sphinxext-opengraph


### PR DESCRIPTION
Fix #1983 Added the OpenGraph information metadata to the documentation configuration so that it looks nice when shared on the platforms supporting The Open Graph protocol.
 
<!---
Thanks for your contribution! ♥️

If this is your first PR to urllib3 please review the Contributing Guide:
https://urllib3.readthedocs.io/en/latest/contributing.html

Adhering to the Contributing Guide means we can review, merge, and release your change faster! :)
--->
