### PR TITLE
Skip memray on pypy

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -30,10 +30,16 @@ def tests_impl(
     # Print OpenSSL information.
     session.run("python", "-m", "OpenSSL.debug")
 
+    session_python_info = session.run(
+        "python",
+        "-c",
+        "import sys; print(sys.implementation.name,sys.version_info.releaselevel)",
+        silent=True,
+    ).strip()  # type: ignore[union-attr] # mypy doesn't know that silent=True  will return a string
+    implementation_name, release_level = session_python_info.split(" ")
+
     memray_supported = True
-    if session.python == "pypy":
-        memray_supported = False
-    if sys.implementation.name != "cpython" or sys.version_info.releaselevel != "final":
+    if implementation_name != "cpython" or release_level != "final":
         memray_supported = False  # pytest-memray requires CPython 3.8+
     elif sys.platform == "win32":
         memray_supported = False

--- a/noxfile.py
+++ b/noxfile.py
@@ -29,11 +29,12 @@ def tests_impl(
     session.run("python", "-c", "import struct; print(struct.calcsize('P') * 8)")
     # Print OpenSSL information.
     session.run("python", "-m", "OpenSSL.debug")
-
+    # Retrieve sys info from the Python implementation under test
+    # to avoid enabling memray when nox runs under CPython but tests PyPy
     session_python_info = session.run(
         "python",
         "-c",
-        "import sys; print(sys.implementation.name,sys.version_info.releaselevel)",
+        "import sys; print(sys.implementation.name, sys.version_info.releaselevel)",
         silent=True,
     ).strip()  # type: ignore[union-attr] # mypy doesn't know that silent=True  will return a string
     implementation_name, release_level = session_python_info.split(" ")

--- a/noxfile.py
+++ b/noxfile.py
@@ -31,6 +31,8 @@ def tests_impl(
     session.run("python", "-m", "OpenSSL.debug")
 
     memray_supported = True
+    if session.python == "pypy":
+        memray_supported = False
     if sys.implementation.name != "cpython" or sys.version_info.releaselevel != "final":
         memray_supported = False  # pytest-memray requires CPython 3.8+
     elif sys.platform == "win32":


### PR DESCRIPTION
Currently `nox -rs test-pypy` can fail with 

```
nox > python -m coverage run --parallel-mode -m pytest --memray --hide-memray-summary -v -ra --color=auto --tb=native --durations=10 --sict-config --strict-markers test/
ERROR: usage: __main__.py [options] [file_or_dir] [file_or_dir] [...]
__main__.py: error: unrecognized arguments: --memray --hide-memray-summary
```

the cause is that although the code in `noxfile.py`  tries to check if memray is supported, it does the check on the python interpreter that  executes nox, **not on the python interpreter used inside the session.** 

This patch disable memray if  `session.python == "pypy"`. 

Alternatively, we could use `session.run()` to write the `sys.implementation.name`, etc  to a file and read that from noxfile.py , so that noxfile.py could use the information from the actual python interpreter for the decision, but IMHO it's way more complicated for little benefit
