### PR TITLE
Fix tests by handling ssl "record layer failure"

### DIFF
--- a/changelog/3268.bugfix.rst
+++ b/changelog/3268.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed test suite to handle "record layer failure" error.

--- a/changelog/3268.bugfix.rst
+++ b/changelog/3268.bugfix.rst
@@ -1,1 +1,1 @@
-Fixed test suite to handle "record layer failure" error.
+Fixed handling of OpenSSL 3.2.0 new error message for misconfiguring an HTTP proxy as HTTPS.

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -862,6 +862,7 @@ def _wrap_proxy_error(err: Exception, proxy_scheme: str | None) -> ProxyError:
     is_likely_http_proxy = (
         "wrong version number" in error_normalized
         or "unknown protocol" in error_normalized
+        or "record layer failure" in error_normalized
     )
     http_proxy_warning = (
         ". Your proxy appears to only use HTTP and not HTTPS, "

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -1293,7 +1293,8 @@ class TestSSL(SocketDummyServerTestCase):
         self._start_server(socket_handler)
         with HTTPSConnectionPool(self.host, self.port, ca_certs=DEFAULT_CA) as pool:
             with pytest.raises(
-                SSLError, match=r"(wrong version number|record overflow)"
+                SSLError,
+                match=r"(wrong version number|record overflow|record layer failure)",
             ):
                 pool.request("GET", "/", retries=False)
 


### PR DESCRIPTION
Closes #3268

Assumes the the ssl error SSL_R_RECORD_LAYER_FAILURE "record layer failure" is equivalent to the "Your proxy appears to only use HTTP and not HTTPS" error. 

<!---
Thanks for your contribution! ♥️

If this is your first PR to urllib3 please review the Contributing Guide:
https://urllib3.readthedocs.io/en/latest/contributing.html

Adhering to the Contributing Guide means we can review, merge, and release your change faster! :)
--->
