### PR TITLE
Fix request and request_encode_url fields docs

### DIFF
--- a/src/urllib3/_request_methods.py
+++ b/src/urllib3/_request_methods.py
@@ -97,8 +97,7 @@ class RequestMethods:
             an iterable of :class:`str`/:class:`bytes`, or a file-like object.
 
         :param fields:
-            Data to encode and send in the request body.  Values are processed
-            by :func:`urllib.parse.urlencode`.
+            Data to encode and send in the URL or request body, depending on ``method``.
 
         :param headers:
             Dictionary of custom headers to send, such as User-Agent,

--- a/src/urllib3/_request_methods.py
+++ b/src/urllib3/_request_methods.py
@@ -164,7 +164,7 @@ class RequestMethods:
             The URL to perform the request on.
 
         :param fields:
-            Data to encode and send in the request body.
+            Data to encode and send in the URL.
 
         :param headers:
             Dictionary of custom headers to send, such as User-Agent,


### PR DESCRIPTION
Looks like it was a copy/paste mistake when request_encode_body/request_encode_url were documented
