### PR TITLE
Bump gh-action-pypi-publish to v1.8.8

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -82,4 +82,4 @@ jobs:
         gh release upload ${{ github.ref_name }} dist/* --repo ${{ github.repository }}
 
     - name: "Publish dists to PyPI"
-      uses: "pypa/gh-action-pypi-publish@a56da0b891b3dc519c7ee3284aff1fad93cc8598"
+      uses: "pypa/gh-action-pypi-publish@f8c70e705ffc13c3b4d1221169b84f12a75d6ca8" # v1.8.8


### PR DESCRIPTION
It upgrades urllib3 from 1.26.13 to 2.0.3 and includes https://github.com/pypa/gh-action-pypi-publish/pull/167. We don't need the nudge ourselves, but it's nice to encourage using newer versions as I suspect I won't be the only one to copy/paste the urllib3 configuration. :)

By the way, Dependabot supports adding a version number next to commit SHAs and will even update it automatically! https://github.blog/changelog/2022-10-31-dependabot-now-updates-comments-in-github-actions-workflows-referencing-action-versions/