### PR TITLE
perf: no need to decode bytes to str for `json.loads`

### DIFF
--- a/changelog/3389.misc.rst
+++ b/changelog/3389.misc.rst
@@ -1,0 +1,1 @@
+Improve performance for ``.json()``

--- a/src/urllib3/contrib/emscripten/response.py
+++ b/src/urllib3/contrib/emscripten/response.py
@@ -227,8 +227,7 @@ class EmscriptenHttpResponseWrapper(BaseHTTPResponse):
 
         :returns: The body of the HTTP response as a Python object.
         """
-        data = self.data.decode("utf-8")
-        return _json.loads(data)
+        return _json.loads(self.data)
 
     def close(self) -> None:
         if not self._closed:

--- a/src/urllib3/response.py
+++ b/src/urllib3/response.py
@@ -379,8 +379,7 @@ class BaseHTTPResponse(io.IOBase):
 
         :returns: The body of the HTTP response as a Python object.
         """
-        data = self.data.decode("utf-8")
-        return _json.loads(data)
+        return _json.loads(self.data)
 
     @property
     def url(self) -> str | None:


### PR DESCRIPTION
<!---
Thanks for your contribution! ♥️

If this is your first PR to urllib3 please review the Contributing Guide:
https://urllib3.readthedocs.io/en/latest/contributing.html

Adhering to the Contributing Guide means we can review, merge, and release your change faster! :)
--->

In a old version of python, `json.loads` take str only. But in python >= 3.6, it can parse bytes directly.

So there is no need to decode body to str, just feed bytes to `json.loads` is fine, for python>=3.8.

https://docs.python.org/3.8/library/json.html#json.loads