### PR TITLE
[1.26] Replace deprecated dash-separated setuptools entries in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -8,11 +8,11 @@ universal = 1
 
 [metadata]
 license_file = LICENSE.txt
-provides-extra =
+provides_extra =
     secure
     socks
     brotli
-requires-dist =
+requires_dist =
     pyOpenSSL>=0.14; extra == 'secure'
     cryptography>=1.3.4; extra == 'secure'
     idna>=2.0.0; extra == 'secure'


### PR DESCRIPTION
As per the following warnings, the v1.x branches of urllib3 will stop building with up-to-date setuptools by 2024-09-26 if not addressed:

    /usr/lib/python3.12/site-packages/setuptools/dist.py:476: SetuptoolsDeprecationWarning: Invalid dash-separated options
    !!

            ********************************************************************************
            Usage of dash-separated 'provides-extra' will not be supported in future
            versions. Please use the underscore name 'provides_extra' instead.

            By 2024-Sep-26, you need to update your project and remove deprecated calls
            or your builds will no longer be supported.

            See https://setuptools.pypa.io/en/latest/userguide/declarative_config.html for details.
            ********************************************************************************

    !!
      opt = self.warn_dash_deprecation(opt, section)
    /usr/lib/python3.12/site-packages/setuptools/dist.py:476: SetuptoolsDeprecationWarning: Invalid dash-separated options
    !!

            ********************************************************************************
            Usage of dash-separated 'requires-dist' will not be supported in future
            versions. Please use the underscore name 'requires_dist' instead.

            By 2024-Sep-26, you need to update your project and remove deprecated calls
            or your builds will no longer be supported.

            See https://setuptools.pypa.io/en/latest/userguide/declarative_config.html for details.
            ********************************************************************************

<!---
Thanks for your contribution! ♥️

If this is your first PR to urllib3 please review the Contributing Guide:
https://urllib3.readthedocs.io/en/latest/contributing.html

Adhering to the Contributing Guide means we can review, merge, and release your change faster! :)
--->
