### PR TITLE
Testing: Install memray on Python 3.13

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -13,7 +13,7 @@ trustme @ git+https://github.com/python-trio/trustme@b3a767f336e20600f30c9ff7838
 cryptography==43.0.1
 backports.zoneinfo==0.2.1;python_version<"3.9"
 towncrier==23.6.0
-pytest-memray==1.7.0;python_version<"3.13" and sys_platform!="win32" and implementation_name=="cpython"
+pytest-memray==1.7.0;sys_platform!="win32" and implementation_name=="cpython"
 trio==0.26.2
 Quart==0.19.4
 quart-trio==0.11.1

--- a/noxfile.py
+++ b/noxfile.py
@@ -43,7 +43,7 @@ def tests_impl(
     session.run("python", "-m", "OpenSSL.debug")
 
     memray_supported = True
-    if implementation_name != "cpython" or release_level != "final":
+    if implementation_name != "cpython":
         memray_supported = False  # pytest-memray requires CPython 3.8+
     elif sys.platform == "win32":
         memray_supported = False


### PR DESCRIPTION
<!---
Thanks for your contribution! ♥️

If this is your first PR to urllib3 please review the Contributing Guide:
https://urllib3.readthedocs.io/en/latest/contributing.html

Adhering to the Contributing Guide means we can review, merge, and release your change faster! :)
--->

There's now a memray release with wheels for Python 3.13: https://github.com/bloomberg/memray/pull/658#issuecomment-2338959083

So we can now install it for testing 3.13.

I think this can skip a changelog.