### PR TITLE
Optimize _encode_invalid_chars

### DIFF
--- a/changelog/3455.feature.rst
+++ b/changelog/3455.feature.rst
@@ -1,0 +1,1 @@
+Optimized _encode_invalid_chars for faster execution.


### PR DESCRIPTION
<!---
Thanks for your contribution! ♥️

If this is your first PR to urllib3 please review the Contributing Guide:
https://urllib3.readthedocs.io/en/latest/contributing.html

Adhering to the Contributing Guide means we can review, merge, and release your change faster! :)
--->

See https://github.com/urllib3/urllib3/issues/3454 for motivation. I haven't benchmarked it in depth, but presumably this should benefit all urllib3 users - it looks like this cuts around half of a second from urllib3's unit tests.

I've included context for what this accomplishes in the commit message and comments, feel free to let me know if you have any questions or concerns. The basic idea is to eliminate unnecessary allocations by preallocating the bytearray.

Note: I ran out of time to submit a proper PR (sorry). I'll gather some concrete numbers to back up this claim next week. 