### PR TITLE
util/ssl: make code resilient to missing hash functions

### DIFF
--- a/changelog/3432.bugfix.rst
+++ b/changelog/3432.bugfix.rst
@@ -1,12 +1,1 @@
-util/ssl: make code resilient to missing hash functions
-
-In certain environments such as in a FIPS enabled system,
-certain algorithms such as md5 may be unavailable. Due
-to the importing of such a module on a system where it
-is unavailable, urllib will crash and is unusable.
-
-This change makes the code more resilient by deferring the
-usage of the hash function module unless they are required.
-If the hash function is unavailable but required, an SSLError
-is raised indicating the same. If the hash function is unavailable
-but not required, urllib functions instead of crashing.
+Fixed a crash where certain standard library hash functions were absent in restricted environments.

--- a/changelog/3432.bugfix.rst
+++ b/changelog/3432.bugfix.rst
@@ -1,0 +1,12 @@
+util/ssl: make code resilient to missing hash functions
+
+In certain environments such as in a FIPS enabled system,
+certain algorithms such as md5 may be unavailable. Due
+to the importing of such a module on a system where it
+is unavailable, urllib will crash and is unusable.
+
+This change makes the code more resilient by deferring the
+usage of the hash function module unless they are required.
+If the hash function is unavailable but required, an SSLError
+is raised indicating the same. If the hash function is unavailable
+but not required, urllib functions instead of crashing.

--- a/src/urllib3/util/ssl_.py
+++ b/src/urllib3/util/ssl_.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import hmac
 import os
 import socket
@@ -7,7 +8,6 @@ import sys
 import typing
 import warnings
 from binascii import unhexlify
-from hashlib import md5, sha1, sha256
 
 from ..exceptions import ProxySchemeUnsupported, SSLError
 from .url import _BRACELESS_IPV6_ADDRZ_RE, _IPV4_RE
@@ -21,7 +21,10 @@ ALPN_PROTOCOLS = ["http/1.1"]
 _TYPE_VERSION_INFO = typing.Tuple[int, int, int, str, int]
 
 # Maps the length of a digest to a possible hash function producing this digest
-HASHFUNC_MAP = {32: md5, 40: sha1, 64: sha256}
+HASHFUNC_MAP = {
+    length: getattr(hashlib, algorithm, None)
+    for length, algorithm in ((32, "md5"), (40, "sha1"), (64, "sha256"))
+}
 
 
 def _is_bpo_43522_fixed(
@@ -159,9 +162,13 @@ def assert_fingerprint(cert: bytes | None, fingerprint: str) -> None:
 
     fingerprint = fingerprint.replace(":", "").lower()
     digest_length = len(fingerprint)
-    hashfunc = HASHFUNC_MAP.get(digest_length)
-    if not hashfunc:
+    if digest_length not in HASHFUNC_MAP:
         raise SSLError(f"Fingerprint of invalid length: {fingerprint}")
+    hashfunc = HASHFUNC_MAP.get(digest_length)
+    if hashfunc is None:
+        raise SSLError(
+            f"Hash function implementation unavailable for fingerprint length: {digest_length}"
+        )
 
     # We need encode() here for py32; works on py2 and p33.
     fingerprint_bytes = unhexlify(fingerprint.encode())

--- a/test/with_dummyserver/test_https.py
+++ b/test/with_dummyserver/test_https.py
@@ -990,6 +990,26 @@ class BaseTestHTTPS(HTTPSHypercornDummyServerTestCase):
         assert ctx.minimum_version == self.tls_version()
         assert ctx.maximum_version == self.tls_version()
 
+    def test_assert_missing_hashfunc(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        fingerprint = "55:39:BF:70:05:12:43:FA:1F:D1:BF:4E:E8:1B:07:1D"
+        with HTTPSConnectionPool(
+            "localhost",
+            self.port,
+            cert_reqs="CERT_REQUIRED",
+            ca_certs=DEFAULT_CA,
+            assert_fingerprint=(fingerprint),
+            ssl_minimum_version=self.tls_version(),
+        ) as https_pool:
+            digest_length = len(fingerprint.replace(":", "").lower())
+            monkeypatch.setitem(urllib3.util.ssl_.HASHFUNC_MAP, digest_length, None)
+            with pytest.raises(MaxRetryError) as cm:
+                https_pool.request("GET", "/", retries=0)
+            assert type(cm.value.reason) is SSLError
+            assert (
+                f"Hash function implementation unavailable for fingerprint length: {digest_length}"
+                == str(cm.value.reason)
+            )
+
 
 @pytest.mark.usefixtures("requires_tlsv1")
 class TestHTTPS_TLSv1(BaseTestHTTPS):


### PR DESCRIPTION
In certain environments such as in a FIPS enabled system, certain algorithms such as md5 may be unavailable. Due to the importing of such a module on a system where it is unavailable, urllib will crash and is unusable.

This change makes the code more resilient by deferring the usage of the hash function module unless they are required. If the hash function is unavailable but required, an SSLError is raised indicating the same. If the hash function is unavailable but not required, urllib functions instead of crashing.

Part of #3432