### PR TITLE
Fix mypy error when adding to default socket options

### DIFF
--- a/changelog/3448.bugfix.rst
+++ b/changelog/3448.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed mypy error when adding to ``HTTPConnection.default_socket_options``.

--- a/src/urllib3/util/connection.py
+++ b/src/urllib3/util/connection.py
@@ -6,7 +6,7 @@ import typing
 from ..exceptions import LocationParseError
 from .timeout import _DEFAULT_TIMEOUT, _TYPE_TIMEOUT
 
-_TYPE_SOCKET_OPTIONS = typing.Sequence[typing.Tuple[int, int, typing.Union[int, bytes]]]
+_TYPE_SOCKET_OPTIONS = typing.List[typing.Tuple[int, int, typing.Union[int, bytes]]]
 
 if typing.TYPE_CHECKING:
     from .._base_connection import BaseHTTPConnection

--- a/test/with_dummyserver/test_connectionpool.py
+++ b/test/with_dummyserver/test_connectionpool.py
@@ -355,7 +355,7 @@ class TestConnectionPool(HypercornDummyServerTestCase):
             try:
                 # Update the default socket options
                 assert conn.socket_options is not None
-                conn.socket_options += [(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)]  # type: ignore[operator]
+                conn.socket_options += [(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)]
                 s = conn._new_conn()  # type: ignore[attr-defined]
                 nagle_disabled = (
                     s.getsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY) > 0


### PR DESCRIPTION
Our [official recommendation to set TCP Keepalives](https://urllib3.readthedocs.io/en/stable/reference/urllib3.connection.html#urllib3.connection.HTTPConnection) currently results in a mypy error because `typing.Sequence` does not support the `+` operator. Indeed, they can be ranges, for example. (And we don't care about the other types that support `+`, like str.) Fittingly, this allows us to remove `type: ignore` in our tests.