### PR TITLE
Remove flask pins from requests downstream tests

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -178,9 +178,6 @@ def downstream_requests(session: nox.Session) -> None:
     session.install(".[socks]", silent=False)
     session.install("-r", "requirements-dev.txt", silent=False)
 
-    # Workaround until https://github.com/psf/httpbin/pull/29 gets released
-    session.install("flask<3", "werkzeug<3", silent=False)
-
     session.cd(root)
     session.install(".", silent=False)
     session.cd(f"{tmp_dir}/requests")


### PR DESCRIPTION
This PR will remove the pins put in place with #3170 now that httpbin 0.10.2 is released.