### PR TITLE
Mark broken Requests test as failing

### DIFF
--- a/ci/0001-Mark-test_redirecting_to_bad_url-as-failing.patch
+++ b/ci/0001-Mark-test_redirecting_to_bad_url-as-failing.patch
@@ -1,0 +1,24 @@
+From 5560e5bc2e5d87d909d4692c4df799bcfbc0817f Mon Sep 17 00:00:00 2001
+From: Quentin Pradet <quentin.pradet@gmail.com>
+Date: Mon, 13 May 2024 00:36:59 +0400
+Subject: [PATCH] Mark test_redirecting_to_bad_url as failing
+
+---
+ tests/test_requests.py | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/tests/test_requests.py b/tests/test_requests.py
+index d05febee..1300db4a 100644
+--- a/tests/test_requests.py
++++ b/tests/test_requests.py
+@@ -2721,6 +2721,7 @@ class TestPreparingURLs:
+         with pytest.raises(requests.exceptions.InvalidURL):
+             r.prepare()
+ 
++    @pytest.mark.xfail
+     @pytest.mark.parametrize("url, exception", (("http://localhost:-1", InvalidURL),))
+     def test_redirecting_to_bad_url(self, httpbin, url, exception):
+         with pytest.raises(exception):
+-- 
+2.39.1
+

--- a/noxfile.py
+++ b/noxfile.py
@@ -181,6 +181,10 @@ def downstream_requests(session: nox.Session) -> None:
     session.cd(root)
     session.install(".", silent=False)
     session.cd(f"{tmp_dir}/requests")
+    for patch in [
+        "0001-Mark-test_redirecting_to_bad_url-as-failing.patch",
+    ]:
+        session.run("git", "apply", f"{root}/ci/{patch}", external=True)
 
     session.run("python", "-c", "import urllib3; print(urllib3.__version__)")
     session.run("pytest", "tests")


### PR DESCRIPTION
Relates #3392 where @franekmagiera and @sigmavirus24 confirmed that the bug is not in urllib3.

We may not need it depending on the outcome of https://github.com/psf/requests/pull/6700 (that I've just seen, sorry).