### PR TITLE
Use -p and -m in mypy

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -279,9 +279,13 @@ def mypy(session: nox.Session) -> None:
     session.run("mypy", "--version")
     session.run(
         "mypy",
+        "-p",
         "dummyserver",
-        "noxfile.py",
-        "src/urllib3",
+        "-m",
+        "noxfile",
+        "-p",
+        "urllib3",
+        "-p",
         "test",
     )
 


### PR DESCRIPTION
Currently `nox -rs lint`  can fail if you happen to have spurious `__init__.py` files in the parent directories of the urllib3 source code:

```
mypy dummyserver noxfile.py src/urllib3 test
Source file found twice under different module names: "rubelagu.git.urllib3.src.urllib3.exceptions" and "urllib3.exceptions"
note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#mapping-file-paths-to-modules for more info
note: Common resolutions include: a) adding `__init__.py` somewhere, b) using `--explicit-package-bases` or adjusting MYPYPATH
```

to prevent this error, we can make use  of `-p` (for packages) and `-m` (for modules) options instead of listing source folders.

so `mypy dummyserver noxfile.py src/urllib3 test` becomes `mypy -p dummyserver -m noxfile -p urllib3 -p test`

Related #3270 

