### PR TITLE
Rudimentary HTTP/2 connection and response

### DIFF
--- a/changelog/3284.feature.rst
+++ b/changelog/3284.feature.rst
@@ -1,0 +1,1 @@
+Added rudimentary support for HTTP/2 via ``urllib3.contrib.h2`` and ``HTTP2Connection`` class.

--- a/noxfile.py
+++ b/noxfile.py
@@ -11,7 +11,7 @@ import nox
 
 def tests_impl(
     session: nox.Session,
-    extras: str = "socks,brotli,zstd",
+    extras: str = "socks,brotli,zstd,h2",
     # hypercorn dependency h2 compares bytes and strings
     # https://github.com/python-hyper/h2/issues/1236
     byte_string_comparisons: bool = False,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,9 @@ zstd = [
 socks = [
   "PySocks>=1.5.6,<2.0,!=1.5.7",
 ]
+h2 = [
+  "h2>=4,<5"
+]
 
 [project.urls]
 "Changelog" = "https://github.com/urllib3/urllib3/blob/main/CHANGES.rst"

--- a/src/urllib3/contrib/http2.py
+++ b/src/urllib3/contrib/http2.py
@@ -29,8 +29,8 @@ class HTTP2Connection(HTTPSConnection):
         self._h2_stream: int | None = None
         self._h2_headers: list[tuple[bytes, bytes]] = []
 
-        if "proxy" in kwargs or "proxy_config" in kwargs:
-            raise ValueError("Proxies aren't supported with HTTP/2")
+        if "proxy" in kwargs or "proxy_config" in kwargs:  # Defensive:
+            raise NotImplementedError("Proxies aren't supported with HTTP/2")
 
         super().__init__(host, port, **kwargs)
 
@@ -84,10 +84,10 @@ class HTTP2Connection(HTTPSConnection):
                 end_stream=True,
             )
 
-    def send(self, data: bytes) -> None:  # type: ignore[override]
+    def send(self, data: bytes) -> None:  # type: ignore[override]  # Defensive:
         if not data:
             return
-        raise ValueError("Sending data isn't supported yet")
+        raise NotImplementedError("Sending data isn't supported yet")
 
     def getresponse(  # type: ignore[override]
         self,
@@ -101,8 +101,10 @@ class HTTP2Connection(HTTPSConnection):
                 if received_data := self.sock.recv(65535):
                     events = h2_conn.receive_data(received_data)
                     for event in events:
-                        if isinstance(event, h2.events.InformationalResponseReceived):
-                            continue
+                        if isinstance(
+                            event, h2.events.InformationalResponseReceived
+                        ):  # Defensive:
+                            continue  # TODO: Does the stdlib do anything with these responses?
 
                         elif isinstance(event, h2.events.ResponseReceived):
                             headers = HTTPHeaderDict()

--- a/src/urllib3/contrib/http2.py
+++ b/src/urllib3/contrib/http2.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+import contextlib
+import threading
+import typing
+
+import h2.config
+import h2.connection
+import h2.events
+
+import urllib3.connection
+import urllib3.util.ssl_
+
+from .._collections import HTTPHeaderDict
+from ..connection import HTTPSConnection
+from ..connectionpool import HTTPSConnectionPool
+
+
+class HTTP2Connection(HTTPSConnection):
+    def __init__(self, host: str, port: int | None = None, **kwargs):
+        self._h2_lock = threading.RLock()
+        self._h2_conn = h2.connection.H2Connection(
+            config=h2.config.H2Configuration(client_side=True)
+        )
+        self._h2_stream: int | None = None
+        self._h2_headers: list[tuple[bytes, bytes]] = []
+
+        if "proxy" in kwargs or "proxy_config" in kwargs:
+            raise ValueError("Proxies aren't supported with HTTP/2")
+
+        super().__init__(host, port, **kwargs)
+
+    @contextlib.contextmanager
+    def _lock_h2_conn(self) -> typing.Generator[h2.connection.H2Connection, None, None]:
+        with self._h2_lock:
+            yield self._h2_conn
+
+    def connect(self) -> None:
+        super().connect()
+
+        with self._lock_h2_conn() as h2_conn:
+            h2_conn.initiate_connection()
+            self.sock.sendall(h2_conn.data_to_send())
+
+    def putrequest(
+        self,
+        method: str,
+        url: str,
+        skip_host: bool = False,
+        skip_accept_encoding: bool = False,
+    ) -> None:
+        with self._lock_h2_conn() as h2_conn:
+            self._h2_stream = h2_conn.get_next_available_stream_id()
+
+            if ":" in self.host:
+                authority = f"[{self.host}]:{self.port or 443}"
+            else:
+                authority = f"{self.host}:{self.port or 443}"
+
+            self._h2_headers.extend(
+                (
+                    (b":scheme", b"https"),
+                    (b":method", method.encode()),
+                    (b":authority", authority.encode()),
+                    (b":path", url.encode()),
+                )
+            )
+
+    def putheader(self, header: str, *values: str) -> None:
+        for value in values:
+            self._h2_headers.append(
+                (header.encode("utf-8").lower(), value.encode("utf-8"))
+            )
+
+    def endheaders(self) -> None:
+        with self._lock_h2_conn() as h2_conn:
+            h2_conn.send_headers(
+                stream_id=self._h2_stream,
+                headers=self._h2_headers,
+                end_stream=True,
+            )
+
+    def send(self, data: bytes) -> None:
+        if not data:
+            return
+        raise ValueError("Sending data isn't supported yet")
+
+    def getresponse(  # type: ignore[override]
+        self,
+    ) -> HTTP2Response:
+        status = None
+        data = bytearray()
+        with self._lock_h2_conn() as h2_conn:
+            end_stream = False
+            while not end_stream:
+                if data := self.sock.recv():
+                    events = h2_conn.receive_data(data)
+                    for event in events:
+                        if isinstance(event, h2.events.InformationalResponseReceived):
+                            continue
+
+                        elif isinstance(event, h2.events.ResponseReceived):
+                            headers = HTTPHeaderDict()
+                            for header, value in event.headers:
+                                if header == b":status":
+                                    status = int(value.decode())
+                                else:
+                                    headers.add(
+                                        header.decode("ascii"), value.decode("ascii")
+                                    )
+
+                        elif isinstance(event, h2.events.DataReceived):
+                            data += event.data
+                            h2_conn.acknowledge_received_data(
+                                event.flow_controlled_length, event.stream_id
+                            )
+
+                        elif isinstance(event, h2.events.StreamEnded):
+                            end_stream = True
+
+                if data_to_send := h2_conn.data_to_send():
+                    self.sock.sendall(data_to_send)
+
+        # We always close to not have to handle connection management.
+        self.close()
+
+        return HTTP2Response(status=status, headers=headers, data=bytes(data))
+
+    def close(self) -> None:
+        with self._lock_h2_conn() as h2_conn:
+            try:
+                self._h2_conn.close_connection()
+                if data := h2_conn.data_to_send():
+                    self.sock.sendall(data)
+            except Exception:
+                pass
+
+        # Reset all our HTTP/2 connection state.
+        self._h2_conn = h2.connection.H2Connection(
+            config=h2.config.H2Configuration(client_side=True)
+        )
+        self._h2_stream = None
+        self._h2_headers = []
+
+        super().close()
+
+
+class HTTP2Response:
+    # TODO: This is a woefully incomplete response object, but works for non-streaming.
+    def __init__(self, status: int, headers: HTTPHeaderDict, data: bytes) -> None:
+        self.status = status
+        self.headers = headers
+        self.data = data
+        self.length_remaining = 0
+
+    def get_redirect_location(self):
+        return None
+
+
+def inject_into_urllib3() -> None:
+    HTTPSConnectionPool.ConnectionCls = HTTP2Connection
+    urllib3.connection.HTTPSConnection = HTTP2Connection  # type: ignore[misc,assignment]
+
+    # TODO: Offer both, but for testing purposes this is handy.
+    urllib3.util.ssl_.ALPN_PROTOCOLS = ["h2"]
+
+
+def extract_from_urllib3() -> None:
+    pass  # TODO: Actually extract from the stdlib.

--- a/src/urllib3/http2.py
+++ b/src/urllib3/http2.py
@@ -11,9 +11,9 @@ import h2.events  # type: ignore[import]
 import urllib3.connection
 import urllib3.util.ssl_
 
-from .._collections import HTTPHeaderDict
-from ..connection import HTTPSConnection
-from ..connectionpool import HTTPSConnectionPool
+from ._collections import HTTPHeaderDict
+from .connection import HTTPSConnection
+from .connectionpool import HTTPSConnectionPool
 
 orig_HTTPSConnection = HTTPSConnection
 
@@ -83,6 +83,8 @@ class HTTP2Connection(HTTPSConnection):
                 headers=self._h2_headers,
                 end_stream=True,
             )
+            if data_to_send := h2_conn.data_to_send():
+                self.sock.sendall(data_to_send)
 
     def send(self, data: bytes) -> None:  # type: ignore[override]  # Defensive:
         if not data:

--- a/test/with_dummyserver/test_http2.py
+++ b/test/with_dummyserver/test_http2.py
@@ -6,8 +6,8 @@ from test import notWindows
 import pytest
 
 import urllib3
+from dummyserver.socketserver import DEFAULT_CERTS
 from dummyserver.testcase import HTTPSHypercornDummyServerTestCase
-from dummyserver.tornadoserver import DEFAULT_CERTS
 
 DEFAULT_CERTS_HTTP2 = DEFAULT_CERTS.copy()
 DEFAULT_CERTS_HTTP2["alpn_protocols"] = ["h2"]

--- a/test/with_dummyserver/test_http2.py
+++ b/test/with_dummyserver/test_http2.py
@@ -16,7 +16,7 @@ DEFAULT_CERTS_HTTP2["alpn_protocols"] = ["h2"]
 
 def setup_module() -> None:
     try:
-        from urllib3.contrib.http2 import inject_into_urllib3
+        from urllib3.http2 import inject_into_urllib3
 
         inject_into_urllib3()
     except ImportError as e:
@@ -25,7 +25,7 @@ def setup_module() -> None:
 
 def teardown_module() -> None:
     try:
-        from urllib3.contrib.http2 import extract_from_urllib3
+        from urllib3.http2 import extract_from_urllib3
 
         extract_from_urllib3()
     except ImportError:

--- a/test/with_dummyserver/test_http2.py
+++ b/test/with_dummyserver/test_http2.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import subprocess
 from test import notWindows
+from test.conftest import ServerConfig
 
 import pytest
 
@@ -58,14 +59,15 @@ class TestHypercornDummyServerTestCase(HTTPSHypercornDummyServerTestCase):
         assert b"< HTTP/2 200" in output
         assert output.endswith(b"Dummy server!")
 
-    def test_simple_http2(self) -> None:
-        with urllib3.PoolManager(ca_certs=self.certs["ca_certs"]) as http:
-            resp = http.request("HEAD", self.base_url, retries=False)
 
-        assert resp.status == 200
-        resp.headers.pop("date")
-        assert resp.headers == {
-            "content-type": "text/html; charset=utf-8",
-            "content-length": "13",
-            "server": "hypercorn-h2",
-        }
+def test_simple_http2(san_server: ServerConfig) -> None:
+    with urllib3.PoolManager(ca_certs=san_server.ca_certs) as http:
+        resp = http.request("HEAD", san_server.base_url, retries=False)
+
+    assert resp.status == 200
+    resp.headers.pop("date")
+    assert resp.headers == {
+        "content-type": "text/html; charset=utf-8",
+        "content-length": "13",
+        "server": "hypercorn-h2",
+    }

--- a/test/with_dummyserver/test_http2.py
+++ b/test/with_dummyserver/test_http2.py
@@ -7,6 +7,10 @@ import pytest
 
 import urllib3
 from dummyserver.testcase import HTTPSHypercornDummyServerTestCase
+from dummyserver.tornadoserver import DEFAULT_CERTS
+
+DEFAULT_CERTS_HTTP2 = DEFAULT_CERTS.copy()
+DEFAULT_CERTS_HTTP2["alpn_protocols"] = ["h2"]
 
 
 def setup_module() -> None:
@@ -28,6 +32,8 @@ def teardown_module() -> None:
 
 
 class TestHypercornDummyServerTestCase(HTTPSHypercornDummyServerTestCase):
+    certs = DEFAULT_CERTS_HTTP2
+
     @classmethod
     def setup_class(cls) -> None:
         super().setup_class()


### PR DESCRIPTION
Part of #3000. This connection and response class are basically as simple as they can get:

* No multiplexing or connection reuse
* No request data
* No response streaming
* No proxies

We should probably make sure that `extract_...` works correctly so the test suite isn't mangled.