### PR TITLE
Run test_requesting_large_resources_via_ssl separately

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,10 +43,22 @@ jobs:
         nox-session: ['']
         include:
           - experimental: false
+          # integration
+          # 3.8 and 3.9 have a known issue with large SSL requests that we work around:
+          # https://github.com/urllib3/urllib3/pull/3181#issuecomment-1794830698
+          - python-version: "3.8"
+            os: ubuntu-latest
+            experimental: false
+            nox-session: test_integration
+          - python-version: "3.9"
+            os: ubuntu-latest
+            experimental: false
+            nox-session: test_integration
           - python-version: "3.12"
             os: ubuntu-latest
             experimental: false
             nox-session: test_integration
+          # pypy
           - python-version: "pypy-3.8"
             os: ubuntu-latest
             experimental: false
@@ -60,6 +72,7 @@ jobs:
             experimental: false
             nox-session: test-pypy
           - python-version: "3.x"
+          # brotli
             os: ubuntu-latest
             experimental: false
             nox-session: test_brotlipy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,10 @@ jobs:
         nox-session: ['']
         include:
           - experimental: false
+          - python-version: "3.12"
+            os: ubuntu-latest
+            experimental: false
+            nox-session: test_integration
           - python-version: "pypy-3.8"
             os: ubuntu-latest
             experimental: false

--- a/changelog/3181.feature.rst
+++ b/changelog/3181.feature.rst
@@ -1,0 +1,4 @@
+Note to redistributors: the urllib3 test suite has been separated in
+two. To run integration tests, you now need to run the tests a second
+time with the `--integration` pytest flag, as in this example: `nox
+-rs test-3.12 -- --integration`.

--- a/noxfile.py
+++ b/noxfile.py
@@ -11,6 +11,7 @@ def tests_impl(
     session: nox.Session,
     extras: str = "socks,brotli,zstd",
     byte_string_comparisons: bool = True,
+    integration: bool = False,
 ) -> None:
     # Install deps and the package itself.
     session.install("-r", "dev-requirements.txt")
@@ -44,6 +45,7 @@ def tests_impl(
         *("--memray", "--hide-memray-summary") if memray_supported else (),
         "-v",
         "-ra",
+        *(("--integration",) if integration else ()),
         f"--color={'yes' if 'GITHUB_ACTIONS' in os.environ else 'auto'}",
         "--tb=native",
         "--durations=10",
@@ -59,7 +61,13 @@ def test(session: nox.Session) -> None:
     tests_impl(session)
 
 
-@nox.session(python=["3"])
+@nox.session(python="3")
+def test_integration(session: nox.Session) -> None:
+    """Run integration tests"""
+    tests_impl(session, integration=True)
+
+
+@nox.session(python="3")
 def test_brotlipy(session: nox.Session) -> None:
     """Check that if 'brotlipy' is installed instead of 'brotli' or
     'brotlicffi' that we still don't blow up.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,7 @@ python_classes = ["Test", "*TestCase"]
 markers = [
     "limit_memory: Limit memory with memray",
     "requires_network: This test needs access to the Internet",
+    "integration: Slow integrations tests not run by default",
 ]
 log_level = "DEBUG"
 filterwarnings = [

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -20,6 +20,32 @@ from urllib3.util import ssl_
 from .tz_stub import stub_timezone_ctx
 
 
+def pytest_addoption(parser: pytest.Parser) -> None:
+    parser.addoption(
+        "--integration",
+        action="store_true",
+        default=False,
+        help="run integration tests only",
+    )
+
+
+def pytest_collection_modifyitems(
+    config: pytest.Config, items: list[pytest.Item]
+) -> None:
+    integration_mode = bool(config.getoption("--integration"))
+    skip_integration = pytest.mark.skip(
+        reason="skipping, need --integration option to run"
+    )
+    skip_normal = pytest.mark.skip(
+        reason="skipping non integration tests in --integration mode"
+    )
+    for item in items:
+        if "integration" in item.keywords and not integration_mode:
+            item.add_marker(skip_integration)
+        elif integration_mode and "integration" not in item.keywords:
+            item.add_marker(skip_normal)
+
+
 class ServerConfig(typing.NamedTuple):
     scheme: str
     host: str

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -11,7 +11,6 @@ import select
 import shutil
 import socket
 import ssl
-import sys
 import tempfile
 import time
 import typing
@@ -1584,10 +1583,7 @@ class TestSSL(SocketDummyServerTestCase):
                 pool.request("GET", "/", retries=False, timeout=LONG_TIMEOUT)
         assert server_closed.wait(LONG_TIMEOUT), "The socket was not terminated"
 
-    @pytest.mark.skipif(
-        os.environ.get("CI") == "true" and sys.implementation.name == "pypy",
-        reason="too slow to run in CI",
-    )
+    @pytest.mark.integration
     @pytest.mark.parametrize(
         "preload_content,read_amt", [(True, None), (False, None), (False, 2**31)]
     )


### PR DESCRIPTION
We have many timeouts on GitHub Actions due to those tests that can take minutes to run on overloaded CI runners. This is compounded by the fact they run six times (3 parametrizations * 2 SSL configuration - pyopenssl and standard library SSL). Running on multiple platforms isn't useful. We found a "Windows-specific" bug once but only because the Windows worker had less memory, and we have `limit_memory` tests now for the memory aspects.