### PR TITLE
Compatibility issue fix with rpyc

### DIFF
--- a/src/urllib3/_collections.py
+++ b/src/urllib3/_collections.py
@@ -353,8 +353,8 @@ class HTTPHeaderDict(typing.MutableMapping[str, str]):
                 self.add(key, val)
         elif isinstance(other, typing.Iterable):
             other = typing.cast(typing.Iterable[typing.Tuple[str, str]], other)
-            for key, value in other:
-                self.add(key, value)
+            for item in other:
+                self.add(item[0], item[1])
         elif hasattr(other, "keys") and hasattr(other, "__getitem__"):
             # THIS IS NOT A TYPESAFE BRANCH
             # In this branch, the object has a `keys` attr but is not a Mapping or any of


### PR DESCRIPTION
**Problem**
I'm using openapi with rpyc for processing rest calls and openapi uses urllib3 for parsing the requests. And I observed this error trace during the call:

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/rpyc/core/protocol.py", line 359, in _dispatch_request
    res = self._HANDLERS[handler](self, *args)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/rpyc/core/protocol.py", line 837, in _handle_call
    return obj(*args, **dict(kwargs))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/cna/cna-nf_sim/nf_sim/lib/python3/openapi/rest.py", line 502, in POST
    return self.request("POST",
           ^^^^^^^^^^^^^^^^^^^^
  File "/usr/cna/cna-nf_sim/nf_sim/lib/python3/openapi/rest.py", line 315, in request
    r = self.pool_manager.request(method,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/urllib3/_request_methods.py", line 121, in request
    return self.request_encode_body(
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/urllib3/_request_methods.py", line 196, in request_encode_body
    extra_kw: dict[str, typing.Any] = {"headers": HTTPHeaderDict(headers)}
                                                  ^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/urllib3/_collections.py", line 252, in __init__
    self.extend(headers)
  File "/usr/local/lib/python3.11/site-packages/urllib3/_collections.py", line 370, in extend
    for key, value in other:
        ^^^^^^^^^^

```

And after some debugging, I found out that rpyc uses its own type "netref" for mirroring the python's primitive types and it doesn't really support the syntax of "for k, v in others:" which is throwing an error "too many values to unpack" error. 

**Solution**
Use the old-fashioned way and it works fine with rpyc integration.

