### PR TITLE
Bump cryptography to 42.0.2 and PyOpenSSL to 24.0.0

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,10 +3,10 @@ coverage==7.4.1
 PySocks==1.7.1
 pytest==7.4.4
 pytest-timeout==2.1.0
-pyOpenSSL==23.2.0
+pyOpenSSL==24.0.0
 idna==3.4
 trustme==1.1.0
-cryptography==41.0.6
+cryptography==42.0.2
 backports.zoneinfo==0.2.1;python_version<"3.9"
 towncrier==23.6.0
 pytest-memray==1.5.0;python_version<"3.13" and sys_platform!="win32" and implementation_name=="cpython"


### PR DESCRIPTION

cryptography 41.0.6 has a moderate security vulnerability

https://github.com/urllib3/urllib3/security/dependabot/12

> A flaw was found in the python-cryptography package. This issue may allow a remote attacker to decrypt captured messages in TLS servers that use RSA key exchanges, which may lead to exposure of confidential or sensitive data.



@dependabot has identified this in #3339 but it failed to update PyOpenSSL accordingly
hence this PR


Closes #3339
