### PR TITLE
Fix TLS 1.3 Post Handshake Auth

### DIFF
--- a/changelog/3325.bugfix.rst
+++ b/changelog/3325.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed TLS 1.3 Post Handshake Auth when the server certificate validation was disabled.

--- a/src/urllib3/util/ssl_.py
+++ b/src/urllib3/util/ssl_.py
@@ -320,13 +320,8 @@ def create_urllib3_context(
     # Enable post-handshake authentication for TLS 1.3, see GH #1634. PHA is
     # necessary for conditional client cert authentication with TLS 1.3.
     # The attribute is None for OpenSSL <= 1.1.0 or does not exist in older
-    # versions of Python. We only enable if certificate verification is enabled to work
-    # around Python issue #37428
-    # See: https://bugs.python.org/issue37428
-    if (
-        cert_reqs == ssl.CERT_REQUIRED
-        and getattr(context, "post_handshake_auth", None) is not None
-    ):
+    # versions of Python.
+    if context.post_handshake_auth is not None:
         context.post_handshake_auth = True
 
     # The order of the below lines setting verify_mode and check_hostname

--- a/src/urllib3/util/ssl_.py
+++ b/src/urllib3/util/ssl_.py
@@ -319,9 +319,9 @@ def create_urllib3_context(
 
     # Enable post-handshake authentication for TLS 1.3, see GH #1634. PHA is
     # necessary for conditional client cert authentication with TLS 1.3.
-    # The attribute is None for OpenSSL <= 1.1.0 or does not exist in older
-    # versions of Python.
-    if getattr(context, "post_handshake_auth") is not None:
+    # The attribute is None for OpenSSL <= 1.1.0 or does not exist when using
+    # an SSLContext created by pyOpenSSL.
+    if getattr(context, "post_handshake_auth", None) is not None:
         context.post_handshake_auth = True
 
     # The order of the below lines setting verify_mode and check_hostname

--- a/src/urllib3/util/ssl_.py
+++ b/src/urllib3/util/ssl_.py
@@ -321,7 +321,7 @@ def create_urllib3_context(
     # necessary for conditional client cert authentication with TLS 1.3.
     # The attribute is None for OpenSSL <= 1.1.0 or does not exist in older
     # versions of Python.
-    if context.post_handshake_auth is not None:
+    if getattr(context, "post_handshake_auth") is not None:
         context.post_handshake_auth = True
 
     # The order of the below lines setting verify_mode and check_hostname

--- a/test/test_ssl.py
+++ b/test/test_ssl.py
@@ -122,7 +122,7 @@ class TestSSL:
             (True, True, ssl.CERT_NONE),
             (True, True, ssl.CERT_OPTIONAL),
             (True, True, ssl.CERT_REQUIRED),
-        ]
+        ],
     )
     def test_create_urllib3_context_pha(
         self,

--- a/test/test_ssl.py
+++ b/test/test_ssl.py
@@ -108,13 +108,28 @@ class TestSSL:
                 ssl_.ssl_wrap_socket(sock, tls_in_tls=True)
 
     @pytest.mark.parametrize(
-        ["pha", "expected_pha"], [(None, None), (False, True), (True, True)]
+        ["pha", "expected_pha", "cert_reqs"],
+        [
+            (None, None, None),
+            (None, None, ssl.CERT_NONE),
+            (None, None, ssl.CERT_OPTIONAL),
+            (None, None, ssl.CERT_REQUIRED),
+            (False, True, None),
+            (False, True, ssl.CERT_NONE),
+            (False, True, ssl.CERT_OPTIONAL),
+            (False, True, ssl.CERT_REQUIRED),
+            (True, True, None),
+            (True, True, ssl.CERT_NONE),
+            (True, True, ssl.CERT_OPTIONAL),
+            (True, True, ssl.CERT_REQUIRED),
+        ]
     )
     def test_create_urllib3_context_pha(
         self,
         monkeypatch: pytest.MonkeyPatch,
         pha: bool | None,
         expected_pha: bool | None,
+        cert_reqs: int | None,
     ) -> None:
         context = mock.create_autospec(ssl_.SSLContext)
         context.set_ciphers = mock.Mock()
@@ -122,7 +137,7 @@ class TestSSL:
         context.post_handshake_auth = pha
         monkeypatch.setattr(ssl_, "SSLContext", lambda *_, **__: context)
 
-        assert ssl_.create_urllib3_context() is context
+        assert ssl_.create_urllib3_context(cert_reqs=cert_reqs) is context
 
         assert context.post_handshake_auth == expected_pha
 


### PR DESCRIPTION
Fixed TLS 1.3 Post Handshake Auth when the server certificate validation was disabled.

Fixes: https://github.com/urllib3/urllib3/issues/3325