### PR TITLE
Debug logs for _new_conn has wrong type format

### DIFF
--- a/changelog/3097.bugfix.rst
+++ b/changelog/3097.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed bug in _new_conn where String Formatting was calling string instead of digit for port.

--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -242,10 +242,10 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         """
         self.num_connections += 1
         log.debug(
-            "Starting new HTTP connection (%d): %s:%s",
+            "Starting new HTTP connection (%d): %s:%d",
             self.num_connections,
             self.host,
-            self.port or "80",
+            self.port or 80,
         )
 
         conn = self.ConnectionCls(


### PR DESCRIPTION
Fixed bug in _new_conn where String Formatting was calling string instead of digit for port.

