### PR TITLE
Prevent enabling HTTP/2 in HTTP tests

### DIFF
--- a/test/with_dummyserver/test_connection.py
+++ b/test/with_dummyserver/test_connection.py
@@ -45,7 +45,7 @@ def test_audit_event(audit_mock: mock.Mock, pool: HTTPConnectionPool) -> None:
         assert len(connect_events) == 1
 
 
-def test_does_not_release_conn(pool: HTTPConnectionPool, http_version: str) -> None:
+def test_does_not_release_conn(pool: HTTPConnectionPool) -> None:
     with contextlib.closing(pool._get_conn()) as conn:
         conn.request("GET", "/")
         response = conn.getresponse()
@@ -54,7 +54,7 @@ def test_does_not_release_conn(pool: HTTPConnectionPool, http_version: str) -> N
         assert pool.pool.qsize() == 0  # type: ignore[union-attr]
 
 
-def test_releases_conn(pool: HTTPConnectionPool, http_version: str) -> None:
+def test_releases_conn(pool: HTTPConnectionPool) -> None:
     with contextlib.closing(pool._get_conn()) as conn:
         conn.request("GET", "/")
         response = conn.getresponse()
@@ -69,7 +69,7 @@ def test_releases_conn(pool: HTTPConnectionPool, http_version: str) -> None:
         assert pool.pool.qsize() == 1  # type: ignore[union-attr]
 
 
-def test_double_getresponse(pool: HTTPConnectionPool, http_version: str) -> None:
+def test_double_getresponse(pool: HTTPConnectionPool) -> None:
     with contextlib.closing(pool._get_conn()) as conn:
         conn.request("GET", "/")
         _ = conn.getresponse()
@@ -79,9 +79,7 @@ def test_double_getresponse(pool: HTTPConnectionPool, http_version: str) -> None
             conn.getresponse()
 
 
-def test_connection_state_properties(
-    pool: HTTPConnectionPool, http_version: str
-) -> None:
+def test_connection_state_properties(pool: HTTPConnectionPool) -> None:
     conn = pool._get_conn()
 
     assert conn.is_closed is True
@@ -111,7 +109,7 @@ def test_connection_state_properties(
     assert conn.proxy_is_verified is None
 
 
-def test_set_tunnel_is_reset(pool: HTTPConnectionPool, http_version: str) -> None:
+def test_set_tunnel_is_reset(pool: HTTPConnectionPool) -> None:
     conn = pool._get_conn()
 
     assert conn.is_closed is True
@@ -133,7 +131,7 @@ def test_set_tunnel_is_reset(pool: HTTPConnectionPool, http_version: str) -> Non
     assert conn._tunnel_scheme is None  # type: ignore[attr-defined]
 
 
-def test_invalid_tunnel_scheme(pool: HTTPConnectionPool, http_version: str) -> None:
+def test_invalid_tunnel_scheme(pool: HTTPConnectionPool) -> None:
     conn = pool._get_conn()
 
     with pytest.raises(ValueError) as e:

--- a/test/with_dummyserver/test_connectionpool.py
+++ b/test/with_dummyserver/test_connectionpool.py
@@ -43,7 +43,7 @@ def wait_for_socket(ready_event: Event) -> None:
 
 
 class TestConnectionPoolTimeouts(SocketDummyServerTestCase):
-    def test_timeout_float(self, http_version: str) -> None:
+    def test_timeout_float(self) -> None:
         block_event = Event()
         ready_event = self.start_basic_handler(block_send=block_event, num=2)
 
@@ -58,7 +58,7 @@ class TestConnectionPoolTimeouts(SocketDummyServerTestCase):
             block_event.set()  # Pre-release block
             pool.request("GET", "/", timeout=LONG_TIMEOUT)
 
-    def test_conn_closed(self, http_version: str) -> None:
+    def test_conn_closed(self) -> None:
         block_event = Event()
         self.start_basic_handler(block_send=block_event, num=1)
 
@@ -78,7 +78,7 @@ class TestConnectionPoolTimeouts(SocketDummyServerTestCase):
 
             block_event.set()
 
-    def test_timeout(self, http_version: str) -> None:
+    def test_timeout(self) -> None:
         # Requests should time out when expected
         block_event = Event()
         ready_event = self.start_basic_handler(block_send=block_event, num=3)
@@ -119,7 +119,7 @@ class TestConnectionPoolTimeouts(SocketDummyServerTestCase):
                 pool.request("GET", "/", timeout=SHORT_TIMEOUT)
             block_event.set()  # Release request
 
-    def test_connect_timeout(self, http_version: str) -> None:
+    def test_connect_timeout(self) -> None:
         url = "/"
         host, port = TARPIT_HOST, 80
         timeout = Timeout(connect=SHORT_TIMEOUT)
@@ -146,7 +146,7 @@ class TestConnectionPoolTimeouts(SocketDummyServerTestCase):
             with pytest.raises(ConnectTimeoutError):
                 pool.request("GET", url, timeout=timeout)
 
-    def test_total_applies_connect(self, http_version: str) -> None:
+    def test_total_applies_connect(self) -> None:
         host, port = TARPIT_HOST, 80
 
         timeout = Timeout(total=None, connect=SHORT_TIMEOUT)
@@ -167,7 +167,7 @@ class TestConnectionPoolTimeouts(SocketDummyServerTestCase):
             finally:
                 conn.close()
 
-    def test_total_timeout(self, http_version: str) -> None:
+    def test_total_timeout(self) -> None:
         block_event = Event()
         ready_event = self.start_basic_handler(block_send=block_event, num=2)
 
@@ -192,7 +192,7 @@ class TestConnectionPoolTimeouts(SocketDummyServerTestCase):
             with pytest.raises(ReadTimeoutError):
                 pool.request("GET", "/")
 
-    def test_create_connection_timeout(self, http_version: str) -> None:
+    def test_create_connection_timeout(self) -> None:
         self.start_basic_handler(block_send=Event(), num=0)  # needed for self.port
 
         timeout = Timeout(connect=SHORT_TIMEOUT, total=LONG_TIMEOUT)
@@ -205,22 +205,33 @@ class TestConnectionPoolTimeouts(SocketDummyServerTestCase):
 
 
 class TestConnectionPool(HypercornDummyServerTestCase):
-    def test_get(self, http_version: str) -> None:
+    def test_http2_test_error(self, http_version: str) -> None:
+        with HTTPConnectionPool(self.host, self.port) as pool:
+            if http_version == "h2":
+                with pytest.raises(
+                    ValueError, match="HTTP/2 support currently only applies to HTTPS.*"
+                ):
+                    r = pool.request("GET", "/")
+            else:
+                r = pool.request("GET", "/")
+                assert r.status == 200
+
+    def test_get(self) -> None:
         with HTTPConnectionPool(self.host, self.port) as pool:
             r = pool.request("GET", "/specific_method", fields={"method": "GET"})
             assert r.status == 200, r.data
 
-    def test_post_url(self, http_version: str) -> None:
+    def test_post_url(self) -> None:
         with HTTPConnectionPool(self.host, self.port) as pool:
             r = pool.request("POST", "/specific_method", fields={"method": "POST"})
             assert r.status == 200, r.data
 
-    def test_urlopen_put(self, http_version: str) -> None:
+    def test_urlopen_put(self) -> None:
         with HTTPConnectionPool(self.host, self.port) as pool:
             r = pool.urlopen("PUT", "/specific_method?method=PUT")
             assert r.status == 200, r.data
 
-    def test_wrong_specific_method(self, http_version: str) -> None:
+    def test_wrong_specific_method(self) -> None:
         # To make sure the dummy server is actually returning failed responses
         with HTTPConnectionPool(self.host, self.port) as pool:
             r = pool.request("GET", "/specific_method", fields={"method": "POST"})
@@ -230,7 +241,7 @@ class TestConnectionPool(HypercornDummyServerTestCase):
             r = pool.request("POST", "/specific_method", fields={"method": "GET"})
             assert r.status == 400, r.data
 
-    def test_upload(self, http_version: str) -> None:
+    def test_upload(self) -> None:
         data = "I'm in ur multipart form-data, hazing a cheezburgr"
         fields: dict[str, _TYPE_FIELD_VALUE_TUPLE] = {
             "upload_param": "filefield",
@@ -243,7 +254,7 @@ class TestConnectionPool(HypercornDummyServerTestCase):
             r = pool.request("POST", "/upload", fields=fields)
             assert r.status == 200, r.data
 
-    def test_one_name_multiple_values(self, http_version: str) -> None:
+    def test_one_name_multiple_values(self) -> None:
         fields = [("foo", "a"), ("foo", "b")]
 
         with HTTPConnectionPool(self.host, self.port) as pool:
@@ -255,7 +266,7 @@ class TestConnectionPool(HypercornDummyServerTestCase):
             r = pool.request("POST", "/echo", fields=fields)
             assert r.data.count(b'name="foo"') == 2
 
-    def test_request_method_body(self, http_version: str) -> None:
+    def test_request_method_body(self) -> None:
         with HTTPConnectionPool(self.host, self.port) as pool:
             body = b"hi"
             r = pool.request("POST", "/echo", body=body)
@@ -265,7 +276,7 @@ class TestConnectionPool(HypercornDummyServerTestCase):
             with pytest.raises(TypeError):
                 pool.request("POST", "/echo", body=body, fields=fields)
 
-    def test_unicode_upload(self, http_version: str) -> None:
+    def test_unicode_upload(self) -> None:
         fieldname = "myfile"
         filename = "\xe2\x99\xa5.txt"
         data = "\xe2\x99\xa5".encode()
@@ -281,7 +292,7 @@ class TestConnectionPool(HypercornDummyServerTestCase):
             r = pool.request("POST", "/upload", fields=fields)
             assert r.status == 200, r.data
 
-    def test_nagle(self, http_version: str) -> None:
+    def test_nagle(self) -> None:
         """Test that connections have TCP_NODELAY turned on"""
         # This test needs to be here in order to be run. socket.create_connection actually tries
         # to connect to the host provided so we need a dummyserver to be running.
@@ -303,11 +314,7 @@ class TestConnectionPool(HypercornDummyServerTestCase):
             ((socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1),),
         ],
     )
-    def test_socket_options(
-        self,
-        socket_options: tuple[int, int, int],
-        http_version: str,
-    ) -> None:
+    def test_socket_options(self, socket_options: tuple[int, int, int]) -> None:
         """Test that connections accept socket options."""
         # This test needs to be here in order to be run. socket.create_connection actually tries to
         # connect to the host provided so we need a dummyserver to be running.
@@ -328,9 +335,7 @@ class TestConnectionPool(HypercornDummyServerTestCase):
 
     @pytest.mark.parametrize("socket_options", [None, []])
     def test_disable_default_socket_options(
-        self,
-        socket_options: list[int] | None,
-        http_version: str,
+        self, socket_options: list[int] | None
     ) -> None:
         """Test that passing None or empty list disables all socket options."""
         # This test needs to be here in order to be run. socket.create_connection actually tries
@@ -345,7 +350,7 @@ class TestConnectionPool(HypercornDummyServerTestCase):
             finally:
                 s.close()
 
-    def test_defaults_are_applied(self, http_version: str) -> None:
+    def test_defaults_are_applied(self) -> None:
         """Test that modifying the default socket options works."""
         # This test needs to be here in order to be run. socket.create_connection actually tries
         # to connect to the host provided so we need a dummyserver to be running.
@@ -369,7 +374,7 @@ class TestConnectionPool(HypercornDummyServerTestCase):
                 conn.close()
                 s.close()
 
-    def test_connection_error_retries(self, http_version: str) -> None:
+    def test_connection_error_retries(self) -> None:
         """ECONNREFUSED error should raise a connection error, with retries"""
         port = find_unused_port()
         with HTTPConnectionPool(self.host, port) as pool:
@@ -377,7 +382,7 @@ class TestConnectionPool(HypercornDummyServerTestCase):
                 pool.request("GET", "/", retries=Retry(connect=3))
             assert type(e.value.reason) is NewConnectionError
 
-    def test_timeout_success(self, http_version: str) -> None:
+    def test_timeout_success(self) -> None:
         timeout = Timeout(connect=3, read=5, total=None)
         with HTTPConnectionPool(self.host, self.port, timeout=timeout) as pool:
             pool.request("GET", "/")
@@ -408,7 +413,6 @@ class TestConnectionPool(HypercornDummyServerTestCase):
         self,
         timeout: _TYPE_TIMEOUT,
         expect_settimeout_calls: typing.Sequence[float | None],
-        http_version: str,
     ) -> None:
         with HTTPConnectionPool(self.host, self.port, timeout=timeout) as pool:
             # Make a request to create a new connection.
@@ -432,7 +436,6 @@ class TestConnectionPool(HypercornDummyServerTestCase):
         self,
         timeout: _TYPE_TIMEOUT,
         expect_settimeout_calls: typing.Sequence[float | None],
-        http_version: str,
     ) -> None:
         with HTTPConnectionPool(self.host, self.port) as pool:
             # Make a request to create a new connection.
@@ -451,7 +454,7 @@ class TestConnectionPool(HypercornDummyServerTestCase):
                 [mock.call(x) for x in expect_settimeout_calls]
             )
 
-    def test_tunnel(self, http_version: str) -> None:
+    def test_tunnel(self) -> None:
         timeout = Timeout(total=None)
         with HTTPConnectionPool(self.host, self.port, timeout=timeout) as pool:
             conn = pool._get_conn()
@@ -478,13 +481,13 @@ class TestConnectionPool(HypercornDummyServerTestCase):
             finally:
                 conn.close()
 
-    def test_redirect_relative_url_no_deprecation(self, http_version: str) -> None:
+    def test_redirect_relative_url_no_deprecation(self) -> None:
         with HTTPConnectionPool(self.host, self.port) as pool:
             with warnings.catch_warnings():
                 warnings.simplefilter("error", DeprecationWarning)
                 pool.request("GET", "/redirect", fields={"target": "/"})
 
-    def test_redirect(self, http_version: str) -> None:
+    def test_redirect(self) -> None:
         with HTTPConnectionPool(self.host, self.port) as pool:
             r = pool.request("GET", "/redirect", fields={"target": "/"}, redirect=False)
             assert r.status == 303
@@ -504,13 +507,13 @@ class TestConnectionPool(HypercornDummyServerTestCase):
         assert data["params"] == {}
         assert "Content-Type" not in HTTPHeaderDict(data["headers"])
 
-    def test_bad_connect(self, http_version: str) -> None:
+    def test_bad_connect(self) -> None:
         with HTTPConnectionPool("badhost.invalid", self.port) as pool:
             with pytest.raises(MaxRetryError) as e:
                 pool.request("GET", "/", retries=5)
             assert type(e.value.reason) is NameResolutionError
 
-    def test_keepalive(self, http_version: str) -> None:
+    def test_keepalive(self) -> None:
         with HTTPConnectionPool(self.host, self.port, block=True, maxsize=1) as pool:
             r = pool.request("GET", "/keepalive?close=0")
             r = pool.request("GET", "/keepalive?close=0")
@@ -519,7 +522,7 @@ class TestConnectionPool(HypercornDummyServerTestCase):
             assert pool.num_connections == 1
             assert pool.num_requests == 2
 
-    def test_keepalive_close(self, http_version: str) -> None:
+    def test_keepalive_close(self) -> None:
         with HTTPConnectionPool(
             self.host, self.port, block=True, maxsize=1, timeout=2
         ) as pool:
@@ -568,7 +571,7 @@ class TestConnectionPool(HypercornDummyServerTestCase):
             # Next request
             r = pool.request("GET", "/keepalive?close=0")
 
-    def test_post_with_urlencode(self, http_version: str) -> None:
+    def test_post_with_urlencode(self) -> None:
         with HTTPConnectionPool(self.host, self.port) as pool:
             data = {"banana": "hammock", "lol": "cat"}
             r = pool.request("POST", "/echo", fields=data, encode_multipart=False)
@@ -651,7 +654,7 @@ class TestConnectionPool(HypercornDummyServerTestCase):
                     headers={"accept-encoding": "garbage-gzip"},
                 )
 
-    def test_connection_count(self, http_version: str) -> None:
+    def test_connection_count(self) -> None:
         with HTTPConnectionPool(self.host, self.port, maxsize=1) as pool:
             pool.request("GET", "/")
             pool.request("GET", "/")
@@ -660,7 +663,7 @@ class TestConnectionPool(HypercornDummyServerTestCase):
             assert pool.num_connections == 1
             assert pool.num_requests == 3
 
-    def test_connection_count_bigpool(self, http_version: str) -> None:
+    def test_connection_count_bigpool(self) -> None:
         with HTTPConnectionPool(self.host, self.port, maxsize=16) as http_pool:
             http_pool.request("GET", "/")
             http_pool.request("GET", "/")
@@ -669,7 +672,7 @@ class TestConnectionPool(HypercornDummyServerTestCase):
             assert http_pool.num_connections == 1
             assert http_pool.num_requests == 3
 
-    def test_partial_response(self, http_version: str) -> None:
+    def test_partial_response(self) -> None:
         with HTTPConnectionPool(self.host, self.port, maxsize=1) as pool:
             req_data = {"lol": "cat"}
             resp_data = urlencode(req_data).encode("utf-8")
@@ -679,7 +682,7 @@ class TestConnectionPool(HypercornDummyServerTestCase):
             assert r.read(5) == resp_data[:5]
             assert r.read() == resp_data[5:]
 
-    def test_lazy_load_twice(self, http_version: str) -> None:
+    def test_lazy_load_twice(self) -> None:
         # This test is sad and confusing. Need to figure out what's
         # going on with partial reads and socket reuse.
 
@@ -732,7 +735,7 @@ class TestConnectionPool(HypercornDummyServerTestCase):
 
             assert pool.num_connections == 1
 
-    def test_for_double_release(self, http_version: str) -> None:
+    def test_for_double_release(self) -> None:
         MAXSIZE = 5
 
         # Check default state
@@ -763,7 +766,7 @@ class TestConnectionPool(HypercornDummyServerTestCase):
             pool.urlopen("GET", "/")
             assert pool.pool.qsize() == MAXSIZE - 2
 
-    def test_release_conn_parameter(self, http_version: str) -> None:
+    def test_release_conn_parameter(self) -> None:
         MAXSIZE = 5
         with HTTPConnectionPool(self.host, self.port, maxsize=MAXSIZE) as pool:
             assert pool.pool is not None
@@ -773,7 +776,7 @@ class TestConnectionPool(HypercornDummyServerTestCase):
             pool.request("GET", "/", release_conn=False, preload_content=False)
             assert pool.pool.qsize() == MAXSIZE - 1
 
-    def test_dns_error(self, http_version: str) -> None:
+    def test_dns_error(self) -> None:
         with HTTPConnectionPool(
             "thishostdoesnotexist.invalid", self.port, timeout=0.001
         ) as pool:
@@ -781,17 +784,17 @@ class TestConnectionPool(HypercornDummyServerTestCase):
                 pool.request("GET", "/test", retries=2)
 
     @pytest.mark.parametrize("char", [" ", "\r", "\n", "\x00"])
-    def test_invalid_method_not_allowed(self, char: str, http_version: str) -> None:
+    def test_invalid_method_not_allowed(self, char: str) -> None:
         with pytest.raises(ValueError):
             with HTTPConnectionPool(self.host, self.port) as pool:
                 pool.request("GET" + char, "/")
 
-    def test_percent_encode_invalid_target_chars(self, http_version: str) -> None:
+    def test_percent_encode_invalid_target_chars(self) -> None:
         with HTTPConnectionPool(self.host, self.port) as pool:
             r = pool.request("GET", "/echo_params?q=\r&k=\n \n")
             assert r.data == b"[('k', '\\n \\n'), ('q', '\\r')]"
 
-    def test_source_address(self, http_version: str) -> None:
+    def test_source_address(self) -> None:
         for addr, is_ipv6 in VALID_SOURCE_ADDRESSES:
             if is_ipv6:
                 # TODO enable if HAS_IPV6_AND_DNS when this is fixed:
@@ -808,10 +811,7 @@ class TestConnectionPool(HypercornDummyServerTestCase):
         "invalid_source_address, is_ipv6", INVALID_SOURCE_ADDRESSES
     )
     def test_source_address_error(
-        self,
-        invalid_source_address: tuple[str, int],
-        is_ipv6: bool,
-        http_version: str,
+        self, invalid_source_address: tuple[str, int], is_ipv6: bool
     ) -> None:
         with HTTPConnectionPool(
             self.host, self.port, source_address=invalid_source_address, retries=False
@@ -824,7 +824,7 @@ class TestConnectionPool(HypercornDummyServerTestCase):
                 with pytest.raises(NewConnectionError):
                     pool.request("GET", f"/source_address?{invalid_source_address}")
 
-    def test_stream_keepalive(self, http_version: str) -> None:
+    def test_stream_keepalive(self) -> None:
         x = 2
 
         with HTTPConnectionPool(self.host, self.port) as pool:
@@ -842,14 +842,14 @@ class TestConnectionPool(HypercornDummyServerTestCase):
             assert pool.num_connections == 1
             assert pool.num_requests == x
 
-    def test_read_chunked_short_circuit(self, http_version: str) -> None:
+    def test_read_chunked_short_circuit(self) -> None:
         with HTTPConnectionPool(self.host, self.port) as pool:
             response = pool.request("GET", "/chunked", preload_content=False)
             response.read()
             with pytest.raises(StopIteration):
                 next(response.read_chunked())
 
-    def test_read_chunked_on_closed_response(self, http_version: str) -> None:
+    def test_read_chunked_on_closed_response(self) -> None:
         with HTTPConnectionPool(self.host, self.port) as pool:
             response = pool.request("GET", "/chunked", preload_content=False)
             response.close()
@@ -864,7 +864,7 @@ class TestConnectionPool(HypercornDummyServerTestCase):
 
             assert b"123" * 4 == response.read()
 
-    def test_cleanup_on_connection_error(self, http_version: str) -> None:
+    def test_cleanup_on_connection_error(self) -> None:
         """
         Test that connections are recycled to the pool on
         connection errors where no http response is received.
@@ -900,18 +900,18 @@ class TestConnectionPool(HypercornDummyServerTestCase):
             # the pool should still contain poolsize elements
             assert http.pool.qsize() == http.pool.maxsize
 
-    def test_mixed_case_hostname(self, http_version: str) -> None:
+    def test_mixed_case_hostname(self) -> None:
         with HTTPConnectionPool("LoCaLhOsT", self.port) as pool:
             response = pool.request("GET", f"http://LoCaLhOsT:{self.port}/")
             assert response.status == 200
 
-    def test_preserves_path_dot_segments(self, http_version: str) -> None:
+    def test_preserves_path_dot_segments(self) -> None:
         """ConnectionPool preserves dot segments in the URI"""
         with HTTPConnectionPool(self.host, self.port) as pool:
             response = pool.request("GET", "/echo_uri/seg0/../seg2")
             assert response.data == b"/echo_uri/seg0/../seg2?"
 
-    def test_default_user_agent_header(self, http_version: str) -> None:
+    def test_default_user_agent_header(self) -> None:
         """ConnectionPool has a default user agent"""
         default_ua = _get_default_user_agent()
         custom_ua = "I'm not a web scraper, what are you talking about?"
@@ -954,10 +954,7 @@ class TestConnectionPool(HypercornDummyServerTestCase):
     )
     @pytest.mark.parametrize("chunked", [True, False])
     def test_user_agent_header_not_sent_twice(
-        self,
-        headers: dict[str, str] | None,
-        chunked: bool,
-        http_version: str,
+        self, headers: dict[str, str] | None, chunked: bool
     ) -> None:
         with HTTPConnectionPool(self.host, self.port) as pool:
             r = pool.request("GET", "/headers", headers=headers, chunked=chunked)
@@ -969,7 +966,7 @@ class TestConnectionPool(HypercornDummyServerTestCase):
             else:
                 assert request_headers["User-Agent"] == "key"
 
-    def test_no_user_agent_header(self, http_version: str) -> None:
+    def test_no_user_agent_header(self) -> None:
         """ConnectionPool can suppress sending a user agent header"""
         custom_ua = "I'm not a web scraper, what are you talking about?"
         with HTTPConnectionPool(self.host, self.port) as pool:
@@ -998,12 +995,7 @@ class TestConnectionPool(HypercornDummyServerTestCase):
 
     @pytest.mark.parametrize("header", ["Content-Length", "content-length"])
     @pytest.mark.parametrize("chunked", [True, False])
-    def test_skip_header_non_supported(
-        self,
-        header: str,
-        chunked: bool,
-        http_version: str,
-    ) -> None:
+    def test_skip_header_non_supported(self, header: str, chunked: bool) -> None:
         with HTTPConnectionPool(self.host, self.port) as pool:
             with pytest.raises(
                 ValueError,
@@ -1026,7 +1018,6 @@ class TestConnectionPool(HypercornDummyServerTestCase):
         chunked: bool,
         pool_request: bool,
         header_type: type[dict[str, str] | HTTPHeaderDict],
-        http_version: str,
     ) -> None:
         # Test that the .request*() methods of ConnectionPool and HTTPConnection
         # don't modify the given 'headers' structure, instead they should
@@ -1060,7 +1051,6 @@ class TestConnectionPool(HypercornDummyServerTestCase):
 
     def test_request_chunked_is_deprecated(
         self,
-        http_version: str,
     ) -> None:
         with HTTPConnectionPool(self.host, self.port) as pool:
             conn = pool._get_conn()
@@ -1077,7 +1067,7 @@ class TestConnectionPool(HypercornDummyServerTestCase):
             assert resp.json()["Transfer-Encoding"] == "chunked"
             conn.close()
 
-    def test_bytes_header(self, http_version: str) -> None:
+    def test_bytes_header(self) -> None:
         with HTTPConnectionPool(self.host, self.port) as pool:
             headers = {"User-Agent": "test header"}
             r = pool.request("GET", "/headers", headers=headers)
@@ -1088,9 +1078,7 @@ class TestConnectionPool(HypercornDummyServerTestCase):
     @pytest.mark.parametrize(
         "user_agent", ["Schönefeld/1.18.0", "Schönefeld/1.18.0".encode("iso-8859-1")]
     )
-    def test_user_agent_non_ascii_user_agent(
-        self, user_agent: str, http_version: str
-    ) -> None:
+    def test_user_agent_non_ascii_user_agent(self, user_agent: str) -> None:
         with HTTPConnectionPool(self.host, self.port, retries=False) as pool:
             r = pool.urlopen(
                 "GET",
@@ -1103,12 +1091,12 @@ class TestConnectionPool(HypercornDummyServerTestCase):
 
 
 class TestRetry(HypercornDummyServerTestCase):
-    def test_max_retry(self, http_version: str) -> None:
+    def test_max_retry(self) -> None:
         with HTTPConnectionPool(self.host, self.port) as pool:
             with pytest.raises(MaxRetryError):
                 pool.request("GET", "/redirect", fields={"target": "/"}, retries=0)
 
-    def test_disabled_retry(self, http_version: str) -> None:
+    def test_disabled_retry(self) -> None:
         """Disabled retries should disable redirect handling."""
         with HTTPConnectionPool(self.host, self.port) as pool:
             r = pool.request("GET", "/redirect", fields={"target": "/"}, retries=False)
@@ -1128,7 +1116,7 @@ class TestRetry(HypercornDummyServerTestCase):
             with pytest.raises(NameResolutionError):
                 pool.request("GET", "/test", retries=False)
 
-    def test_read_retries(self, http_version: str) -> None:
+    def test_read_retries(self) -> None:
         """Should retry for status codes in the forcelist"""
         with HTTPConnectionPool(self.host, self.port) as pool:
             retry = Retry(read=1, status_forcelist=[418])
@@ -1140,7 +1128,7 @@ class TestRetry(HypercornDummyServerTestCase):
             )
             assert resp.status == 200
 
-    def test_read_total_retries(self, http_version: str) -> None:
+    def test_read_total_retries(self) -> None:
         """HTTP response w/ status code in the forcelist should be retried"""
         with HTTPConnectionPool(self.host, self.port) as pool:
             headers = {"test-name": "test_read_total_retries"}
@@ -1150,10 +1138,8 @@ class TestRetry(HypercornDummyServerTestCase):
             )
             assert resp.status == 200
 
-    def test_retries_wrong_forcelist(self, http_version: str) -> None:
+    def test_retries_wrong_forcelist(self) -> None:
         """HTTP response w/ status code not in forcelist shouldn't be retried"""
-        if http_version == "h2":
-            pytest.skip("HTTP/2 does not support status_forcelist")
         with HTTPConnectionPool(self.host, self.port) as pool:
             retry = Retry(total=1, status_forcelist=[202])
             resp = pool.request(
@@ -1164,7 +1150,7 @@ class TestRetry(HypercornDummyServerTestCase):
             )
             assert resp.status == 418
 
-    def test_default_method_forcelist_retried(self, http_version: str) -> None:
+    def test_default_method_forcelist_retried(self) -> None:
         """urllib3 should retry methods in the default method forcelist"""
         with HTTPConnectionPool(self.host, self.port) as pool:
             retry = Retry(total=1, status_forcelist=[418])
@@ -1176,10 +1162,8 @@ class TestRetry(HypercornDummyServerTestCase):
             )
             assert resp.status == 200
 
-    def test_retries_wrong_method_list(self, http_version: str) -> None:
+    def test_retries_wrong_method_list(self) -> None:
         """Method not in our allowed list should not be retried, even if code matches"""
-        if http_version == "h2":
-            pytest.skip("HTTP/2 does not support allowed_methods")
         with HTTPConnectionPool(self.host, self.port) as pool:
             headers = {"test-name": "test_wrong_allowed_method"}
             retry = Retry(total=1, status_forcelist=[418], allowed_methods=["POST"])
@@ -1190,16 +1174,13 @@ class TestRetry(HypercornDummyServerTestCase):
 
     def test_read_retries_unsuccessful(
         self,
-        http_version: str,
     ) -> None:
-        if http_version == "h2":
-            pytest.skip("HTTP/2 does not pass here")
         with HTTPConnectionPool(self.host, self.port) as pool:
             headers = {"test-name": "test_read_retries_unsuccessful"}
             resp = pool.request("GET", "/successful_retry", headers=headers, retries=1)
             assert resp.status == 418
 
-    def test_retry_reuse_safe(self, http_version: str) -> None:
+    def test_retry_reuse_safe(self) -> None:
         """It should be possible to reuse a Retry object across requests"""
         with HTTPConnectionPool(self.host, self.port) as pool:
             headers = {"test-name": "test_retry_safe"}
@@ -1215,9 +1196,7 @@ class TestRetry(HypercornDummyServerTestCase):
             )
             assert resp.status == 200
 
-    def test_retry_return_in_response(self, http_version: str) -> None:
-        if http_version == "h2":
-            pytest.skip("HTTP/2 does not pass here")
+    def test_retry_return_in_response(self) -> None:
         with HTTPConnectionPool(self.host, self.port) as pool:
             headers = {"test-name": "test_retry_return_in_response"}
             retry = Retry(total=2, status_forcelist=[418])
@@ -1231,7 +1210,7 @@ class TestRetry(HypercornDummyServerTestCase):
                 RequestHistory("GET", "/successful_retry", None, 418, None),
             )
 
-    def test_retry_redirect_history(self, http_version: str) -> None:
+    def test_retry_redirect_history(self) -> None:
         with HTTPConnectionPool(self.host, self.port) as pool:
             resp = pool.request("GET", "/redirect", fields={"target": "/"})
             assert resp.status == 200
@@ -1240,7 +1219,7 @@ class TestRetry(HypercornDummyServerTestCase):
                 RequestHistory("GET", "/redirect?target=%2F", None, 303, "/"),
             )
 
-    def test_multi_redirect_history(self, http_version: str) -> None:
+    def test_multi_redirect_history(self) -> None:
         with HTTPConnectionPool(self.host, self.port) as pool:
             r = pool.request(
                 "GET",
@@ -1278,7 +1257,7 @@ class TestRetry(HypercornDummyServerTestCase):
 
 
 class TestRetryAfter(HypercornDummyServerTestCase):
-    def test_retry_after(self, http_version: str) -> None:
+    def test_retry_after(self) -> None:
         # Request twice in a second to get a 429 response.
         with HTTPConnectionPool(self.host, self.port) as pool:
             r = pool.request(
@@ -1336,7 +1315,7 @@ class TestRetryAfter(HypercornDummyServerTestCase):
             )
             assert r.status == 418
 
-    def test_redirect_after(self, http_version: str) -> None:
+    def test_redirect_after(self) -> None:
         with HTTPConnectionPool(self.host, self.port) as pool:
             r = pool.request("GET", "/redirect_after", retries=False)
             assert r.status == 303
@@ -1365,7 +1344,7 @@ class TestRetryAfter(HypercornDummyServerTestCase):
 
 
 class TestFileBodiesOnRetryOrRedirect(HypercornDummyServerTestCase):
-    def test_retries_put_filehandle(self, http_version: str) -> None:
+    def test_retries_put_filehandle(self) -> None:
         """HTTP PUT retry with a file-like object should not timeout"""
         with HTTPConnectionPool(self.host, self.port, timeout=LONG_TIMEOUT) as pool:
             retry = Retry(total=3, status_forcelist=[418])
@@ -1388,7 +1367,7 @@ class TestFileBodiesOnRetryOrRedirect(HypercornDummyServerTestCase):
             )
             assert resp.status == 200
 
-    def test_redirect_put_file(self, http_version: str) -> None:
+    def test_redirect_put_file(self) -> None:
         """PUT with file object should work with a redirection response"""
         with HTTPConnectionPool(self.host, self.port, timeout=LONG_TIMEOUT) as pool:
             retry = Retry(total=3, status_forcelist=[418])
@@ -1413,7 +1392,7 @@ class TestFileBodiesOnRetryOrRedirect(HypercornDummyServerTestCase):
             assert resp.status == 200
             assert resp.data == data
 
-    def test_redirect_with_failed_tell(self, http_version: str) -> None:
+    def test_redirect_with_failed_tell(self) -> None:
         """Abort request if failed to get a position from tell()"""
 
         class BadTellObject(io.BytesIO):
@@ -1433,7 +1412,7 @@ class TestFileBodiesOnRetryOrRedirect(HypercornDummyServerTestCase):
 
 
 class TestRetryPoolSize(HypercornDummyServerTestCase):
-    def test_pool_size_retry(self, http_version: str) -> None:
+    def test_pool_size_retry(self) -> None:
         retries = Retry(total=1, raise_on_status=False, status_forcelist=[404])
         with HTTPConnectionPool(
             self.host, self.port, maxsize=10, retries=retries, block=True
@@ -1443,7 +1422,7 @@ class TestRetryPoolSize(HypercornDummyServerTestCase):
 
 
 class TestRedirectPoolSize(HypercornDummyServerTestCase):
-    def test_pool_size_redirect(self, http_version: str) -> None:
+    def test_pool_size_redirect(self) -> None:
         retries = Retry(
             total=1, raise_on_status=False, status_forcelist=[404], redirect=True
         )


### PR DESCRIPTION
Today, enabling HTTP/2 only affects HTTPS. Allowing `http_version` in HTTP tests gives a false sense of test coverage.

@tcdent Sorry that we did not realize this earlier.
