### PR TITLE
Bugfix: Allow auth in url

### DIFF
--- a/changelog/2968.bugfix.rst
+++ b/changelog/2968.bugfix.rst
@@ -1,0 +1,2 @@
+Allowed passing authorization information in url.
+Updated ``urllib3.poolmanager.PoolManager().urlopen()`` to check for the update authorization headers.

--- a/src/urllib3/poolmanager.py
+++ b/src/urllib3/poolmanager.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import base64
 import functools
 import logging
 import typing
@@ -436,6 +437,12 @@ class PoolManager(RequestMethods):
 
         if "headers" not in kw:
             kw["headers"] = self.headers
+
+        if u.auth is not None:
+            encoded_auth_bytes = base64.b64encode(u.auth.encode())
+            encoded_auth = encoded_auth_bytes.decode("utf-8")
+            authorization_headers = {"authorization": f"Basic {encoded_auth}"}
+            kw["headers"] = authorization_headers
 
         if self._proxy_requires_url_absolute_form(u):
             response = conn.urlopen(method, url, **kw)

--- a/test/with_dummyserver/test_poolmanager.py
+++ b/test/with_dummyserver/test_poolmanager.py
@@ -667,6 +667,17 @@ class TestPoolManager(HypercornDummyServerTestCase):
             "object, or iterable. Instead was <BadBody>"
         )
 
+    def test_authentication_with_url(self) -> None:
+        with PoolManager() as http:
+            url_with_auth = f"http://user:pass@{self.host}:{self.port}"
+            r = http.urlopen("GET", f"{url_with_auth}/headers")
+
+            assert r.status == 200
+
+            data = r.json()
+
+            assert data["Authorization"] == "Basic dXNlcjpwYXNz"
+
 
 @pytest.mark.skipif(not HAS_IPV6, reason="IPv6 is not supported on this system")
 class TestIPv6PoolManager(IPv6HypercornDummyServerTestCase):


### PR DESCRIPTION
Update urllib3.poolmanager.PoolManager().urlopen() to check for authorization headers in URL.
Bug fix for issue  #2968  

