### PR TITLE
[1.26] Configure OS for RTD to fix building docs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,5 +1,10 @@
 version: 2
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3"
+
 python:
   install:
     - method: pip

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
 -r ../dev-requirements.txt
 sphinx>3.0.0
-requests>=2,<2.16
+requests>=2
 furo


### PR DESCRIPTION
RTD has been failing to build docs because the OS was not configured explicitly.

https://readthedocs.org/projects/urllib3/builds/22093531/