### PR TITLE
Keep GitHub Action versions as comments

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: "Checkout repository"
-        uses: "actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744"
+        uses: "actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744" # v3.6.0
         with:
           # `towncrier check` runs `git diff --name-only origin/main...`, which
           # needs a non-shallow clone.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - name: "Checkout repository"
-        uses: "actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744"
+        uses: "actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744" # v3.6.0
 
       - name: "Setup Python"
-        uses: "actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1"
+        uses: "actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1" # v4.7.0
         with:
           python-version: "3.x"
           cache: "pip"
@@ -87,10 +87,10 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: "Checkout repository"
-        uses: "actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744"
+        uses: "actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744" # v3.6.0
 
       - name: "Setup Python ${{ matrix.python-version }}"
-        uses: "actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1"
+        uses: "actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1" # v4.7.0
         with:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
@@ -106,7 +106,7 @@ jobs:
           NOX_SESSION: ${{ matrix.nox-session }}
 
       - name: "Upload artifact"
-        uses: "actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce"
+        uses: "actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce" # v3.1.2
         with:
           name: coverage-data
           path: ".coverage.*"
@@ -119,10 +119,10 @@ jobs:
     needs: test
     steps:
       - name: "Checkout repository"
-        uses: "actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744"
+        uses: "actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744" # v3.6.0
 
       - name: "Setup Python"
-        uses: "actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1"
+        uses: "actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1" # v4.7.0
         with:
           python-version: "3.x"
 
@@ -130,7 +130,7 @@ jobs:
         run: "python -m pip install --upgrade coverage"
 
       - name: "Download artifact"
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+        uses: "actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a" # v3.0.2
         with:
           name: coverage-data
 
@@ -142,7 +142,7 @@ jobs:
 
       - if: ${{ failure() }}
         name: "Upload report if check failed"
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce
+        uses: "actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce" # v3.1.2
         with:
           name: coverage-report
           path: htmlcov

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,16 +20,16 @@ jobs:
       security-events: write
     steps:
     - name: "Checkout repository"
-      uses: "actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744"
+      uses: "actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744" # v3.6.0
 
     - name: "Run CodeQL init"
-      uses: "github/codeql-action/init@cdcdbb579706841c47f7063dda365e292e5cad7a"
+      uses: "github/codeql-action/init@cdcdbb579706841c47f7063dda365e292e5cad7a" # v2.13.4
       with:
         config-file: "./.github/codeql.yml"
         languages: "python"
 
     - name: "Run CodeQL autobuild"
-      uses: "github/codeql-action/autobuild@cdcdbb579706841c47f7063dda365e292e5cad7a"
+      uses: "github/codeql-action/autobuild@cdcdbb579706841c47f7063dda365e292e5cad7a" # v2.13.4
 
     - name: "Run CodeQL analyze"
-      uses: "github/codeql-action/analyze@cdcdbb579706841c47f7063dda365e292e5cad7a"
+      uses: "github/codeql-action/analyze@cdcdbb579706841c47f7063dda365e292e5cad7a" # v2.13.4

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - name: "Checkout repository"
-        uses: "actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744"
+        uses: "actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744" # v3.6.0
 
       - name: "Setup Python"
-        uses: "actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1"
+        uses: "actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1" # v4.7.0
         with:
           python-version: "3.x"
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,16 +11,16 @@ jobs:
 
     steps:
       - name: "Checkout repository"
-        uses: "actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744"
+        uses: "actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744" # v3.6.0
 
       - name: "Setup Python"
-        uses: "actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1"
+        uses: "actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1" # v4.7.0
         with:
           python-version: "3.x"
           cache: pip
 
       - name: "Run pre-commit"
-        uses: pre-commit/action@646c83fcd040023954eafda54b4db0192ce70507
+        uses: "pre-commit/action@646c83fcd040023954eafda54b4db0192ce70507" # v3.0.0
 
       - name: "Install dependencies"
         run: python -m pip install nox

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
       - name: "Checkout repository"
-        uses: "actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744"
+        uses: "actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744" # v3.6.0
 
       - name: "Setup Python"
-        uses: "actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1"
+        uses: "actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1" # v4.7.0
         with:
           python-version: "3.x"
 
@@ -40,7 +40,7 @@ jobs:
           cd dist && echo "::set-output name=hashes::$(sha256sum * | base64 -w0)"
 
       - name: "Upload dists"
-        uses: "actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce"
+        uses: "actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce" # v3.1.2
         with:
           name: "dist"
           path: "dist/"
@@ -70,7 +70,7 @@ jobs:
 
     steps:
     - name: "Download dists"
-      uses: "actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a"
+      uses: "actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a" # v3.0.2
       with:
         name: "dist"
         path: "dist/"

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -17,15 +17,15 @@ jobs:
       id-token: write
       contents: read
       actions: read
-    
+
     steps:
       - name: "Checkout repository"
-        uses: "actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744"
+        uses: "actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744" # v3.6.0
         with:
           persist-credentials: false
 
       - name: "Run Scorecard"
-        uses: "ossf/scorecard-action@08b4669551908b1024bb425080c797723083c031"
+        uses: "ossf/scorecard-action@08b4669551908b1024bb425080c797723083c031" # v2.2.0
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
Dependabot will keep the comments, which will make updates to SHAs easier to reason about for mere humans.

See https://github.blog/changelog/2022-10-31-dependabot-now-updates-comments-in-github-actions-workflows-referencing-action-versions/ for more details. The idea is to merge this before #3116 in order to test it.