### PR TITLE
Allow passing negative integers as `amt` to read methods

### DIFF
--- a/changelog/3122.bugfix.rst
+++ b/changelog/3122.bugfix.rst
@@ -1,0 +1,2 @@
+Allowed passing negative integers as ``amt`` to read methods of
+:class:`http.client.HTTPResponse` as an alternative to ``None``.

--- a/src/urllib3/contrib/emscripten/response.py
+++ b/src/urllib3/contrib/emscripten/response.py
@@ -155,7 +155,7 @@ class EmscriptenHttpResponseWrapper(BaseHTTPResponse):
                 self.length_is_certain = True
                 # wrap body in IOStream
                 self._response.body = BytesIO(self._response.body)
-            if amt is not None:
+            if amt is not None and amt >= 0:
                 # don't cache partial content
                 cache_content = False
                 data = self._response.body.read(amt)

--- a/src/urllib3/response.py
+++ b/src/urllib3/response.py
@@ -935,7 +935,10 @@ class HTTPResponse(BaseHTTPResponse):
         if decode_content is None:
             decode_content = self.decode_content
 
-        if amt is not None:
+        if amt and amt < 0:
+            # Negative numbers and `None` should be treated the same.
+            amt = None
+        elif amt is not None:
             cache_content = False
 
             if len(self._decoded_buffer) >= amt:
@@ -995,6 +998,9 @@ class HTTPResponse(BaseHTTPResponse):
         """
         if decode_content is None:
             decode_content = self.decode_content
+        if amt and amt < 0:
+            # Negative numbers and `None` should be treated the same.
+            amt = None
         # try and respond without going to the network
         if self._has_decoded_content:
             if not decode_content:
@@ -1188,6 +1194,11 @@ class HTTPResponse(BaseHTTPResponse):
             # then return immediately.
             if self._fp.fp is None:  # type: ignore[union-attr]
                 return None
+
+            if amt and amt < 0:
+                # Negative numbers and `None` should be treated the same,
+                # but httplib handles only `None` correctly.
+                amt = None
 
             while True:
                 self._update_chunk_length()

--- a/test/test_response.py
+++ b/test/test_response.py
@@ -217,6 +217,12 @@ class TestResponse:
         assert r.read() == b""
         assert r.read() == b""
 
+    @pytest.mark.parametrize("amt", (None, -1))
+    def test_reference_read_until_eof(self, amt: int | None) -> None:
+        fp = BytesIO(b"foo")
+        r = HTTPResponse(fp, preload_content=False)
+        assert r.read(amt) == b"foo"
+
     def test_reference_read1(self) -> None:
         fp = BytesIO(b"foobar")
         r = HTTPResponse(fp, preload_content=False)
@@ -226,6 +232,12 @@ class TestResponse:
         assert r.read1(2) == b"oo"
         assert r.read1() == b"bar"
         assert r.read1() == b""
+
+    @pytest.mark.parametrize("amt", (None, -1))
+    def test_reference_read1_without_limit(self, amt: int | None) -> None:
+        fp = BytesIO(b"foo")
+        r = HTTPResponse(fp, preload_content=False)
+        assert r.read1(amt) == b"foo"
 
     def test_reference_read1_nodecode(self) -> None:
         fp = BytesIO(b"foobar")
@@ -1262,7 +1274,8 @@ class TestResponse:
         response = list(resp.read_chunked(2))
         assert expected_response == response
 
-    def test_mock_transfer_encoding_chunked_unlmtd_read(self) -> None:
+    @pytest.mark.parametrize("amt", (None, -1))
+    def test_mock_transfer_encoding_chunked_unlmtd_read(self, amt: int | None) -> None:
         stream = [b"foooo", b"bbbbaaaaar"]
         fp = MockChunkedEncodingResponse(stream)
         r = httplib.HTTPResponse(MockSock)  # type: ignore[arg-type]
@@ -1272,7 +1285,7 @@ class TestResponse:
         resp = HTTPResponse(
             r, preload_content=False, headers={"transfer-encoding": "chunked"}
         )
-        assert stream == list(resp.read_chunked())
+        assert stream == list(resp.read_chunked(amt))
 
     def test_read_not_chunked_response_as_chunks(self) -> None:
         fp = BytesIO(b"foo")

--- a/test/test_response.py
+++ b/test/test_response.py
@@ -217,11 +217,11 @@ class TestResponse:
         assert r.read() == b""
         assert r.read() == b""
 
-    @pytest.mark.parametrize("amt", (None, -1))
-    def test_reference_read_until_eof(self, amt: int | None) -> None:
+    @pytest.mark.parametrize("read_args", ((), (None,), (-1,)))
+    def test_reference_read_until_eof(self, read_args: tuple[typing.Any, ...]) -> None:
         fp = BytesIO(b"foo")
         r = HTTPResponse(fp, preload_content=False)
-        assert r.read(amt) == b"foo"
+        assert r.read(*read_args) == b"foo"
 
     def test_reference_read1(self) -> None:
         fp = BytesIO(b"foobar")
@@ -233,11 +233,13 @@ class TestResponse:
         assert r.read1() == b"bar"
         assert r.read1() == b""
 
-    @pytest.mark.parametrize("amt", (None, -1))
-    def test_reference_read1_without_limit(self, amt: int | None) -> None:
+    @pytest.mark.parametrize("read1_args", ((), (None,), (-1,)))
+    def test_reference_read1_without_limit(
+        self, read1_args: tuple[typing.Any, ...]
+    ) -> None:
         fp = BytesIO(b"foo")
         r = HTTPResponse(fp, preload_content=False)
-        assert r.read1(amt) == b"foo"
+        assert r.read1(*read1_args) == b"foo"
 
     def test_reference_read1_nodecode(self) -> None:
         fp = BytesIO(b"foobar")
@@ -1274,8 +1276,10 @@ class TestResponse:
         response = list(resp.read_chunked(2))
         assert expected_response == response
 
-    @pytest.mark.parametrize("amt", (None, -1))
-    def test_mock_transfer_encoding_chunked_unlmtd_read(self, amt: int | None) -> None:
+    @pytest.mark.parametrize("read_chunked_args", ((), (None,), (-1,)))
+    def test_mock_transfer_encoding_chunked_unlmtd_read(
+        self, read_chunked_args: tuple[typing.Any, ...]
+    ) -> None:
         stream = [b"foooo", b"bbbbaaaaar"]
         fp = MockChunkedEncodingResponse(stream)
         r = httplib.HTTPResponse(MockSock)  # type: ignore[arg-type]
@@ -1285,7 +1289,7 @@ class TestResponse:
         resp = HTTPResponse(
             r, preload_content=False, headers={"transfer-encoding": "chunked"}
         )
-        assert stream == list(resp.read_chunked(amt))
+        assert stream == list(resp.read_chunked(*read_chunked_args))
 
     def test_read_not_chunked_response_as_chunks(self) -> None:
         fp = BytesIO(b"foo")


### PR DESCRIPTION
Fixes #3122.

According to https://docs.python.org/3/library/io.html#io.BufferedIOBase.read, if the [size] argument is omitted, `None`, or negative, data is read and returned until EOF is reached.

urllib3 (as well as httplib) breaks when a negative number is passed to its read methods. This PR fixes the issue by making urllib3 treat negative numbers the same as `None`.