### PR TITLE
Adding checks for proxy_ssl_context definition

### DIFF
--- a/changelog/2577.bugfix.rst
+++ b/changelog/2577.bugfix.rst
@@ -1,0 +1,2 @@
+`proxy_ssl_context` is now used to connect to HTTPS proxies when 
+using `use_forwarding_with_https = True`.

--- a/src/urllib3/poolmanager.py
+++ b/src/urllib3/poolmanager.py
@@ -562,6 +562,18 @@ class ProxyManager(PoolManager):
         if proxy.scheme not in ("http", "https"):
             raise ProxySchemeUnknown(proxy.scheme)
 
+        if use_forwarding_for_https and "ssl_context" in connection_pool_kw:
+            if proxy_ssl_context:
+                raise ValueError(
+                    "ssl_context and proxy_ssl_context are both defined, "
+                    "only proxy_ssl_context should be used when use_forwarding_for_https = True"
+                )
+            else:
+                raise ValueError(
+                    "proxy_ssl_context should be used, not ssl_context "
+                    "when use_forwarding_for_https = True"
+                )
+
         if not proxy.port:
             port = port_by_scheme.get(proxy.scheme, 80)
             proxy = proxy._replace(port=port)


### PR DESCRIPTION
Starting a fix for #2577 

Added just the checking logic for `proxy_ssl_context` and `ssl_context` being defined.