### PR TITLE
Fix JSON example in user guide

### DIFF
--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -319,28 +319,27 @@ dictionary in the ``fields`` argument provided to
 JSON
 ~~~~
 
-You can send a JSON request by specifying the data as ``json`` argument,
-urllib3 automatically encodes data using ``json`` module with ``UTF-8`` 
-encoding. Also by default ``"Content-Type"`` in headers is set to 
-``"application/json"`` if not specified when calling
-:meth:`~urllib3.PoolManager.request`:
+To send JSON in the body of a request, provide the data in the ``json`` argument to 
+:meth:`~urllib3.PoolManager.request` and  urllib3 will automatically encode the data
+using the ``json`` module with ``UTF-8`` encoding. 
+In addition, when ``json`` is provided, the ``"Content-Type"`` in headers is set to 
+``"application/json"`` if not specified otherwise.
 
 .. code-block:: python
 
     import urllib3
 
-    data = {"attribute": "value"}
-
     resp = urllib3.request(
         "POST",
         "https://httpbin.org/post",
-        body=data,
+        json={"attribute": "value"},
         headers={"Content-Type": "application/json"}
     )
 
     print(resp.json())
-    # {"attribute": "value"}
-
+    # {'headers': {'Content-Type': 'application/json', ...}, 
+    #  'data': '{"attribute":"value"}', 'json': {'attribute': 'value'}, ...}
+    
 Files & Binary Data
 ~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
The current example in the docs does not work, since it uses 'body' not 'json'. After a close reading, I tried using 'json' instead, and it worked :)
My PR rewords the text, fixes the example, and provides a fuller example of the output (though still compressed slightly).
