### PR TITLE
Stop naming botocore/requests tests "integration"

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/release.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release.md
@@ -1,4 +1,4 @@
-* [ ]  See if all tests, including integration, pass
+* [ ]  See if all tests, including downstream, pass
 * [ ]  Get the release pull request approved by a [CODEOWNER](https://github.com/urllib3/urllib3/blob/main/.github/CODEOWNERS)
 * [ ]  Squash merge the release pull request with message "`Release <VERSION>`"
 * [ ]  Tag with X.Y.Z, push tag on urllib3/urllib3 (not on your fork, update `<REMOTE>` accordingly)

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 permissions: "read-all"
 
 jobs:
-  integration:
+  downstream:
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Those tests are today named both downstream and integration, which inconsistent. Since #3181 is going to take the name "integration", let's name the existing tests "downstream" exclusively.