### PR TITLE
Disable coverage under pypy3.9-v7.3.15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
             os: ubuntu-latest
             experimental: false
             nox-session: test-pypy
-          - python-version: "pypy-3.9-v7.3.13"
+          - python-version: "pypy-3.9-v7.3.15"
             os: ubuntu-latest
             experimental: false
             nox-session: test-pypy

--- a/noxfile.py
+++ b/noxfile.py
@@ -65,9 +65,9 @@ def tests_impl(
         "python",
         *(("-bb",) if byte_string_comparisons else ()),
         "-m",
-        "coverage",
-        "run",
-        "--parallel-mode",
+        *("coverage", "run", "--parallel-mode")
+        if not session.name.startswith("test-pypy3.9")
+        else (),
         "-m",
         "pytest",
         *("--memray", "--hide-memray-summary") if memray_supported else (),


### PR DESCRIPTION
<!---
Thanks for your contribution! ♥️

If this is your first PR to urllib3 please review the Contributing Guide:
https://urllib3.readthedocs.io/en/latest/contributing.html

Adhering to the Contributing Guide means we can review, merge, and release your change faster! :)
--->

This is a test , not meant to be ever merged. 

I'm trying to determine if the problem with pypy3.9-v7.3.15 (slow test that take more that 30 minutes) go away if we skip coverage `-m coverage run --parallel-mode`, that will determine if it's a problem/regression with pypy3.9-7.3.15 or with coverage under pypy3.9-v7.3.15 