### PR TITLE
GitHub Actions: Only attempt to publish for upstream

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,7 @@ permissions:
 
 jobs:
   build:
+    if: github.repository_owner == 'urllib3'
     name: "Build distribution 📦"
     runs-on: "ubuntu-latest"
     outputs:


### PR DESCRIPTION
<!---
Thanks for your contribution! ♥️

If this is your first PR to urllib3 please review the Contributing Guide:
https://urllib3.readthedocs.io/en/latest/contributing.html

Adhering to the Contributing Guide means we can review, merge, and release your change faster! :)
--->

It unsurprisingly fails for forks, so skip it in the same way as `scorecards.yml`:

https://github.com/hugovk/urllib3/actions/runs/10758514893/job/29834070711

(This could also be more tightly scoped to just those steps needing upload permissions, if you also want to test the other steps on forks.)