### PR TITLE
CI: Only run cron jobs for upstream

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,6 +12,7 @@ permissions: "read-all"
 
 jobs:
   analyze:
+    if: github.repository_owner == "urllib3"
     name: "Analyze"
     runs-on: "ubuntu-latest"
     permissions:

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -10,6 +10,7 @@ permissions: read-all
 
 jobs:
   analysis:
+    if: github.repository_owner == "urllib3"
     name: "Scorecard"
     runs-on: "ubuntu-latest"
     permissions:


### PR DESCRIPTION
<!---
Thanks for your contribution! ♥️

If this is your first PR to urllib3 please review the Contributing Guide:
https://urllib3.readthedocs.io/en/latest/contributing.html

Adhering to the Contributing Guide means we can review, merge, and release your change faster! :)
--->

These two crons have been running on my fork:

![image](https://github.com/urllib3/urllib3/assets/1324225/71bb1fdd-5367-4cad-a408-635c259f68a2)

I don't think we need them for forks.

This config doesn't stop the workflows starting on schedule, but it immediately skips them to save lots of CI time.

More info:

https://dev.to/hugovk/til-how-to-disable-cron-for-github-forks-2d0l
