### PR TITLE
Fix download-artifacts version for Test PyPI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -99,7 +99,7 @@ jobs:
 
     steps:
     - name: "Download dists"
-      uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+      uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
       with:
         name: "dist"
         path: "dist/"


### PR DESCRIPTION
The upload-artifact and download-artifact actions should use the same major version, and I missed while merging two different pull requests, https://github.com/urllib3/urllib3/pull/3385 and https://github.com/urllib3/urllib3/pull/3411.

Fixes this failure: https://github.com/urllib3/urllib3/actions/runs/9607566386/job/26499026545
Tested here: https://github.com/pquentin/urllib3/actions/runs/9609221789/job/26503384351