### PR TITLE
Use more precise clock for test_timeout on Windows

### DIFF
--- a/test/with_dummyserver/test_connectionpool.py
+++ b/test/with_dummyserver/test_connectionpool.py
@@ -98,10 +98,10 @@ class TestConnectionPoolTimeouts(SocketDummyServerTestCase):
             self.host, self.port, timeout=short_timeout, retries=False
         ) as pool:
             wait_for_socket(ready_event)
-            now = time.time()
+            now = time.perf_counter()
             with pytest.raises(ReadTimeoutError):
                 pool.request("GET", "/", timeout=LONG_TIMEOUT)
-            delta = time.time() - now
+            delta = time.perf_counter() - now
 
             message = "timeout was pool-level SHORT_TIMEOUT rather than request-level LONG_TIMEOUT"
             assert delta >= (LONG_TIMEOUT - 1e-5), message
@@ -1301,6 +1301,7 @@ class TestRetryAfter(HypercornDummyServerTestCase):
             r = pool.request("GET", "/redirect_after", retries=False)
             assert r.status == 303
 
+            # Real timestamps are needed for this test
             t = time.time()
             r = pool.request("GET", "/redirect_after")
             assert r.status == 200


### PR DESCRIPTION
On Windows, the clock used by `time.time()` has a resolution that is higher than 15ms, which sometimes breaks `test_timeout` that relies on a short timeout. Using `time.perf_counter()` makes this issue less likely.

You can such a failure here: https://github.com/urllib3/urllib3/actions/runs/9552707050/job/26329891735

```
   File "D:\a\urllib3\urllib3\test\with_dummyserver\test_connectionpool.py", line 107, in test_timeout
    assert delta >= (LONG_TIMEOUT - 1e-5), message
AssertionError: timeout was pool-level SHORT_TIMEOUT rather than request-level LONG_TIMEOUT
assert 0.4998745918273926 >= (0.5 - 1e-05)
```

The test fails because the timeout was 12.5ms shorter than expected.

Also, the Retry-After tests do need time.time() so I have added a comment as I've tried multiple times to switch away from it in the past.