### PR TITLE
Add license field to pyproject.toml

### DIFF
--- a/changelog/3522.feature
+++ b/changelog/3522.feature
@@ -1,0 +1,1 @@
+Apply PEP 639 by specifying the license fields in pyproject.toml.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,8 @@ build-backend = "hatchling.build"
 name = "urllib3"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 readme = "README.md"
+license = "MIT"
+license-files = ["LICENSE.txt"]
 keywords = ["urllib", "httplib", "threadsafe", "filepost", "http", "https", "ssl", "pooling"]
 authors = [
   {name = "Andrey Petrov", email = "andrey.petrov@shazow.net"}
@@ -20,7 +22,6 @@ maintainers = [
 classifiers = [
   "Environment :: Web Environment",
   "Intended Audience :: Developers",
-  "License :: OSI Approved :: MIT License",
   "Operating System :: OS Independent",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",


### PR DESCRIPTION
While investigating this package on deps.dev[1], I discovered this package is shown as having an unknown license. Given the packaging guidelines, this is likely a bug in deps.dev, but I thought we could work around it with one line in the project metadata.

1: https://deps.dev/pypi/urllib3

<!---
Thanks for your contribution! ♥️

If this is your first PR to urllib3 please review the Contributing Guide:
https://urllib3.readthedocs.io/en/latest/contributing.html

Adhering to the Contributing Guide means we can review, merge, and release your change faster! :)
--->
