### PR TITLE
Added BaseHTTPResponse to __all__

### DIFF
--- a/changelog/3078.feature.rst
+++ b/changelog/3078.feature.rst
@@ -1,1 +1,1 @@
-Added ``BaseHTTPResponse`` to ``__all__``
+Added ``BaseHTTPResponse`` to ``__all__`` in ``__init__.py``

--- a/changelog/3078.feature.rst
+++ b/changelog/3078.feature.rst
@@ -1,0 +1,1 @@
+Added ``BaseHTTPResponse`` to ``__all__``

--- a/src/urllib3/__init__.py
+++ b/src/urllib3/__init__.py
@@ -81,6 +81,7 @@ __all__ = (
     "make_headers",
     "proxy_from_url",
     "request",
+    "BaseHTTPResponse"
 )
 
 logging.getLogger(__name__).addHandler(NullHandler())

--- a/src/urllib3/__init__.py
+++ b/src/urllib3/__init__.py
@@ -81,7 +81,7 @@ __all__ = (
     "make_headers",
     "proxy_from_url",
     "request",
-    "BaseHTTPResponse"
+    "BaseHTTPResponse",
 )
 
 logging.getLogger(__name__).addHandler(NullHandler())


### PR DESCRIPTION
Added `BaseHTTPResponse` to `__all__` for type hinting purposes.

Signed off by: Eutropios

<!---
Thanks for your contribution! ♥️

If this is your first PR to urllib3 please review the Contributing Guide:
https://urllib3.readthedocs.io/en/latest/contributing.html

Adhering to the Contributing Guide means we can review, merge, and release your change faster! :)
--->

Closes https://github.com/urllib3/urllib3/issues/3078