### PR TITLE
Unpin pypy version in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
             os: ubuntu-latest
             experimental: false
             nox-session: test-pypy3.8
-          - python-version: "pypy-3.9-v7.3.13"
+          - python-version: "pypy-3.9"
             os: ubuntu-latest
             experimental: false
             nox-session: test-pypy3.9


### PR DESCRIPTION
https://github.com/pypy/pypy/issues/4877#issuecomment-2293763561

I recently tested main on pypy3.9-7.3.14 and it's not as slow as before https://github.com/urllib3/urllib3/pull/3308  and #3323

<!---
Thanks for your contribution! ♥️

If this is your first PR to urllib3 please review the Contributing Guide:
https://urllib3.readthedocs.io/en/latest/contributing.html

Adhering to the Contributing Guide means we can review, merge, and release your change faster! :)
--->
