### PR TITLE
Fix test by adding wait/sleep until server is ready

### DIFF
--- a/changelog/3269.bugfix.rst
+++ b/changelog/3269.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed issue where test suite will fail because the server did not have enought time to start up.

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -12,6 +12,7 @@ import shutil
 import socket
 import ssl
 import tempfile
+import time
 import typing
 import zlib
 from collections import OrderedDict
@@ -1250,6 +1251,7 @@ class TestProxyManager(SocketDummyServerTestCase):
             sock.close()
 
         self._start_server(http_socket_handler)
+        time.sleep(0.1)
         base_url = f"https://{self.host}:{self.port}"
 
         with ProxyManager(base_url, cert_reqs="NONE") as proxy:
@@ -1293,7 +1295,7 @@ class TestSSL(SocketDummyServerTestCase):
         self._start_server(socket_handler)
         with HTTPSConnectionPool(self.host, self.port, ca_certs=DEFAULT_CA) as pool:
             with pytest.raises(
-                SSLError, match=r"(wrong version number|record overflow)"
+                SSLError, match=r"(wrong version number|record overflow|record layer failure)"
             ):
                 pool.request("GET", "/", retries=False)
 


### PR DESCRIPTION
<!---
Thanks for your contribution! ♥️

If this is your first PR to urllib3 please review the Contributing Guide:
https://urllib3.readthedocs.io/en/latest/contributing.html

Adhering to the Contributing Guide means we can review, merge, and release your change faster! :)
--->

Closes #3268 

The following test are sensitive to the start time of the dummyserver

- TestProxyManager::test_https_proxymanager_connected_to_http_proxy[http]
- TestProxyManager::test_https_proxymanager_connected_to_http_proxy[https]
- TestSSL::test_ssl_failure_midway_through_conn

By adding a short waiting period after starting the server with `time.sleep(0.1)` the following test failures are less likely

```
nox -s test-3.11 --error-on-missing-interpreters
nox > Running session test-3.11
nox > Re-using existing virtual environment at .nox/test-3-11.
nox > pip --version
pip 23.3.2 from /Users/rubelagu/git/urllib3/.nox/test-3-11/lib/python3.11/site-packages/pip (python 3.11)
nox > python --version
Python 3.11.4
nox > python -c 'import struct; print(struct.calcsize('"'"'P'"'"') * 8)'
64
nox > python -m OpenSSL.debug
pyOpenSSL: 23.2.0
cryptography: 41.0.6
cffi: 1.16.0
cryptography's compiled against OpenSSL: OpenSSL 3.1.4 24 Oct 2023
cryptography's linked OpenSSL: OpenSSL 3.1.4 24 Oct 2023
Python's OpenSSL: OpenSSL 1.1.1w  11 Sep 2023
Python executable: /Users/rubelagu/git/urllib3/.nox/test-3-11/bin/python
Python version: 3.11.4 (main, Jul  3 2023, 16:10:55) [Clang 14.0.3 (clang-1403.0.22.14.1)]
Platform: darwin
sys.path: ['/Users/rubelagu/git/urllib3', '/Users/rubelagu/.pyenv/versions/3.11.4/lib/python311.zip', '/Users/rubelagu/.pyenv/versions/3.11.4/lib/python3.11', '/Users/rubelagu/.pyenv/versions/3.11.4/lib/python3.11/lib-dynload', '/Users/rubelagu/git/urllib3/.nox/test-3-11/lib/python3.11/site-packages']
nox > python -m coverage run --parallel-mode -m pytest --memray --hide-memray-summary -v -ra --color=auto --tb=native --durations=10 --strict-config --strict-markers test/
========================================== test session starts ==========================================

...
FAILED test/with_dummyserver/test_socketlevel.py::TestProxyManager::test_https_proxymanager_connected_to_http_proxy[http] - assert 'Your proxy appears to only use HTTP and not HTTPS' in "('Unable to connect to proxy', SSLError(SSLError(1, '[SSL] record layer failure (_ssl.c:1000)')))"
FAILED test/with_dummyserver/test_socketlevel.py::TestProxyManager::test_https_proxymanager_connected_to_http_proxy[https] - assert 'Your proxy appears to only use HTTP and not HTTPS' in "('Unable to connect to proxy', SSLError(SSLError(1, '[SSL] record layer failure (_ssl.c:1000)')))"
FAILED test/with_dummyserver/test_socketlevel.py::TestSSL::test_ssl_failure_midway_through_conn - AssertionError: Regex pattern did not match.
```
