### PR TITLE
Add read1 tests, fix failures, revise code, document

### DIFF
--- a/test/test_response.py
+++ b/test/test_response.py
@@ -740,11 +740,12 @@ class TestResponse:
 
         assert resp.read1(1) == b"f"
 
+        # TODO: change error message to "read1", or make it general (e.g. "read/read1")
         with pytest.raises(
             RuntimeError,
             match=(
-                r"Calling read1\(decode_content=False\) is not supported after "
-                r"read1\(decode_content=True\) was called"
+                r"Calling read\(decode_content=False\) is not supported after "
+                r"read\(decode_content=True\) was called"
             ),
         ):
             resp.read1(1, decode_content=False)
@@ -752,8 +753,8 @@ class TestResponse:
         with pytest.raises(
             RuntimeError,
             match=(
-                r"Calling read1\(decode_content=False\) is not supported after "
-                r"read1\(decode_content=True\) was called"
+                r"Calling read\(decode_content=False\) is not supported after "
+                r"read\(decode_content=True\) was called"
             ),
         ):
             resp.read1(decode_content=False)


### PR DESCRIPTION
<!---
Thanks for your contribution! ♥️

If this is your first PR to urllib3 please review the Contributing Guide:
https://urllib3.readthedocs.io/en/latest/contributing.html

Adhering to the Contributing Guide means we can review, merge, and release your change faster! :)
--->

- re #3250


This came up during work on #2799.

It looks like `HTTPResponse.read1()` does not raise the expected `DecodeError` when the (to be decoded) data is incomplete.

* Add tests for read1 that lead to failures
* Add an additional reference test for `read`, which passes.
  * Failing read1 tests: https://github.com/urllib3/urllib3/actions/runs/7352783311/job/20017967313?pr=3248#step:7:572
* Fix test failures (starting with commit 15eaf26
* Reduce test-code duplication via `read1` parameter cc4b9b8

