### PR TITLE
Typechecking fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,3 +116,6 @@ warn_redundant_casts = true
 warn_return_any = true
 warn_unused_configs = true
 warn_unused_ignores = true
+enable_error_code = [
+  "ignore-without-code",
+]

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -160,11 +160,6 @@ class HTTPConnection(_HTTPConnection):
         self._tunnel_port: int | None = None
         self._tunnel_scheme: str | None = None
 
-    # https://github.com/python/mypy/issues/4125
-    # Mypy treats this as LSP violation, which is considered a bug.
-    # If `host` is made a property it violates LSP, because a writeable attribute is overridden with a read-only one.
-    # However, there is also a `host` setter so LSP is not violated.
-    # Potentially, a `@host.deleter` might be needed depending on how this issue will be fixed.
     @property
     def host(self) -> str:
         """

--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -748,8 +748,8 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         # have to copy the headers dict so we can safely change it without those
         # changes being reflected in anyone else's copy.
         if not http_tunnel_required:
-            headers = headers.copy()  # type: ignore[attr-defined]
-            headers.update(self.proxy_headers)  # type: ignore[union-attr]
+            headers = HTTPHeaderDict(headers)
+            headers.update(self.proxy_headers)
 
         # Must keep the exception bound to a separate variable or else Python 3
         # complains about UnboundLocalError.

--- a/test/with_dummyserver/test_connectionpool.py
+++ b/test/with_dummyserver/test_connectionpool.py
@@ -231,7 +231,7 @@ class TestConnectionPool(HTTPDummyServerTestCase):
             "upload_filename": "lolcat.txt",
             "filefield": ("lolcat.txt", data),
         }
-        fields["upload_size"] = len(data)  # type: ignore
+        fields["upload_size"] = len(data)  # type: ignore[assignment]
 
         with HTTPConnectionPool(self.host, self.port) as pool:
             r = pool.request("POST", "/upload", fields=fields)
@@ -270,7 +270,7 @@ class TestConnectionPool(HTTPDummyServerTestCase):
             "upload_filename": filename,
             fieldname: (filename, data),
         }
-        fields["upload_size"] = size  # type: ignore
+        fields["upload_size"] = size  # type: ignore[assignment]
         with HTTPConnectionPool(self.host, self.port) as pool:
             r = pool.request("POST", "/upload", fields=fields)
             assert r.status == 200, r.data


### PR DESCRIPTION
a couple of typechecking fixes, derived by enabling mypy's `ignore-without-code` and paying attention to the places that it flagged

the first commit is the most interesting one: a supposedly immutable dictionary of headers was being updated.  This went in at #2250, so far as I can see without comment, I guess this is simply not intended?

the second commit ever so slighly rearranges some similar code in a way that satisfies the typechecker, and the third enables `ignore-without-code`.