### PR TITLE
Fix Open Graph metadata in docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -72,6 +72,9 @@ exclude_patterns = ["_build"]
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = "friendly"
 
+# The base URL with a proper language and version.
+html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "/")
+
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 html_theme = "furo"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -41,7 +41,7 @@ extensions = [
 # Open Graph metadata
 ogp_title = "urllib3 documentation"
 ogp_type = "website"
-ogp_image = "https://github.com/urllib3/urllib3/raw/main/docs/_static/banner_github.svg"
+ogp_social_cards = {"image": "images/logo.png", "line_color": "#F09837"}
 ogp_description = "urllib3 is a user-friendly HTTP client library for Python."
 
 # Test code blocks only when explicitly specified

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,7 +40,6 @@ extensions = [
 
 # Open Graph metadata
 ogp_title = "urllib3 documentation"
-ogp_site_url = "https://urllib3.readthedocs.io"
 ogp_type = "website"
 ogp_image = "https://github.com/urllib3/urllib3/raw/main/docs/_static/banner_github.svg"
 ogp_description = "urllib3 is a user-friendly HTTP client library for Python."


### PR DESCRIPTION
#3034 introduced the metadata but `og:url` was not matching real versioned ones.
This PR deletes the `ogp_site_url` config as it is not needed on RtD (thanks @hugovk for [the tip](https://github.com/urllib3/urllib3/pull/3034#issuecomment-1579937636).)

Also, the SVG image is not supported for `og:image`, I am replacing it with social cards.