### PR TITLE
[1.26] Fix `brotli` extra for Python 2.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,9 @@ setup(
     python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*",
     extras_require={
         "brotli": [
-            "brotli>=1.0.9; (os_name != 'nt' or python_version >= '3') and platform_python_implementation == 'CPython'",
+            # https://github.com/google/brotli/issues/1074
+            "brotli==1.0.9; os_name != 'nt' and python_version < '3' and platform_python_implementation == 'CPython'",
+            "brotli>=1.0.9; python_version >= '3' and platform_python_implementation == 'CPython'",
             "brotlicffi>=0.8.0; (os_name != 'nt' or python_version >= '3') and platform_python_implementation != 'CPython'",
             "brotlipy>=0.6.0; os_name == 'nt' and python_version < '3'",
         ],


### PR DESCRIPTION
The extra has been requiring `brotli>=1.0.9`. Brotli 1.1.0 dropped support for Python 2.7, but pip still installs it for 2.7.
https://github.com/google/brotli/issues/1074