### PR TITLE
PoolManager: Fix incorrect retry configuration in case of redirection

### DIFF
--- a/src/urllib3/poolmanager.py
+++ b/src/urllib3/poolmanager.py
@@ -459,7 +459,7 @@ class PoolManager(RequestMethods):
 
         retries = kw.get("retries")
         if not isinstance(retries, Retry):
-            retries = Retry.from_int(retries, redirect=redirect)
+            retries = Retry.from_int(retries, redirect=redirect, default=conn.retries)
 
         # Strip headers marked as unsafe to forward to the redirected location.
         # Check remove_headers_on_redirect to avoid a potential network call within


### PR DESCRIPTION
Hi,

When handling a redirection, PoolManager will not use the wanted retry configuration but use the default retry configuration instead.

Best,
Rémi 