### PR TITLE
Make `BytesQueueBuffer.get_all` more memory efficient

### DIFF
--- a/src/urllib3/response.py
+++ b/src/urllib3/response.py
@@ -291,8 +291,9 @@ class BytesQueueBuffer:
         if len(buffer) == 1:
             result = buffer.pop()
         else:
-            result = b"".join(buffer)
-            buffer.clear()
+            ret = io.BytesIO()
+            ret.writelines(buffer.popleft() for _ in range(len(buffer)))
+            result = ret.getvalue()
         self._size = 0
         return result
 

--- a/test/test_response.py
+++ b/test/test_response.py
@@ -98,7 +98,7 @@ class TestBytesQueueBuffer:
         ids=("get", "get_all"),
     )
     @pytest.mark.limit_memory("12.5 MB")  # assert that we're not doubling memory usage
-    def test_memory_usage_of_get(
+    def test_memory_usage(
         self, get_func: typing.Callable[[BytesQueueBuffer], str]
     ) -> None:
         # Allocate 10 1MiB chunks


### PR DESCRIPTION
This PR adds memray tests for functionality added in #3186 and improves memory efficiency of `BytesQueueBuffer.get_all`.