### PR TITLE
Fix tests by upgrading quart-trio and pinning Quart

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -11,5 +11,6 @@ backports.zoneinfo==0.2.1;python_version<"3.9"
 towncrier==23.6.0
 pytest-memray==1.5.0;sys_platform!="win32" and implementation_name=="cpython"
 trio==0.23.1
-quart-trio==0.11.0
+Quart==0.19.4
+quart-trio==0.11.1
 hypercorn==0.15.0

--- a/mypy-requirements.txt
+++ b/mypy-requirements.txt
@@ -5,7 +5,8 @@ tornado>=6.1
 pytest>=6.2
 trustme==0.9.0
 trio==0.23.1
-quart-trio==0.11.0
+Quart==0.19.4
+quart-trio==0.11.1
 hypercorn==0.15.0
 types-backports
 types-requests


### PR DESCRIPTION
There was [a new release](https://github.com/pgjones/quart-trio/blob/main/CHANGELOG.rst#0111-2023-11-19) of quart-trio that fixed support for the latest Quart.
Upgrading to quart-trio 0.11.1 looks to fix our CI. I did that and pinned Quart for CI too to avoid such problems in the future.