### PR TITLE
Use proxy_ssl_context as SSL ctx when forwarding (PR V2)

### DIFF
--- a/changelog/2577.bugfix.rst
+++ b/changelog/2577.bugfix.rst
@@ -2,5 +2,5 @@ The ``proxy_ssl_context`` argument for ``urllib3.ProxyManager`` will be used
 for the connection to the proxy when the connection is forwarded, either because
 ``use_forwarding_for_https`` is set to ``True`` or because the target is a HTTP destination.
 Previously, ``proxy_ssl_context`` was not used in these situations. If ``ssl_context``
-is passed as a keyword argument, it will be used if ``proxy_ssl_context`` is not set,
-but this use is deprecated.
+was passed as a keyword argument, it had been used if ``proxy_ssl_context`` were not set,
+but setting ``ssl_context`` will now raise an error.

--- a/changelog/2577.bugfix.rst
+++ b/changelog/2577.bugfix.rst
@@ -1,0 +1,6 @@
+The ``proxy_ssl_context`` argument for ``urllib3.ProxyManager`` will be used
+for the connection to the proxy when the connection is forwarded, either because
+``use_forwarding_for_https`` is set to ``True`` or because the target is a HTTP destination.
+Previously, ``proxy_ssl_context`` was not used in these situations. If ``ssl_context``
+is passed as a keyword argument, it will be used if ``proxy_ssl_context`` is not set,
+but this use is deprecated.

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -561,9 +561,7 @@ class HTTPSConnection(HTTPConnection):
                 raise ValueError(
                     "The 'ssl_context' parameter cannot be set when use_forwarding_for_https is True. Use the 'proxy_ssl_context' parameter to customize the connection to the proxy"
                 )
-            else:
-
-                self.ssl_context = proxy_config.ssl_context
+            self.ssl_context = proxy_config.ssl_context
         else:
             self.ssl_context = ssl_context
 
@@ -665,7 +663,7 @@ class HTTPSConnection(HTTPConnection):
         # Remove trailing '.' from fqdn hostnames to allow certificate validation
         server_hostname_rm_dot = server_hostname.rstrip(".")
 
-        if self._connecting_to_proxy and self.proxy_config:
+        if self.proxy_is_forwarding and self.proxy_config:
             ssl_context = self.proxy_config.ssl_context
         else:
             ssl_context = self.ssl_context
@@ -683,7 +681,7 @@ class HTTPSConnection(HTTPConnection):
             key_file=self.key_file,
             key_password=self.key_password,
             server_hostname=server_hostname_rm_dot,
-            ssl_context=self.ssl_context,
+            ssl_context=ssl_context,
             tls_in_tls=tls_in_tls,
             assert_hostname=self.assert_hostname,
             assert_fingerprint=self.assert_fingerprint,

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -554,26 +554,16 @@ class HTTPSConnection(HTTPConnection):
 
         if proxy_config and proxy_config.use_forwarding_for_https:
             if proxy_config.ssl_context is not None and ssl_context is not None:
-                warnings.warn(
-                    "The 'ssl_context' parameter is not used to configure the connection to the proxy when the 'use_forwarding_for_https' parameter is set to True "
-                    "and should not be set. The 'proxy_ssl_context' parameter is used to configure the connection. "
-                    "In a later urllib3 v2.x release, setting ssl_context will result in an error",
-                    DeprecationWarning,
-                    stacklevel=2,
+                raise ValueError(
+                    "The 'ssl_context' parameter cannot be set when use_forwarding_for_https is True"
                 )
             elif proxy_config.ssl_context is None and ssl_context is not None:
-                warnings.warn(
-                    "The 'ssl_context' parameter should not be used to configure the connection to the proxy when the 'use_forwarding_for_https' parameter is set to True, "
-                    "Use the 'proxy_ssl_context' parameter to customize the connection. "
-                    "In a later urllib3 v2.x release, setting ssl_context will result in an error",
-                    DeprecationWarning,
-                    stacklevel=2,
+                raise ValueError(
+                    "The 'ssl_context' parameter cannot be set when use_forwarding_for_https is True. Use the 'proxy_ssl_context' parameter to customize the connection to the proxy"
                 )
-                self.proxy_config = ProxyConfig(
-                    ssl_context, proxy_config.use_forwarding_for_https
-                )
+            else:
 
-            self.ssl_context = proxy_config.ssl_context
+                self.ssl_context = proxy_config.ssl_context
         else:
             self.ssl_context = ssl_context
 

--- a/test/with_dummyserver/test_proxy_poolmanager.py
+++ b/test/with_dummyserver/test_proxy_poolmanager.py
@@ -130,14 +130,25 @@ class TestHTTPProxyManager(HypercornDummyProxyTestCase):
     def test_https_proxy_with_proxy_ssl_context(self) -> None:
         proxy_ssl_context = create_urllib3_context()
         proxy_ssl_context.load_verify_locations(DEFAULT_CA)
+        ctx = ssl.create_default_context()
+        ctx.load_verify_locations(DEFAULT_CA)
         with proxy_from_url(
             self.https_proxy_url,
             proxy_ssl_context=proxy_ssl_context,
-            ca_certs=DEFAULT_CA,
+            ssl_context=ctx,
         ) as https:
             r = https.request("GET", f"{self.https_url}/")
             assert r.status == 200
 
+            r = https.request("GET", f"{self.http_url}/")
+            assert r.status == 200
+
+    def test_https_proxy_with_proxy_ssl_context_to_http_target(self) -> None:
+        proxy_ssl_context = create_urllib3_context()
+        proxy_ssl_context.load_verify_locations(DEFAULT_CA)
+        with proxy_from_url(
+            self.https_proxy_url, proxy_ssl_context=proxy_ssl_context
+        ) as https:
             r = https.request("GET", f"{self.http_url}/")
             assert r.status == 200
 
@@ -443,6 +454,39 @@ class TestHTTPProxyManager(HypercornDummyProxyTestCase):
                 returned_headers.get("Host") == f"{self.https_host}:{self.https_port}"
             )
 
+    def test_forwarding_for_https_with_proxy_ctx(self) -> None:
+        proxy_ctx = ssl.create_default_context()
+        proxy_ctx.load_verify_locations(DEFAULT_CA)
+        with proxy_from_url(
+            self.https_proxy_url,
+            proxy_ssl_context=proxy_ctx,
+            use_forwarding_for_https=True,
+        ) as proxy:
+            proxy.request("GET", f"{self.https_url}/")
+
+    def test_forwarding_for_https_error_with_ssl_ctx(self) -> None:
+        proxy_ctx = ssl.create_default_context()
+        proxy_ctx.load_verify_locations(DEFAULT_CA)
+        ctx = ssl.create_default_context()
+        ctx.load_verify_locations(DEFAULT_CA)
+        with proxy_from_url(
+            self.https_proxy_url,
+            proxy_ssl_context=proxy_ctx,
+            use_forwarding_for_https=True,
+            ssl_context=ctx,
+        ) as proxy:
+            with pytest.warns(DeprecationWarning):
+                proxy.request("GET", self.https_url)
+
+    def test_forwarding_for_https_error_with_only_ssl_ctx(self) -> None:
+        ctx = ssl.create_default_context()
+        ctx.load_verify_locations(DEFAULT_CA)
+        with proxy_from_url(
+            self.https_proxy_url, use_forwarding_for_https=True, ssl_context=ctx
+        ) as proxy:
+            with pytest.warns(DeprecationWarning):
+                proxy.request("GET", self.https_url)
+
     def test_headerdict(self) -> None:
         default_headers = HTTPHeaderDict(a="b")
         proxy_headers = HTTPHeaderDict()
@@ -637,19 +681,13 @@ class TestHTTPProxyManager(HypercornDummyProxyTestCase):
     @pytest.mark.filterwarnings("default::ResourceWarning")
     @requires_network()
     @pytest.mark.parametrize(
-        ["proxy_scheme", "use_forwarding_for_https"],
+        ["proxy_scheme"],
         [
-            ("http", False),
-            ("https", False),
-            ("https", True),
+            ("http",),
+            ("https",),
         ],
     )
-    def test_proxy_https_target_tls_error(
-        self, proxy_scheme: str, use_forwarding_for_https: str
-    ) -> None:
-        if proxy_scheme == "https" and use_forwarding_for_https:
-            pytest.skip("Test is expected to fail due to urllib3/urllib3#2577")
-
+    def test_proxy_https_target_tls_error(self, proxy_scheme: str) -> None:
         proxy_url = self.https_proxy_url if proxy_scheme == "https" else self.proxy_url
         proxy_ctx = ssl.create_default_context()
         proxy_ctx.load_verify_locations(DEFAULT_CA)
@@ -659,7 +697,7 @@ class TestHTTPProxyManager(HypercornDummyProxyTestCase):
             proxy_url,
             proxy_ssl_context=proxy_ctx,
             ssl_context=ctx,
-            use_forwarding_for_https=use_forwarding_for_https,
+            use_forwarding_for_https=False,
         ) as proxy:
             with pytest.raises(MaxRetryError) as e:
                 proxy.request("GET", self.https_url)

--- a/test/with_dummyserver/test_proxy_poolmanager.py
+++ b/test/with_dummyserver/test_proxy_poolmanager.py
@@ -475,7 +475,9 @@ class TestHTTPProxyManager(HypercornDummyProxyTestCase):
             use_forwarding_for_https=True,
             ssl_context=ctx,
         ) as proxy:
-            with pytest.warns(DeprecationWarning):
+            with pytest.raises(
+                ValueError, match="The 'ssl_context' parameter cannot be set"
+            ):
                 proxy.request("GET", self.https_url)
 
     def test_forwarding_for_https_error_with_only_ssl_ctx(self) -> None:
@@ -484,7 +486,9 @@ class TestHTTPProxyManager(HypercornDummyProxyTestCase):
         with proxy_from_url(
             self.https_proxy_url, use_forwarding_for_https=True, ssl_context=ctx
         ) as proxy:
-            with pytest.warns(DeprecationWarning):
+            with pytest.raises(
+                ValueError, match="The 'ssl_context' parameter cannot be set"
+            ):
                 proxy.request("GET", self.https_url)
 
     def test_headerdict(self) -> None:


### PR DESCRIPTION
<!---
Thanks for your contribution! ♥️

If this is your first PR to urllib3 please review the Contributing Guide:
https://urllib3.readthedocs.io/en/latest/contributing.html

Adhering to the Contributing Guide means we can review, merge, and release your change faster! :)
--->

rebased and slightly updated PR

- #2651 (by @ avi364)

~Some tests failing.~