### PR TITLE
Fix a link to Towncrier docs

### DIFF
--- a/changelog/README.rst
+++ b/changelog/README.rst
@@ -14,7 +14,7 @@ Make sure to use full sentences in the **past tense** and use punctuation, examp
 
 Each file should be named like ``<ISSUE>.<TYPE>.rst``, where ``<ISSUE>`` is an issue
 number, and ``<TYPE>`` is one of the `five towncrier default types
-<https://towncrier.readthedocs.io/en/latest/#news-fragments>`_
+<https://towncrier.readthedocs.io/en/latest/tutorial.html#creating-news-fragments>`_
 
 So for example: ``123.feature.rst``, ``456.bugfix.rst``.
 


### PR DESCRIPTION
A link to Towncrier docs no longer opens a wanted section