### PR TITLE
Distinguish between truncated and excess content in response

### DIFF
--- a/changelog/3261.misc.rst
+++ b/changelog/3261.misc.rst
@@ -1,1 +1,1 @@
-Made re-raised ProtocolError more verbose regarding corner cases.
+Made raised ``urllib3.exceptions.ProtocolError`` more verbose when a response contains content unexpectedly.

--- a/changelog/3261.misc.rst
+++ b/changelog/3261.misc.rst
@@ -1,0 +1,1 @@
+Made re-raised ProtocolError more verbose regarding corner cases.

--- a/src/urllib3/exceptions.py
+++ b/src/urllib3/exceptions.py
@@ -252,9 +252,12 @@ class IncompleteRead(HTTPError, httplib_IncompleteRead):
     for ``partial`` to avoid creating large objects on streamed reads.
     """
 
+    partial: int  # type: ignore[assignment]
+    expected: int
+
     def __init__(self, partial: int, expected: int) -> None:
-        self.partial: int = partial  # type: ignore[assignment]
-        self.expected: int = expected
+        self.partial = partial
+        self.expected = expected
 
     def __repr__(self) -> str:
         return "IncompleteRead(%i bytes read, %i more expected)" % (

--- a/src/urllib3/exceptions.py
+++ b/src/urllib3/exceptions.py
@@ -253,12 +253,12 @@ class IncompleteRead(HTTPError, httplib_IncompleteRead):
     """
 
     def __init__(self, partial: int, expected: int) -> None:
-        self.partial = partial  # type: ignore[assignment]
-        self.expected = expected
+        self.partial: int = partial  # type: ignore[assignment]
+        self.expected: int = expected
 
     def __repr__(self) -> str:
         return "IncompleteRead(%i bytes read, %i more expected)" % (
-            self.partial,  # type: ignore[str-format]
+            self.partial,
             self.expected,
         )
 

--- a/src/urllib3/response.py
+++ b/src/urllib3/response.py
@@ -749,8 +749,18 @@ class HTTPResponse(BaseHTTPResponse):
 
                 raise ReadTimeoutError(self._pool, None, "Read timed out.") from e  # type: ignore[arg-type]
 
+            except IncompleteRead as e:
+                if (
+                    e.expected is not None
+                    and e.partial is not None
+                    and int(e.expected) == -int(e.partial)
+                ):
+                    arg = f"Protocol violation: Response may not contain content: {e!r}"
+                else:
+                    arg = f"Connection broken: {e!r}"
+                raise ProtocolError(arg, e) from e
+
             except (HTTPException, OSError) as e:
-                # This includes IncompleteRead.
                 raise ProtocolError(f"Connection broken: {e!r}", e) from e
 
             # If no exception is thrown, we should avoid cleaning up

--- a/src/urllib3/response.py
+++ b/src/urllib3/response.py
@@ -753,7 +753,7 @@ class HTTPResponse(BaseHTTPResponse):
                 if (
                     e.expected is not None
                     and e.partial is not None
-                    and int(e.expected) == -int(e.partial)
+                    and e.expected == -e.partial
                 ):
                     arg = "Protocol violation: Response may not contain content."
                 else:

--- a/src/urllib3/response.py
+++ b/src/urllib3/response.py
@@ -755,7 +755,7 @@ class HTTPResponse(BaseHTTPResponse):
                     and e.partial is not None
                     and int(e.expected) == -int(e.partial)
                 ):
-                    arg = f"Protocol violation: Response may not contain content: {e!r}"
+                    arg = "Protocol violation: Response may not contain content."
                 else:
                     arg = f"Connection broken: {e!r}"
                 raise ProtocolError(arg, e) from e

--- a/src/urllib3/response.py
+++ b/src/urllib3/response.py
@@ -755,7 +755,7 @@ class HTTPResponse(BaseHTTPResponse):
                     and e.partial is not None
                     and e.expected == -e.partial
                 ):
-                    arg = "Protocol violation: Response may not contain content."
+                    arg = "Response may not contain content."
                 else:
                     arg = f"Connection broken: {e!r}"
                 raise ProtocolError(arg, e) from e

--- a/test/test_response.py
+++ b/test/test_response.py
@@ -1504,6 +1504,33 @@ class TestResponse:
                 resp.read()
             assert e.value.args[0] == mac_error
 
+    def test_unexpected_body(self) -> None:
+        with pytest.raises(ProtocolError) as excinfo:
+            fp = BytesIO(b"12345")
+            headers = {"content-length": "5"}
+            resp = HTTPResponse(fp, status=204, headers=headers)
+            resp.read(16)
+        assert "Protocol violation: Response may not contain content" in str(
+            excinfo.value
+        )
+
+        with pytest.raises(ProtocolError):
+            fp = BytesIO(b"12345")
+            headers = {"content-length": "0"}
+            resp = HTTPResponse(fp, status=204, headers=headers)
+            resp.read(16)
+        assert "Protocol violation: Response may not contain content" in str(
+            excinfo.value
+        )
+
+        with pytest.raises(ProtocolError):
+            fp = BytesIO(b"12345")
+            resp = HTTPResponse(fp, status=204)
+            resp.read(16)
+        assert "Protocol violation: Response may not contain content" in str(
+            excinfo.value
+        )
+
 
 class MockChunkedEncodingResponse:
     def __init__(self, content: list[bytes]) -> None:

--- a/test/test_response.py
+++ b/test/test_response.py
@@ -1293,7 +1293,7 @@ class TestResponse:
 
         orig_ex = ctx.value.args[1]
         assert isinstance(orig_ex, IncompleteRead)
-        assert orig_ex.partial == 0  # type: ignore[comparison-overlap]
+        assert orig_ex.partial == 0
         assert orig_ex.expected == content_length
 
     def test_incomplete_chunk(self) -> None:

--- a/test/test_response.py
+++ b/test/test_response.py
@@ -1510,26 +1510,20 @@ class TestResponse:
             headers = {"content-length": "5"}
             resp = HTTPResponse(fp, status=204, headers=headers)
             resp.read(16)
-        assert "Protocol violation: Response may not contain content" in str(
-            excinfo.value
-        )
+        assert "Response may not contain content" in str(excinfo.value)
 
         with pytest.raises(ProtocolError):
             fp = BytesIO(b"12345")
             headers = {"content-length": "0"}
             resp = HTTPResponse(fp, status=204, headers=headers)
             resp.read(16)
-        assert "Protocol violation: Response may not contain content" in str(
-            excinfo.value
-        )
+        assert "Response may not contain content" in str(excinfo.value)
 
         with pytest.raises(ProtocolError):
             fp = BytesIO(b"12345")
             resp = HTTPResponse(fp, status=204)
             resp.read(16)
-        assert "Protocol violation: Response may not contain content" in str(
-            excinfo.value
-        )
+        assert "Response may not contain content" in str(excinfo.value)
 
 
 class MockChunkedEncodingResponse:


### PR DESCRIPTION
`HTTPResponse._raw_read` raises `IncompleteRead` if the content length does not match the expected content length. For malformed responses (e.g. 204 response with content) the re-raised `ProtocolError` was a bit too unclear about the unexpected excess content being the reason for the exception.

With this change, the exception points out, that the client is not dealing with a connection error but a protocol violation.

Closes #3261
