### PR TITLE
Update accept_encoding=True documentation for Zstandard

### DIFF
--- a/src/urllib3/util/request.py
+++ b/src/urllib3/util/request.py
@@ -68,8 +68,10 @@ def make_headers(
 
     :param accept_encoding:
         Can be a boolean, list, or string.
-        ``True`` translates to 'gzip,deflate'.  If either the ``brotli`` or
-        ``brotlicffi`` package is installed 'gzip,deflate,br' is used instead.
+        ``True`` translates to 'gzip,deflate'.  If the dependencies for
+        Brotli (either the ``brotli`` or ``brotlicffi`` package) and/or Zstandard
+        (the ``zstandard`` package) algorithms are installed, then their encodings are
+        included in the string ('br' and 'zstd', respectively).
         List will get joined by comma.
         String will be used as provided.
 


### PR DESCRIPTION
Currently, `zstd` is not mentioned, even though it [will be added](https://github.com/urllib3/urllib3/blob/2458bfcd3dacdf6c196e98d077fc6bb02a5fc1df/src/urllib3/util/request.py#L31-L36) in the `accept_encoding=True` case if `zstandard` is installed.
<!---
Thanks for your contribution! ♥️

If this is your first PR to urllib3 please review the Contributing Guide:
https://urllib3.readthedocs.io/en/latest/contributing.html

Adhering to the Contributing Guide means we can review, merge, and release your change faster! :)
--->
