### PR TITLE
Connecting with proxy trailing '.' fix

### DIFF
--- a/changelog/2244.bugfix.rst
+++ b/changelog/2244.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed issue where requests against urls with trailing dots were failing due to SSL errors
+when using proxy.

--- a/dummyserver/testcase.py
+++ b/dummyserver/testcase.py
@@ -221,6 +221,7 @@ class HTTPDummyProxyTestCase:
     https_port: typing.ClassVar[int]
     https_url: typing.ClassVar[str]
     https_url_alt: typing.ClassVar[str]
+    https_url_fqdn: typing.ClassVar[str]
 
     proxy_host: typing.ClassVar[str] = "localhost"
     proxy_host_alt: typing.ClassVar[str] = "127.0.0.1"

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -639,6 +639,9 @@ class HTTPSConnection(HTTPConnection):
                 SystemTimeWarning,
             )
 
+        # Remove trailing '.' from fqdn hostnames to allow certificate validation
+        server_hostname_rm_dot = server_hostname.rstrip(".")
+
         sock_and_verified = _ssl_wrap_socket_and_match_hostname(
             sock=sock,
             cert_reqs=self.cert_reqs,
@@ -651,7 +654,7 @@ class HTTPSConnection(HTTPConnection):
             cert_file=self.cert_file,
             key_file=self.key_file,
             key_password=self.key_password,
-            server_hostname=server_hostname,
+            server_hostname=server_hostname_rm_dot,
             ssl_context=self.ssl_context,
             tls_in_tls=tls_in_tls,
             assert_hostname=self.assert_hostname,

--- a/test/with_dummyserver/test_proxy_poolmanager.py
+++ b/test/with_dummyserver/test_proxy_poolmanager.py
@@ -9,7 +9,7 @@ import shutil
 import socket
 import ssl
 import tempfile
-from test import LONG_TIMEOUT, SHORT_TIMEOUT, withPyOpenSSL
+from test import LONG_TIMEOUT, SHORT_TIMEOUT, resolvesLocalhostFQDN, withPyOpenSSL
 from test.conftest import ServerConfig
 
 import pytest
@@ -47,6 +47,7 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
         cls.http_url_alt = f"http://{cls.http_host_alt}:{int(cls.http_port)}"
         cls.https_url = f"https://{cls.https_host}:{int(cls.https_port)}"
         cls.https_url_alt = f"https://{cls.https_host_alt}:{int(cls.https_port)}"
+        cls.https_url_fqdn = f"https://{cls.https_host}.:{int(cls.https_port)}"
         cls.proxy_url = f"http://{cls.proxy_host}:{int(cls.proxy_port)}"
         cls.https_proxy_url = f"https://{cls.proxy_host}:{int(cls.https_proxy_port)}"
 
@@ -172,6 +173,12 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
             assert r.status == 200
 
             r = http.request("GET", f"{self.https_url}/")
+            assert r.status == 200
+
+    @resolvesLocalhostFQDN()
+    def test_proxy_https_fqdn(self) -> None:
+        with proxy_from_url(self.proxy_url, ca_certs=DEFAULT_CA) as http:
+            r = http.request("GET", f"{self.https_url_fqdn}/")
             assert r.status == 200
 
     def test_proxy_verified(self) -> None:


### PR DESCRIPTION
Candidate fix for #2244

This change strips the trailing '.' for proxy requests and adds a new unit test to ensure we can correctly fetch from `localhost.`