### PR TITLE
Stop casting request headers to HTTPHeaderDict

### DIFF
--- a/changelog/3343.bugfix.rst
+++ b/changelog/3343.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed ``HTTPConnectionPool.urlopen`` to stop automatically casting non-proxy headers to ``HTTPHeaderDict``. This change was premature as it did not apply to proxy headers and ``HTTPHeaderDict`` does not handle byte header values correctly yet.

--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -751,8 +751,8 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         # have to copy the headers dict so we can safely change it without those
         # changes being reflected in anyone else's copy.
         if not http_tunnel_required:
-            headers = HTTPHeaderDict(headers)
-            headers.update(self.proxy_headers)
+            headers = headers.copy()  # type: ignore[attr-defined]
+            headers.update(self.proxy_headers)  # type: ignore[union-attr]
 
         # Must keep the exception bound to a separate variable or else Python 3
         # complains about UnboundLocalError.


### PR DESCRIPTION
While this was done to fix a mypy error, we did not notice the consequences:

 * This breaks boto3 that subclasses HTTPConnection because HTTPHeaderDict does not support bytes values yet.
 * When proxying, headers are still a dictionary by default.

We can decide to reintroduce a forced conversion to HTTPHeaderDict in urllib3 3.0 if the above issues are fixed.

Closes #3343, partly reverts #3134