### PR TITLE
Make BaseHTTPResponse a base class of HTTP2Response

### DIFF
--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -556,7 +556,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
             # HTTP version
             http_version,
             response.status,
-            response.length_remaining,  # type: ignore[attr-defined]
+            getattr(response, "length_remaining", None),
         )
 
         return response

--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -556,7 +556,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
             # HTTP version
             http_version,
             response.status,
-            getattr(response, "length_remaining", None),
+            response.length_remaining,  # type: ignore[attr-defined]
         )
 
         return response

--- a/src/urllib3/http2.py
+++ b/src/urllib3/http2.py
@@ -193,7 +193,7 @@ class HTTP2Response(BaseHTTPResponse):
 
 
 def inject_into_urllib3() -> None:
-    HTTPSConnectionPool.ConnectionCls = HTTP2Connection  # type: ignore[assignment]
+    HTTPSConnectionPool.ConnectionCls = HTTP2Connection
     urllib3.connection.HTTPSConnection = HTTP2Connection  # type: ignore[misc]
 
     # TODO: Offer 'http/1.1' as well, but for testing purposes this is handy.

--- a/src/urllib3/http2.py
+++ b/src/urllib3/http2.py
@@ -10,6 +10,7 @@ import h2.events  # type: ignore[import]
 
 import urllib3.connection
 import urllib3.util.ssl_
+from urllib3.response import BaseHTTPResponse
 
 from ._collections import HTTPHeaderDict
 from .connection import HTTPSConnection
@@ -54,6 +55,7 @@ class HTTP2Connection(HTTPSConnection):
         skip_accept_encoding: bool = False,
     ) -> None:
         with self._lock_h2_conn() as h2_conn:
+            self._request_url = url
             self._h2_stream = h2_conn.get_next_available_stream_id()
 
             if ":" in self.host:
@@ -134,7 +136,12 @@ class HTTP2Connection(HTTPSConnection):
         self.close()
 
         assert status is not None
-        return HTTP2Response(status=status, headers=headers, data=bytes(data))
+        return HTTP2Response(
+            status=status,
+            headers=headers,
+            request_url=self._request_url,
+            data=bytes(data),
+        )
 
     def close(self) -> None:
         with self._lock_h2_conn() as h2_conn:
@@ -155,13 +162,31 @@ class HTTP2Connection(HTTPSConnection):
         super().close()
 
 
-class HTTP2Response:
+class HTTP2Response(BaseHTTPResponse):
     # TODO: This is a woefully incomplete response object, but works for non-streaming.
-    def __init__(self, status: int, headers: HTTPHeaderDict, data: bytes) -> None:
-        self.status = status
-        self.headers = headers
-        self.data = data
-        self.length_remaining = 0
+    def __init__(
+        self,
+        status: int,
+        headers: HTTPHeaderDict,
+        request_url: str,
+        data: bytes,
+        decode_content: bool = False,  # TODO: support decoding
+    ) -> None:
+        super().__init__(
+            status=status,
+            headers=headers,
+            # Following CPython, we map HTTP versions to major * 10 + minor integers
+            version=20,
+            # No reason phrase in HTTP/2
+            reason=None,
+            decode_content=decode_content,
+            request_url=request_url,
+        )
+        self._data = data
+
+    @property
+    def data(self) -> bytes:
+        return self._data
 
     def get_redirect_location(self) -> None:
         return None

--- a/src/urllib3/http2.py
+++ b/src/urllib3/http2.py
@@ -183,6 +183,7 @@ class HTTP2Response(BaseHTTPResponse):
             request_url=request_url,
         )
         self._data = data
+        self.length_remaining = 0
 
     @property
     def data(self) -> bytes:

--- a/test/with_dummyserver/test_https.py
+++ b/test/with_dummyserver/test_https.py
@@ -139,6 +139,7 @@ class TestHTTPS(HTTPSHypercornDummyServerTestCase):
             r = https_pool.request("GET", "/")
             assert r.status == 200, r.data
             assert r.headers["server"] == f"hypercorn-{http_version}"
+            assert r.data == b"Dummy server!"
 
     @resolvesLocalhostFQDN()
     def test_dotted_fqdn(self) -> None:


### PR DESCRIPTION
Closes #3297

As mentioned in #3297, it turns out we already had `version`, an integer that tells us the HTTP version using a convention from `http.client` (10 means HTTP/1.0, 11 means HTTP/1.1 and 20 means HTTP/2.0). I'm happy to add an `http_version` string field too.

This pull request was sponsored by [Elastic](https://www.elastic.co/), my employer.