### PR TITLE
Fix timeout tests on Windows

### DIFF
--- a/test/with_dummyserver/test_connectionpool.py
+++ b/test/with_dummyserver/test_connectionpool.py
@@ -98,10 +98,10 @@ class TestConnectionPoolTimeouts(SocketDummyServerTestCase):
             self.host, self.port, timeout=short_timeout, retries=False
         ) as pool:
             wait_for_socket(ready_event)
-            now = time.time()
+            now = time.perf_counter()
             with pytest.raises(ReadTimeoutError):
                 pool.request("GET", "/", timeout=LONG_TIMEOUT)
-            delta = time.time() - now
+            delta = time.perf_counter() - now
 
             message = "timeout was pool-level SHORT_TIMEOUT rather than request-level LONG_TIMEOUT"
             assert delta >= LONG_TIMEOUT, message
@@ -1301,24 +1301,24 @@ class TestRetryAfter(HypercornDummyServerTestCase):
             r = pool.request("GET", "/redirect_after", retries=False)
             assert r.status == 303
 
-            t = time.time()
+            t = time.perf_counter()
             r = pool.request("GET", "/redirect_after")
             assert r.status == 200
-            delta = time.time() - t
+            delta = time.perf_counter() - t
             assert delta >= 1
 
-            t = time.time()
+            t = time.perf_counter()
             timestamp = t + 2
             r = pool.request("GET", "/redirect_after?date=" + str(timestamp))
             assert r.status == 200
-            delta = time.time() - t
+            delta = time.perf_counter() - t
             assert delta >= 1
 
             # Retry-After is past
-            t = time.time()
+            t = time.perf_counter()
             timestamp = t - 1
             r = pool.request("GET", "/redirect_after?date=" + str(timestamp))
-            delta = time.time() - t
+            delta = time.perf_counter() - t
             assert r.status == 200
             assert delta < 1
 


### PR DESCRIPTION
`TestConnectionPoolTimeouts::test_timeout` sometimes fails with `assert 0.4999573230743408 >= 0.5`. The default clock on Windows has an average
granularity of 15.625ms which maybe means that our code sometimes
thinks that we waited less than we actually did? Switching to
perf_counter() should fix this issue.

https://randomascii.wordpress.com/2020/10/04/windows-timer-resolution-the-great-rule-change/ contains more details.

Noticed in https://github.com/urllib3/urllib3/actions/runs/7384069987/job/20086320256?pr=3256 (and earlier).