### PR TITLE
Turn proxy_app into a class to allow configuring it

### DIFF
--- a/dummyserver/asgi_proxy.py
+++ b/dummyserver/asgi_proxy.py
@@ -27,82 +27,83 @@ async def _read_body(receive: ASGIReceiveCallable) -> bytes:
     return bytes(body)
 
 
-async def absolute_uri(
-    scope: HTTPScope,
-    receive: ASGIReceiveCallable,
-    send: ASGISendCallable,
-) -> None:
-    async with httpx.AsyncClient() as client:
-        client_response = await client.request(
-            method=scope["method"],
-            url=scope["path"],
-            headers=list(scope["headers"]),
-            content=await _read_body(receive),
-        )
-
-    headers = []
-    for header in (
-        "Date",
-        "Cache-Control",
-        "Server",
-        "Content-Type",
-        "Location",
-    ):
-        v = client_response.headers.get(header)
-        if v:
-            headers.append((header.encode(), v.encode()))
-    headers.append((b"Content-Length", str(len(client_response.content)).encode()))
-
-    await send(
-        HTTPResponseStartEvent(
-            type="http.response.start",
-            status=client_response.status_code,
-            headers=headers,
-        )
-    )
-    await send(
-        HTTPResponseBodyEvent(
-            type="http.response.body",
-            body=client_response.content,
-            more_body=False,
-        )
-    )
-
-
-async def connect(scope: HTTPScope, send: ASGISendCallable) -> None:
-    async def start_forward(
-        reader: trio.SocketStream, writer: trio.SocketStream
+class ProxyApp:
+    async def __call__(
+        self, scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable
     ) -> None:
-        while True:
-            try:
-                data = await reader.receive_some(4096)
-            except trio.ClosedResourceError:
-                break
-            if not data:
-                break
-            await writer.send_all(data)
-        await writer.aclose()
+        print(scope)
+        assert scope["type"] == "http"
+        if scope["method"] in ["GET", "POST"]:
+            await self.absolute_uri(scope, receive, send)
+        elif scope["method"] == "CONNECT":
+            await self.connect(scope, send)
+        else:
+            raise ValueError(scope["method"])
 
-    host, port = scope["path"].split(":")
-    upstream = await trio.open_tcp_stream(host, int(port))
+    async def absolute_uri(
+        self,
+        scope: HTTPScope,
+        receive: ASGIReceiveCallable,
+        send: ASGISendCallable,
+    ) -> None:
+        async with httpx.AsyncClient() as client:
+            client_response = await client.request(
+                method=scope["method"],
+                url=scope["path"],
+                headers=list(scope["headers"]),
+                content=await _read_body(receive),
+            )
 
-    await send({"type": "http.response.start", "status": 200, "headers": []})
-    await send({"type": "http.response.body", "body": b"", "more_body": True})
+        headers = []
+        for header in (
+            "Date",
+            "Cache-Control",
+            "Server",
+            "Content-Type",
+            "Location",
+        ):
+            v = client_response.headers.get(header)
+            if v:
+                headers.append((header.encode(), v.encode()))
+        headers.append((b"Content-Length", str(len(client_response.content)).encode()))
 
-    client = typing.cast(trio.SocketStream, scope["extensions"]["_transport"])
+        await send(
+            HTTPResponseStartEvent(
+                type="http.response.start",
+                status=client_response.status_code,
+                headers=headers,
+            )
+        )
+        await send(
+            HTTPResponseBodyEvent(
+                type="http.response.body",
+                body=client_response.content,
+                more_body=False,
+            )
+        )
 
-    async with trio.open_nursery(strict_exception_groups=True) as nursery:
-        nursery.start_soon(start_forward, client, upstream)
-        nursery.start_soon(start_forward, upstream, client)
+    async def connect(self, scope: HTTPScope, send: ASGISendCallable) -> None:
+        async def start_forward(
+            reader: trio.SocketStream, writer: trio.SocketStream
+        ) -> None:
+            while True:
+                try:
+                    data = await reader.receive_some(4096)
+                except trio.ClosedResourceError:
+                    break
+                if not data:
+                    break
+                await writer.send_all(data)
+            await writer.aclose()
 
+        host, port = scope["path"].split(":")
+        upstream = await trio.open_tcp_stream(host, int(port))
 
-async def proxy_app(
-    scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable
-) -> None:
-    assert scope["type"] == "http"
-    if scope["method"] in ["GET", "POST"]:
-        await absolute_uri(scope, receive, send)
-    elif scope["method"] == "CONNECT":
-        await connect(scope, send)
-    else:
-        raise ValueError(scope["method"])
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b"", "more_body": True})
+
+        client = typing.cast(trio.SocketStream, scope["extensions"]["_transport"])
+
+        async with trio.open_nursery(strict_exception_groups=True) as nursery:
+            nursery.start_soon(start_forward, client, upstream)
+            nursery.start_soon(start_forward, upstream, client)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -11,7 +11,7 @@ import pytest
 import trustme
 
 from dummyserver.app import hypercorn_app
-from dummyserver.asgi_proxy import proxy_app
+from dummyserver.asgi_proxy import ProxyApp
 from dummyserver.hypercornserver import run_hypercorn_in_thread
 from dummyserver.testcase import HTTPSHypercornDummyServerTestCase
 from dummyserver.tornadoserver import HAS_IPV6
@@ -116,7 +116,7 @@ def run_server_and_proxy_in_thread(
         proxy_config.certfile = proxy_certs["certfile"]
         proxy_config.keyfile = proxy_certs["keyfile"]
         proxy_config.bind = [f"{proxy_host}:0"]
-        stack.enter_context(run_hypercorn_in_thread(proxy_config, proxy_app))
+        stack.enter_context(run_hypercorn_in_thread(proxy_config, ProxyApp()))
         proxy_port = typing.cast(int, parse_url(proxy_config.bind[0]).port)
 
         yield (


### PR DESCRIPTION
This pull request makes no difference, but prepares the switch of `HTTPDummyProxyTestCase` to `Hypercorn`.