### PR TITLE
Document the parameters for `urllib3.request()`

### DIFF
--- a/src/urllib3/__init__.py
+++ b/src/urllib3/__init__.py
@@ -142,6 +142,10 @@ def request(
     :param body:
         Data to send in the request body, either :class:`str`, :class:`bytes`,
         an iterable of :class:`str`/:class:`bytes`, or a file-like object.
+
+    :param fields:
+        Data to encode and send in the request body.  Values are processed
+        by :func:`urllib.parse.urlencode`.
     """
 
     return _DEFAULT_POOL.request(

--- a/src/urllib3/__init__.py
+++ b/src/urllib3/__init__.py
@@ -132,6 +132,9 @@ def request(
     Therefore, its side effects could be shared across dependencies relying on it.
     To avoid side effects create a new ``PoolManager`` instance and use it instead.
     The method does not accept low-level ``**urlopen_kw`` keyword arguments.
+
+    :param method:
+        HTTP request method (such as GET, POST, PUT, etc.)
     """
 
     return _DEFAULT_POOL.request(

--- a/src/urllib3/__init__.py
+++ b/src/urllib3/__init__.py
@@ -138,6 +138,10 @@ def request(
 
     :param url:
         The URL to perform the request on.
+
+    :param body:
+        Data to send in the request body, either :class:`str`, :class:`bytes`,
+        an iterable of :class:`str`/:class:`bytes`, or a file-like object.
     """
 
     return _DEFAULT_POOL.request(

--- a/src/urllib3/__init__.py
+++ b/src/urllib3/__init__.py
@@ -144,8 +144,7 @@ def request(
         an iterable of :class:`str`/:class:`bytes`, or a file-like object.
 
     :param fields:
-        Data to encode and send in the request body.  Values are processed
-        by :func:`urllib.parse.urlencode`.
+        Data to encode and send in the request body.
 
     :param headers:
         Dictionary of custom headers to send, such as User-Agent,

--- a/src/urllib3/__init__.py
+++ b/src/urllib3/__init__.py
@@ -146,6 +146,10 @@ def request(
     :param fields:
         Data to encode and send in the request body.  Values are processed
         by :func:`urllib.parse.urlencode`.
+
+    :param headers:
+        Dictionary of custom headers to send, such as User-Agent,
+        If-None-Match, etc.
     """
 
     return _DEFAULT_POOL.request(

--- a/src/urllib3/__init__.py
+++ b/src/urllib3/__init__.py
@@ -183,6 +183,11 @@ def request(
         If specified, overrides the default timeout for this one
         request. It may be a float (in seconds) or an instance of
         :class:`urllib3.util.Timeout`.
+
+    :param json:
+        Data to encode and send as JSON with UTF-encoded in the request body.
+        The ``"Content-Type"`` header will be set to ``"application/json"``
+        unless specified otherwise.
     """
 
     return _DEFAULT_POOL.request(

--- a/src/urllib3/__init__.py
+++ b/src/urllib3/__init__.py
@@ -150,6 +150,39 @@ def request(
     :param headers:
         Dictionary of custom headers to send, such as User-Agent,
         If-None-Match, etc.
+
+    :param bool preload_content:
+        If True, the response's body will be preloaded into memory.
+
+    :param bool decode_content:
+        If True, will attempt to decode the body based on the
+        'content-encoding' header.
+
+    :param redirect:
+        If True, automatically handle redirects (status codes 301, 302,
+        303, 307, 308). Each redirect counts as a retry. Disabling retries
+        will disable redirect, too.
+
+    :param retries:
+        Configure the number of retries to allow before raising a
+        :class:`~urllib3.exceptions.MaxRetryError` exception.
+
+        Pass ``None`` to retry until you receive a response. Pass a
+        :class:`~urllib3.util.retry.Retry` object for fine-grained control
+        over different types of retries.
+        Pass an integer number to retry connection errors that many times,
+        but no other types of errors. Pass zero to never retry.
+
+        If ``False``, then retries are disabled and any exception is raised
+        immediately. Also, instead of raising a MaxRetryError on redirects,
+        the redirect response will be returned.
+
+    :type retries: :class:`~urllib3.util.retry.Retry`, False, or an int.
+
+    :param timeout:
+        If specified, overrides the default timeout for this one
+        request. It may be a float (in seconds) or an instance of
+        :class:`urllib3.util.Timeout`.
     """
 
     return _DEFAULT_POOL.request(

--- a/src/urllib3/__init__.py
+++ b/src/urllib3/__init__.py
@@ -135,6 +135,9 @@ def request(
 
     :param method:
         HTTP request method (such as GET, POST, PUT, etc.)
+
+    :param url:
+        The URL to perform the request on.
     """
 
     return _DEFAULT_POOL.request(

--- a/src/urllib3/_request_methods.py
+++ b/src/urllib3/_request_methods.py
@@ -88,6 +88,9 @@ class RequestMethods:
 
         :param method:
             HTTP request method (such as GET, POST, PUT, etc.)
+
+        :param url:
+            The URL to perform the request on.
         """
         method = method.upper()
 
@@ -136,6 +139,9 @@ class RequestMethods:
 
         :param method:
             HTTP request method (such as GET, POST, PUT, etc.)
+
+        :param url:
+            The URL to perform the request on.
         """
         if headers is None:
             headers = self.headers
@@ -195,6 +201,9 @@ class RequestMethods:
 
         :param method:
             HTTP request method (such as GET, POST, PUT, etc.)
+
+        :param url:
+            The URL to perform the request on.
         """
         if headers is None:
             headers = self.headers

--- a/src/urllib3/_request_methods.py
+++ b/src/urllib3/_request_methods.py
@@ -99,6 +99,11 @@ class RequestMethods:
         :param fields:
             Data to encode and send in the request body.  Values are processed
             by :func:`urllib.parse.urlencode`.
+
+        :param headers:
+            Dictionary of custom headers to send, such as User-Agent,
+            If-None-Match, etc. If None, pool headers are used. If provided,
+            these headers completely replace any pool-specific headers.
         """
         method = method.upper()
 
@@ -154,6 +159,11 @@ class RequestMethods:
         :param fields:
             Data to encode and send in the request body.  Values are processed
             by :func:`urllib.parse.urlencode`.
+
+        :param headers:
+            Dictionary of custom headers to send, such as User-Agent,
+            If-None-Match, etc. If None, pool headers are used. If provided,
+            these headers completely replace any pool-specific headers.
         """
         if headers is None:
             headers = self.headers
@@ -220,6 +230,11 @@ class RequestMethods:
         :param fields:
             Data to encode and send in the request body.  Values are processed
             by :func:`urllib.parse.urlencode`.
+
+        :param headers:
+            Dictionary of custom headers to send, such as User-Agent,
+            If-None-Match, etc. If None, pool headers are used. If provided,
+            these headers completely replace any pool-specific headers.
         """
         if headers is None:
             headers = self.headers

--- a/src/urllib3/_request_methods.py
+++ b/src/urllib3/_request_methods.py
@@ -91,6 +91,10 @@ class RequestMethods:
 
         :param url:
             The URL to perform the request on.
+
+        :param body:
+            Data to send in the request body, either :class:`str`, :class:`bytes`,
+            an iterable of :class:`str`/:class:`bytes`, or a file-like object.
         """
         method = method.upper()
 

--- a/src/urllib3/_request_methods.py
+++ b/src/urllib3/_request_methods.py
@@ -104,6 +104,11 @@ class RequestMethods:
             Dictionary of custom headers to send, such as User-Agent,
             If-None-Match, etc. If None, pool headers are used. If provided,
             these headers completely replace any pool-specific headers.
+
+        :param json:
+            Data to encode and send as JSON with UTF-encoded in the request body.
+            The ``"Content-Type"`` header will be set to ``"application/json"``
+            unless specified otherwise.
         """
         method = method.upper()
 

--- a/src/urllib3/_request_methods.py
+++ b/src/urllib3/_request_methods.py
@@ -162,8 +162,7 @@ class RequestMethods:
             The URL to perform the request on.
 
         :param fields:
-            Data to encode and send in the request body.  Values are processed
-            by :func:`urllib.parse.urlencode`.
+            Data to encode and send in the request body.
 
         :param headers:
             Dictionary of custom headers to send, such as User-Agent,
@@ -233,13 +232,20 @@ class RequestMethods:
             The URL to perform the request on.
 
         :param fields:
-            Data to encode and send in the request body.  Values are processed
-            by :func:`urllib.parse.urlencode`.
+            Data to encode and send in the request body.
 
         :param headers:
             Dictionary of custom headers to send, such as User-Agent,
             If-None-Match, etc. If None, pool headers are used. If provided,
             these headers completely replace any pool-specific headers.
+
+        :param encode_multipart:
+            If True, encode the ``fields`` using the multipart/form-data MIME
+            format.
+
+        :param multipart_boundary:
+            If not specified, then a random boundary will be generated using
+            :func:`urllib3.filepost.choose_boundary`.
         """
         if headers is None:
             headers = self.headers

--- a/src/urllib3/_request_methods.py
+++ b/src/urllib3/_request_methods.py
@@ -85,6 +85,9 @@ class RequestMethods:
         option to drop down to more specific methods when necessary, such as
         :meth:`request_encode_url`, :meth:`request_encode_body`,
         or even the lowest level :meth:`urlopen`.
+
+        :param method:
+            HTTP request method (such as GET, POST, PUT, etc.)
         """
         method = method.upper()
 
@@ -130,6 +133,9 @@ class RequestMethods:
         """
         Make a request using :meth:`urlopen` with the ``fields`` encoded in
         the url. This is useful for request methods like GET, HEAD, DELETE, etc.
+
+        :param method:
+            HTTP request method (such as GET, POST, PUT, etc.)
         """
         if headers is None:
             headers = self.headers
@@ -186,6 +192,9 @@ class RequestMethods:
         be overwritten because it depends on the dynamic random boundary string
         which is used to compose the body of the request. The random boundary
         string can be explicitly set with the ``multipart_boundary`` parameter.
+
+        :param method:
+            HTTP request method (such as GET, POST, PUT, etc.)
         """
         if headers is None:
             headers = self.headers

--- a/src/urllib3/_request_methods.py
+++ b/src/urllib3/_request_methods.py
@@ -95,6 +95,10 @@ class RequestMethods:
         :param body:
             Data to send in the request body, either :class:`str`, :class:`bytes`,
             an iterable of :class:`str`/:class:`bytes`, or a file-like object.
+
+        :param fields:
+            Data to encode and send in the request body.  Values are processed
+            by :func:`urllib.parse.urlencode`.
         """
         method = method.upper()
 
@@ -146,6 +150,10 @@ class RequestMethods:
 
         :param url:
             The URL to perform the request on.
+
+        :param fields:
+            Data to encode and send in the request body.  Values are processed
+            by :func:`urllib.parse.urlencode`.
         """
         if headers is None:
             headers = self.headers
@@ -208,6 +216,10 @@ class RequestMethods:
 
         :param url:
             The URL to perform the request on.
+
+        :param fields:
+            Data to encode and send in the request body.  Values are processed
+            by :func:`urllib.parse.urlencode`.
         """
         if headers is None:
             headers = self.headers


### PR DESCRIPTION
This documents the `urllib3.request()` function, and a couple of its intermediaries, as described in https://github.com/urllib3/urllib3/issues/3011.

I built the docs locally to check the parameters were appearing correctly in both the user and reference guide. I did get one warning, but I think it was unrelated to my change. (`urllib3/src/urllib3/contrib/socks.py:docstring of urllib3.contrib.socks.SOCKSConnection.socket_options:1:py:class reference target not found: connection._TYPE_SOCKET_OPTIONS`)

https://urllib3.readthedocs.io/en/stable/reference/urllib3.request.html:

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td>
<img src="https://github.com/urllib3/urllib3/assets/301220/20648c0a-07f6-4536-a0fa-21d878891783">
</td>
<td>
<img src="https://github.com/urllib3/urllib3/assets/301220/5cc73f31-6571-4180-b577-f12fff749089">
</td>
</tr>
</table>

https://urllib3.readthedocs.io/en/stable/reference/urllib3.poolmanager.html#urllib3.PoolManager.request (linked from `request()` in the user guide):

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td>
<img src="https://github.com/urllib3/urllib3/assets/301220/ea192725-942d-47d6-96a2-0db576451dac">
</td>
<td>
<img src="https://github.com/urllib3/urllib3/assets/301220/90b070aa-3f36-4894-ad2f-e103fccfc2d9">
</td>
</tr>
</table>

## Notes for reviewers

* Most of the parameter descriptions are copied directly from `HTTP(S)ConnectionPool.urlopen()`, with the exception of `json` and `fields`. 
* I split the patch into individual commits as I was going along because I thought I might end up writing more detailed "where did this text come from" messages, but I can easily squash them down into a single commit if that's preferred.
* I didn't write a changelog entry because documenting a single function didn't feel like a change that needed one, but I can add one if you think it's important.

Fixes https://github.com/urllib3/urllib3/issues/3011