### PR TITLE
Remove requires_ssl_context_keyfile_password()

### DIFF
--- a/test/__init__.py
+++ b/test/__init__.py
@@ -217,15 +217,6 @@ def requires_network() -> typing.Callable[[_TestFuncT], _TestFuncT]:
     )
 
 
-def requires_ssl_context_keyfile_password() -> (
-    typing.Callable[[_TestFuncT], _TestFuncT]
-):
-    return pytest.mark.skipif(
-        lazy_condition(lambda: ssl_.IS_SECURETRANSPORT),
-        reason="Test requires password parameter for SSLContext.load_cert_chain()",
-    )
-
-
 def resolvesLocalhostFQDN() -> typing.Callable[[_TestFuncT], _TestFuncT]:
     """Test requires successful resolving of 'localhost.'"""
     return pytest.mark.skipif(

--- a/test/with_dummyserver/test_https.py
+++ b/test/with_dummyserver/test_https.py
@@ -14,7 +14,6 @@ from test import (
     TARPIT_HOST,
     notSecureTransport,
     requires_network,
-    requires_ssl_context_keyfile_password,
     resolvesLocalhostFQDN,
 )
 from test.conftest import ServerConfig
@@ -189,7 +188,6 @@ class TestHTTPS(HTTPSDummyServerTestCase):
             with pytest.raises((SSLError, ProtocolError)):
                 https_pool.request("GET", "/certificate", retries=False)
 
-    @requires_ssl_context_keyfile_password()
     def test_client_key_password(self) -> None:
         with HTTPSConnectionPool(
             self.host,
@@ -204,7 +202,6 @@ class TestHTTPS(HTTPSDummyServerTestCase):
             subject = r.json()
             assert subject["organizationalUnitName"].startswith("Testing cert")
 
-    @requires_ssl_context_keyfile_password()
     def test_client_encrypted_key_requires_password(self) -> None:
         with HTTPSConnectionPool(
             self.host,

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -23,7 +23,6 @@ from test import (
     SHORT_TIMEOUT,
     notSecureTransport,
     notWindows,
-    requires_ssl_context_keyfile_password,
     resolvesLocalhostFQDN,
 )
 from threading import Event
@@ -329,11 +328,9 @@ class TestClientCerts(SocketDummyServerTestCase):
                 done_receiving.set()
             done_receiving.set()
 
-    @requires_ssl_context_keyfile_password()
     def test_client_cert_with_string_password(self) -> None:
         self.run_client_cert_with_password_test("letmein")
 
-    @requires_ssl_context_keyfile_password()
     def test_client_cert_with_bytes_password(self) -> None:
         self.run_client_cert_with_password_test(b"letmein")
 
@@ -385,7 +382,6 @@ class TestClientCerts(SocketDummyServerTestCase):
 
             assert len(client_certs) == 1
 
-    @requires_ssl_context_keyfile_password()
     def test_load_keyfile_with_invalid_password(self) -> None:
         assert ssl_.SSLContext is not None
         context = ssl_.SSLContext(ssl_.PROTOCOL_SSLv23)


### PR DESCRIPTION
SSLContext.load_cert_chain() supports passwords since Python 3.3. Note that this test was only executed on macOS, as requires_ssl_context_keyfile_password was actually only requiring the presence of Secure Transport.