### PR TITLE
Migrate emscripten test server to Hypercorn

### DIFF
--- a/dummyserver/app.py
+++ b/dummyserver/app.py
@@ -151,7 +151,7 @@ async def echo_json() -> ResponseTypes:
     if request.method == "OPTIONS":
         return await make_response("", 200)
     data = await request.get_data()
-    return await make_response(data, 200, [("Content-Type", "application/json")])
+    return await make_response(data, 200, request.headers)
 
 
 @hypercorn_app.route("/echo_uri/<path:rest>")

--- a/dummyserver/app.py
+++ b/dummyserver/app.py
@@ -5,10 +5,14 @@ import contextlib
 import datetime
 import email.utils
 import gzip
+import json
+import mimetypes
 import zlib
 from io import BytesIO
+from pathlib import Path
 from typing import Iterator
 
+import trio
 from quart import make_response, request
 
 # TODO switch to Response if https://github.com/pallets/quart/issues/288 is fixed
@@ -280,3 +284,127 @@ async def successful_retry() -> ResponseTypes:
         return await make_response("Retry successful!", 200)
     else:
         return await make_response("need to keep retrying!", 418)
+
+
+pyodide_testing_app = QuartTrio(__name__)
+DEFAULT_HEADERS = [
+    # Allow cross-origin requests for emscripten
+    ("Access-Control-Allow-Origin", "*"),
+    ("Cross-Origin-Opener-Policy", "same-origin"),
+    ("Cross-Origin-Embedder-Policy", "require-corp"),
+    ("Feature-Policy", "sync-xhr *;"),
+    ("Access-Control-Allow-Headers", "*"),
+]
+
+
+@pyodide_testing_app.route("/")
+@pyodide_testing_app.route("/index")
+async def pyodide_index() -> ResponseTypes:
+    return await make_response("Dummy server!", 200, DEFAULT_HEADERS)
+
+
+@pyodide_testing_app.route("/status")
+async def pyodide_status() -> ResponseTypes:
+    values = await request.values
+    status = values.get("status", "200 OK")
+    status_code = status.split(" ")[0]
+    return await make_response("", status_code, DEFAULT_HEADERS)
+
+
+@pyodide_testing_app.route("/specific_method", methods=["POST", "PUT", "GET"])
+async def pyodide_specific_method() -> ResponseTypes:
+    values = await request.values
+    expected_method = values.get("method", "GET")
+    method = request.method
+    if method.upper() == expected_method.upper():
+        return await make_response("", 200, DEFAULT_HEADERS)
+    else:
+        return await make_response("Wrong method", 400, DEFAULT_HEADERS)
+
+
+@pyodide_testing_app.route("/slow")
+async def slow() -> ResponseTypes:
+    await trio.sleep(10)
+    return await make_response("TEN SECONDS LATER", 200, DEFAULT_HEADERS)
+
+
+@pyodide_testing_app.route("/bigfile")
+async def bigfile() -> ResponseTypes:
+    # great big text file, should force streaming
+    # if supported
+    bigdata = 1048576 * b"WOOO YAY BOOYAKAH"
+    return await make_response(bigdata, 200, DEFAULT_HEADERS)
+
+
+@pyodide_testing_app.route("/mediumfile")
+async def mediumfile() -> ResponseTypes:
+    # quite big file
+    bigdata = 1024 * b"WOOO YAY BOOYAKAH"
+    return await make_response(bigdata, 200, DEFAULT_HEADERS)
+
+
+@pyodide_testing_app.route("/echo_json", methods=["POST", "OPTIONS"])
+async def pyodide_echo_json() -> ResponseTypes:
+    if request.method == "OPTIONS":
+        return await make_response("", 200, DEFAULT_HEADERS)
+    data = await request.get_data(as_text=True)
+    parsed = json.loads(data)
+    return await make_response(
+        json.dumps(parsed),
+        200,
+        DEFAULT_HEADERS + [("Content-Type", "application/json")],
+    )
+
+
+@pyodide_testing_app.route("/upload", methods=["POST", "OPTIONS"])
+async def pyodide_upload() -> ResponseTypes:
+    if request.method == "OPTIONS":
+        return await make_response("", 200, DEFAULT_HEADERS)
+    spare_data = await request.get_data(parse_form_data=True)
+    if len(spare_data) != 0:
+        return await make_response("Bad upload data", 404, DEFAULT_HEADERS)
+    files = await request.files
+    form = await request.form
+    if form["upload_param"] != "filefield" or form["upload_filename"] != "lolcat.txt":
+        return await make_response("Bad upload form values", 404, DEFAULT_HEADERS)
+    if len(files) != 1 or files.get("filefield") is None:
+        return await make_response("Missing file in form", 404, DEFAULT_HEADERS)
+    file = files["filefield"]
+    if file.filename != "lolcat.txt":
+        return await make_response(
+            f"File name incorrect {file.name}", 404, DEFAULT_HEADERS
+        )
+    data = file.read().decode("utf-8")
+    if data != "I'm in ur multipart form-data, hazing a cheezburgr":
+        return await make_response(f"File data incorrect {data}", 200, DEFAULT_HEADERS)
+    return await make_response("Uploaded file correct", 200, DEFAULT_HEADERS)
+
+
+@pyodide_testing_app.route("/pyodide/<py_file>")
+async def pyodide(py_file: str) -> ResponseTypes:
+    file_path = Path(pyodide_testing_app.config["pyodide_dist_dir"], py_file)
+    if file_path.exists():
+        mime_type, encoding = mimetypes.guess_type(file_path)
+        if not mime_type:
+            mime_type = "text/plain"
+        return await make_response(
+            file_path.read_bytes(), 200, DEFAULT_HEADERS + [("Content-Type", mime_type)]
+        )
+    else:
+        return await make_response("", 404, DEFAULT_HEADERS)
+
+
+@pyodide_testing_app.route("/wheel/dist.whl")
+async def wheel() -> ResponseTypes:
+    # serve our wheel
+    wheel_folder = Path(__file__).parent.parent / "dist"
+    wheels = list(wheel_folder.glob("*.whl"))
+    if len(wheels) > 0:
+        wheel = wheels[0]
+        headers = DEFAULT_HEADERS + [
+            ("Content-Disposition", f"inline; filename='{wheel.name}'")
+        ]
+        resp = await make_response(wheel.read_bytes(), 200, headers)
+        return resp
+    else:
+        return await make_response(f"NO WHEEL IN {wheel_folder}", 404, DEFAULT_HEADERS)

--- a/src/urllib3/contrib/emscripten/connection.py
+++ b/src/urllib3/contrib/emscripten/connection.py
@@ -116,9 +116,9 @@ class EmscriptenHTTPConnection:
             if self._response is None:
                 self._response = send_request(request)
         except _TimeoutError as e:
-            raise TimeoutError(e.message)
+            raise TimeoutError(e.message) from e
         except _RequestError as e:
-            raise HTTPException(e.message)
+            raise HTTPException(e.message) from e
 
     def getresponse(self) -> BaseHTTPResponse:
         if self._response is not None:

--- a/test/contrib/emscripten/conftest.py
+++ b/test/contrib/emscripten/conftest.py
@@ -43,8 +43,6 @@ def testserver_http(
         http_port = typing.cast(int, parse_url(http_server_config.bind[0]).port)
 
         https_server_config = hypercorn.Config()
-        https_server_config.accesslog = "/tmp/https_access.txt"
-        https_server_config.errorlog = "/tmp/https_error.txt"
         https_server_config.certfile = DEFAULT_CERTS["certfile"]
         https_server_config.keyfile = DEFAULT_CERTS["keyfile"]
         https_server_config.verify_mode = DEFAULT_CERTS["cert_reqs"]

--- a/test/contrib/emscripten/test_emscripten.py
+++ b/test/contrib/emscripten/test_emscripten.py
@@ -630,6 +630,7 @@ def test_post_receive_json(
             "POST",
             f"http://{host}:{port}/echo_json",
             body=json.dumps(json_data).encode("utf-8"),
+            headers={"Content-type": "application/json"},
         )
         response = conn.getresponse()
         assert isinstance(response, BaseHTTPResponse)


### PR DESCRIPTION
While this should be relatively straightforward, various tests don't work, including some that just hang, and I have no idea how to debug this. I made some progress by looking at the server logs and noticed a few 404 errors, but everything looks good from the server point of view now. And the client errors are cryptic like "No module named js" (and that's after I changed two raise statements to stop throwing away exceptions).

@joemarshall Would you mind taking a look? This is the last test using Tornado, which I am in the process in removing, in order to have a test server that supports HTTP/2.