### PR TITLE
[1.26] Upgrade actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,9 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set up Python 3.7
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.7"
       - name: Check packages
@@ -82,11 +82,11 @@ jobs:
     continue-on-error: ${{ matrix.experimental }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set Up Python - ${{ matrix.python-version }}
         if: matrix.python-version != '2.7'
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
@@ -102,7 +102,7 @@ jobs:
 
       - name: Set Up Python 3 to run nox
         if: matrix.python-version == '2.7' || matrix.python-version == 'pypy2.7'
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3"
 
@@ -123,9 +123,9 @@ jobs:
 
       - name: Upload Coverage
         if: ${{ matrix.nox-session != 'unsupported_python2' }}
-        uses: "actions/upload-artifact@v2"
+        uses: "actions/upload-artifact@v4"
         with:
-          name: coverage-data
+          name: coverage-data-${{ matrix.python-version }}-${{ matrix.os }}-${{ matrix.experimental }}-${{ matrix.nox-session }}
           path: ".coverage.*"
           if-no-files-found: error
 
@@ -157,9 +157,9 @@ jobs:
           PYTHON_VERSION: ${{ matrix.python-version }}
 
       - name: Upload Coverage
-        uses: "actions/upload-artifact@v2"
+        uses: "actions/upload-artifact@v4"
         with:
-          name: coverage-data
+          name: coverage-data-${{ matrix.python-version }}-test_requesting_large_resources_via_ssl
           path: ".coverage.*"
           if-no-files-found: error
 
@@ -168,9 +168,9 @@ jobs:
     runs-on: "ubuntu-latest"
     needs: [test, test_requesting_large_resources_via_ssl]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: "Use latest Python so it understands all syntax"
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.10"
 
@@ -178,9 +178,10 @@ jobs:
         run: "python -m pip install --upgrade coverage"
 
       - name: "Download coverage data"
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
-          name: coverage-data
+          pattern: coverage-data-*
+          merge-multiple: true
 
       - name: "Combine & check coverage"
         run: |
@@ -189,7 +190,7 @@ jobs:
           python -m coverage report --ignore-errors --show-missing --fail-under=100
 
       - name: "Upload report if check failed"
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-report
           path: htmlcov

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,11 +10,11 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set up Python 3.8
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: "3.8"
       - name: Lint the code
-        uses: pre-commit/action@v2.0.0
+        uses: pre-commit/action@v3.0.1
 


### PR DESCRIPTION
CI runs in 1.26.x produce many warnings because we use old versions of various actions, this PR updates the actions to the latest versions