### PR TITLE
[1.26] Improve error message when calling urllib3.request()

### DIFF
--- a/src/urllib3/request.py
+++ b/src/urllib3/request.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 
 import sys
-import warnings
 
 from .filepost import encode_multipart_formdata
 from .packages import six
@@ -176,16 +175,18 @@ class RequestMethods(object):
 
 if not six.PY2:
 
-    class RequestModule(object):
+    class RequestModule(sys.modules[__name__].__class__):
         def __call__(self, *args, **kwargs):
             """
             If user tries to call this module directly urllib3 v2.x style raise an error to the user
+            suggesting they may need urllib3 v2
             """
-            warnings.warn(
-                "urllib3.requests() method is not supported in this release\n"
+            raise TypeError(
+                "TypeError: 'module' object is not callable\n"
+                "urllib3.requests() method is not supported in this release, "
                 "upgrade to urllib3 v2 to use it"
             )
 
         RequestMethods = RequestMethods
 
-    sys.modules[__name__] = RequestModule()
+    sys.modules[__name__].__class__ = RequestModule

--- a/src/urllib3/request.py
+++ b/src/urllib3/request.py
@@ -184,7 +184,8 @@ if not six.PY2:
             raise TypeError(
                 "'module' object is not callable\n"
                 "urllib3.request() method is not supported in this release, "
-                "upgrade to urllib3 v2 to use it"
+                "upgrade to urllib3 v2 to use it\n"
+                "see https://urllib3.readthedocs.io/en/stable/v2-migration-guide.html"
             )
 
     sys.modules[__name__].__class__ = RequestModule

--- a/src/urllib3/request.py
+++ b/src/urllib3/request.py
@@ -1,170 +1,187 @@
 from __future__ import absolute_import
 
+import sys
+import warnings
+
 from .filepost import encode_multipart_formdata
 from .packages.six.moves.urllib.parse import urlencode
 
-__all__ = ["RequestMethods"]
+__all__ = ["request"]
 
 
-class RequestMethods(object):
-    """
-    Convenience mixin for classes who implement a :meth:`urlopen` method, such
-    as :class:`urllib3.HTTPConnectionPool` and
-    :class:`urllib3.PoolManager`.
+class request(object):
+    # If user tries to call this module directly raise an error to the user
+    def __call__(self, *args, **kwargs):
 
-    Provides behavior for making common types of HTTP request methods and
-    decides which type of request field encoding to use.
-
-    Specifically,
-
-    :meth:`.request_encode_url` is for sending requests whose fields are
-    encoded in the URL (such as GET, HEAD, DELETE).
-
-    :meth:`.request_encode_body` is for sending requests whose fields are
-    encoded in the *body* of the request using multipart or www-form-urlencoded
-    (such as for POST, PUT, PATCH).
-
-    :meth:`.request` is for making any kind of request, it will look up the
-    appropriate encoding format and use one of the above two methods to make
-    the request.
-
-    Initializer parameters:
-
-    :param headers:
-        Headers to include with all requests, unless other headers are given
-        explicitly.
-    """
-
-    _encode_url_methods = {"DELETE", "GET", "HEAD", "OPTIONS"}
-
-    def __init__(self, headers=None):
-        self.headers = headers or {}
-
-    def urlopen(
-        self,
-        method,
-        url,
-        body=None,
-        headers=None,
-        encode_multipart=True,
-        multipart_boundary=None,
-        **kw
-    ):  # Abstract
-        raise NotImplementedError(
-            "Classes extending RequestMethods must implement "
-            "their own ``urlopen`` method."
+        warnings.warn(
+            "urllib3.requests() method is not supported in this release"
+            "upgrade to urllib3 v2 to use it "
         )
 
-    def request(self, method, url, fields=None, headers=None, **urlopen_kw):
+    class RequestMethods(object):
         """
-        Make a request using :meth:`urlopen` with the appropriate encoding of
-        ``fields`` based on the ``method`` used.
+        Convenience mixin for classes who implement a :meth:`urlopen` method, such
+        as :class:`urllib3.HTTPConnectionPool` and
+        :class:`urllib3.PoolManager`.
 
-        This is a convenience method that requires the least amount of manual
-        effort. It can be used in most situations, while still having the
-        option to drop down to more specific methods when necessary, such as
-        :meth:`request_encode_url`, :meth:`request_encode_body`,
-        or even the lowest level :meth:`urlopen`.
+        Provides behavior for making common types of HTTP request methods and
+        decides which type of request field encoding to use.
+
+        Specifically,
+
+        :meth:`.request_encode_url` is for sending requests whose fields are
+        encoded in the URL (such as GET, HEAD, DELETE).
+
+        :meth:`.request_encode_body` is for sending requests whose fields are
+        encoded in the *body* of the request using multipart or www-form-urlencoded
+        (such as for POST, PUT, PATCH).
+
+        :meth:`.request` is for making any kind of request, it will look up the
+        appropriate encoding format and use one of the above two methods to make
+        the request.
+
+        Initializer parameters:
+
+        :param headers:
+            Headers to include with all requests, unless other headers are given
+            explicitly.
         """
-        method = method.upper()
 
-        urlopen_kw["request_url"] = url
+        _encode_url_methods = {"DELETE", "GET", "HEAD", "OPTIONS"}
 
-        if method in self._encode_url_methods:
-            return self.request_encode_url(
-                method, url, fields=fields, headers=headers, **urlopen_kw
+        def __init__(self, headers=None):
+            self.headers = headers or {}
+
+        def urlopen(
+            self,
+            method,
+            url,
+            body=None,
+            headers=None,
+            encode_multipart=True,
+            multipart_boundary=None,
+            **kw
+        ):  # Abstract
+            raise NotImplementedError(
+                "Classes extending RequestMethods must implement "
+                "their own ``urlopen`` method."
             )
-        else:
-            return self.request_encode_body(
-                method, url, fields=fields, headers=headers, **urlopen_kw
-            )
 
-    def request_encode_url(self, method, url, fields=None, headers=None, **urlopen_kw):
-        """
-        Make a request using :meth:`urlopen` with the ``fields`` encoded in
-        the url. This is useful for request methods like GET, HEAD, DELETE, etc.
-        """
-        if headers is None:
-            headers = self.headers
+        def request(self, method, url, fields=None, headers=None, **urlopen_kw):
+            """
+            Make a request using :meth:`urlopen` with the appropriate encoding of
+            ``fields`` based on the ``method`` used.
 
-        extra_kw = {"headers": headers}
-        extra_kw.update(urlopen_kw)
+            This is a convenience method that requires the least amount of manual
+            effort. It can be used in most situations, while still having the
+            option to drop down to more specific methods when necessary, such as
+            :meth:`request_encode_url`, :meth:`request_encode_body`,
+            or even the lowest level :meth:`urlopen`.
+            """
+            method = method.upper()
 
-        if fields:
-            url += "?" + urlencode(fields)
+            urlopen_kw["request_url"] = url
 
-        return self.urlopen(method, url, **extra_kw)
-
-    def request_encode_body(
-        self,
-        method,
-        url,
-        fields=None,
-        headers=None,
-        encode_multipart=True,
-        multipart_boundary=None,
-        **urlopen_kw
-    ):
-        """
-        Make a request using :meth:`urlopen` with the ``fields`` encoded in
-        the body. This is useful for request methods like POST, PUT, PATCH, etc.
-
-        When ``encode_multipart=True`` (default), then
-        :func:`urllib3.encode_multipart_formdata` is used to encode
-        the payload with the appropriate content type. Otherwise
-        :func:`urllib.parse.urlencode` is used with the
-        'application/x-www-form-urlencoded' content type.
-
-        Multipart encoding must be used when posting files, and it's reasonably
-        safe to use it in other times too. However, it may break request
-        signing, such as with OAuth.
-
-        Supports an optional ``fields`` parameter of key/value strings AND
-        key/filetuple. A filetuple is a (filename, data, MIME type) tuple where
-        the MIME type is optional. For example::
-
-            fields = {
-                'foo': 'bar',
-                'fakefile': ('foofile.txt', 'contents of foofile'),
-                'realfile': ('barfile.txt', open('realfile').read()),
-                'typedfile': ('bazfile.bin', open('bazfile').read(),
-                              'image/jpeg'),
-                'nonamefile': 'contents of nonamefile field',
-            }
-
-        When uploading a file, providing a filename (the first parameter of the
-        tuple) is optional but recommended to best mimic behavior of browsers.
-
-        Note that if ``headers`` are supplied, the 'Content-Type' header will
-        be overwritten because it depends on the dynamic random boundary string
-        which is used to compose the body of the request. The random boundary
-        string can be explicitly set with the ``multipart_boundary`` parameter.
-        """
-        if headers is None:
-            headers = self.headers
-
-        extra_kw = {"headers": {}}
-
-        if fields:
-            if "body" in urlopen_kw:
-                raise TypeError(
-                    "request got values for both 'fields' and 'body', can only specify one."
-                )
-
-            if encode_multipart:
-                body, content_type = encode_multipart_formdata(
-                    fields, boundary=multipart_boundary
+            if method in self._encode_url_methods:
+                return self.request_encode_url(
+                    method, url, fields=fields, headers=headers, **urlopen_kw
                 )
             else:
-                body, content_type = (
-                    urlencode(fields),
-                    "application/x-www-form-urlencoded",
+                return self.request_encode_body(
+                    method, url, fields=fields, headers=headers, **urlopen_kw
                 )
 
-            extra_kw["body"] = body
-            extra_kw["headers"] = {"Content-Type": content_type}
+        def request_encode_url(
+            self, method, url, fields=None, headers=None, **urlopen_kw
+        ):
+            """
+            Make a request using :meth:`urlopen` with the ``fields`` encoded in
+            the url. This is useful for request methods like GET, HEAD, DELETE, etc.
+            """
+            if headers is None:
+                headers = self.headers
 
-        extra_kw["headers"].update(headers)
-        extra_kw.update(urlopen_kw)
+            extra_kw = {"headers": headers}
+            extra_kw.update(urlopen_kw)
 
-        return self.urlopen(method, url, **extra_kw)
+            if fields:
+                url += "?" + urlencode(fields)
+
+            return self.urlopen(method, url, **extra_kw)
+
+        def request_encode_body(
+            self,
+            method,
+            url,
+            fields=None,
+            headers=None,
+            encode_multipart=True,
+            multipart_boundary=None,
+            **urlopen_kw
+        ):
+            """
+            Make a request using :meth:`urlopen` with the ``fields`` encoded in
+            the body. This is useful for request methods like POST, PUT, PATCH, etc.
+
+            When ``encode_multipart=True`` (default), then
+            :func:`urllib3.encode_multipart_formdata` is used to encode
+            the payload with the appropriate content type. Otherwise
+            :func:`urllib.parse.urlencode` is used with the
+            'application/x-www-form-urlencoded' content type.
+
+            Multipart encoding must be used when posting files, and it's reasonably
+            safe to use it in other times too. However, it may break request
+            signing, such as with OAuth.
+
+            Supports an optional ``fields`` parameter of key/value strings AND
+            key/filetuple. A filetuple is a (filename, data, MIME type) tuple where
+            the MIME type is optional. For example::
+
+                fields = {
+                    'foo': 'bar',
+                    'fakefile': ('foofile.txt', 'contents of foofile'),
+                    'realfile': ('barfile.txt', open('realfile').read()),
+                    'typedfile': ('bazfile.bin', open('bazfile').read(),
+                                'image/jpeg'),
+                    'nonamefile': 'contents of nonamefile field',
+                }
+
+            When uploading a file, providing a filename (the first parameter of the
+            tuple) is optional but recommended to best mimic behavior of browsers.
+
+            Note that if ``headers`` are supplied, the 'Content-Type' header will
+            be overwritten because it depends on the dynamic random boundary string
+            which is used to compose the body of the request. The random boundary
+            string can be explicitly set with the ``multipart_boundary`` parameter.
+            """
+            if headers is None:
+                headers = self.headers
+
+            extra_kw = {"headers": {}}
+
+            if fields:
+                if "body" in urlopen_kw:
+                    raise TypeError(
+                        "request got values for both 'fields' and 'body', can only specify one."
+                    )
+
+                if encode_multipart:
+                    body, content_type = encode_multipart_formdata(
+                        fields, boundary=multipart_boundary
+                    )
+                else:
+                    body, content_type = (
+                        urlencode(fields),
+                        "application/x-www-form-urlencoded",
+                    )
+
+                extra_kw["body"] = body
+                extra_kw["headers"] = {"Content-Type": content_type}
+
+            extra_kw["headers"].update(headers)
+            extra_kw.update(urlopen_kw)
+
+            return self.urlopen(method, url, **extra_kw)
+
+
+sys.modules[__name__] = request()

--- a/src/urllib3/request.py
+++ b/src/urllib3/request.py
@@ -131,7 +131,7 @@ class RequestMethods(object):
                 'fakefile': ('foofile.txt', 'contents of foofile'),
                 'realfile': ('barfile.txt', open('realfile').read()),
                 'typedfile': ('bazfile.bin', open('bazfile').read(),
-                            'image/jpeg'),
+                              'image/jpeg'),
                 'nonamefile': 'contents of nonamefile field',
             }
 
@@ -182,11 +182,9 @@ if not six.PY2:
             suggesting they may need urllib3 v2
             """
             raise TypeError(
-                "TypeError: 'module' object is not callable\n"
-                "urllib3.requests() method is not supported in this release, "
+                "'module' object is not callable\n"
+                "urllib3.request() method is not supported in this release, "
                 "upgrade to urllib3 v2 to use it"
             )
-
-        RequestMethods = RequestMethods
 
     sys.modules[__name__].__class__ = RequestModule

--- a/src/urllib3/request.py
+++ b/src/urllib3/request.py
@@ -6,182 +6,187 @@ import warnings
 from .filepost import encode_multipart_formdata
 from .packages.six.moves.urllib.parse import urlencode
 
+from .packages import six
+
 __all__ = ["request"]
 
 
-class request(object):
-    # If user tries to call this module directly raise an error to the user
-    def __call__(self, *args, **kwargs):
+class RequestMethods(object):
+    """
+    Convenience mixin for classes who implement a :meth:`urlopen` method, such
+    as :class:`urllib3.HTTPConnectionPool` and
+    :class:`urllib3.PoolManager`.
 
-        warnings.warn(
-            "urllib3.requests() method is not supported in this release"
-            "upgrade to urllib3 v2 to use it "
+    Provides behavior for making common types of HTTP request methods and
+    decides which type of request field encoding to use.
+
+    Specifically,
+
+    :meth:`.request_encode_url` is for sending requests whose fields are
+    encoded in the URL (such as GET, HEAD, DELETE).
+
+    :meth:`.request_encode_body` is for sending requests whose fields are
+    encoded in the *body* of the request using multipart or www-form-urlencoded
+    (such as for POST, PUT, PATCH).
+
+    :meth:`.request` is for making any kind of request, it will look up the
+    appropriate encoding format and use one of the above two methods to make
+    the request.
+
+    Initializer parameters:
+
+    :param headers:
+        Headers to include with all requests, unless other headers are given
+        explicitly.
+    """
+
+    _encode_url_methods = {"DELETE", "GET", "HEAD", "OPTIONS"}
+
+    def __init__(self, headers=None):
+        self.headers = headers or {}
+
+    def urlopen(
+        self,
+        method,
+        url,
+        body=None,
+        headers=None,
+        encode_multipart=True,
+        multipart_boundary=None,
+        **kw
+    ):  # Abstract
+        raise NotImplementedError(
+            "Classes extending RequestMethods must implement "
+            "their own ``urlopen`` method."
         )
 
-    class RequestMethods(object):
+    def request(self, method, url, fields=None, headers=None, **urlopen_kw):
         """
-        Convenience mixin for classes who implement a :meth:`urlopen` method, such
-        as :class:`urllib3.HTTPConnectionPool` and
-        :class:`urllib3.PoolManager`.
+        Make a request using :meth:`urlopen` with the appropriate encoding of
+        ``fields`` based on the ``method`` used.
 
-        Provides behavior for making common types of HTTP request methods and
-        decides which type of request field encoding to use.
-
-        Specifically,
-
-        :meth:`.request_encode_url` is for sending requests whose fields are
-        encoded in the URL (such as GET, HEAD, DELETE).
-
-        :meth:`.request_encode_body` is for sending requests whose fields are
-        encoded in the *body* of the request using multipart or www-form-urlencoded
-        (such as for POST, PUT, PATCH).
-
-        :meth:`.request` is for making any kind of request, it will look up the
-        appropriate encoding format and use one of the above two methods to make
-        the request.
-
-        Initializer parameters:
-
-        :param headers:
-            Headers to include with all requests, unless other headers are given
-            explicitly.
+        This is a convenience method that requires the least amount of manual
+        effort. It can be used in most situations, while still having the
+        option to drop down to more specific methods when necessary, such as
+        :meth:`request_encode_url`, :meth:`request_encode_body`,
+        or even the lowest level :meth:`urlopen`.
         """
+        method = method.upper()
 
-        _encode_url_methods = {"DELETE", "GET", "HEAD", "OPTIONS"}
+        urlopen_kw["request_url"] = url
 
-        def __init__(self, headers=None):
-            self.headers = headers or {}
-
-        def urlopen(
-            self,
-            method,
-            url,
-            body=None,
-            headers=None,
-            encode_multipart=True,
-            multipart_boundary=None,
-            **kw
-        ):  # Abstract
-            raise NotImplementedError(
-                "Classes extending RequestMethods must implement "
-                "their own ``urlopen`` method."
+        if method in self._encode_url_methods:
+            return self.request_encode_url(
+                method, url, fields=fields, headers=headers, **urlopen_kw
+            )
+        else:
+            return self.request_encode_body(
+                method, url, fields=fields, headers=headers, **urlopen_kw
             )
 
-        def request(self, method, url, fields=None, headers=None, **urlopen_kw):
-            """
-            Make a request using :meth:`urlopen` with the appropriate encoding of
-            ``fields`` based on the ``method`` used.
+    def request_encode_url(self, method, url, fields=None, headers=None, **urlopen_kw):
+        """
+        Make a request using :meth:`urlopen` with the ``fields`` encoded in
+        the url. This is useful for request methods like GET, HEAD, DELETE, etc.
+        """
+        if headers is None:
+            headers = self.headers
 
-            This is a convenience method that requires the least amount of manual
-            effort. It can be used in most situations, while still having the
-            option to drop down to more specific methods when necessary, such as
-            :meth:`request_encode_url`, :meth:`request_encode_body`,
-            or even the lowest level :meth:`urlopen`.
-            """
-            method = method.upper()
+        extra_kw = {"headers": headers}
+        extra_kw.update(urlopen_kw)
 
-            urlopen_kw["request_url"] = url
+        if fields:
+            url += "?" + urlencode(fields)
 
-            if method in self._encode_url_methods:
-                return self.request_encode_url(
-                    method, url, fields=fields, headers=headers, **urlopen_kw
+        return self.urlopen(method, url, **extra_kw)
+
+    def request_encode_body(
+        self,
+        method,
+        url,
+        fields=None,
+        headers=None,
+        encode_multipart=True,
+        multipart_boundary=None,
+        **urlopen_kw
+    ):
+        """
+        Make a request using :meth:`urlopen` with the ``fields`` encoded in
+        the body. This is useful for request methods like POST, PUT, PATCH, etc.
+
+        When ``encode_multipart=True`` (default), then
+        :func:`urllib3.encode_multipart_formdata` is used to encode
+        the payload with the appropriate content type. Otherwise
+        :func:`urllib.parse.urlencode` is used with the
+        'application/x-www-form-urlencoded' content type.
+
+        Multipart encoding must be used when posting files, and it's reasonably
+        safe to use it in other times too. However, it may break request
+        signing, such as with OAuth.
+
+        Supports an optional ``fields`` parameter of key/value strings AND
+        key/filetuple. A filetuple is a (filename, data, MIME type) tuple where
+        the MIME type is optional. For example::
+
+            fields = {
+                'foo': 'bar',
+                'fakefile': ('foofile.txt', 'contents of foofile'),
+                'realfile': ('barfile.txt', open('realfile').read()),
+                'typedfile': ('bazfile.bin', open('bazfile').read(),
+                            'image/jpeg'),
+                'nonamefile': 'contents of nonamefile field',
+            }
+
+        When uploading a file, providing a filename (the first parameter of the
+        tuple) is optional but recommended to best mimic behavior of browsers.
+
+        Note that if ``headers`` are supplied, the 'Content-Type' header will
+        be overwritten because it depends on the dynamic random boundary string
+        which is used to compose the body of the request. The random boundary
+        string can be explicitly set with the ``multipart_boundary`` parameter.
+        """
+        if headers is None:
+            headers = self.headers
+
+        extra_kw = {"headers": {}}
+
+        if fields:
+            if "body" in urlopen_kw:
+                raise TypeError(
+                    "request got values for both 'fields' and 'body', can only specify one."
+                )
+
+            if encode_multipart:
+                body, content_type = encode_multipart_formdata(
+                    fields, boundary=multipart_boundary
                 )
             else:
-                return self.request_encode_body(
-                    method, url, fields=fields, headers=headers, **urlopen_kw
+                body, content_type = (
+                    urlencode(fields),
+                    "application/x-www-form-urlencoded",
                 )
 
-        def request_encode_url(
-            self, method, url, fields=None, headers=None, **urlopen_kw
-        ):
+            extra_kw["body"] = body
+            extra_kw["headers"] = {"Content-Type": content_type}
+
+        extra_kw["headers"].update(headers)
+        extra_kw.update(urlopen_kw)
+
+        return self.urlopen(method, url, **extra_kw)
+
+
+if six.PY3:
+
+    class RequestModule(object):
+        def __call__(self, *args, **kwargs):
             """
-            Make a request using :meth:`urlopen` with the ``fields`` encoded in
-            the url. This is useful for request methods like GET, HEAD, DELETE, etc.
+            If user tries to call this module directly urllib3 v2.x style raise an error to the user
             """
-            if headers is None:
-                headers = self.headers
+            warnings.warn(
+                "urllib3.requests() method is not supported in this release\n"
+                "upgrade to urllib3 v2 to use it"
+            )
 
-            extra_kw = {"headers": headers}
-            extra_kw.update(urlopen_kw)
+        RequestMethods = RequestMethods
 
-            if fields:
-                url += "?" + urlencode(fields)
-
-            return self.urlopen(method, url, **extra_kw)
-
-        def request_encode_body(
-            self,
-            method,
-            url,
-            fields=None,
-            headers=None,
-            encode_multipart=True,
-            multipart_boundary=None,
-            **urlopen_kw
-        ):
-            """
-            Make a request using :meth:`urlopen` with the ``fields`` encoded in
-            the body. This is useful for request methods like POST, PUT, PATCH, etc.
-
-            When ``encode_multipart=True`` (default), then
-            :func:`urllib3.encode_multipart_formdata` is used to encode
-            the payload with the appropriate content type. Otherwise
-            :func:`urllib.parse.urlencode` is used with the
-            'application/x-www-form-urlencoded' content type.
-
-            Multipart encoding must be used when posting files, and it's reasonably
-            safe to use it in other times too. However, it may break request
-            signing, such as with OAuth.
-
-            Supports an optional ``fields`` parameter of key/value strings AND
-            key/filetuple. A filetuple is a (filename, data, MIME type) tuple where
-            the MIME type is optional. For example::
-
-                fields = {
-                    'foo': 'bar',
-                    'fakefile': ('foofile.txt', 'contents of foofile'),
-                    'realfile': ('barfile.txt', open('realfile').read()),
-                    'typedfile': ('bazfile.bin', open('bazfile').read(),
-                                'image/jpeg'),
-                    'nonamefile': 'contents of nonamefile field',
-                }
-
-            When uploading a file, providing a filename (the first parameter of the
-            tuple) is optional but recommended to best mimic behavior of browsers.
-
-            Note that if ``headers`` are supplied, the 'Content-Type' header will
-            be overwritten because it depends on the dynamic random boundary string
-            which is used to compose the body of the request. The random boundary
-            string can be explicitly set with the ``multipart_boundary`` parameter.
-            """
-            if headers is None:
-                headers = self.headers
-
-            extra_kw = {"headers": {}}
-
-            if fields:
-                if "body" in urlopen_kw:
-                    raise TypeError(
-                        "request got values for both 'fields' and 'body', can only specify one."
-                    )
-
-                if encode_multipart:
-                    body, content_type = encode_multipart_formdata(
-                        fields, boundary=multipart_boundary
-                    )
-                else:
-                    body, content_type = (
-                        urlencode(fields),
-                        "application/x-www-form-urlencoded",
-                    )
-
-                extra_kw["body"] = body
-                extra_kw["headers"] = {"Content-Type": content_type}
-
-            extra_kw["headers"].update(headers)
-            extra_kw.update(urlopen_kw)
-
-            return self.urlopen(method, url, **extra_kw)
-
-
-sys.modules[__name__] = request()
+    sys.modules[__name__] = RequestModule()

--- a/src/urllib3/request.py
+++ b/src/urllib3/request.py
@@ -4,11 +4,10 @@ import sys
 import warnings
 
 from .filepost import encode_multipart_formdata
+from .packages import six
 from .packages.six.moves.urllib.parse import urlencode
 
-from .packages import six
-
-__all__ = ["request"]
+__all__ = ["RequestMethods"]
 
 
 class RequestMethods(object):
@@ -175,7 +174,7 @@ class RequestMethods(object):
         return self.urlopen(method, url, **extra_kw)
 
 
-if six.PY3:
+if not six.PY2:
 
     class RequestModule(object):
         def __call__(self, *args, **kwargs):

--- a/test/test_request.py
+++ b/test/test_request.py
@@ -3,7 +3,11 @@ import six
 
 import urllib3
 
-@pytest.mark.skipif(six.PY2, reason="This behaviour isn't added when running urllib3 in Python 2",)
+
+@pytest.mark.skipif(
+    six.PY2,
+    reason="This behaviour isn't added when running urllib3 in Python 2",
+)
 class TestRequestImport(object):
     def test_request_import_warning(self):
         """Ensure an appropriate error is raised to the user

--- a/test/test_request.py
+++ b/test/test_request.py
@@ -1,0 +1,11 @@
+import pytest
+
+import urllib3
+
+
+class TestRequestImport(object):
+    def test_request_import_warning(self):
+        """Ensure an appropriate error is raised to the user
+        if they try and import urllib3.request directly"""
+        with pytest.warns(UserWarning):
+            urllib3.request(1, a=2)

--- a/test/test_request.py
+++ b/test/test_request.py
@@ -9,8 +9,13 @@ import urllib3
     reason="This behaviour isn't added when running urllib3 in Python 2",
 )
 class TestRequestImport(object):
-    def test_request_import_warning(self):
+    def test_request_import_error(self):
         """Ensure an appropriate error is raised to the user
         if they try and run urllib3.request()"""
-        with pytest.warns(UserWarning):
+        with pytest.raises(TypeError) as exc_info:
             urllib3.request(1, a=2)
+        assert "urllib3 v2" in exc_info.value.args[0]
+
+    def test_request_method_import(self):
+        """Ensure that * method imports are not broken by this change"""
+        from urllib3.request import urlencode  # noqa: F401

--- a/test/test_request.py
+++ b/test/test_request.py
@@ -1,11 +1,12 @@
 import pytest
+import six
 
 import urllib3
 
-
+@pytest.mark.skipif(six.PY2, reason="This behaviour isn't added when running urllib3 in Python 2",)
 class TestRequestImport(object):
     def test_request_import_warning(self):
         """Ensure an appropriate error is raised to the user
-        if they try and import urllib3.request directly"""
+        if they try and run urllib3.request()"""
         with pytest.warns(UserWarning):
             urllib3.request(1, a=2)

--- a/test/test_request.py
+++ b/test/test_request.py
@@ -1,3 +1,5 @@
+import types
+
 import pytest
 import six
 
@@ -16,6 +18,9 @@ class TestRequestImport(object):
             urllib3.request(1, a=2)
         assert "urllib3 v2" in exc_info.value.args[0]
 
-    def test_request_method_import(self):
-        """Ensure that * method imports are not broken by this change"""
-        from urllib3.request import urlencode  # noqa: F401
+    def test_request_module_properties(self):
+        """Ensure properties of the overridden request module
+        are still present"""
+        assert isinstance(urllib3.request, types.ModuleType)
+        expected_attrs = {"RequestMethods", "encode_multipart_formdata", "urlencode"}
+        assert set(dir(urllib3.request)).issuperset(expected_attrs)

--- a/test/test_request.py
+++ b/test/test_request.py
@@ -1,9 +1,9 @@
 import types
 
 import pytest
-import six
 
 import urllib3
+from urllib3.packages import six
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
My attempt at closing #3046 . Sharing in-case someone recognises the issue.

I created `class request` to wrap `RequestMethods` and used the suggested method of overriding the module with an instance of the `request` class.

Added a unit test to ensure that a warning is raised for the user when trying to call `urllib3.request()`.

This is working in everything but Python 2.7. I'm having a nightmare trying to fix some sort of class namespace issue. Namespaces and imports appear to work differently in Python 2.7, so any imports are inaccessible from inside the class. `warning`, `urlencode` and `encode_multipart_formdata` are failing because these imports aren't visible, we're just getting `NoneType` for them.

```
________________ TestRequestImport.test_request_import_warning _________________
Traceback (most recent call last):
  File "/Users/runner/work/urllib3/urllib3/test/test_request.py", line 11, in test_request_import_warning
    urllib3.request(1, a=2)
  File "/Users/runner/work/urllib3/urllib3/.nox/test-2-7/lib/python2.7/site-packages/_pytest/recwarn.py", line 227, in __exit__
    if all(a is None for a in exc_info):
  File "/Users/runner/work/urllib3/urllib3/.nox/test-2-7/lib/python2.7/site-packages/_pytest/recwarn.py", line 227, in <genexpr>
    if all(a is None for a in exc_info):
TypeError: expected string or Unicode object, NoneType found
```
