### PR TITLE
Add the maximum time to wait for Retry-After header

### DIFF
--- a/changelog/1338.feature.rst
+++ b/changelog/1338.feature.rst
@@ -1,2 +1,3 @@
 Add the maximum time to wait for ``Retry-After`` header.
-if you set ``max_retry_wait_length`` in ``Retry`` object, and if the value of ``Retry-After`` header exceeds this, will only wait for ``max_retry_wait_length`` before retry. Otherwise, it will keep using the ``Retry-After`` header value (if have).
+
+If you set ``max_retry_wait_length`` in ``Retry`` object, and if the value of ``Retry-After`` header exceeds this, will only wait for ``max_retry_wait_length`` before retry. Otherwise, it will keep using the ``Retry-After`` header value (if have).

--- a/changelog/1338.feature.rst
+++ b/changelog/1338.feature.rst
@@ -1,0 +1,2 @@
+Add the maximum time to wait for ``Retry-After`` header.
+if you set ``max_retry_wait_length`` in ``Retry`` object, and if the value of ``Retry-After`` header exceeds this, will only wait for ``max_retry_wait_length`` before retry. Otherwise, it will keep using the ``Retry-After`` header value (if have).

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -12,7 +12,7 @@ towncrier==23.6.0
 pytest-memray==1.7.0;python_version<"3.14" and sys_platform!="win32" and implementation_name=="cpython"
 trio==0.26.2
 # https://github.com/pallets/quart/pull/369
-Quart @ git+https://github.com/pallets/quart@5f9d977cfbcaf2844efb5309b0c80a4289af1958
+Quart
 quart-trio==0.11.1
 # https://github.com/pgjones/hypercorn/issues/62
 # https://github.com/pgjones/hypercorn/issues/168

--- a/src/urllib3/util/retry.py
+++ b/src/urllib3/util/retry.py
@@ -178,7 +178,7 @@ class Retry:
         Sequence of headers to remove from the request when a response
         indicating a redirect is returned before firing off the redirected
         request.
-        
+
     :param float max_retry_wait_length:
         The maximum value of time to wait for retry. If the value of Retry-After
         header is larger than this, will only wait for this value.
@@ -268,7 +268,7 @@ class Retry:
             remove_headers_on_redirect=self.remove_headers_on_redirect,
             respect_retry_after_header=self.respect_retry_after_header,
             backoff_jitter=self.backoff_jitter,
-            max_retry_wait_length=self.max_retry_wait_length
+            max_retry_wait_length=self.max_retry_wait_length,
         )
 
         params.update(kw)
@@ -337,11 +337,14 @@ class Retry:
         if retry_after is None:
             return None
 
-        retry_after = self.parse_retry_after(retry_after)
-        if (self.max_retry_wait_length != None and retry_after > self.max_retry_wait_length):
+        retry_after_float = self.parse_retry_after(retry_after)
+        if (
+            self.max_retry_wait_length is not None
+            and retry_after_float > self.max_retry_wait_length
+        ):
             return self.max_retry_wait_length
 
-        return retry_after
+        return retry_after_float
 
     def sleep_for_retry(self, response: BaseHTTPResponse) -> bool:
         retry_after = self.get_retry_after(response)

--- a/src/urllib3/util/retry.py
+++ b/src/urllib3/util/retry.py
@@ -268,6 +268,7 @@ class Retry:
             remove_headers_on_redirect=self.remove_headers_on_redirect,
             respect_retry_after_header=self.respect_retry_after_header,
             backoff_jitter=self.backoff_jitter,
+            max_retry_wait_length=self.max_retry_wait_length
         )
 
         params.update(kw)

--- a/test/test_retry.py
+++ b/test/test_retry.py
@@ -345,6 +345,22 @@ class TestRetry:
 
         assert retry.remove_headers_on_redirect == {"x-api-secret"}
 
+    def test_max_retry_wait_length(self) -> None:
+        retry_1 = Retry()
+        http_response_1 = HTTPResponse(headers={})
+        print(retry_1.get_retry_after(http_response_1))
+        assert retry_1.get_retry_after(http_response_1) == None
+        
+        retry_2 = Retry()
+        http_response_2 = HTTPResponse(headers={"Retry-After": "10"})
+        print(retry_2.get_retry_after(http_response_2))
+        assert retry_2.get_retry_after(http_response_2) == 10
+        
+        retry_3 = Retry(max_retry_wait_length = 2)
+        http_response_3 = HTTPResponse(headers={"Retry-After": "10"})
+        print(retry_3.get_retry_after(http_response_3))
+        assert retry_3.get_retry_after(http_response_3) == 2
+
     @pytest.mark.parametrize("value", ["-1", "+1", "1.0", "\xb2"])  # \xb2 = ^2
     def test_parse_retry_after_invalid(self, value: str) -> None:
         retry = Retry()

--- a/test/test_retry.py
+++ b/test/test_retry.py
@@ -349,14 +349,14 @@ class TestRetry:
         retry_1 = Retry()
         http_response_1 = HTTPResponse(headers={})
         print(retry_1.get_retry_after(http_response_1))
-        assert retry_1.get_retry_after(http_response_1) == None
-        
+        assert retry_1.get_retry_after(http_response_1) is None
+
         retry_2 = Retry()
         http_response_2 = HTTPResponse(headers={"Retry-After": "10"})
         print(retry_2.get_retry_after(http_response_2))
         assert retry_2.get_retry_after(http_response_2) == 10
-        
-        retry_3 = Retry(max_retry_wait_length = 2)
+
+        retry_3 = Retry(max_retry_wait_length=2)
         http_response_3 = HTTPResponse(headers={"Retry-After": "10"})
         print(retry_3.get_retry_after(http_response_3))
         assert retry_3.get_retry_after(http_response_3) == 2

--- a/test/with_dummyserver/test_max_retry_wait_length.py
+++ b/test/with_dummyserver/test_max_retry_wait_length.py
@@ -15,6 +15,7 @@ class TestMaxRetryWaitLength(SocketDummyServerTestCase):
         """
         Start a server that sends a Retry-After header with the specified value.
         """
+
         def socket_handler(listener: socket.socket) -> None:
             sock = listener.accept()[0]
             sock.send(
@@ -37,14 +38,16 @@ class TestMaxRetryWaitLength(SocketDummyServerTestCase):
         with HTTPConnectionPool(self.host, self.port) as pool:
             retries = Retry(total=1, max_retry_wait_length=2)
             print(retries.max_retry_wait_length)
-            
+
             start_time = time.time()
             with pytest.raises(Exception):  # Catch the retry failure
                 pool.urlopen("GET", "/", retries=retries)
             elapsed_time = time.time() - start_time
 
             # Ensure that we waited no longer than the specified max_retry_wait_length
-            assert elapsed_time < 3, f"Elapsed time {elapsed_time} exceeded the max retry wait length"
+            assert (
+                elapsed_time < 3
+            ), f"Elapsed time {elapsed_time} exceeded the max retry wait length"
 
     def test_no_max_retry_wait_length(self) -> None:
         """
@@ -55,14 +58,16 @@ class TestMaxRetryWaitLength(SocketDummyServerTestCase):
 
         with HTTPConnectionPool(self.host, self.port) as pool:
             retries = Retry(total=1)
-            
+
             start_time = time.time()
             with pytest.raises(Exception):  # Catch the retry failure
                 pool.urlopen("GET", "/", retries=retries)
             elapsed_time = time.time() - start_time
 
             # Ensure that we waited for at least the Retry-After value
-            assert elapsed_time >= 5, f"Elapsed time {elapsed_time} was less than expected Retry-After"
+            assert (
+                elapsed_time >= 5
+            ), f"Elapsed time {elapsed_time} was less than expected Retry-After"
 
     def test_invalid_retry_after_header(self) -> None:
         """
@@ -73,14 +78,16 @@ class TestMaxRetryWaitLength(SocketDummyServerTestCase):
 
         with HTTPConnectionPool(self.host, self.port) as pool:
             retries = Retry(total=1, max_retry_wait_length=2)
-            
+
             start_time = time.time()
             with pytest.raises(Exception):  # Catch the retry failure
                 pool.urlopen("GET", "/", retries=retries)
             elapsed_time = time.time() - start_time
 
             # Ensure that no additional wait time occurred due to invalid Retry-After
-            assert elapsed_time < 1, f"Elapsed time {elapsed_time} exceeded the expected behavior for invalid Retry-After"
+            assert (
+                elapsed_time < 1
+            ), f"Elapsed time {elapsed_time} exceeded the expected behavior for invalid Retry-After"
 
 
 if __name__ == "__main__":

--- a/test/with_dummyserver/test_max_retry_wait_length.py
+++ b/test/with_dummyserver/test_max_retry_wait_length.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import socket
+import time
+
+import pytest
+
+from dummyserver.testcase import SocketDummyServerTestCase
+from urllib3 import HTTPConnectionPool
+from urllib3.util.retry import Retry
+
+
+class TestMaxRetryWaitLength(SocketDummyServerTestCase):
+    def start_retry_after_handler(self, retry_after_value: str) -> None:
+        """
+        Start a server that sends a Retry-After header with the specified value.
+        """
+        def socket_handler(listener: socket.socket) -> None:
+            sock = listener.accept()[0]
+            sock.send(
+                f"HTTP/1.1 429 Too Many Requests\r\n"
+                f"Retry-After: {retry_after_value}\r\n"
+                f"Content-Length: 0\r\n"
+                f"Connection: close\r\n\r\n".encode()
+            )
+            sock.close()
+
+        self._start_server(socket_handler)
+
+    def test_max_retry_wait_length_respected(self) -> None:
+        """
+        Test that max_retry_wait_length is respected when the Retry-After value is larger.
+        """
+        # Start a dummy server that returns a Retry-After of 10 seconds
+        self.start_retry_after_handler("10")
+
+        with HTTPConnectionPool(self.host, self.port) as pool:
+            retries = Retry(total=1, max_retry_wait_length=2)
+            print(retries.max_retry_wait_length)
+            
+            start_time = time.time()
+            with pytest.raises(Exception):  # Catch the retry failure
+                pool.urlopen("GET", "/", retries=retries)
+            elapsed_time = time.time() - start_time
+
+            # Ensure that we waited no longer than the specified max_retry_wait_length
+            assert elapsed_time < 3, f"Elapsed time {elapsed_time} exceeded the max retry wait length"
+
+    def test_no_max_retry_wait_length(self) -> None:
+        """
+        Test behavior when max_retry_wait_length is not specified (default behavior).
+        """
+        # Start a dummy server that returns a Retry-After of 5 seconds
+        self.start_retry_after_handler("5")
+
+        with HTTPConnectionPool(self.host, self.port) as pool:
+            retries = Retry(total=1)
+            
+            start_time = time.time()
+            with pytest.raises(Exception):  # Catch the retry failure
+                pool.urlopen("GET", "/", retries=retries)
+            elapsed_time = time.time() - start_time
+
+            # Ensure that we waited for at least the Retry-After value
+            assert elapsed_time >= 5, f"Elapsed time {elapsed_time} was less than expected Retry-After"
+
+    def test_invalid_retry_after_header(self) -> None:
+        """
+        Test behavior when an invalid Retry-After header is received.
+        """
+        # Start a dummy server with an invalid Retry-After header
+        self.start_retry_after_handler("invalid")
+
+        with HTTPConnectionPool(self.host, self.port) as pool:
+            retries = Retry(total=1, max_retry_wait_length=2)
+            
+            start_time = time.time()
+            with pytest.raises(Exception):  # Catch the retry failure
+                pool.urlopen("GET", "/", retries=retries)
+            elapsed_time = time.time() - start_time
+
+            # Ensure that no additional wait time occurred due to invalid Retry-After
+            assert elapsed_time < 1, f"Elapsed time {elapsed_time} exceeded the expected behavior for invalid Retry-After"
+
+
+if __name__ == "__main__":
+    pytest.main()

--- a/test/with_dummyserver/test_max_retry_wait_length.py
+++ b/test/with_dummyserver/test_max_retry_wait_length.py
@@ -32,8 +32,8 @@ class TestMaxRetryWaitLength(SocketDummyServerTestCase):
         """
         Test that max_retry_wait_length is respected when the Retry-After value is larger.
         """
-        # Start a dummy server that returns a Retry-After of 10 seconds
-        self.start_retry_after_handler("10")
+        # Start a dummy server that returns a Retry-After of 100 seconds
+        self.start_retry_after_handler("100")
 
         with HTTPConnectionPool(self.host, self.port) as pool:
             retries = Retry(total=1, max_retry_wait_length=2)
@@ -46,7 +46,7 @@ class TestMaxRetryWaitLength(SocketDummyServerTestCase):
 
             # Ensure that we waited no longer than the specified max_retry_wait_length
             assert (
-                elapsed_time < 3
+                elapsed_time < 20  # github actions may be very slow
             ), f"Elapsed time {elapsed_time} exceeded the max retry wait length"
 
     def test_no_max_retry_wait_length(self) -> None:


### PR DESCRIPTION
Implementation for #1338 Retry.get_retry_after does't respect time-out

Currently if you set `max_retry_wait_length` in `Retry` object, and if the value of `Retry-After` header exceeds this, will only wait for `max_retry_wait_length` before retry. Otherwise, it will keep using the `Retry-After` header value (if have).

Current github actions fail due to python3.14 and the version of `Quart`, see https://github.com/urllib3/urllib3/pull/3498. I temporarily remove the version of `Quart` to pass the versions below 3.14.