### PR TITLE
[1.26] Backport changes to the publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,29 +2,32 @@ name: Publish to PyPI
 
 on:
   push:
+    branches:
+      # We don't publish to Test PyPI on pushes to 1.26.x yet because there is
+      # no mechanism to get a dynamic version number in the branch yet.
+      # - "1.26.x"
+      - "main"
     tags:
       - "*"
 
 permissions:
-  contents: "read"
-  # Needed to access the workflow's OIDC identity.
-  id-token: "write"
+  contents: read
 
 jobs:
   build:
-    name: "Build dists"
+    name: "Build distribution 📦"
     runs-on: "ubuntu-latest"
-    environment:
-      name: "publish"
     outputs:
       hashes: ${{ steps.hash.outputs.hashes }}
 
     steps:
       - name: "Checkout repository"
-        uses: "actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8"
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+        with:
+          fetch-depth: 0 # Needed to fetch the version from git
 
       - name: "Setup Python"
-        uses: "actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984"
+        uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
         with:
           python-version: "3.x"
 
@@ -39,10 +42,10 @@ jobs:
       - name: "Generate hashes"
         id: hash
         run: |
-          cd dist && echo "::set-output name=hashes::$(sha256sum * | base64 -w0)"
+          cd dist && echo "hashes=$(sha256sum * | base64 -w0)" >> $GITHUB_OUTPUT
 
       - name: "Upload dists"
-        uses: "actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb"
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         with:
           name: "dist"
           path: "dist/"
@@ -54,25 +57,26 @@ jobs:
     permissions:
       actions: read
       contents: write
-      id-token: write
-    uses: "slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.2.1"
+      id-token: write # Needed to access the workflow's OIDC identity.
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
     with:
       base64-subjects: "${{ needs.build.outputs.hashes }}"
       upload-assets: true
-      compile-generator: true # Workaround for https://github.com/slsa-framework/slsa-github-generator/issues/1163
 
-  publish:
-    name: "Publish"
+  publish-to-pypi-and-github:
+    name: "Publish to PyPI"
     if: startsWith(github.ref, 'refs/tags/')
     needs: ["build", "provenance"]
     permissions:
-      contents: write
+      contents: write # Needed for making GitHub releases
       id-token: write # Needed for trusted publishing to PyPI.
     runs-on: "ubuntu-latest"
+    environment:
+      name: "publish"
 
     steps:
     - name: "Download dists"
-      uses: "actions/download-artifact@9782bd6a9848b53b110e712e20e42d89988822b7"
+      uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
       with:
         name: "dist"
         path: "dist/"
@@ -84,4 +88,25 @@ jobs:
         gh release upload ${{ github.ref_name }} dist/* --repo ${{ github.repository }}
 
     - name: "Publish dists to PyPI"
-      uses: "pypa/gh-action-pypi-publish@a56da0b891b3dc519c7ee3284aff1fad93cc8598"
+      uses: pypa/gh-action-pypi-publish@ec4db0b4ddc65acdf4bff5fa45ac92d78b56bdf0 # v1.9.0
+
+  publish-to-test-pypi:
+    name: "Publish to Test PyPI"
+    needs: ["build", "provenance"]
+    permissions:
+      id-token: write # Needed for trusted publishing to PyPI.
+    runs-on: "ubuntu-latest"
+    environment:
+      name: "testpypi"
+
+    steps:
+    - name: "Download dists"
+      uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
+      with:
+        name: "dist"
+        path: "dist/"
+
+    - name: "Publish dists to Test PyPI"
+      uses: pypa/gh-action-pypi-publish@ec4db0b4ddc65acdf4bff5fa45ac92d78b56bdf0 # v1.9.0
+      with:
+        repository-url: https://test.pypi.org/legacy/


### PR DESCRIPTION
Our publish workflow had [failed](https://github.com/urllib3/urllib3/actions/runs/9549560548) last 1.26.19 release because of outdated SLSA generator, we updated the generator in the main branch after that, and we need to backport the change

Here I'm just copying `.github/workflows/publish.yml` from the main branch with one change: disabling publishing to Test PyPI on pushes to 1.26.x
https://github.com/urllib3/urllib3/blob/3da3eb4dc09d58aa63aae4b7d6bdb9ee403a11d1/.github/workflows/publish.yml#L6-L8