### PR TITLE
Bump towncrier version

### DIFF
--- a/changelog/3099.misc.rst
+++ b/changelog/3099.misc.rst
@@ -1,0 +1,1 @@
+Remove before merging, this just makes sure the new version works.

--- a/changelog/3099.misc.rst
+++ b/changelog/3099.misc.rst
@@ -1,1 +1,0 @@
-Remove before merging, this just makes sure the new version works.

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -9,5 +9,5 @@ trustme==0.9.0
 cryptography==39.0.2;implementation_name=="pypy" and implementation_version<"7.3.10"
 cryptography==41.0.3;implementation_name!="pypy" or implementation_version>="7.3.10"
 backports.zoneinfo==0.2.1;python_version<"3.9"
-towncrier==21.9.0
+towncrier==23.6.0
 pytest-memray==1.4.0;python_version>="3.8" and python_version<"3.12" and sys_platform!="win32" and implementation_name=="cpython"


### PR DESCRIPTION
Closes #3099

Our current version is two years old at this point, and there's no way to link to the old docs anymore. The simplest fix is thus to bump the version. I'm not sure if I should use a permalink for the docs or not.