### PR TITLE
[1.26] util/ssl: make code resilient to missing hash functions

### DIFF
--- a/src/urllib3/util/ssl_.py
+++ b/src/urllib3/util/ssl_.py
@@ -1,11 +1,11 @@
 from __future__ import absolute_import
 
+import hashlib
 import hmac
 import os
 import sys
 import warnings
 from binascii import hexlify, unhexlify
-from hashlib import md5, sha1, sha256
 
 from ..exceptions import (
     InsecurePlatformWarning,
@@ -24,7 +24,10 @@ IS_SECURETRANSPORT = False
 ALPN_PROTOCOLS = ["http/1.1"]
 
 # Maps the length of a digest to a possible hash function producing this digest
-HASHFUNC_MAP = {32: md5, 40: sha1, 64: sha256}
+HASHFUNC_MAP = {
+    length: getattr(hashlib, algorithm, None)
+    for length, algorithm in ((32, "md5"), (40, "sha1"), (64, "sha256"))
+}
 
 
 def _const_compare_digest_backport(a, b):
@@ -191,9 +194,15 @@ def assert_fingerprint(cert, fingerprint):
 
     fingerprint = fingerprint.replace(":", "").lower()
     digest_length = len(fingerprint)
-    hashfunc = HASHFUNC_MAP.get(digest_length)
-    if not hashfunc:
+    if digest_length not in HASHFUNC_MAP:
         raise SSLError("Fingerprint of invalid length: {0}".format(fingerprint))
+    hashfunc = HASHFUNC_MAP.get(digest_length)
+    if hashfunc is None:
+        raise SSLError(
+            "Hash function implementation unavailable for fingerprint length: {0}".format(
+                digest_length
+            )
+        )
 
     # We need encode() here for py32; works on py2 and p33.
     fingerprint_bytes = unhexlify(fingerprint.encode())


### PR DESCRIPTION
Backport of https://github.com/urllib3/urllib3/pull/3434
---
In certain environments such as in a FIPS enabled system, certain algorithms such as md5 may be unavailable. Due to the importing of such a module on a system where it is unavailable, urllib will crash and is unusable.

This change makes the code more resilient by deferring the usage of the hash function module unless they are required. If the hash function is unavailable but required, an SSLError is raised indicating the same. If the hash function is unavailable but not required, urllib functions instead of crashing.

