### PR TITLE
Fix downstream requests test

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -117,6 +117,9 @@ def downstream_requests(session: nox.Session) -> None:
     session.install(".[socks]", silent=False)
     session.install("-r", "requirements-dev.txt", silent=False)
 
+    # Workaround until https://github.com/psf/httpbin/pull/29 gets released
+    session.install("flask<3", "werkzeug<3", silent=False)
+
     session.cd(root)
     session.install(".", silent=False)
     session.cd(f"{tmp_dir}/requests")


### PR DESCRIPTION
This has been failing for weeks now. I've always thought that the problem was going to be fixed quickly (only a release is needed at this point) and did not want to include a workaround for only a few days before having to revert it. But it is still an issue so let's put a measure in place.