### PR TITLE
 Add HTTPResponse.shutdown() to stop blocking reads 

### DIFF
--- a/changelog/2868.feature.rst
+++ b/changelog/2868.feature.rst
@@ -1,0 +1,1 @@
+Add ``HTTResponse.shutdown()`` to stop any ongoing or future reads for a specific response. It calls ``shutdown(SHUT_RD)`` on the underlying socket.

--- a/changelog/2868.feature.rst
+++ b/changelog/2868.feature.rst
@@ -1,1 +1,1 @@
-Add ``HTTResponse.shutdown()`` to stop any ongoing or future reads for a specific response. It calls ``shutdown(SHUT_RD)`` on the underlying socket.
+Added ``HTTPResponse.shutdown()`` to stop any ongoing or future reads for a specific response. It calls ``shutdown(SHUT_RD)`` on the underlying socket.

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -11,7 +11,7 @@ cryptography==43.0.1
 towncrier==23.6.0
 pytest-memray==1.7.0;sys_platform!="win32" and implementation_name=="cpython"
 trio==0.26.2
-Quart==0.19.8
+Quart==0.19.9
 quart-trio==0.11.1
 # https://github.com/pgjones/hypercorn/issues/62
 # https://github.com/pgjones/hypercorn/issues/168

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -506,6 +506,11 @@ class HTTPConnection(_HTTPConnection):
         # This is needed here to avoid circular import errors
         from .response import HTTPResponse
 
+        # Save a reference to the shutdown function before ownership is passed
+        # to httplib_response
+        # TODO should we implement it everywhere?
+        _shutdown = getattr(self.sock, "shutdown", None)
+
         # Get the response from http.client.HTTPConnection
         httplib_response = super().getresponse()
 
@@ -534,6 +539,7 @@ class HTTPConnection(_HTTPConnection):
             enforce_content_length=resp_options.enforce_content_length,
             request_method=resp_options.request_method,
             request_url=resp_options.request_url,
+            sock_shutdown=_shutdown,
         )
         return response
 

--- a/src/urllib3/contrib/pyopenssl.py
+++ b/src/urllib3/contrib/pyopenssl.py
@@ -366,9 +366,11 @@ class WrappedSocket:
             )
             total_sent += sent
 
-    def shutdown(self) -> None:
-        # FIXME rethrow compatible exceptions should we ever use this
-        self.connection.shutdown()
+    def shutdown(self, how: int) -> None:
+        try:
+            self.connection.shutdown(how)
+        except OpenSSL.SSL.Error as e:
+            raise ssl.SSLError(f"shutdown error: {e!r}") from e
 
     def close(self) -> None:
         self._closed = True

--- a/src/urllib3/contrib/pyopenssl.py
+++ b/src/urllib3/contrib/pyopenssl.py
@@ -368,7 +368,7 @@ class WrappedSocket:
 
     def shutdown(self, how: int) -> None:
         try:
-            self.connection.shutdown(how)
+            self.connection.shutdown()
         except OpenSSL.SSL.Error as e:
             raise ssl.SSLError(f"shutdown error: {e!r}") from e
 

--- a/src/urllib3/response.py
+++ b/src/urllib3/response.py
@@ -441,6 +441,9 @@ class BaseHTTPResponse(io.IOBase):
     def drain_conn(self) -> None:
         raise NotImplementedError()
 
+    def shutdown(self) -> None:
+        raise NotImplementedError()
+
     def close(self) -> None:
         raise NotImplementedError()
 
@@ -1069,7 +1072,6 @@ class HTTPResponse(BaseHTTPResponse):
     def readable(self) -> bool:
         return True
 
-    # TODO should it be defined in BaseHTTPResponse?
     def shutdown(self) -> None:
         if not self._sock_shutdown:
             raise ValueError("Cannot shutdown socket as self._sock_shutdown is not set")

--- a/src/urllib3/response.py
+++ b/src/urllib3/response.py
@@ -1076,6 +1076,8 @@ class HTTPResponse(BaseHTTPResponse):
         self._sock_shutdown(socket.SHUT_RD)
 
     def close(self) -> None:
+        self._sock_shutdown = None
+
         if not self.closed and self._fp:
             self._fp.close()
 

--- a/test/test_response.py
+++ b/test/test_response.py
@@ -204,6 +204,13 @@ class TestResponse:
         assert r.data == b"foo"
         assert fp.tell() == len(b"foo")
 
+    def test_no_shutdown(self) -> None:
+        r = HTTPResponse()
+        with pytest.raises(
+            ValueError, match="Cannot shutdown socket as self._sock_shutdown is not set"
+        ):
+            r.shutdown()
+
     def test_decode_bad_data(self) -> None:
         fp = BytesIO(b"\x00" * 10)
         with pytest.raises(DecodeError):

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -14,6 +14,7 @@ import socket
 import ssl
 import tempfile
 import threading
+import time
 import typing
 import zlib
 from collections import OrderedDict
@@ -32,7 +33,13 @@ from dummyserver.socketserver import (
     get_unreachable_address,
 )
 from dummyserver.testcase import SocketDummyServerTestCase, consume_socket
-from urllib3 import HTTPConnectionPool, HTTPSConnectionPool, ProxyManager, util
+from urllib3 import (
+    BaseHTTPResponse,
+    HTTPConnectionPool,
+    HTTPSConnectionPool,
+    ProxyManager,
+    util,
+)
 from urllib3._collections import HTTPHeaderDict
 from urllib3.connection import HTTPConnection, _get_default_user_agent
 from urllib3.connectionpool import _url_from_pool
@@ -1015,7 +1022,7 @@ class TestSocketClosing(SocketDummyServerTestCase):
             assert ssl_sock.fileno() > 0
 
     def test_socket_shutdown_stops_recv(self) -> None:
-        timed_out = Event()
+        timed_out, starting_read = Event(), Event()
 
         def socket_handler(listener: socket.socket) -> None:
             sock = listener.accept()[0]
@@ -1038,15 +1045,32 @@ class TestSocketClosing(SocketDummyServerTestCase):
 
         self._start_server(socket_handler)
 
-        with HTTPConnectionPool(self.host, self.port) as pool:
-            response = pool.urlopen("GET", "/", preload_content=False, retries=0)
-            # Calling shutdown here calls shutdown() on the underlying socket,
-            # so that the remaining read will fail instead of blocking
-            # indefinitely
-            response.shutdown()
-            with pytest.raises(ProtocolError, match="Connection broken"):
-                response.read()
-            timed_out.set()
+        class TestClient(threading.Thread):
+            def __init__(self, host: str, port: int) -> None:
+                super().__init__()
+                self.host, self.port = host, port
+                self.response: BaseHTTPResponse | None = None
+
+            def run(self) -> None:
+                with HTTPConnectionPool(self.host, self.port) as pool:
+                    self.response = pool.urlopen(
+                        "GET", "/", preload_content=False, retries=0
+                    )
+                    with pytest.raises(ProtocolError, match="IncompleteRead"):
+                        starting_read.set()
+                        self.response.read()
+
+        test_client = TestClient(self.host, self.port)
+        test_client.start()
+        # First, wait to make sure the client is really stuck reading
+        starting_read.wait(5)
+        time.sleep(LONG_TIMEOUT)
+        # Calling shutdown here calls shutdown() on the underlying socket,
+        # so that the remaining read will fail instead of blocking
+        # indefinitely
+        assert test_client.response is not None
+        test_client.response.shutdown()
+        timed_out.set()
 
 
 class TestProxyManager(SocketDummyServerTestCase):

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -1056,7 +1056,7 @@ class TestSocketClosing(SocketDummyServerTestCase):
                     self.response = pool.urlopen(
                         "GET", "/", preload_content=False, retries=0
                     )
-                    with pytest.raises(ProtocolError, match="IncompleteRead"):
+                    with pytest.raises(ProtocolError, match="Connection broken"):
                         starting_read.set()
                         self.response.read()
 

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -1066,7 +1066,9 @@ class TestSocketClosing(SocketDummyServerTestCase):
                 self.response: BaseHTTPResponse | None = None
 
             def run(self) -> None:
-                with HTTPSConnectionPool(self.host, self.port, ca_certs=DEFAULT_CA) as pool:
+                with HTTPSConnectionPool(
+                    self.host, self.port, ca_certs=DEFAULT_CA
+                ) as pool:
                     self.response = pool.urlopen(
                         "GET", "/", preload_content=False, retries=0
                     )

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -1041,7 +1041,7 @@ class TestSocketClosing(SocketDummyServerTestCase):
         with HTTPConnectionPool(self.host, self.port) as pool:
             response = pool.urlopen("GET", "/", preload_content=False, retries=0)
             # Calling shutdown here calls shutdown() on the underlying socket,
-            # so that the reamining read will fail instead of blocking
+            # so that the remaining read will fail instead of blocking
             # indefinitely
             response.shutdown()
             with pytest.raises(ProtocolError, match="Connection broken"):


### PR DESCRIPTION
Closes #2868

There was a first round of review in https://github.com/pquentin/urllib3/pull/27

This pull request is sponsored by LaunchDarkly. Thank you!