### PR TITLE
Add support for Python 3.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,8 +89,6 @@ jobs:
             os: ubuntu-latest
             nox-session: emscripten
             experimental: true
-          - python-version: "3.13"
-            experimental: true
         exclude:
           # Ubuntu 22.04 comes with OpenSSL 3.0, so only CPython 3.9+ is compatible with it
           # https://github.com/python/cpython/issues/83001

--- a/changelog/3473.feature.rst
+++ b/changelog/3473.feature.rst
@@ -1,0 +1,1 @@
+Added support for Python 3.13.

--- a/noxfile.py
+++ b/noxfile.py
@@ -30,12 +30,6 @@ def tests_impl(
     ).strip()  # type: ignore[union-attr] # mypy doesn't know that silent=True  will return a string
     implementation_name, release_level = session_python_info.split(" ")
 
-    # zstd cannot be installed on CPython 3.13 yet because it pins
-    # an incompatible CFFI version.
-    # https://github.com/indygreg/python-zstandard/issues/210
-    if release_level != "final":
-        extras = extras.replace(",zstd", "")
-
     # Install deps and the package itself.
     session.install("-r", "dev-requirements.txt")
     session.install(f".[{extras}]")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",


### PR DESCRIPTION
<!---
Thanks for your contribution! ♥️

If this is your first PR to urllib3 please review the Contributing Guide:
https://urllib3.readthedocs.io/en/latest/contributing.html

Adhering to the Contributing Guide means we can review, merge, and release your change faster! :)
--->

The final Python 3.13 release candidate is out now! :rocket:

The Release Manager has issued a [call to action](https://discuss.python.org/t/python-3-13-0rc2-3-12-6-3-11-10-3-10-15-3-9-20-and-3-8-20-are-now-available/63161?u=hugovk]):

> We strongly encourage maintainers of third-party Python projects to prepare their projects for 3.13 compatibilities during this phase, and where necessary publish Python 3.13 wheels on PyPI to be ready for the final release of 3.13.0. Any binary wheels built against Python 3.13.0rc2 will work with future versions of Python 3.13. As always, report any issues to [the Python bug tracker](https://github.com/python/cpython/issues).


3.13 is already tested, let's mark it as non-experimental and add the Trove classifier.

zstd can now also be installed for 3.13: https://github.com/indygreg/python-zstandard/issues/210#issuecomment-2336604856
