### PR TITLE
Fix ssl_version tests

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,7 +1,7 @@
 h2==4.1.0
 coverage==7.4.1
 PySocks==1.7.1
-pytest==8.0.0
+pytest==7.4.4
 pytest-timeout==2.1.0
 pyOpenSSL==23.2.0
 idna==3.4

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,7 +1,7 @@
 h2==4.1.0
 coverage==7.4.1
 PySocks==1.7.1
-pytest==7.4.2
+pytest==8.0.0
 pytest-timeout==2.1.0
 pyOpenSSL==23.2.0
 idna==3.4

--- a/test/contrib/test_pyopenssl.py
+++ b/test/contrib/test_pyopenssl.py
@@ -38,7 +38,6 @@ def teardown_module() -> None:
 from ..test_ssl import TestSSL  # noqa: E402, F401
 from ..test_util import TestUtilSSL  # noqa: E402, F401
 from ..with_dummyserver.test_https import (  # noqa: E402, F401
-    TestHTTPS,
     TestHTTPS_IPV4SAN,
     TestHTTPS_IPV6SAN,
     TestHTTPS_TLSv1,

--- a/test/with_dummyserver/test_https.py
+++ b/test/with_dummyserver/test_https.py
@@ -65,7 +65,7 @@ PASSWORD_CLIENT_KEYFILE = "client_password.key"
 CLIENT_CERT = CLIENT_INTERMEDIATE_PEM
 
 
-class TestHTTPS(HTTPSHypercornDummyServerTestCase):
+class BaseTestHTTPS(HTTPSHypercornDummyServerTestCase):
     tls_protocol_name: str | None = None
 
     def tls_protocol_not_default(self) -> bool:
@@ -992,25 +992,25 @@ class TestHTTPS(HTTPSHypercornDummyServerTestCase):
 
 
 @pytest.mark.usefixtures("requires_tlsv1")
-class TestHTTPS_TLSv1(TestHTTPS):
+class TestHTTPS_TLSv1(BaseTestHTTPS):
     tls_protocol_name = "TLSv1"
     certs = TLSv1_CERTS
 
 
 @pytest.mark.usefixtures("requires_tlsv1_1")
-class TestHTTPS_TLSv1_1(TestHTTPS):
+class TestHTTPS_TLSv1_1(BaseTestHTTPS):
     tls_protocol_name = "TLSv1.1"
     certs = TLSv1_1_CERTS
 
 
 @pytest.mark.usefixtures("requires_tlsv1_2")
-class TestHTTPS_TLSv1_2(TestHTTPS):
+class TestHTTPS_TLSv1_2(BaseTestHTTPS):
     tls_protocol_name = "TLSv1.2"
     certs = TLSv1_2_CERTS
 
 
 @pytest.mark.usefixtures("requires_tlsv1_3")
-class TestHTTPS_TLSv1_3(TestHTTPS):
+class TestHTTPS_TLSv1_3(BaseTestHTTPS):
     tls_protocol_name = "TLSv1.3"
     certs = TLSv1_3_CERTS
 


### PR DESCRIPTION
The current test setup gives some errors when `ssl.HAS_TLSv1.3`, since 
there is no corresponding `ssl.PROTOCOL_TLSv1.3`. 

I modified the test suite to use `ssl.PROTOCOL_TLS_CLIENT` when `TLSv1.3`, and skipping the following case when testing the TLSv1.3 case
* `test_ssl_version_is_deprecated`
* `test_ssl_context_ssl_version_uses_ssl_min_max_versions `



<!---
Thanks for your contribution! ♥️

If this is your first PR to urllib3 please review the Contributing Guide:
https://urllib3.readthedocs.io/en/latest/contributing.html

Adhering to the Contributing Guide means we can review, merge, and release your change faster! :)
--->
