### PR TITLE
Implement context-manager for BaseHTTPResponse

### DIFF
--- a/src/urllib3/response.py
+++ b/src/urllib3/response.py
@@ -7,6 +7,7 @@ import logging
 import re
 import sys
 import typing
+import types
 import warnings
 import zlib
 from contextlib import contextmanager
@@ -346,6 +347,20 @@ class BaseHTTPResponse(io.IOBase):
 
         self._decoder: ContentDecoder | None = None
         self.length_remaining: int | None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: types.TracebackType | None,
+    ) -> None:
+        self.close()
+        self.release_conn()
+
+        return None
 
     def get_redirect_location(self) -> str | None | typing.Literal[False]:
         """

--- a/test/test_response.py
+++ b/test/test_response.py
@@ -588,6 +588,21 @@ class TestResponse:
         assert resp.data == b"foo"
         assert resp.closed
 
+    def test_close_context_manager(self) -> None:
+        r = httplib.HTTPResponse(MockSock, method="HEAD")  # type: ignore[arg-type]
+        resp = HTTPResponse(
+            "",
+            original_response=r,
+        )
+        setattr(resp, "release_conn", mock.Mock())
+        setattr(resp, "close", mock.Mock())
+
+        with resp:
+            pass
+
+        resp.close.assert_called_once_with()  # type: ignore[attr-defined]
+        resp.release_conn.assert_called_once_with()  # type: ignore[attr-defined]
+
     @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
     def test_base_io(self) -> None:
         resp = BaseHTTPResponse(


### PR DESCRIPTION
<!---
Thanks for your contribution! ♥️

If this is your first PR to urllib3 please review the Contributing Guide:
https://urllib3.readthedocs.io/en/latest/contributing.html

Adhering to the Contributing Guide means we can review, merge, and release your change faster! :)
--->

Implement context-manager for `BaseHTTPResponse` to automatically call `close()` and `release_conn()`.