### PR TITLE
Treat x-gzip content encoding as gzip

### DIFF
--- a/changelog/3174.bugfix.rst
+++ b/changelog/3174.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed decoding Gzip-encoded responses which specified ``x-gzip`` content-encoding.

--- a/src/urllib3/response.py
+++ b/src/urllib3/response.py
@@ -208,7 +208,9 @@ def _get_decoder(mode: str) -> ContentDecoder:
     if "," in mode:
         return MultiDecoder(mode)
 
-    if mode == "gzip":
+    # According to RFC 9110 section 8.4.1.3, recipients should
+    # consider x-gzip equivalent to gzip
+    if mode in ("gzip", "x-gzip"):
         return GzipDecoder()
 
     if brotli is not None and mode == "br":
@@ -280,7 +282,7 @@ class BytesQueueBuffer:
 
 
 class BaseHTTPResponse(io.IOBase):
-    CONTENT_DECODERS = ["gzip", "deflate"]
+    CONTENT_DECODERS = ["gzip", "x-gzip", "deflate"]
     if brotli is not None:
         CONTENT_DECODERS += ["br"]
     if zstd is not None:

--- a/test/test_response.py
+++ b/test/test_response.py
@@ -229,14 +229,15 @@ class TestResponse:
         assert r.read() == b""
         assert r.read() == b""
 
-    def test_chunked_decoding_gzip(self) -> None:
+    @pytest.mark.parametrize("content_encoding", ["gzip", "x-gzip"])
+    def test_chunked_decoding_gzip(self, content_encoding: str) -> None:
         compress = zlib.compressobj(6, zlib.DEFLATED, 16 + zlib.MAX_WBITS)
         data = compress.compress(b"foo")
         data += compress.flush()
 
         fp = BytesIO(data)
         r = HTTPResponse(
-            fp, headers={"content-encoding": "gzip"}, preload_content=False
+            fp, headers={"content-encoding": content_encoding}, preload_content=False
         )
 
         assert r.read(1) == b"f"


### PR DESCRIPTION
According to RFC 9110, the "x-gzip" content coding should be treated as "gzip".

Fixes #3174

<!---
Thanks for your contribution! ♥️

If this is your first PR to urllib3 please review the Contributing Guide:
https://urllib3.readthedocs.io/en/latest/contributing.html

Adhering to the Contributing Guide means we can review, merge, and release your change faster! :)
--->
