### PR TITLE
Tests: Use a mark for requires_network

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,9 @@ include = [
 [tool.pytest.ini_options]
 xfail_strict = true
 python_classes = ["Test", "*TestCase"]
-markers = ["limit_memory"]
+markers = [
+    "limit_memory: Limit memory with memray",
+]
 log_level = "DEBUG"
 filterwarnings = [
     "error",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,7 @@ xfail_strict = true
 python_classes = ["Test", "*TestCase"]
 markers = [
     "limit_memory: Limit memory with memray",
+    "requires_network: This test needs access to the Internet",
 ]
 log_level = "DEBUG"
 filterwarnings = [

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -181,14 +181,26 @@ def requires_network() -> typing.Callable[[_TestFuncT], _TestFuncT]:
             else:
                 raise
 
+    def _decorator_requires_internet(
+        decorator: typing.Callable[[_TestFuncT], _TestFuncT]
+    ) -> typing.Callable[[_TestFuncT], _TestFuncT]:
+        """Mark a decorator with the "requires_internet" mark"""
+
+        def wrapper(f: _TestFuncT) -> typing.Any:
+            return pytest.mark.requires_network(decorator(f))
+
+        return wrapper
+
     global _requires_network_has_route
 
     if _requires_network_has_route is None:
         _requires_network_has_route = _has_route()
 
-    return pytest.mark.skipif(
-        not _requires_network_has_route,
-        reason="Can't run the test because the network is unreachable",
+    return _decorator_requires_internet(
+        pytest.mark.skipif(
+            not _requires_network_has_route,
+            reason="Can't run the test because the network is unreachable",
+        )
     )
 
 


### PR DESCRIPTION
As an alternative to #3162, we can add a `requires_network` pytest mark, rather than relying on automatic network detection.

The use-case here is Debian package builds without Intenet access. We have environments where Internet access is available, and environments where it isn't. We'd like to be able to specify our expectation to the test-suite.