### PR TITLE
Test publish workflow on every push

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,12 @@
 name: Publish to PyPI
 
-on: push
+on:
+  push:
+    branches:
+      - "1.26.x"
+      - "main"
+    tags:
+      - "*"
 
 permissions:
   contents: read

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,19 +1,14 @@
 name: Publish to PyPI
 
-on:
-  push:
-    tags:
-      - "*"
+on: push
 
 permissions:
   contents: read
 
 jobs:
   build:
-    name: "Build dists"
+    name: "Build distribution 📦"
     runs-on: "ubuntu-latest"
-    environment:
-      name: "publish"
     outputs:
       hashes: ${{ steps.hash.outputs.hashes }}
 
@@ -59,14 +54,16 @@ jobs:
       upload-assets: true
       compile-generator: true # Workaround for https://github.com/slsa-framework/slsa-github-generator/issues/1163
 
-  publish:
-    name: "Publish"
+  publish-to-pypi-and-github:
+    name: "Publish to PyPI"
     if: startsWith(github.ref, 'refs/tags/')
     needs: ["build", "provenance"]
     permissions:
-      contents: write
+      contents: write # Needed for making GitHub releases
       id-token: write # Needed for trusted publishing to PyPI.
     runs-on: "ubuntu-latest"
+    environment:
+      name: "publish"
 
     steps:
     - name: "Download dists"
@@ -83,3 +80,24 @@ jobs:
 
     - name: "Publish dists to PyPI"
       uses: pypa/gh-action-pypi-publish@ec4db0b4ddc65acdf4bff5fa45ac92d78b56bdf0 # v1.9.0
+
+  publish-to-test-pypi:
+    name: "Publish to Test PyPI"
+    needs: ["build", "provenance"]
+    permissions:
+      id-token: write # Needed for trusted publishing to PyPI.
+    runs-on: "ubuntu-latest"
+    environment:
+      name: "testpypi"
+
+    steps:
+    - name: "Download dists"
+      uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+      with:
+        name: "dist"
+        path: "dist/"
+
+    - name: "Publish dists to Test PyPI"
+      uses: pypa/gh-action-pypi-publish@ec4db0b4ddc65acdf4bff5fa45ac92d78b56bdf0 # v1.9.0
+      with:
+        repository-url: https://test.pypi.org/legacy/


### PR DESCRIPTION
As documented in https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/. The `testpypi` GitHub environment is not set up yet, and nothing is tested.