### PR TITLE
[1.26] Fix running CPython 2.7 tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,14 +29,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["2.7", "3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
         os: [macos-11, windows-latest, ubuntu-latest]
         experimental: [false]
         nox-session: ['']
         exclude:
-          # GitHub Actions dropped support for Python 2.7 and 3.7 in Ubuntu 22.04
-          - python-version: "2.7"
-            os: ubuntu-latest
+          # actions/setup-python dropped support for 3.6 in Ubuntu 22.04
           - python-version: "3.6"
             os: ubuntu-latest
           # Python 3.7 does not fully support OpenSSL 3, the default on Ubuntu 22.04
@@ -45,7 +43,7 @@ jobs:
             os: ubuntu-latest
         include:
           - python-version: "2.7"
-            os: ubuntu-20.04
+            os: ubuntu-latest
             experimental: false
             nox-session: ''
           - python-version: "3.6"
@@ -89,9 +87,19 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set Up Python - ${{ matrix.python-version }}
+        if: matrix.python-version != '2.7'
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+
+      # Unfortunately, actions/setup-python does not support CPython 2.7.
+      - name: Set Up Python - 2.7
+        if: matrix.python-version == '2.7'
+        run: |
+          sudo apt update
+          sudo apt install python2.7-dev python-is-python3
+          curl https://bootstrap.pypa.io/pip/2.7/get-pip.py --output get-pip.py
+          sudo python2.7 get-pip.py
 
       - name: Set Up Python 3 to run nox
         if: matrix.python-version == '2.7' || matrix.python-version == 'pypy2.7'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
             os: ubuntu-latest
         include:
           - python-version: "2.7"
-            os: ubuntu-20.04
+            os: ubuntu-latest
             experimental: false
             nox-session: ''
           - python-version: "3.6"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
             os: ubuntu-latest
         include:
           - python-version: "2.7"
-            os: ubuntu-latest
+            os: ubuntu-20.04
             experimental: false
             nox-session: ''
           - python-version: "3.6"

--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -3,7 +3,7 @@
 
 if [[ "${NOX_SESSION}" == "app_engine" ]]; then
     export GAE_SDK_PATH=$HOME/.cache/google_appengine
-    python2 -m pip install gcp-devrel-py-tools==0.0.16
+    python2.7 -m pip install gcp-devrel-py-tools==0.0.16
     gcp-devrel-py-tools download-appengine-sdk "$(dirname ${GAE_SDK_PATH})"
 fi
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -55,7 +55,8 @@ def google_brotli(session):
     # https://pypi.org/project/Brotli/ is the Google version of brotli, so
     # install it separately and don't install our brotli extra (which installs
     # brotlipy).
-    session.install("brotli")
+    # https://github.com/google/brotli/issues/1074
+    session.install("brotli==1.0.9" if session.python == "2.7" else "brotli")
     tests_impl(session, extras="socks,secure")
 
 

--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,9 @@ setup(
     python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*",
     extras_require={
         "brotli": [
-            "brotli>=1.0.9; (os_name != 'nt' or python_version >= '3') and platform_python_implementation == 'CPython'",
+            # https://github.com/google/brotli/issues/1074
+            "brotli==1.0.9; os_name != 'nt' and python_version < '3' and platform_python_implementation == 'CPython'",
+            "brotli>=1.0.9; python_version >= '3' and platform_python_implementation == 'CPython'",
             "brotlicffi>=0.8.0; (os_name != 'nt' or python_version >= '3') and platform_python_implementation != 'CPython'",
             "brotlipy>=0.6.0; os_name == 'nt' and python_version < '3'",
         ],

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -437,7 +437,7 @@ class HTTPSConnection(HTTPConnection):
             and self.ssl_version is None
             and hasattr(self.sock, "version")
             and self.sock.version() in {"TLSv1", "TLSv1.1"}
-        ):
+        ):  # Defensive:
             warnings.warn(
                 "Negotiating TLSv1/TLSv1.1 by default is deprecated "
                 "and will be disabled in urllib3 v2.0.0. Connecting to "


### PR DESCRIPTION
Fixes #3077

actions/setup-python dropped support for CPython 2.7.
Since we still need to run tests using the version, CI starts to use Ubuntu's CPython 2.7 version.
Unfortunately, testing using CPython 2.7 on macOS and Windows is dropped by this PR.

This PR is based on #3136 to display the tests passing.