### PR TITLE
Remove ALPN_PROTOCOLS export from urllib3.util

### DIFF
--- a/src/urllib3/http2/__init__.py
+++ b/src/urllib3/http2/__init__.py
@@ -24,7 +24,6 @@ def inject_into_urllib3() -> None:
 
     # Import here to avoid circular dependencies.
     from .. import connection as urllib3_connection
-    from .. import util as urllib3_util
     from ..connectionpool import HTTPSConnectionPool
     from ..util import ssl_ as urllib3_util_ssl
     from .connection import HTTP2Connection
@@ -36,18 +35,15 @@ def inject_into_urllib3() -> None:
     urllib3_connection.HTTPSConnection = HTTP2Connection  # type: ignore[misc]
 
     # TODO: Offer 'http/1.1' as well, but for testing purposes this is handy.
-    urllib3_util.ALPN_PROTOCOLS = ["h2"]
     urllib3_util_ssl.ALPN_PROTOCOLS = ["h2"]
 
 
 def extract_from_urllib3() -> None:
     from .. import connection as urllib3_connection
-    from .. import util as urllib3_util
     from ..connectionpool import HTTPSConnectionPool
     from ..util import ssl_ as urllib3_util_ssl
 
     HTTPSConnectionPool.ConnectionCls = orig_HTTPSConnection
     urllib3_connection.HTTPSConnection = orig_HTTPSConnection  # type: ignore[misc]
 
-    urllib3_util.ALPN_PROTOCOLS = ["http/1.1"]
     urllib3_util_ssl.ALPN_PROTOCOLS = ["http/1.1"]

--- a/src/urllib3/util/__init__.py
+++ b/src/urllib3/util/__init__.py
@@ -6,7 +6,6 @@ from .request import SKIP_HEADER, SKIPPABLE_HEADERS, make_headers
 from .response import is_fp_closed
 from .retry import Retry
 from .ssl_ import (
-    ALPN_PROTOCOLS,
     IS_PYOPENSSL,
     SSLContext,
     assert_fingerprint,
@@ -22,7 +21,6 @@ from .wait import wait_for_read, wait_for_write
 __all__ = (
     "IS_PYOPENSSL",
     "SSLContext",
-    "ALPN_PROTOCOLS",
     "Retry",
     "Timeout",
     "Url",

--- a/test/with_dummyserver/test_https.py
+++ b/test/with_dummyserver/test_https.py
@@ -967,7 +967,7 @@ class BaseTestHTTPS(HTTPSHypercornDummyServerTestCase):
         ) as pool:
             r = pool.request("GET", "/alpn_protocol", retries=0)
             assert r.status == 200
-            assert r.data.decode("utf-8") == util.ALPN_PROTOCOLS[0]
+            assert r.data.decode("utf-8") == urllib3.util.ssl_.ALPN_PROTOCOLS[0]
             assert (
                 r.data.decode("utf-8") == {"h11": "http/1.1", "h2": "h2"}[http_version]
             )

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -32,7 +32,7 @@ from dummyserver.socketserver import (
     get_unreachable_address,
 )
 from dummyserver.testcase import SocketDummyServerTestCase, consume_socket
-from urllib3 import HTTPConnectionPool, HTTPSConnectionPool, ProxyManager, util
+from urllib3 import HTTPConnectionPool, HTTPSConnectionPool, ProxyManager
 from urllib3._collections import HTTPHeaderDict
 from urllib3.connection import HTTPConnection, _get_default_user_agent
 from urllib3.connectionpool import _url_from_pool
@@ -126,7 +126,7 @@ class TestALPN(SocketDummyServerTestCase):
                 pass
             successful = done_receiving.wait(LONG_TIMEOUT)
             assert successful, "Timed out waiting for connection accept"
-            for protocol in util.ALPN_PROTOCOLS:
+            for protocol in ssl_.ALPN_PROTOCOLS:
                 assert (
                     protocol.encode("ascii") in self.buf
                 ), "missing ALPN protocol in SSL handshake"


### PR DESCRIPTION
If it's in two places, `urllib3.http2.inject_into_urllib3()` needs to update both places.

This was suggested in https://github.com/urllib3/urllib3/pull/3324#discussion_r1493830543.
