### PR TITLE
Fix lint on Python 3.12

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
       - id: isort
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 6.0.0
+    rev: 6.1.0
     hooks:
       - id: flake8
         additional_dependencies: [flake8-2020]

--- a/noxfile.py
+++ b/noxfile.py
@@ -131,7 +131,7 @@ def format(session: nox.Session) -> None:
     lint(session)
 
 
-@nox.session
+@nox.session(python="3.12")
 def lint(session: nox.Session) -> None:
     session.install("pre-commit")
     session.run("pre-commit", "run", "--all-files")
@@ -139,7 +139,7 @@ def lint(session: nox.Session) -> None:
     mypy(session)
 
 
-@nox.session(python="3.8")
+@nox.session(python="3.12")
 def mypy(session: nox.Session) -> None:
     """Run mypy."""
     session.install("-r", "mypy-requirements.txt")

--- a/test/test_ssltransport.py
+++ b/test/test_ssltransport.py
@@ -91,11 +91,11 @@ def validate_response(
 
 def validate_peercert(ssl_socket: SSLTransport) -> None:
     binary_cert = ssl_socket.getpeercert(binary_form=True)
-    assert type(binary_cert) == bytes
+    assert isinstance(binary_cert, bytes)
     assert len(binary_cert) > 0
 
     cert = ssl_socket.getpeercert()
-    assert type(cert) == dict
+    assert isinstance(cert, dict)
     assert "serialNumber" in cert
     assert cert["serialNumber"] != ""
 
@@ -222,7 +222,7 @@ class SingleTLSLayerTestCase(SocketDummyServerTestCase):
             sock, self.client_context, server_hostname="localhost"
         ) as ssock:
             cipher = ssock.cipher()
-            assert type(cipher) == tuple
+            assert isinstance(cipher, tuple)
 
             # No chosen protocol through ALPN or NPN.
             assert ssock.selected_alpn_protocol() is None

--- a/test/test_ssltransport.py
+++ b/test/test_ssltransport.py
@@ -91,11 +91,11 @@ def validate_response(
 
 def validate_peercert(ssl_socket: SSLTransport) -> None:
     binary_cert = ssl_socket.getpeercert(binary_form=True)
-    assert isinstance(binary_cert, bytes)
+    assert type(binary_cert) is bytes
     assert len(binary_cert) > 0
 
     cert = ssl_socket.getpeercert()
-    assert isinstance(cert, dict)
+    assert type(cert) is dict
     assert "serialNumber" in cert
     assert cert["serialNumber"] != ""
 
@@ -222,7 +222,7 @@ class SingleTLSLayerTestCase(SocketDummyServerTestCase):
             sock, self.client_context, server_hostname="localhost"
         ) as ssock:
             cipher = ssock.cipher()
-            assert isinstance(cipher, tuple)
+            assert type(cipher) is tuple
 
             # No chosen protocol through ALPN or NPN.
             assert ssock.selected_alpn_protocol() is None
@@ -484,11 +484,11 @@ class TlsInTlsTestCase(SocketDummyServerTestCase):
                 write.flush()
 
                 response = read.read()
-                assert isinstance(response, str)
+                assert type(response) is str
                 if "\r" not in response:
                     # Carriage return will be removed when reading as a file on
                     # some platforms.  We add it before the comparison.
-                    assert isinstance(response, str)
+                    assert type(response) is str
                     response = response.replace("\n", "\r\n")
                 validate_response(response, binary=False)
 

--- a/test/tz_stub.py
+++ b/test/tz_stub.py
@@ -9,7 +9,7 @@ from contextlib import contextmanager
 import pytest
 
 try:
-    import zoneinfo  # type: ignore[import]
+    import zoneinfo
 except ImportError:
     # Python < 3.9
     from backports import zoneinfo  # type: ignore[no-redef]

--- a/test/with_dummyserver/test_connectionpool.py
+++ b/test/with_dummyserver/test_connectionpool.py
@@ -363,7 +363,7 @@ class TestConnectionPool(HTTPDummyServerTestCase):
         with HTTPConnectionPool(self.host, port) as pool:
             with pytest.raises(MaxRetryError) as e:
                 pool.request("GET", "/", retries=Retry(connect=3))
-            assert isinstance(e.value.reason, NewConnectionError)
+            assert type(e.value.reason) is NewConnectionError
 
     def test_timeout_success(self) -> None:
         timeout = Timeout(connect=3, read=5, total=None)
@@ -495,7 +495,7 @@ class TestConnectionPool(HTTPDummyServerTestCase):
         with HTTPConnectionPool("badhost.invalid", self.port) as pool:
             with pytest.raises(MaxRetryError) as e:
                 pool.request("GET", "/", retries=5)
-            assert isinstance(e.value.reason, NameResolutionError)
+            assert type(e.value.reason) is NameResolutionError
 
     def test_keepalive(self) -> None:
         with HTTPConnectionPool(self.host, self.port, block=True, maxsize=1) as pool:
@@ -1063,7 +1063,7 @@ class TestConnectionPool(HTTPDummyServerTestCase):
                 conn.request("GET", "/headers", chunked=chunked)
 
             assert pool.headers == {"key": "val"}
-            assert isinstance(pool.headers, header_type)
+            assert type(pool.headers) is header_type
 
         with HTTPConnectionPool(self.host, self.port) as pool:
             if pool_request:

--- a/test/with_dummyserver/test_connectionpool.py
+++ b/test/with_dummyserver/test_connectionpool.py
@@ -363,7 +363,7 @@ class TestConnectionPool(HTTPDummyServerTestCase):
         with HTTPConnectionPool(self.host, port) as pool:
             with pytest.raises(MaxRetryError) as e:
                 pool.request("GET", "/", retries=Retry(connect=3))
-            assert type(e.value.reason) == NewConnectionError
+            assert isinstance(e.value.reason, NewConnectionError)
 
     def test_timeout_success(self) -> None:
         timeout = Timeout(connect=3, read=5, total=None)
@@ -495,7 +495,7 @@ class TestConnectionPool(HTTPDummyServerTestCase):
         with HTTPConnectionPool("badhost.invalid", self.port) as pool:
             with pytest.raises(MaxRetryError) as e:
                 pool.request("GET", "/", retries=5)
-            assert type(e.value.reason) == NameResolutionError
+            assert isinstance(e.value.reason, NameResolutionError)
 
     def test_keepalive(self) -> None:
         with HTTPConnectionPool(self.host, self.port, block=True, maxsize=1) as pool:

--- a/test/with_dummyserver/test_https.py
+++ b/test/with_dummyserver/test_https.py
@@ -213,7 +213,7 @@ class TestHTTPS(HTTPSDummyServerTestCase):
             with pytest.raises(MaxRetryError, match="password is required") as e:
                 https_pool.request("GET", "/certificate")
 
-            assert isinstance(e.value.reason, SSLError)
+            assert type(e.value.reason) is SSLError
 
     def test_verified(self) -> None:
         with HTTPSConnectionPool(
@@ -293,7 +293,7 @@ class TestHTTPS(HTTPSDummyServerTestCase):
         ) as https_pool:
             with pytest.raises(MaxRetryError) as e:
                 https_pool.request("GET", "/", retries=0)
-            assert isinstance(e.value.reason, SSLError)
+            assert type(e.value.reason) is SSLError
             assert "doesn't match" in str(
                 e.value.reason
             ) or "certificate verify failed" in str(e.value.reason)
@@ -308,7 +308,7 @@ class TestHTTPS(HTTPSDummyServerTestCase):
         ) as https_pool:
             with pytest.raises(MaxRetryError) as e:
                 https_pool.request("GET", "/")
-            assert isinstance(e.value.reason, SSLError)
+            assert type(e.value.reason) is SSLError
             assert (
                 "certificate verify failed" in str(e.value.reason)
                 # PyPy is more specific
@@ -342,7 +342,7 @@ class TestHTTPS(HTTPSDummyServerTestCase):
         ) as https_pool:
             with pytest.raises(MaxRetryError) as e:
                 https_pool.request("GET", "/")
-            assert isinstance(e.value.reason, SSLError)
+            assert type(e.value.reason) is SSLError
             # there is a different error message depending on whether or
             # not pyopenssl is injected
             assert (
@@ -490,7 +490,7 @@ class TestHTTPS(HTTPSDummyServerTestCase):
         def _test_request(pool: HTTPSConnectionPool) -> SSLError:
             with pytest.raises(MaxRetryError) as cm:
                 pool.request("GET", "/", retries=0)
-            assert isinstance(cm.value.reason, SSLError)
+            assert type(cm.value.reason) is SSLError
             return cm.value.reason
 
         with HTTPSConnectionPool(
@@ -533,7 +533,7 @@ class TestHTTPS(HTTPSDummyServerTestCase):
         ) as https_pool:
             with pytest.raises(MaxRetryError) as cm:
                 https_pool.request("GET", "/", retries=0)
-            assert isinstance(cm.value.reason, SSLError)
+            assert type(cm.value.reason) is SSLError
 
     def test_verify_none_and_good_fingerprint(self) -> None:
         with HTTPSConnectionPool(
@@ -1099,7 +1099,7 @@ class TestHTTPS_Hostname:
         # IP addresses should fail for commonName.
         else:
             assert err is not None
-            assert isinstance(err.reason, SSLError)
+            assert type(err.reason) is SSLError
             assert isinstance(
                 err.reason.args[0], (ssl.SSLCertVerificationError, CertificateError)
             )

--- a/test/with_dummyserver/test_https.py
+++ b/test/with_dummyserver/test_https.py
@@ -1099,7 +1099,7 @@ class TestHTTPS_Hostname:
         # IP addresses should fail for commonName.
         else:
             assert err is not None
-            assert type(err.reason) == SSLError
+            assert isinstance(err.reason, SSLError)
             assert isinstance(
                 err.reason.args[0], (ssl.SSLCertVerificationError, CertificateError)
             )

--- a/test/with_dummyserver/test_proxy_poolmanager.py
+++ b/test/with_dummyserver/test_proxy_poolmanager.py
@@ -148,10 +148,9 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
 
             with pytest.raises(MaxRetryError) as e:
                 http.request("GET", f"{target_url}/")
-            assert type(e.value.reason) == ProxyError
-            assert (
-                type(e.value.reason.original_error)
-                == urllib3.exceptions.NameResolutionError
+            assert isinstance(e.value.reason, ProxyError)
+            assert isinstance(
+                e.value.reason.original_error, urllib3.exceptions.NameResolutionError
             )
 
     def test_oldapi(self) -> None:
@@ -467,7 +466,7 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
             # We sent the request to the proxy but didn't get any response
             # so we're not sure if that's being caused by the proxy or the
             # target so we put the blame on the target.
-            assert type(e.value.reason) == ReadTimeoutError
+            assert isinstance(e.value.reason, ReadTimeoutError)
 
     @requires_network()
     @pytest.mark.parametrize(
@@ -487,7 +486,7 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
                 timeout = Timeout(connect=LONG_TIMEOUT, read=SHORT_TIMEOUT)
                 proxy.request("GET", target_url, timeout=timeout)
 
-            assert type(e.value.reason) == ReadTimeoutError
+            assert isinstance(e.value.reason, ReadTimeoutError)
 
     @requires_network()
     @pytest.mark.parametrize(
@@ -514,8 +513,8 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
             with pytest.raises(MaxRetryError) as e:
                 proxy.request("GET", target_url)
 
-            assert type(e.value.reason) == ProxyError
-            assert type(e.value.reason.original_error) == ConnectTimeoutError
+            assert isinstance(e.value.reason, ProxyError)
+            assert isinstance(e.value.reason.original_error, ConnectTimeoutError)
 
     @requires_network()
     @pytest.mark.parametrize(
@@ -533,8 +532,8 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
             with pytest.raises(MaxRetryError) as e:
                 proxy.request("GET", target_url)
 
-            assert type(e.value.reason) == ProxyError
-            assert type(e.value.reason.original_error) == ConnectTimeoutError
+            assert isinstance(e.value.reason, ProxyError)
+            assert isinstance(e.value.reason.original_error, ConnectTimeoutError)
 
     @requires_network()
     @pytest.mark.parametrize(
@@ -557,8 +556,8 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
         ) as proxy:
             with pytest.raises(MaxRetryError) as e:
                 proxy.request("GET", target_url)
-            assert type(e.value.reason) == ProxyError
-            assert type(e.value.reason.original_error) == SSLError
+            assert isinstance(e.value.reason, ProxyError)
+            assert isinstance(e.value.reason.original_error, SSLError)
 
     @requires_network()
     @pytest.mark.parametrize(
@@ -588,7 +587,7 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
         ) as proxy:
             with pytest.raises(MaxRetryError) as e:
                 proxy.request("GET", self.https_url)
-            assert type(e.value.reason) == SSLError
+            assert isinstance(e.value.reason, SSLError)
 
     def test_scheme_host_case_insensitive(self) -> None:
         """Assert that upper-case schemes and hosts are normalized."""

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -1260,7 +1260,7 @@ class TestProxyManager(SocketDummyServerTestCase):
 
             errored.set()  # Avoid a ConnectionAbortedError on Windows.
 
-            assert type(e.value.reason) == ProxyError
+            assert isinstance(e.value.reason, ProxyError)
             assert "Your proxy appears to only use HTTP and not HTTPS" in str(
                 e.value.reason
             )

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -1260,7 +1260,7 @@ class TestProxyManager(SocketDummyServerTestCase):
 
             errored.set()  # Avoid a ConnectionAbortedError on Windows.
 
-            assert isinstance(e.value.reason, ProxyError)
+            assert type(e.value.reason) is ProxyError
             assert "Your proxy appears to only use HTTP and not HTTPS" in str(
                 e.value.reason
             )
@@ -1389,7 +1389,7 @@ class TestSSL(SocketDummyServerTestCase):
 
         with pytest.raises(MaxRetryError) as cm:
             request()
-        assert isinstance(cm.value.reason, SSLError)
+        assert type(cm.value.reason) is SSLError
         # Should not hang, see https://github.com/urllib3/urllib3/issues/529
         with pytest.raises(MaxRetryError):
             request()
@@ -1883,7 +1883,7 @@ class TestBrokenHeaders(SocketDummyServerTestCase):
             for record in logs:
                 if (
                     "Failed to parse headers" in record.msg
-                    and isinstance(record.args, tuple)
+                    and type(record.args) is tuple
                     and _url_from_pool(pool, "/") == record.args[0]
                 ):
                     if (


### PR DESCRIPTION
GitHub Actions now defaults to Python 3.12, which made flake8 6.0 report E231 errors because it was looking at f-strings incorrectly. Upgrading to 6.1 fixed the issue, but introduced E721 that I fixed too.

This commit also changes `nox -s lint` and `nox -s mypy` to use Python 3.12, allowing to remove one type ignore.

This was noticed by @dimbleby in #3134. Thanks!
