### PR TITLE
Fix HeaderParsingError Warning

### DIFF
--- a/src/urllib3/util/response.py
+++ b/src/urllib3/util/response.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import http.client as httplib
-from email.errors import MultipartInvariantViolationDefect, StartBoundaryNotFoundDefect
+from email.errors import MultipartInvariantViolationDefect, StartBoundaryNotFoundDefect, NoBoundaryInMultipartDefect
 
 from ..exceptions import HeaderParsingError
 
@@ -80,7 +80,7 @@ def assert_header_parsing(headers: httplib.HTTPMessage) -> None:
         defect
         for defect in headers.defects
         if not isinstance(
-            defect, (StartBoundaryNotFoundDefect, MultipartInvariantViolationDefect)
+            defect, (StartBoundaryNotFoundDefect, MultipartInvariantViolationDefect, NoBoundaryInMultipartDefect)
         )
     ]
 


### PR DESCRIPTION
When I use requests to download files, I encountered the warning with exception below:
```
urllib3.exceptions.HeaderParsingError: [NoBoundaryInMultipartDefect()], unparsed data: ''
```
And with this pr, it can be fixed.


<!---
Thanks for your contribution! ♥️

If this is your first PR to urllib3 please review the Contributing Guide:
https://urllib3.readthedocs.io/en/latest/contributing.html

Adhering to the Contributing Guide means we can review, merge, and release your change faster! :)
--->
