### PR TITLE
Bind test server sockets to IPv6 and IPv4

### DIFF
--- a/dummyserver/hypercornserver.py
+++ b/dummyserver/hypercornserver.py
@@ -2,18 +2,82 @@ from __future__ import annotations
 
 import concurrent.futures
 import contextlib
+import errno
 import functools
+import socket
 import sys
 import threading
+import traceback
 import typing
 
 import hypercorn
+import hypercorn.config
 import hypercorn.trio
 import hypercorn.typing
 import trio
 from quart_trio import QuartTrio
 
 from urllib3.util.url import parse_url
+
+
+class Config(hypercorn.Config):
+    def create_sockets(self) -> hypercorn.config.Sockets:
+        assert len(self.bind) == 1
+        secure_sockets, insecure_sockets = [], []
+        if self.ssl_enabled:
+            secure_sockets = self._create_urllib3_sockets(self.bind[0])
+        else:
+            insecure_sockets = self._create_urllib3_sockets(self.bind[0])
+        return hypercorn.config.Sockets(
+            secure_sockets, insecure_sockets, quic_sockets=[]
+        )
+
+    def _retry_create_urllib3_sockets(self, bind: str) -> list[socket.socket]:
+        # When we request a socket with host localhost and port zero, Hypercorn
+        # only binds to IPv4. But we want to bind to IPv6 too, otherwise we
+        # waste about 2 second for each test on Windows since urllib3 tries
+        # IPv6 first as it does not implement Happy Eyeballs.
+        # We want to use the same port for IPv4 and IPv6, so we first get a
+        # free port in IPv4 and request the same port in IPv6. But that port
+        # could easily be taken with IPv6 already, especially on crowded CI
+        # environments, which would fail the run. For this reason we retry
+        # _create_urllib3_sockets up to 10 times, which completely eliminates
+        # this failure mode.
+        for i in range(10):
+            try:
+                return self._create_urllib3_sockets(bind)
+            except OSError as e:
+                if e.errno == errno.EADDRINUSE:
+                    print(
+                        f"Retrying binding to {bind} after EADDRINUSE", file=sys.stderr
+                    )
+        raise OSError("failed to bind socket")
+
+    def _create_urllib3_sockets(self, bind: str) -> list[socket.socket]:
+        sockets = []
+
+        bind = bind.replace("[", "").replace("]", "")
+        host = bind.rsplit(":", 1)[0]
+        port = 0  # Get a random port
+        family = socket.AF_INET6 if ":" in host else socket.AF_UNSPEC
+
+        for res in socket.getaddrinfo(
+            host, port, family, socket.SOCK_STREAM, 0, socket.AI_PASSIVE
+        ):
+            af, socktype, proto, canonname, sockadddr = res
+
+            sock = socket.socket(af, socket.SOCK_STREAM, proto)
+
+            sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+
+            sock.setblocking(False)
+            sock.bind((host, port))
+            port = sock.getsockname()[1]
+            sock.set_inheritable(True)
+            sockets.append(sock)
+
+        return sockets
 
 
 # https://github.com/pgjones/hypercorn/blob/19dfb96411575a6a647cdea63fa581b48ebb9180/src/hypercorn/utils.py#L172-L178
@@ -25,28 +89,35 @@ async def graceful_shutdown(shutdown_event: threading.Event) -> None:
 
 
 async def _start_server(
-    config: hypercorn.Config,
+    config: Config,
     app: QuartTrio,
     ready_event: threading.Event,
     shutdown_event: threading.Event,
 ) -> None:
     async with trio.open_nursery() as nursery:
-        config.bind = await nursery.start(
-            functools.partial(
-                hypercorn.trio.serve,
-                app,
-                config,
-                shutdown_trigger=functools.partial(graceful_shutdown, shutdown_event),
+        try:
+            config.bind = await nursery.start(
+                functools.partial(
+                    hypercorn.trio.serve,
+                    app,
+                    config,
+                    shutdown_trigger=functools.partial(
+                        graceful_shutdown, shutdown_event
+                    ),
+                )
             )
-        )
-        ready_event.set()
+            ready_event.set()
+        except Exception:
+            print("Starting server failed", file=sys.stderr)
+            traceback.print_exc()
+            raise
 
 
 @contextlib.contextmanager
 def run_hypercorn_in_thread(
     host: str, certs: dict[str, typing.Any] | None, app: hypercorn.typing.ASGIFramework
 ) -> typing.Iterator[int]:
-    config = hypercorn.Config()
+    config = Config()
     if certs:
         config.certfile = certs["certfile"]
         config.keyfile = certs["keyfile"]
@@ -89,7 +160,7 @@ def main() -> int:
     # For debugging dummyserver itself - PYTHONPATH=src python -m dummyserver.hypercornserver
     from .app import hypercorn_app
 
-    config = hypercorn.Config()
+    config = Config()
     config.bind = ["localhost:0"]
     ready_event = threading.Event()
     shutdown_event = threading.Event()


### PR DESCRIPTION
We lost that feature when migrating from Tornado to Hypercorn. We reimplement it here by overriding `hypercorn.Config.create_sockets`.

This makes Windows tests fast again (from 20 minutes to 4 minutes, and no longer the bottleneck), as on Windows trying to bind to IPv6 would take 2 seconds to fail, making tests much slower. This was quite baffling, but PyInstrument and then some prints in `create_connection` helped find the problem. I documented my thought process in https://fosstodon.org/@quentinpradet/113380164503305815.

I also included a change to print a traceback when the server fails to start, which has been really useful for debugging.