### PR TITLE
Encode string bodies to Latin-1 isntead of UTF-8

### DIFF
--- a/src/urllib3/util/request.py
+++ b/src/urllib3/util/request.py
@@ -213,7 +213,7 @@ def body_to_chunks(
 
     # Bytes or strings become bytes
     elif isinstance(body, (str, bytes)):
-        chunks = (to_bytes(body),)
+        chunks = (to_bytes(body, "latin-1"),)
         content_length = len(chunks[0])
 
     # File-like object, TODO: use seek() and tell() for length?

--- a/src/urllib3/util/request.py
+++ b/src/urllib3/util/request.py
@@ -227,7 +227,7 @@ def body_to_chunks(
                 if not datablock:
                     break
                 if encode:
-                    datablock = datablock.encode("iso-8859-1")
+                    datablock = datablock.encode("latin-1")
                 yield datablock
 
         chunks = chunk_readable()

--- a/test/with_dummyserver/test_connectionpool.py
+++ b/test/with_dummyserver/test_connectionpool.py
@@ -1089,7 +1089,7 @@ class TestConnectionPool(HTTPDummyServerTestCase):
             assert request_headers["User-Agent"] == "test header"
 
     @pytest.mark.parametrize(
-        "user_agent", ["Schönefeld/1.18.0", "Schönefeld/1.18.0".encode("iso-8859-1")]
+        "user_agent", ["Schönefeld/1.18.0", "Schönefeld/1.18.0".encode("latin-1")]
     )
     def test_user_agent_non_ascii_user_agent(self, user_agent: str) -> None:
         with HTTPConnectionPool(self.host, self.port, retries=False) as pool:


### PR DESCRIPTION
Relates #3053 by fixing the immediate regression. We may introduce warnings in the future to help users not rely on this behavior. The changes are split in 3 commits (but squashing is fine if we merge this):

1. I've changed the default encoding of simple bodies from UTF-8 to Latin-1, and made the code more explicit and tested
2. Even though the formal name of the encoding is ISO-8859-1, we used `latin-1` in enough places that I preferred to be consistent and updated the remaining occurrences of `iso-8859-1` to `latin-1`.
3. Chunked encoding already used Latin-1, but I've changed the test to ensure it stays that way in the future.
