### PR TITLE
Add explicit_package_bases to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,7 @@ add_imports = "from __future__ import annotations"
 
 [tool.mypy]
 mypy_path = "src"
+explicit_package_bases = true
 check_untyped_defs = true
 disallow_any_generics = true
 disallow_incomplete_defs = true


### PR DESCRIPTION
<!---
Thanks for your contribution! ♥️

If this is your first PR to urllib3 please review the Contributing Guide:
https://urllib3.readthedocs.io/en/latest/contributing.html

Adhering to the Contributing Guide means we can review, merge, and release your change faster! :)
--->

Currently the mypy step of `nox -rs lint` can fail if for example you have a  `__init__.py` file in you `~`/`$HOME` directory

```
nox -rs lint
nox > Running session lint
nox > Re-using existing virtual environment at .nox/lint.
nox > python -m pip install pre-commit
nox > pre-commit run --all-files
pyupgrade................................................................Passed
black....................................................................Passed
isort....................................................................Passed
flake8...................................................................Passed
prettier.................................................................Passed
eslint...................................................................Passed
nox > python -m pip install -r mypy-requirements.txt
nox > mypy --version
mypy 1.5.1 (compiled: yes)
nox > mypy dummyserver noxfile.py src/urllib3 test
/Users/rubelagu/__init__.py: error: Source file found twice under different module names: "rubelagu.git.urllib3.src.urllib3.exceptions" and "urllib3.exceptions"
/Users/rubelagu/__init__.py: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#mapping-file-paths-to-modules for more info
/Users/rubelagu/__init__.py: note: Common resolutions include: a) adding `__init__.py` somewhere, b) using `--explicit-package-bases` or adjusting MYPYPATH
Found 1 error in 1 file (errors prevented further checking)
nox > Command mypy dummyserver noxfile.py src/urllib3 test failed with exit code 2
nox > Session lint failed.
``` 

by adding  the [explicit_package_bases = true](https://mypy.readthedocs.io/en/stable/config_file.html#confval-explicit_package_bases) as option to mypy then that kind of problem is prevented, making it more reliable. 

