### PR TITLE
Clarify Tornado involvement in dummyserver names

### DIFF
--- a/dummyserver/https_proxy.py
+++ b/dummyserver/https_proxy.py
@@ -10,7 +10,7 @@ import tornado.ioloop
 import tornado.web
 
 from dummyserver.proxy import ProxyHandler
-from dummyserver.server import DEFAULT_CERTS, ssl_options_to_context
+from dummyserver.tornadoserver import DEFAULT_CERTS, ssl_options_to_context
 
 
 def run_proxy(port: int, certs: dict[str, typing.Any] = DEFAULT_CERTS) -> None:

--- a/dummyserver/server.py
+++ b/dummyserver/server.py
@@ -262,7 +262,7 @@ def _run_and_close_tornado(
 
 
 @contextlib.contextmanager
-def run_loop_in_thread() -> Generator[tornado.ioloop.IOLoop, None, None]:
+def run_tornado_loop_in_thread() -> Generator[tornado.ioloop.IOLoop, None, None]:
     loop_started: concurrent.futures.Future[
         tuple[tornado.ioloop.IOLoop, asyncio.Event]
     ] = concurrent.futures.Future()

--- a/dummyserver/testcase.py
+++ b/dummyserver/testcase.py
@@ -12,7 +12,7 @@ from tornado import httpserver, ioloop, web
 
 from dummyserver.handlers import TestingApp
 from dummyserver.proxy import ProxyHandler
-from dummyserver.server import (
+from dummyserver.tornadoserver import (
     DEFAULT_CERTS,
     HAS_IPV6,
     SocketServerThread,

--- a/dummyserver/testcase.py
+++ b/dummyserver/testcase.py
@@ -16,8 +16,8 @@ from dummyserver.server import (
     DEFAULT_CERTS,
     HAS_IPV6,
     SocketServerThread,
-    run_loop_in_thread,
     run_tornado_app,
+    run_tornado_loop_in_thread,
 )
 from urllib3.connection import HTTPConnection
 from urllib3.util.ssltransport import SSLTransport
@@ -172,7 +172,7 @@ class HTTPDummyServerTestCase:
     @classmethod
     def _start_server(cls) -> None:
         with contextlib.ExitStack() as stack:
-            io_loop = stack.enter_context(run_loop_in_thread())
+            io_loop = stack.enter_context(run_tornado_loop_in_thread())
 
             async def run_app() -> None:
                 app = web.Application([(r".*", TestingApp)])
@@ -240,7 +240,7 @@ class HTTPDummyProxyTestCase:
     @classmethod
     def setup_class(cls) -> None:
         with contextlib.ExitStack() as stack:
-            io_loop = stack.enter_context(run_loop_in_thread())
+            io_loop = stack.enter_context(run_tornado_loop_in_thread())
 
             async def run_app() -> None:
                 app = web.Application([(r".*", TestingApp)])

--- a/dummyserver/tornadoserver.py
+++ b/dummyserver/tornadoserver.py
@@ -296,7 +296,7 @@ def run_tornado_loop_in_thread() -> Generator[tornado.ioloop.IOLoop, None, None]
 
 
 def main() -> int:
-    # For debugging dummyserver itself - python -m dummyserver.server
+    # For debugging dummyserver itself - PYTHONPATH=src python -m dummyserver.tornadoserver
     from .handlers import TestingApp
 
     host = "127.0.0.1"

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -13,7 +13,7 @@ from tornado import web
 
 from dummyserver.handlers import TestingApp
 from dummyserver.proxy import ProxyHandler
-from dummyserver.server import HAS_IPV6, run_loop_in_thread, run_tornado_app
+from dummyserver.server import HAS_IPV6, run_tornado_app, run_tornado_loop_in_thread
 from dummyserver.testcase import HTTPSDummyServerTestCase
 from urllib3.util import ssl_
 
@@ -79,7 +79,7 @@ def run_server_in_thread(
     ca.cert_pem.write_to_path(ca_cert_path)
     server_certs = _write_cert_to_dir(server_cert, tmpdir)
 
-    with run_loop_in_thread() as io_loop:
+    with run_tornado_loop_in_thread() as io_loop:
 
         async def run_app() -> int:
             app = web.Application([(r".*", TestingApp)])
@@ -107,7 +107,7 @@ def run_server_and_proxy_in_thread(
     server_certs = _write_cert_to_dir(server_cert, tmpdir)
     proxy_certs = _write_cert_to_dir(proxy_cert, tmpdir, "proxy")
 
-    with run_loop_in_thread() as io_loop:
+    with run_tornado_loop_in_thread() as io_loop:
 
         async def run_app() -> tuple[ServerConfig, ServerConfig]:
             app = web.Application([(r".*", TestingApp)])

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -13,8 +13,12 @@ from tornado import web
 
 from dummyserver.handlers import TestingApp
 from dummyserver.proxy import ProxyHandler
-from dummyserver.server import HAS_IPV6, run_tornado_app, run_tornado_loop_in_thread
 from dummyserver.testcase import HTTPSDummyServerTestCase
+from dummyserver.tornadoserver import (
+    HAS_IPV6,
+    run_tornado_app,
+    run_tornado_loop_in_thread,
+)
 from urllib3.util import ssl_
 
 from .tz_stub import stub_timezone_ctx

--- a/test/contrib/test_socks.py
+++ b/test/contrib/test_socks.py
@@ -11,8 +11,8 @@ from unittest.mock import Mock, patch
 import pytest
 import socks as py_socks  # type: ignore[import]
 
-from dummyserver.server import DEFAULT_CA, DEFAULT_CERTS
 from dummyserver.testcase import IPV4SocketDummyServerTestCase
+from dummyserver.tornadoserver import DEFAULT_CA, DEFAULT_CERTS
 from urllib3.contrib import socks
 from urllib3.exceptions import ConnectTimeoutError, NewConnectionError
 

--- a/test/test_connectionpool.py
+++ b/test/test_connectionpool.py
@@ -12,7 +12,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from dummyserver.server import DEFAULT_CA
+from dummyserver.tornadoserver import DEFAULT_CA
 from urllib3 import Retry
 from urllib3.connection import HTTPConnection
 from urllib3.connectionpool import (

--- a/test/test_ssltransport.py
+++ b/test/test_ssltransport.py
@@ -9,8 +9,8 @@ from unittest import mock
 
 import pytest
 
-from dummyserver.server import DEFAULT_CA, DEFAULT_CERTS
 from dummyserver.testcase import SocketDummyServerTestCase, consume_socket
+from dummyserver.tornadoserver import DEFAULT_CA, DEFAULT_CERTS
 from urllib3.util import ssl_
 from urllib3.util.ssltransport import SSLTransport
 

--- a/test/with_dummyserver/test_connectionpool.py
+++ b/test/with_dummyserver/test_connectionpool.py
@@ -12,8 +12,8 @@ from urllib.parse import urlencode
 
 import pytest
 
-from dummyserver.server import HAS_IPV6_AND_DNS, NoIPv6Warning
 from dummyserver.testcase import HTTPDummyServerTestCase, SocketDummyServerTestCase
+from dummyserver.tornadoserver import HAS_IPV6_AND_DNS, NoIPv6Warning
 from urllib3 import HTTPConnectionPool, encode_multipart_formdata
 from urllib3._collections import HTTPHeaderDict
 from urllib3.connection import _get_default_user_agent

--- a/test/with_dummyserver/test_https.py
+++ b/test/with_dummyserver/test_https.py
@@ -23,13 +23,13 @@ import trustme
 
 import urllib3.util as util
 import urllib3.util.ssl_
-from dummyserver.server import (
+from dummyserver.testcase import HTTPSDummyServerTestCase
+from dummyserver.tornadoserver import (
     DEFAULT_CA,
     DEFAULT_CA_KEY,
     DEFAULT_CERTS,
     encrypt_key_pem,
 )
-from dummyserver.testcase import HTTPSDummyServerTestCase
 from urllib3 import HTTPSConnectionPool
 from urllib3.connection import RECENT_DATE, HTTPSConnection, VerifiedHTTPSConnection
 from urllib3.exceptions import (

--- a/test/with_dummyserver/test_poolmanager.py
+++ b/test/with_dummyserver/test_poolmanager.py
@@ -7,8 +7,8 @@ from unittest import mock
 
 import pytest
 
-from dummyserver.server import HAS_IPV6
 from dummyserver.testcase import HTTPDummyServerTestCase, IPv6HTTPDummyServerTestCase
+from dummyserver.tornadoserver import HAS_IPV6
 from urllib3 import HTTPHeaderDict, HTTPResponse, request
 from urllib3.connectionpool import port_by_scheme
 from urllib3.exceptions import MaxRetryError, URLSchemeUnknown

--- a/test/with_dummyserver/test_proxy_poolmanager.py
+++ b/test/with_dummyserver/test_proxy_poolmanager.py
@@ -16,8 +16,8 @@ import pytest
 import trustme
 
 import urllib3.exceptions
-from dummyserver.server import DEFAULT_CA, HAS_IPV6, get_unreachable_address
 from dummyserver.testcase import HTTPDummyProxyTestCase, IPv6HTTPDummyProxyTestCase
+from dummyserver.tornadoserver import DEFAULT_CA, HAS_IPV6, get_unreachable_address
 from urllib3 import HTTPResponse
 from urllib3._collections import HTTPHeaderDict
 from urllib3.connection import VerifiedHTTPSConnection

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -24,13 +24,13 @@ from unittest import mock
 import pytest
 import trustme
 
-from dummyserver.server import (
+from dummyserver.testcase import SocketDummyServerTestCase, consume_socket
+from dummyserver.tornadoserver import (
     DEFAULT_CA,
     DEFAULT_CERTS,
     encrypt_key_pem,
     get_unreachable_address,
 )
-from dummyserver.testcase import SocketDummyServerTestCase, consume_socket
 from urllib3 import HTTPConnectionPool, HTTPSConnectionPool, ProxyManager, util
 from urllib3._collections import HTTPHeaderDict
 from urllib3.connection import HTTPConnection, _get_default_user_agent


### PR DESCRIPTION
This is part of https://github.com/urllib3/urllib3/pull/3190, but I'd like to change the names in a separate commit to get a cleaner history. This is also the right pull request to bikeshed about the names.