### PR TITLE
Add Python 3.12 macOS to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,16 +64,11 @@ jobs:
             os: ubuntu-20.04  # CPython 3.9.2 is not available for ubuntu-22.04.
             experimental: false
             nox-session: test-3.9
-          - python-version: "3.12"
-            experimental: true
         exclude:
           # Ubuntu 22.04 comes with OpenSSL 3.0, so only CPython 3.9+ is compatible with it
           # https://github.com/python/cpython/issues/83001
           - python-version: "3.8"
             os: ubuntu-22.04
-          # Testing with non-final CPython on macOS is too slow for CI.
-          - python-version: "3.12"
-            os: macos-11
 
     runs-on: ${{ matrix.os }}
     name: ${{ fromJson('{"macos-11":"macOS","windows-latest":"Windows","ubuntu-latest":"Ubuntu","ubuntu-20.04":"Ubuntu 20.04 (OpenSSL 1.1.1)","ubuntu-22.04":"Ubuntu 22.04 (OpenSSL 3.0)"}')[matrix.os] }} ${{ matrix.python-version }} ${{ matrix.nox-session}}


### PR DESCRIPTION
Just like Python 3.10 and Python 3.11, Python 3.12 is too slow on `test_requesting_large_resources_via_ssl`, but that does not feel like a reason to not include it.