### PR TITLE
ci: replace deprecated set-output

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,7 +37,7 @@ jobs:
       - name: "Generate hashes"
         id: hash
         run: |
-          cd dist && echo "::set-output name=hashes::$(sha256sum * | base64 -w0)"
+          cd dist && echo "hashes=$(sha256sum * | base64 -w0)" >> $GITHUB_OUTPUT
 
       - name: "Upload dists"
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2


### PR DESCRIPTION
Closes https://github.com/urllib3/urllib3/issues/3160 by replacing the deprecated `set-output` with the newer `$GITHUB_OUTPUT` environment files, as described in [GitHub's Blog](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/). 
I [did a test action run](https://github.com/FineFindus/urllib3/actions/runs/6749422237), and it did not get any warnings, so it should be fixed.
![Action run without deprecation warning](https://github.com/urllib3/urllib3/assets/63370021/fb6f7ac9-c56a-4b39-83ff-5985743c4538)

