### PR TITLE
Fix TestConnectionPoolTimeouts::test_timeout

### DIFF
--- a/test/with_dummyserver/test_connectionpool.py
+++ b/test/with_dummyserver/test_connectionpool.py
@@ -104,7 +104,7 @@ class TestConnectionPoolTimeouts(SocketDummyServerTestCase):
             delta = time.time() - now
 
             message = "timeout was pool-level SHORT_TIMEOUT rather than request-level LONG_TIMEOUT"
-            assert delta >= LONG_TIMEOUT, message
+            assert delta >= (LONG_TIMEOUT - 1e-5), message
             block_event.set()  # Release request
 
             # Timeout passed directly to request should raise a request timeout


### PR DESCRIPTION
<!---
Thanks for your contribution! ♥️

If this is your first PR to urllib3 please review the Contributing Guide:
https://urllib3.readthedocs.io/en/latest/contributing.html

Adhering to the Contributing Guide means we can review, merge, and release your change faster! :)
--->

I got the following test failure https://github.com/urllib3/urllib3/actions/runs/7486491572/job/20376966639?pr=3275

```
FAILED test/with_dummyserver/test_connectionpool.py::TestConnectionPoolTimeouts::test_timeout - AssertionError: timeout was pool-level SHORT_TIMEOUT rather than request-level LONG_TIMEOUT
assert 0.4999978542327881 >= 0.5
```

In this case `0.499997` is really `0.5` and the discrepancy is due to the floating point arithmetic limitations explained in [pytest.approx][2] and [Floating Point Arithmetic: Issues and Limitations][1]

This PR change the test to give a tolerance of `1e-5` on that test.


[1]: https://docs.python.org/3/tutorial/floatingpoint.html
[2]: https://docs.pytest.org/en/7.1.x/reference/reference.html#pytest-approx

