### PR TITLE
Fix coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,7 @@ jobs:
           python-version: "3.x"
 
       - name: "Install coverage"
-        run: "python -m pip install --upgrade coverage"
+        run: "python -m pip install -r dev-requirements.txt"
 
       - name: "Download artifact"
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2


### PR DESCRIPTION
We recently had coverage issues, where `coverage combine` complained about missing coverage in a way that made no sense, see https://github.com/urllib3/urllib3/actions/runs/7214376906/job/19669120651:

```
Name                                           Stmts   Miss  Cover   Missing
----------------------------------------------------------------------------
...
src/urllib3/_base_connection.py                   38     26    32%   68-143
```

However, this lines up with the release of [coverage.py 7.3.3](https://github.com/nedbat/coveragepy/releases/tag/7.3.3). Since we are not pinning the version of coverage in the action but pin when running tests, this can lead to issues. Let's see if that solves this particular one.