### PR TITLE
Add support for having a maximum retry after wait length.

### DIFF
--- a/changelog/1338.feature.rst
+++ b/changelog/1338.feature.rst
@@ -1,0 +1,1 @@
+Added support for having a maximum retry after wait length.

--- a/src/urllib3/exceptions.py
+++ b/src/urllib3/exceptions.py
@@ -82,6 +82,13 @@ ConnectionError = ProtocolError
 # Leaf Exceptions
 
 
+class MaxRetryWaitExceededError(HTTPError):
+    def __init__(self, retry_after_header_value: float) -> None:
+        self.retry_after_header_value = retry_after_header_value
+
+        super().__init__()
+
+
 class MaxRetryError(RequestError):
     """Raised when the maximum number of retries is exceeded.
 

--- a/src/urllib3/util/retry.py
+++ b/src/urllib3/util/retry.py
@@ -13,6 +13,7 @@ from ..exceptions import (
     ConnectTimeoutError,
     InvalidHeader,
     MaxRetryError,
+    MaxRetryWaitExceededError,
     ProtocolError,
     ProxyError,
     ReadTimeoutError,
@@ -215,6 +216,7 @@ class Retry:
             str
         ] = DEFAULT_REMOVE_HEADERS_ON_REDIRECT,
         backoff_jitter: float = 0.0,
+        max_retry_wait_length: float | None = None,
     ) -> None:
         self.total = total
         self.connect = connect
@@ -239,6 +241,7 @@ class Retry:
             h.lower() for h in remove_headers_on_redirect
         )
         self.backoff_jitter = backoff_jitter
+        self.max_retry_wait_length = max_retry_wait_length
 
     def new(self, **kw: typing.Any) -> Retry:
         params = dict(
@@ -331,6 +334,8 @@ class Retry:
     def sleep_for_retry(self, response: BaseHTTPResponse) -> bool:
         retry_after = self.get_retry_after(response)
         if retry_after:
+            if self.max_retry_wait_length and retry_after > self.max_retry_wait_length:
+                raise MaxRetryWaitExceededError(retry_after_header_value=retry_after)
             time.sleep(retry_after)
             return True
 

--- a/test/test_retry.py
+++ b/test/test_retry.py
@@ -10,6 +10,7 @@ from urllib3.exceptions import (
     ConnectTimeoutError,
     InvalidHeader,
     MaxRetryError,
+    MaxRetryWaitExceededError,
     ReadTimeoutError,
     ResponseError,
     SSLError,
@@ -419,3 +420,18 @@ class TestRetry:
                 sleep_mock.assert_called_with(sleep_duration)
             else:
                 sleep_mock.assert_not_called()
+
+    def test_max_retry_wait_length_exceeded(self) -> None:
+        max_retry_after = 3600
+        actual_retry_after = max_retry_after + 100
+        retry = Retry(
+            respect_retry_after_header=True, max_retry_wait_length=max_retry_after
+        )
+
+        response = HTTPResponse(
+            status=503, headers={"Retry-After": str(actual_retry_after)}
+        )
+
+        with pytest.raises(MaxRetryWaitExceededError) as e:
+            retry.sleep(response)
+        assert e.value.retry_after_header_value == actual_retry_after


### PR DESCRIPTION
Introducing a new feature that allows you to set a maximum duration for retry wait length using the `max_retry_wait_length` argument. If a response contains a `Retry-After` header with value greater than the maximum set and `respect_retry_after_header` is set to `True`, we will raise a `MaxRetryWaitExceededError`.