### PR TITLE
Fix a name of an attribute in docs

### DIFF
--- a/notes/connection-lifecycle.md
+++ b/notes/connection-lifecycle.md
@@ -54,7 +54,7 @@ After connecting to the origin, the connection can be checked to see if `is_veri
 ```python
 if not conn.is_verified:
     # There isn't a verified TLS connection to target origin.
-if not conn.is_proxy_verified:
+if not conn.proxy_is_verified:
     # There isn't a verified TLS connection to proxy origin.
 ```
 


### PR DESCRIPTION
Docs suggested using `conn.is_proxy_verified` to check whether TLS connection to a proxy origin is verified, but the actual attribute name is `proxy_is_verified`.