### PR TITLE
Migrate TestHTTPS to Hypercorn

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -13,4 +13,5 @@ pytest-memray==1.5.0;sys_platform!="win32" and implementation_name=="cpython"
 trio==0.23.1
 Quart==0.19.4
 quart-trio==0.11.1
-hypercorn==0.15.0
+# https://github.com/pgjones/hypercorn/issues/62
+hypercorn @ git+https://github.com/urllib3/hypercorn@tls-extension

--- a/dummyserver/app.py
+++ b/dummyserver/app.py
@@ -27,6 +27,22 @@ async def index() -> ResponseTypes:
     return await make_response("Dummy server!")
 
 
+@hypercorn_app.route("/alpn_protocol")
+async def alpn_protocol() -> ResponseTypes:
+    """Return the requester's certificate."""
+    alpn_protocol = request.scope["extensions"]["tls"]["alpn_protocol"]
+    return await make_response(alpn_protocol)
+
+
+@hypercorn_app.route("/certificate")
+async def certificate() -> ResponseTypes:
+    """Return the requester's certificate."""
+    print("scope", request.scope)
+    subject = request.scope["extensions"]["tls"]["client_cert_name"]
+    subject_as_dict = dict(part.split("=") for part in subject.split(", "))
+    return await make_response(subject_as_dict)
+
+
 @hypercorn_app.route("/specific_method", methods=["GET", "POST", "PUT"])
 async def specific_method() -> ResponseTypes:
     "Confirm that the request matches the desired method type"

--- a/test/with_dummyserver/test_https.py
+++ b/test/with_dummyserver/test_https.py
@@ -901,7 +901,7 @@ class TestHTTPS(HTTPSHypercornDummyServerTestCase):
                 conn = https_pool._get_conn()
                 try:
                     conn.connect()
-                    if maximum_version != self.tls_version():
+                    if maximum_version == TLSVersion.MAXIMUM_SUPPORTED:
                         # A higher protocol than tls_protocol_name could be negotiated
                         assert conn.sock.version() >= self.tls_protocol_name  # type: ignore[attr-defined]
                     else:

--- a/test/with_dummyserver/test_https.py
+++ b/test/with_dummyserver/test_https.py
@@ -23,7 +23,7 @@ import trustme
 
 import urllib3.util as util
 import urllib3.util.ssl_
-from dummyserver.testcase import HTTPSDummyServerTestCase
+from dummyserver.testcase import HTTPSHypercornDummyServerTestCase
 from dummyserver.tornadoserver import (
     DEFAULT_CA,
     DEFAULT_CA_KEY,
@@ -65,7 +65,7 @@ PASSWORD_CLIENT_KEYFILE = "client_password.key"
 CLIENT_CERT = CLIENT_INTERMEDIATE_PEM
 
 
-class TestHTTPS(HTTPSDummyServerTestCase):
+class TestHTTPS(HTTPSHypercornDummyServerTestCase):
     tls_protocol_name: str | None = None
 
     def tls_protocol_not_default(self) -> bool:
@@ -447,6 +447,8 @@ class TestHTTPS(HTTPSDummyServerTestCase):
             # the python ssl module).
             if hasattr(conn.sock, "server_hostname"):  # type: ignore[attr-defined]
                 assert conn.sock.server_hostname == "localhost"  # type: ignore[attr-defined]
+            conn.getresponse().close()
+            conn.close()
 
     def test_assert_fingerprint_md5(self) -> None:
         with HTTPSConnectionPool(
@@ -794,6 +796,7 @@ class TestHTTPS(HTTPSDummyServerTestCase):
             self.port,
             ca_certs=DEFAULT_CA,
             ssl_minimum_version=self.tls_version(),
+            ssl_maximum_version=self.tls_version(),
         ) as https_pool:
             conn = https_pool._get_conn()
             try:
@@ -898,7 +901,11 @@ class TestHTTPS(HTTPSDummyServerTestCase):
                 conn = https_pool._get_conn()
                 try:
                     conn.connect()
-                    assert conn.sock.version() == self.tls_protocol_name  # type: ignore[attr-defined]
+                    if maximum_version != self.tls_version():
+                        # A higher protocol than tls_protocol_name could be negotiated
+                        assert conn.sock.version() >= self.tls_protocol_name  # type: ignore[attr-defined]
+                    else:
+                        assert conn.sock.version() == self.tls_protocol_name  # type: ignore[attr-defined]
                 finally:
                     conn.close()
 


### PR DESCRIPTION
Note: I'm planning to clean up the Tornado tests after finishing the migration, instead of removing the exact bits that are unused, which would take time.

I'm using a fork of Hypercorn here. I'm planning to merge everything back upstream as soon as possible, but doing so requires implementing the full ASGI specification, which is more work.

This migration uncovered two bugs in the test suite that was not considering that asking for "TLS 1.2 or above" could result in "TLS 1.3". Apparently this is something that Tornado was doing wrong?