### PR TITLE
Add codespell support (config, workflow to detect/not fix) and make it fix few typos

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,3 +32,10 @@ repos:
     hooks:
       - id: eslint
         args: ["--fix"]
+  - repo: https://github.com/codespell-project/codespell
+    # Configuration for codespell is in pyproject.toml
+    rev: v2.3.0
+    hooks:
+    - id: codespell
+      additional_dependencies:
+      - tomli

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1111,7 +1111,7 @@ Fixed
 
 * Pools can be used as context managers. (Issue #545)
 
-* Don't re-use connections which experienced an SSLError. (Issue #529)
+* Don't reuse connections which experienced an SSLError. (Issue #529)
 
 * Don't fail when gzip decoding an empty stream. (Issue #535)
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -6,7 +6,7 @@
 We as members, contributors, and leaders pledge to make participation in our
 community a harassment-free experience for everyone, regardless of age, body
 size, visible or invisible disability, ethnicity, sex characteristics, gender
-identity and expression, level of experience, education, socio-economic status,
+identity and expression, level of experience, education, socioeconomic status,
 nationality, personal appearance, race, religion, or sexual identity
 and orientation.
 

--- a/docs/advanced-usage.rst
+++ b/docs/advanced-usage.rst
@@ -24,7 +24,7 @@ However, keep in mind that this does increase memory and socket consumption.
 Similarly, the :class:`~connectionpool.ConnectionPool` class keeps a pool
 of individual :class:`~connection.HTTPConnection` instances. These connections
 are used during an individual request and returned to the pool when the request
-is complete. By default only one connection will be saved for re-use. If you
+is complete. By default only one connection will be saved for reuse. If you
 are making many requests to the same host simultaneously it might improve
 performance to increase this number.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,4 +134,4 @@ enable_error_code = [
 skip = '.git*,*.svg'
 check-hidden = true
 # ignore-regex = ''
-# ignore-words-list = ''
+ignore-words-list = 'fo,te'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,3 +128,10 @@ warn_unused_ignores = true
 enable_error_code = [
   "ignore-without-code",
 ]
+
+[tool.codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = '.git*,*.svg'
+check-hidden = true
+# ignore-regex = ''
+# ignore-words-list = ''

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -658,7 +658,7 @@ class HTTPSConnection(HTTPConnection):
     def connect(self) -> None:
         # Today we don't need to be doing this step before the /actual/ socket
         # connection, however in the future we'll need to decide whether to
-        # create a new socket or re-use an existing "shared" socket as a part
+        # create a new socket or reuse an existing "shared" socket as a part
         # of the HTTP/2 handshake dance.
         if self._tunnel_host is not None and self._tunnel_port is not None:
             probe_http2_host = self._tunnel_host

--- a/test/test_ssltransport.py
+++ b/test/test_ssltransport.py
@@ -284,7 +284,7 @@ class SocketProxyDummyServer(SocketDummyServerTestCase):
     def start_proxy_handler(self) -> None:
         """
         Socket handler for the proxy. Terminates the first TLS layer and tunnels
-        any bytes needed for client <-> server communicatin.
+        any bytes needed for client <-> server communication.
         """
 
         def proxy_handler(listener: socket.socket) -> None:


### PR DESCRIPTION
More about codespell: https://github.com/codespell-project/codespell .

I personally introduced it to dozens if not hundreds of projects already and so far only positive feedback.

CI workflow has 'permissions' set only to 'read' so also should be safe.