### PR TITLE
Pin to pypy-3.9-v7.3.13 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
             os: ubuntu-latest
             experimental: false
             nox-session: test-pypy
-          - python-version: "pypy-3.9"
+          - python-version: "pypy-3.9-v7.3.13"
             os: ubuntu-latest
             experimental: false
             nox-session: test-pypy


### PR DESCRIPTION
<!---
Thanks for your contribution! ♥️

If this is your first PR to urllib3 please review the Contributing Guide:
https://urllib3.readthedocs.io/en/latest/contributing.html

Adhering to the Contributing Guide means we can review, merge, and release your change faster! :)
--->


CI seems to be continuosly failing on the `test-pypy` under `pypy3.9`. 

Currently `pypy3.9` is mapped to `pypy3.9-v7.3.15` and I believe this particular version of pypy is causing the "coverage" take way longer. 

In this PR I'm pinning the version to `pypy3.9-v7.3.13`, this I think makes the `test-pypy` to complete in under 8 minutes instead of the current +30 minutes which causes the CI job to be cancelled.


Closes #3305 