### PR TITLE
Adjust tolerance for floating-point comparison on Windows to avoid flakiness in CI

### DIFF
--- a/changelog/3413.bugfix.rst
+++ b/changelog/3413.bugfix.rst
@@ -1,0 +1,1 @@
+Adjust tolerance for floating-point comparison on Windows to avoid flakiness in CI

--- a/test/with_dummyserver/test_connectionpool.py
+++ b/test/with_dummyserver/test_connectionpool.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import io
+import platform
 import socket
 import time
 import typing
@@ -104,7 +105,12 @@ class TestConnectionPoolTimeouts(SocketDummyServerTestCase):
             delta = time.perf_counter() - now
 
             message = "timeout was pool-level SHORT_TIMEOUT rather than request-level LONG_TIMEOUT"
-            assert delta >= (LONG_TIMEOUT - 1e-5), message
+            if platform.system() == "Windows":
+                # Adjust tolerance for floating-point comparison on Windows to
+                # avoid flakiness in CI #3413
+                assert delta >= (LONG_TIMEOUT - 1e-3), message
+            else:
+                assert delta >= (LONG_TIMEOUT - 1e-5), message
             block_event.set()  # Release request
 
             # Timeout passed directly to request should raise a request timeout


### PR DESCRIPTION
`TestConnectionPoolTimeouts.test_timeout` will often fail on Windows due to what appears to be a floating point error. 

This PR increases the tolerance for the comparison on Windows to help the test pass more frequently. 

This is related to Issue #3413

<!---
Thanks for your contribution! ♥️

If this is your first PR to urllib3 please review the Contributing Guide:
https://urllib3.readthedocs.io/en/latest/contributing.html

Adhering to the Contributing Guide means we can review, merge, and release your change faster! :)
--->
