### PR TITLE
[1.26] Use vendored six in urllib3.contrib.securetransport

### DIFF
--- a/src/urllib3/contrib/securetransport.py
+++ b/src/urllib3/contrib/securetransport.py
@@ -64,7 +64,7 @@ import struct
 import threading
 import weakref
 
-import six
+from ..packages import six
 
 from .. import util
 from ..util.ssl_ import PROTOCOL_TLS_CLIENT

--- a/src/urllib3/contrib/securetransport.py
+++ b/src/urllib3/contrib/securetransport.py
@@ -64,9 +64,8 @@ import struct
 import threading
 import weakref
 
-from ..packages import six
-
 from .. import util
+from ..packages import six
 from ..util.ssl_ import PROTOCOL_TLS_CLIENT
 from ._securetransport.bindings import CoreFoundation, Security, SecurityConst
 from ._securetransport.low_level import (


### PR DESCRIPTION
Otherwise, I get:

    ModuleNotFoundError: No module named 'six'

Note that this is otherwise untested.

<!---
Thanks for your contribution! ♥️

If this is your first PR to urllib3 please review the Contributing Guide:
https://urllib3.readthedocs.io/en/latest/contributing.html

Adhering to the Contributing Guide means we can review, merge, and release your change faster! :)
--->

I've seen this in Fedora when I wanted to smoke test importing all submodules.
This module is only for macOS, so I do not have a way to check anything further than that.
I realize the 1.26.x series is probably security-only, feel free to close this if you are not interested.
Also, feel free to amend this in any way you wish.