### PR TITLE
Enable testing on PyPy3.9 and PyPy3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,14 @@ jobs:
             os: ubuntu-latest
             experimental: false
             nox-session: test-pypy
+          - python-version: "pypy-3.9"
+            os: ubuntu-latest
+            experimental: false
+            nox-session: test-pypy
+          - python-version: "pypy-3.10"
+            os: ubuntu-latest
+            experimental: false
+            nox-session: test-pypy
           - python-version: "3.x"
             os: ubuntu-latest
             experimental: false


### PR DESCRIPTION
Add `pypy-3.9` and `pypy-3.10` to GitHub Actions testing matrix.