### PR TITLE
Fix CI after attrs 24.1.0 release

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -14,7 +14,8 @@ cryptography==42.0.4
 backports.zoneinfo==0.2.1;python_version<"3.9"
 towncrier==23.6.0
 pytest-memray==1.5.0;python_version<"3.13" and sys_platform!="win32" and implementation_name=="cpython"
-trio==0.25.0
+attrs==23.2.0  # https://github.com/python-trio/trio/issues/3053
+trio==0.26.0
 Quart==0.19.4
 quart-trio==0.11.1
 # https://github.com/pgjones/hypercorn/issues/62


### PR DESCRIPTION
See https://github.com/python-trio/trio/issues/3053 for details. Another option would be to ignore the warning, but we don't use attrs ourselves so don't really care about the version and I'm hoping that trio will quickly fix the issue.