### PR TITLE
Clarify docstring for Retry backoff factor

### DIFF
--- a/src/urllib3/util/retry.py
+++ b/src/urllib3/util/retry.py
@@ -143,7 +143,7 @@ class Retry:
         (most errors are resolved immediately by a second try without a
         delay). urllib3 will sleep for::
 
-            {backoff factor} * (2 ** ({number of total retries} - 1))
+            {backoff factor} * (2 ** ({number of previous retries}))
 
         seconds. If `backoff_jitter` is non-zero, this sleep is extended by::
 


### PR DESCRIPTION
### Proposed Changes

This PR makes two changes to the docs for Retry's `backoff_factor`:

1. Change "number of total retries" to "number of previous retries"
    - The current description ("number of total retries") could be misunderstood to refer to the `total` argument provided to a [Retry instance](https://urllib3.readthedocs.io/en/stable/reference/urllib3.util.html#urllib3.util.Retry)
2. Remove `- 1` from the end of the formula
    - As written, I don't think this formula is correct (at least it is prone to misunderstanding)... consider a backoff factor of 1:
        - Since the first retry occurs immediately, let's consider how many seconds the current formula predicts between the second and third retries:
            - The time between the first and second retries (where the number of total retries is 1) is predicted to be: `1 * (2 ** (1 - 1))` or 1 second
            - The time between the second and third retries (where the number of total retries is 2) is predicted to be: `1 * (2 ** (2 - 1))` or 2 seconds
        - In actuality, however, the time between the first and second retries is 2 seconds with 4 seconds between the second and third retries
        - The table below summarizes my findings

| Retry # | Number of total retries (one of the variables in the current formula) | Elapsed seconds predicted by current formula | Actual elapsed seconds |
|--------------|-----------|------------| ------------|
| 1 | 0 | n/a (occurs immediately) | n/a (occurs immediately) |
| 2 | 1 | 1 | 2 |
| 3 | 2 | 2 | 4 |
| 4 | 3 | 4 | 0 |

### Validating this Change

To validate that the updated formula is correct, run this in one process:

```python
python3 -m http.server
```

And this in another process:

```
from urllib3.util.retry import Retry
import requests
from requests.adapters import HTTPAdapter

session = requests.Session()
retry = Retry(
    total=3,
    backoff_factor=1,
    status_forcelist=[200],
)
adapter = HTTPAdapter(max_retries=retry)
session.mount('http://', adapter)
session.mount('https://', adapter)

session.get("http://localhost:8000")
```

This script will make requests to the webserver with a backoff factor of 1 and you can note the interval between each retry.

### Conclusion

All in all, I think making these two changes will clarify how the backoff factor works and how long it will wait between retries.

Please let me know if you have any questions or suggestions!