### PR TITLE
Ensure no remote connections during testing

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -18,3 +18,4 @@ quart-trio==0.11.1
 # https://github.com/pgjones/hypercorn/issues/169
 hypercorn @ git+https://github.com/urllib3/hypercorn@urllib3-changes
 httpx==0.25.2
+pytest-socket==0.7.0

--- a/noxfile.py
+++ b/noxfile.py
@@ -81,6 +81,9 @@ def tests_impl(
         "--durations=10",
         "--strict-config",
         "--strict-markers",
+        "--disable-socket",
+        "--allow-unix-socket",
+        "--allow-hosts=localhost,::1,127.0.0.0,240.0.0.0",  # See `TARPIT_HOST`
         *pytest_extra_args,
         *(session.posargs or ("test/",)),
         env=pytest_session_envvars,


### PR DESCRIPTION
As a way to prevent the test suite from making remote calls to anywhere unexpected, use the `pytest-socket` plugin to disable any calls to hosts other than localhost.

<!---
Thanks for your contribution! ♥️

If this is your first PR to urllib3 please review the Contributing Guide:
https://urllib3.readthedocs.io/en/latest/contributing.html

Adhering to the Contributing Guide means we can review, merge, and release your change faster! :)
--->
