### PR TITLE
Rely on OpenSSL ALPN support

### DIFF
--- a/dummyserver/socketserver.py
+++ b/dummyserver/socketserver.py
@@ -168,11 +168,8 @@ def ssl_options_to_context(  # type: ignore[no-untyped-def]
     ctx.verify_mode = cert_reqs
     if ctx.verify_mode != cert_none:
         ctx.load_verify_locations(cafile=ca_certs)
-    if alpn_protocols and hasattr(ctx, "set_alpn_protocols"):
-        try:
-            ctx.set_alpn_protocols(alpn_protocols)
-        except NotImplementedError:
-            pass
+    if alpn_protocols:
+        ctx.set_alpn_protocols(alpn_protocols)
     return ctx
 
 

--- a/src/urllib3/util/ssl_.py
+++ b/src/urllib3/util/ssl_.py
@@ -464,10 +464,7 @@ def ssl_wrap_socket(
         else:
             context.load_cert_chain(certfile, keyfile, key_password)
 
-    try:
-        context.set_alpn_protocols(ALPN_PROTOCOLS)
-    except NotImplementedError:  # Defensive: in CI, we always have set_alpn_protocols
-        pass
+    context.set_alpn_protocols(ALPN_PROTOCOLS)
 
     ssl_sock = _ssl_wrap_socket_impl(sock, context, tls_in_tls, server_hostname)
     return ssl_sock

--- a/src/urllib3/util/ssltransport.py
+++ b/src/urllib3/util/ssltransport.py
@@ -193,9 +193,6 @@ class SSLTransport:
     def selected_alpn_protocol(self) -> str | None:
         return self.sslobj.selected_alpn_protocol()
 
-    def selected_npn_protocol(self) -> str | None:
-        return self.sslobj.selected_npn_protocol()
-
     def shared_ciphers(self) -> list[tuple[str, str, int]] | None:
         return self.sslobj.shared_ciphers()
 

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -32,18 +32,13 @@ except ImportError:
 else:
     HAS_ZSTD = True
 
-from urllib3 import util
 from urllib3.connectionpool import ConnectionPool
 from urllib3.exceptions import HTTPWarning
-from urllib3.util import ssl_
 
 try:
     import urllib3.contrib.pyopenssl as pyopenssl
 except ImportError:
     pyopenssl = None  # type: ignore[assignment]
-
-if typing.TYPE_CHECKING:
-    import ssl
 
 
 _RT = typing.TypeVar("_RT")  # return type
@@ -88,19 +83,6 @@ def _can_resolve(host: str) -> bool:
         return True
     except socket.gaierror:
         return False
-
-
-def has_alpn(ctx_cls: type[ssl.SSLContext] | None = None) -> bool:
-    """Detect if ALPN support is enabled."""
-    ctx_cls = ctx_cls or util.SSLContext
-    ctx = ctx_cls(protocol=ssl_.PROTOCOL_TLS)  # type: ignore[misc, attr-defined]
-    try:
-        if hasattr(ctx, "set_alpn_protocols"):
-            ctx.set_alpn_protocols(ssl_.ALPN_PROTOCOLS)
-            return True
-    except NotImplementedError:
-        pass
-    return False
 
 
 # Some systems might not resolve "localhost." correctly.

--- a/test/test_ssltransport.py
+++ b/test/test_ssltransport.py
@@ -230,9 +230,8 @@ class SingleTLSLayerTestCase(SocketDummyServerTestCase):
             cipher = ssock.cipher()
             assert type(cipher) is tuple
 
-            # No chosen protocol through ALPN or NPN.
+            # No chosen protocol.
             assert ssock.selected_alpn_protocol() is None
-            assert ssock.selected_npn_protocol() is None
 
             shared_ciphers = ssock.shared_ciphers()
             # SSLContext.shared_ciphers() changed behavior completely in a patch version.

--- a/test/with_dummyserver/test_https.py
+++ b/test/with_dummyserver/test_https.py
@@ -48,8 +48,6 @@ from urllib3.exceptions import (
 from urllib3.util.ssl_match_hostname import CertificateError
 from urllib3.util.timeout import Timeout
 
-from .. import has_alpn
-
 TLSv1_CERTS = DEFAULT_CERTS.copy()
 TLSv1_CERTS["ssl_version"] = getattr(ssl, "PROTOCOL_TLSv1", None)
 
@@ -953,8 +951,6 @@ class BaseTestHTTPS(HTTPSHypercornDummyServerTestCase):
 
     def test_alpn_default(self, http_version: str) -> None:
         """Default ALPN protocols are sent by default."""
-        if not has_alpn() or not has_alpn(ssl.SSLContext):
-            pytest.skip("ALPN-support not available")
         with HTTPSConnectionPool(
             self.host,
             self.port,

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -49,7 +49,7 @@ from urllib3.util import ssl_, ssl_wrap_socket
 from urllib3.util.retry import Retry
 from urllib3.util.timeout import Timeout
 
-from .. import LogRecorder, has_alpn
+from .. import LogRecorder
 
 if typing.TYPE_CHECKING:
     from _typeshed import StrOrBytesPath
@@ -108,9 +108,6 @@ class TestSNI(SocketDummyServerTestCase):
 
 class TestALPN(SocketDummyServerTestCase):
     def test_alpn_protocol_in_first_request_packet(self) -> None:
-        if not has_alpn():
-            pytest.skip("ALPN-support not available")
-
         done_receiving = Event()
         self.buf = b""
 


### PR DESCRIPTION
OpenSSL 1.1.1+ always supports ALPN, but does not support NPN. The Python NPN functions are no-ops with OpenSSL 1.1.1+.

Source: https://github.com/python/cpython/pull/23014