### PR TITLE
Added pickling support to NewConnectionError and NameResolutionError

### DIFF
--- a/changelog/3480.bugfix.rst
+++ b/changelog/3480.bugfix.rst
@@ -1,0 +1,1 @@
+Added pickling support to ``NewConnectionError`` and ``NameResolutionError``.

--- a/src/urllib3/exceptions.py
+++ b/src/urllib3/exceptions.py
@@ -143,6 +143,10 @@ class NewConnectionError(ConnectTimeoutError, HTTPError):
         self.conn = conn
         super().__init__(f"{conn}: {message}")
 
+    def __reduce__(self) -> _TYPE_REDUCE_RESULT:
+        # For pickling purposes.
+        return self.__class__, (None, None)
+
     @property
     def pool(self) -> HTTPConnection:
         warnings.warn(
@@ -161,6 +165,10 @@ class NameResolutionError(NewConnectionError):
     def __init__(self, host: str, conn: HTTPConnection, reason: socket.gaierror):
         message = f"Failed to resolve '{host}' ({reason})"
         super().__init__(conn, message)
+
+    def __reduce__(self) -> _TYPE_REDUCE_RESULT:
+        # For pickling purposes.
+        return self.__class__, (None, None, None)
 
 
 class EmptyPoolError(PoolError):

--- a/test/test_exceptions.py
+++ b/test/test_exceptions.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pickle
+import socket
 from email.errors import MessageDefect
 from test import DUMMY_POOL
 
@@ -17,6 +18,7 @@ from urllib3.exceptions import (
     HTTPError,
     LocationParseError,
     MaxRetryError,
+    NameResolutionError,
     NewConnectionError,
     ReadTimeoutError,
 )
@@ -38,6 +40,8 @@ class TestPickle:
             EmptyPoolError(HTTPConnectionPool("localhost"), ""),
             HostChangedError(HTTPConnectionPool("localhost"), "/", 0),
             ReadTimeoutError(HTTPConnectionPool("localhost"), "/", ""),
+            NewConnectionError(HTTPConnection("localhost"), ""),
+            NameResolutionError("", HTTPConnection("localhost"), socket.gaierror()),
         ],
     )
     def test_exceptions(self, exception: Exception) -> None:


### PR DESCRIPTION
<!---
Thanks for your contribution! ♥️

If this is your first PR to urllib3 please review the Contributing Guide:
https://urllib3.readthedocs.io/en/latest/contributing.html

Adhering to the Contributing Guide means we can review, merge, and release your change faster! :)
--->
Found out that these two exceptions don't support pickling. Added reduce in similar fashion to other Exceptions (will lose info but you can pickle it...)