### PR TITLE
[1.26] Fix handling of OpenSSL 3.2.0 new error message "record layer failure"

### DIFF
--- a/changelog/3268.bugfix.rst
+++ b/changelog/3268.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed handling of OpenSSL 3.2.0 new error message for misconfiguring an HTTP proxy as HTTPS.

--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -768,7 +768,9 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
                 # so we try to cover our bases here!
                 message = " ".join(re.split("[^a-z]", str(ssl_error).lower()))
                 return (
-                    "wrong version number" in message or "unknown protocol" in message
+                    "wrong version number" in message
+                    or "unknown protocol" in message
+                    or "record layer failure" in message
                 )
 
             # Try to detect a common user error with proxies which is to

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -1223,7 +1223,8 @@ class TestSSL(SocketDummyServerTestCase):
         self._start_server(socket_handler)
         with HTTPSConnectionPool(self.host, self.port, ca_certs=DEFAULT_CA) as pool:
             with pytest.raises(
-                SSLError, match=r"(wrong version number|record overflow)"
+                SSLError,
+                match=r"(wrong version number|record overflow|record layer failure)",
             ):
                 pool.request("GET", "/", retries=False)
 


### PR DESCRIPTION
This backports #3271 to 1.26.x