### PR TITLE
Fix docstring of retries arg to request

### DIFF
--- a/src/urllib3/__init__.py
+++ b/src/urllib3/__init__.py
@@ -167,7 +167,7 @@ def request(
         Configure the number of retries to allow before raising a
         :class:`~urllib3.exceptions.MaxRetryError` exception.
 
-        Pass ``None`` to retry until you receive a response. Pass a
+        If ``None`` (default) will retry 3 times, see ``Retry.DEFAULT``. Pass a
         :class:`~urllib3.util.retry.Retry` object for fine-grained control
         over different types of retries.
         Pass an integer number to retry connection errors that many times,

--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -649,7 +649,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
             Configure the number of retries to allow before raising a
             :class:`~urllib3.exceptions.MaxRetryError` exception.
 
-            Pass ``None`` to retry until you receive a response. Pass a
+            If ``None`` (default) will retry 3 times, see ``Retry.DEFAULT``. Pass a
             :class:`~urllib3.util.retry.Retry` object for fine-grained control
             over different types of retries.
             Pass an integer number to retry connection errors that many times,


### PR DESCRIPTION
`urllib3.request(..., retries=None)` does _not_ result in infinite retries, whereas the [current docstring](https://github.com/urllib3/urllib3/blob/2.2.0/src/urllib3/__init__.py#L170) seems to suggest that it would with this confusing sentence:
> Pass ``None`` to retry until you receive a response

What happens is `None` ends up getting passed through all the way to `PoolManager.urlopen` [which passes it](https://github.com/urllib3/urllib3/blob/2.2.0/src/urllib3/poolmanager.py#L460-L462) to `Retry.from_int` [which ends up](https://github.com/urllib3/urllib3/blob/2.2.0/src/urllib3/util/retry.py#L274-L275) using `cls.DEFAULT` which is set to `Retry(3)` [here](https://github.com/urllib3/urllib3/blob/2.2.0/src/urllib3/util/retry.py#L529).

So this PR aims to avoid confusion by ensuring that this docstring (which ends up [here in the docs](https://urllib3.readthedocs.io/en/stable/reference/urllib3.request.html)) is (a) true and (b) agrees with [the user guide](https://urllib3.readthedocs.io/en/2.2.0/user-guide.html#retrying-requests) which correctly says:
> By default, urllib3 will retry requests 3 times and follow up to 3 redirects.

---

P.S. I've looked at https://urllib3.readthedocs.io/en/latest/contributing.html and a test doesn't seem necessary for a docstring fix, I'm unsure if a changelog needs adding for such a small change?