### PR TITLE
Use pytest-memray limit_memory current_thread_only setting

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -13,7 +13,7 @@ trustme @ git+https://github.com/python-trio/trustme@b3a767f336e20600f30c9ff7838
 cryptography==42.0.4
 backports.zoneinfo==0.2.1;python_version<"3.9"
 towncrier==23.6.0
-pytest-memray==1.5.0;python_version<"3.13" and sys_platform!="win32" and implementation_name=="cpython"
+pytest-memray==1.7.0;python_version<"3.13" and sys_platform!="win32" and implementation_name=="cpython"
 trio==0.26.2
 Quart==0.19.4
 quart-trio==0.11.1

--- a/test/test_response.py
+++ b/test/test_response.py
@@ -96,7 +96,9 @@ class TestBytesQueueBuffer:
         (lambda b: b.get(len(b)), lambda b: b.get_all()),
         ids=("get", "get_all"),
     )
-    @pytest.mark.limit_memory("12.5 MB")  # assert that we're not doubling memory usage
+    @pytest.mark.limit_memory(
+        "12.5 MB", current_thread_only=True
+    )  # assert that we're not doubling memory usagelimit_mem
     def test_memory_usage(
         self, get_func: typing.Callable[[BytesQueueBuffer], str]
     ) -> None:
@@ -108,7 +110,7 @@ class TestBytesQueueBuffer:
 
         assert len(get_func(buffer)) == 10 * 2**20
 
-    @pytest.mark.limit_memory("10.01 MB")
+    @pytest.mark.limit_memory("10.01 MB", current_thread_only=True)
     def test_get_all_memory_usage_single_chunk(self) -> None:
         buffer = BytesQueueBuffer()
         chunk = bytes(10 * 2**20)  # 10 MiB
@@ -1095,7 +1097,7 @@ class TestResponse:
             (False, 10 * 2**20, "read1"),
         ],
     )
-    @pytest.mark.limit_memory("25 MB")
+    @pytest.mark.limit_memory("25 MB", current_thread_only=True)
     def test_buffer_memory_usage_decode_one_chunk(
         self, preload_content: bool, amt: int, read_meth: str
     ) -> None:
@@ -1119,7 +1121,7 @@ class TestResponse:
             (False, 10 * 2**20, "read1"),
         ],
     )
-    @pytest.mark.limit_memory("10.5 MB")
+    @pytest.mark.limit_memory("10.5 MB", current_thread_only=True)
     def test_buffer_memory_usage_no_decoding(
         self, preload_content: bool, amt: int, read_meth: str
     ) -> None:


### PR DESCRIPTION
Some time ago I requested this functionality to the pytest-memray team https://github.com/bloomberg/pytest-memray/issues/111,

Now that functionality is available since `pytest-memray==1.6.0`.

Enabling `current_thread_only` will give less false positives, as memory in the server threads (which is not part of  the SUT, in this case urllib3) will not be reported.

The need for this setting comes from #3358 where we had to modify a bunch of test cases to properly clean up resources due to false positives.

<!---
Thanks for your contribution! ♥️

If this is your first PR to urllib3 please review the Contributing Guide:
https://urllib3.readthedocs.io/en/latest/contributing.html

Adhering to the Contributing Guide means we can review, merge, and release your change faster! :)
--->
