### PR TITLE
Run emscripten tests faster in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     name: ${{ fromJson('{"macos-15":"macOS","windows-latest":"Windows","ubuntu-latest":"Ubuntu","ubuntu-20.04":"Ubuntu 20.04 (OpenSSL 1.1.1)","ubuntu-22.04":"Ubuntu 22.04 (OpenSSL 3.0)"}')[matrix.os] }} ${{ matrix.python-version }} ${{ matrix.nox-session}}
     continue-on-error: ${{ matrix.experimental }}
-    timeout-minutes: 30
+    timeout-minutes: 10
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,10 +103,10 @@ jobs:
 
       - name: "Install Chrome"
         uses: browser-actions/setup-chrome@db1b524c26f20a8d1a10f7fc385c92387e2d0477 # v1.7.1
-        if: ${{ matrix.nox-session == 'emscripten' }}
+        if: ${{ matrix.nox-session == 'emscripten(chrome)' }}
       - name: "Install Firefox"
         uses: browser-actions/setup-firefox@233224b712fc07910ded8c15fb95a555c86da76f # v1.5.0
-        if: ${{ matrix.nox-session == 'emscripten' }}
+        if: ${{ matrix.nox-session == 'emscripten(firefox)' }}
       - name: "Run tests"
         # If no explicit NOX_SESSION is set, run the default tests for the chosen Python version
         run: nox -s ${NOX_SESSION:-test-$PYTHON_VERSION}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,9 +73,13 @@ jobs:
             os: ubuntu-20.04  # CPython 3.9.2 is not available for ubuntu-22.04.
             experimental: false
             nox-session: test-3.9
-          - python-version: "3.11"
+          - python-version: "3.12"
             os: ubuntu-latest
-            nox-session: emscripten
+            nox-session: emscripten(firefox)
+            experimental: true
+          - python-version: "3.12"
+            os: ubuntu-latest
+            nox-session: emscripten(chrome)
             experimental: true
 
     runs-on: ${{ matrix.os }}

--- a/emscripten-requirements.txt
+++ b/emscripten-requirements.txt
@@ -1,3 +1,6 @@
 pytest-pyodide==0.54.0
 pyodide-build==0.24.1
 webdriver-manager==4.0.1
+# With https://github.com/SeleniumHQ/selenium/pull/13286, we now get the following warning:
+# DeprecationWarning: setting remote_server_addr in RemoteConnection() is deprecated, set in ClientConfig instance instead
+selenium==4.25.0

--- a/emscripten-requirements.txt
+++ b/emscripten-requirements.txt
@@ -1,6 +1,3 @@
 pytest-pyodide==0.54.0
 pyodide-build==0.24.1
 webdriver-manager==4.0.1
-# With https://github.com/SeleniumHQ/selenium/pull/13286, we now get the following warning:
-# DeprecationWarning: setting remote_server_addr in RemoteConnection() is deprecated, set in ClientConfig instance instead
-selenium==4.25.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,7 +104,7 @@ filterwarnings = [
     # https://github.com/SeleniumHQ/selenium/issues/13328
     '''default:unclosed file <_io\.BufferedWriter name='/dev/null'>:ResourceWarning''',
     # https://github.com/SeleniumHQ/selenium/issues/14686
-    '''default:setting remote_server_addr in RemoteConnection() is deprecated, set in ClientConfig instance instead:DeprecationWarning'''
+    '''default:setting remote_server_addr in RemoteConnection\(\) is deprecated, set in ClientConfig instance instead:DeprecationWarning'''
 ]
 
 [tool.isort]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,8 +99,12 @@ filterwarnings = [
     '''default:ssl\.PROTOCOL_TLSv1_1 is deprecated:DeprecationWarning''',
     '''default:ssl\.PROTOCOL_TLSv1_2 is deprecated:DeprecationWarning''',
     '''default:ssl NPN is deprecated, use ALPN instead:DeprecationWarning''',
-    '''default:Async generator 'quart\.wrappers\.response\.DataBody\.__aiter__\.<locals>\._aiter' was garbage collected.*:ResourceWarning''',  # https://github.com/pallets/quart/issues/301
-    '''default:unclosed file <_io\.BufferedWriter name='/dev/null'>:ResourceWarning''',  # https://github.com/SeleniumHQ/selenium/issues/13328
+    # https://github.com/pallets/quart/issues/301
+    '''default:Async generator 'quart\.wrappers\.response\.DataBody\.__aiter__\.<locals>\._aiter' was garbage collected.*:ResourceWarning''',
+    # https://github.com/SeleniumHQ/selenium/issues/13328
+    '''default:unclosed file <_io\.BufferedWriter name='/dev/null'>:ResourceWarning''',
+    # https://github.com/SeleniumHQ/selenium/issues/14686
+    '''default:setting remote_server_addr in RemoteConnection() is deprecated, set in ClientConfig instance instead:DeprecationWarning'''
 ]
 
 [tool.isort]


### PR DESCRIPTION
By running Firefox and Chrome in parallel, not collecting thousands of skipped tests, and not printing thousands of line of wget progress.

With this change, all steps run in 5 minutes or less.