### PR TITLE
Introducing urllib3 Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
   <a href="https://deps.dev/pypi/urllib3"><img alt="OpenSSF Scorecard" src="https://api.securityscorecards.dev/projects/github.com/urllib3/urllib3/badge" /></a>
   <a href="https://slsa.dev"><img alt="SLSA 3" src="https://slsa.dev/images/gh-badge-level3.svg" /></a>
   <a href="https://bestpractices.coreinfrastructure.org/projects/6227"><img alt="CII Best Practices" src="https://bestpractices.coreinfrastructure.org/projects/6227/badge" /></a>
+  <a href="https://gurubase.io/g/urllib3"><img alt="Gurubase" src="https://img.shields.io/badge/Gurubase-Ask%20urllib3%20Guru-006BFF" /></a>
 </p>
 
 urllib3 is a powerful, *user-friendly* HTTP client for Python. Much of the


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [urllib3 Guru](https://gurubase.io/g/urllib3) to Gurubase. urllib3 Guru uses the data from this repo and data from the [docs](https://urllib3.readthedocs.io) to answer questions by leveraging the LLM.

In this PR, I showcased the "urllib3 Guru", which highlights that urllib3 now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable urllib3 Guru in Gurubase, just let me know that's totally fine.
