### PR TITLE
Add license identifier to project metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ keywords = ["urllib", "httplib", "threadsafe", "filepost", "http", "https", "ssl
 authors = [
   {name = "Andrey Petrov", email = "andrey.petrov@shazow.net"}
 ]
+license = { text = "MIT" }
 maintainers = [
   {name = "Seth Michael Larson", email="sethmichaellarson@gmail.com"},
   {name = "Quentin Pradet", email="quentin@pradet.me"},


### PR DESCRIPTION
<!---
Thanks for your contribution! ♥️

If this is your first PR to urllib3 please review the Contributing Guide:
https://urllib3.readthedocs.io/en/latest/contributing.html

Adhering to the Contributing Guide means we can review, merge, and release your change faster! :)
--->

License scanning tools (such as the one used by GitLab) rely on the project metadata (made available via the PyPi API) to detect the license for a package.

Currently, `license: null` is returned.

This PR adds the license to the project metadata.
