### PR TITLE
avoid dev dep on freezegun and python-dateutil

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,4 @@
 coverage==7.0.4
-freezegun==1.2.2
 tornado==6.2
 PySocks==1.7.1
 pytest==7.2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,8 +102,6 @@ filterwarnings = [
     # https://github.com/pytest-dev/pytest/issues/10977
     '''default:ast\.(Num|NameConstant|Str) is deprecated and will be removed in Python 3\.14; use ast\.Constant instead:DeprecationWarning:_pytest''',
     '''default:Attribute s is deprecated and will be removed in Python 3\.14; use value instead:DeprecationWarning:_pytest''',
-    # https://github.com/dateutil/dateutil/issues/1284
-    '''default:datetime\.utcfromtimestamp\(\) is deprecated and scheduled for removal in a future version\.*:DeprecationWarning:dateutil''',
 ]
 
 [tool.isort]

--- a/test/test_retry.py
+++ b/test/test_retry.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from test import DUMMY_POOL
 from unittest import mock
 
-import freezegun  # type: ignore[import]
 import pytest
 
 from urllib3.exceptions import (
@@ -400,7 +399,7 @@ class TestRetry:
     ) -> None:
         retry = Retry(respect_retry_after_header=respect_retry_after_header)
 
-        with freezegun.freeze_time("2019-06-03 11:00:00", tz_offset=0), mock.patch(
+        with mock.patch("time.time", return_value=1559559600.0), mock.patch(
             "time.sleep"
         ) as sleep_mock:
             # for the default behavior, it must be in RETRY_AFTER_STATUS_CODES

--- a/test/test_retry.py
+++ b/test/test_retry.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import datetime
 from test import DUMMY_POOL
 from unittest import mock
 
@@ -399,9 +400,9 @@ class TestRetry:
     ) -> None:
         retry = Retry(respect_retry_after_header=respect_retry_after_header)
 
-        with mock.patch("time.time", return_value=1559559600.0), mock.patch(
-            "time.sleep"
-        ) as sleep_mock:
+        with mock.patch(
+            "time.time", return_value=datetime.datetime(2019, 6, 3, 11, 0).timestamp()
+        ), mock.patch("time.sleep") as sleep_mock:
             # for the default behavior, it must be in RETRY_AFTER_STATUS_CODES
             response = HTTPResponse(
                 status=503, headers={"Retry-After": retry_after_header}

--- a/test/test_retry.py
+++ b/test/test_retry.py
@@ -401,7 +401,10 @@ class TestRetry:
         retry = Retry(respect_retry_after_header=respect_retry_after_header)
 
         with mock.patch(
-            "time.time", return_value=datetime.datetime(2019, 6, 3, 11, 0).timestamp()
+            "time.time",
+            return_value=datetime.datetime(
+                2019, 6, 3, 11, tzinfo=datetime.timezone.utc
+            ).timestamp(),
         ), mock.patch("time.sleep") as sleep_mock:
             # for the default behavior, it must be in RETRY_AFTER_STATUS_CODES
             response = HTTPResponse(


### PR DESCRIPTION
freezegun depends on python-dateutil for date parsing, python-dateutil hasn't has a release since Jul 14, 2021, and it looks like it's simpler to patch time.time to test Retry instead