### PR TITLE
CI: Use single quotes, double quotes are invalid

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,7 +12,7 @@ permissions: "read-all"
 
 jobs:
   analyze:
-    if: github.repository_owner == "urllib3"
+    if: github.repository_owner == 'urllib3'
     name: "Analyze"
     runs-on: "ubuntu-latest"
     permissions:

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -10,7 +10,7 @@ permissions: read-all
 
 jobs:
   analysis:
-    if: github.repository_owner == "urllib3"
+    if: github.repository_owner == 'urllib3'
     name: "Scorecard"
     runs-on: "ubuntu-latest"
     permissions:


### PR DESCRIPTION
<!---
Thanks for your contribution! ♥️

If this is your first PR to urllib3 please review the Contributing Guide:
https://urllib3.readthedocs.io/en/latest/contributing.html

Adhering to the Contributing Guide means we can review, merge, and release your change faster! :)
--->

Follow on from https://github.com/urllib3/urllib3/pull/3237.

Sorry, double quotes are invalid, they need to be single quotes...

> The workflow is not valid. .github/workflows/scorecards.yml (Line: 13, Col: 9): Unexpected symbol: '"urllib3"'. Located at position 28 within expression: github.repository_owner == "urllib3"

https://github.com/urllib3/urllib3/actions/runs/7247042897


Correctly parsed and skipped on my fork:

https://github.com/hugovk/urllib3/actions/runs/7247177991