### PR TITLE
Fix pypy ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,7 @@ jobs:
         if: ${{ matrix.nox-session == 'emscripten' }}
       - name: "Run tests"
         # If no explicit NOX_SESSION is set, run the default tests for the chosen Python version
-        run: nox -s ${NOX_SESSION:-test-$PYTHON_VERSION} --error-on-missing-interpreters
+        run: nox -s ${NOX_SESSION:-test-$PYTHON_VERSION}
         env:
           PYTHON_VERSION: ${{ matrix.python-version }}
           NOX_SESSION: ${{ matrix.nox-session }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,15 +66,15 @@ jobs:
           - python-version: "pypy-3.8"
             os: ubuntu-latest
             experimental: false
-            nox-session: test-pypy
+            nox-session: test-pypy3.8
           - python-version: "pypy-3.9"
             os: ubuntu-latest
             experimental: false
-            nox-session: test-pypy
+            nox-session: test-pypy3.9
           - python-version: "pypy-3.10"
             os: ubuntu-latest
             experimental: false
-            nox-session: test-pypy
+            nox-session: test-pypy3.10
           - python-version: "3.x"
           # brotli
             os: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
             os: ubuntu-latest
             experimental: false
             nox-session: test-pypy3.8
-          - python-version: "pypy-3.9"
+          - python-version: "pypy-3.9-v7.3.13"
             os: ubuntu-latest
             experimental: false
             nox-session: test-pypy3.9

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -13,8 +13,8 @@ If you wish to add a new feature or fix a bug:
    to start making your changes.
 #. Write a test which shows that the bug was fixed or that the feature works
    as expected.
-#. Format your changes with black using command `$ nox -rs format` and lint your
-   changes using command `nox -rs lint`.
+#. Format your changes with black using command ``nox -rs format`` and lint your
+   changes using command ``nox -rs lint``.
 #. Add a `changelog entry
    <https://github.com/urllib3/urllib3/blob/main/changelog/README.rst>`__.
 #. Send a pull request and bug the maintainer until it gets merged and published.
@@ -36,7 +36,7 @@ We use some external dependencies, multiple interpreters and code coverage
 analysis while running test suite. Our ``noxfile.py`` handles much of this for
 you::
 
-  $ nox --reuse-existing-virtualenvs --sessions test-3.8 test-3.9
+  $ nox --reuse-existing-virtualenvs --sessions test-3.8 test-3.9 test-pypy3.8 test-pypy3.10
   [ Nox will create virtualenv if needed, install the specified dependencies, and run the commands in order.]
   nox > Running session test-3.8
   .......
@@ -48,6 +48,21 @@ you::
   .......
   .......
   nox > Session test-3.9 was successful.
+
+
+Note that for nox to test different interpreters, the interpreters must be on the
+`PATH` first. Check with `which` to see if the interpreter is on the `PATH`
+like so::
+
+  $ which python3.8
+  ~/.pyenv/versions/3.8.16/bin/python3.8
+
+  $ which python3.9
+  ~/.pyenv/versions/3.9.6/bin/python3.9
+
+  $ which pypy3.8
+  ~/.pyenv/versions/pypy3.8-7.3.11/bin/pypy3.8
+
 
 There is also a nox command for running all of our tests and multiple python
 versions.::

--- a/noxfile.py
+++ b/noxfile.py
@@ -8,6 +8,8 @@ from pathlib import Path
 
 import nox
 
+nox.options.error_on_missing_interpreters = True
+
 
 def tests_impl(
     session: nox.Session,
@@ -76,7 +78,9 @@ def tests_impl(
     )
 
 
-@nox.session(python=["3.8", "3.9", "3.10", "3.11", "3.12", "pypy"])
+@nox.session(
+    python=["3.8", "3.9", "3.10", "3.11", "3.12", "pypy3.8", "pypy3.9", "pypy3.10"]
+)
 def test(session: nox.Session) -> None:
     tests_impl(session)
 


### PR DESCRIPTION
<!---
Thanks for your contribution! ♥️

If this is your first PR to urllib3 please review the Contributing Guide:
https://urllib3.readthedocs.io/en/latest/contributing.html

Adhering to the Contributing Guide means we can review, merge, and release your change faster! :)
--->

This is not ready for review yet. 

I suspect the pypy3.9 tests usually  takes more that 30 minutes due to some regresion between pypy3.9-v7.3.13 and pypy3.9-7.3.15. 

The other alternative is that there coverage is much slower in this pypy3.9-v7.3.15 , like is this other issue https://github.com/nedbat/coveragepy/issues/1339 


Closes #3305 