### PR TITLE
Address zizmor issues

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -4,7 +4,9 @@ on:
   pull_request:
     types: [labeled, unlabeled, opened, reopened, synchronize]
 
-permissions: "read-all"
+permissions:
+  contents: "read"
+  pull-requests: "read"
 
 jobs:
   check-changelog-entry:
@@ -18,6 +20,7 @@ jobs:
           # `towncrier check` runs `git diff --name-only origin/main...`, which
           # needs a non-shallow clone.
           fetch-depth: 0
+          persist-credentials: false
 
       - name: "Check changelog"
         if: "!contains(github.event.pull_request.labels.*.name, 'Skip Changelog')"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,8 @@ name: CI
 
 on: [push, pull_request, workflow_dispatch]
 
-permissions: "read-all"
+permissions:
+  contents: "read"
 
 defaults:
   run:
@@ -18,6 +19,8 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+        with:
+          persist-credentials: false
 
       - name: "Setup Python"
         uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
@@ -99,6 +102,7 @@ jobs:
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
         with:
           fetch-depth: 0 # Needed to fetch the version from git
+          persist-credentials: false
 
       - name: "Setup Python ${{ matrix.python-version }}"
         uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
@@ -160,6 +164,8 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+        with:
+          persist-credentials: false
 
       - name: "Setup Python"
         uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,7 +9,8 @@ on:
     - cron: "0 0 * * 5"
   workflow_dispatch:
 
-permissions: "read-all"
+permissions:
+  contents: "read"
 
 jobs:
   analyze:
@@ -23,6 +24,8 @@ jobs:
     steps:
     - name: "Checkout repository"
       uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+      with:
+        persist-credentials: false
 
     - name: "Run CodeQL init"
       uses: github/codeql-action/init@662472033e021d55d94146f66f6058822b0b39fd # v3.27.0

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -2,7 +2,8 @@ name: Downstream
 
 on: [push, pull_request, workflow_dispatch]
 
-permissions: "read-all"
+permissions:
+  contents: "read"
 
 jobs:
   downstream:
@@ -16,6 +17,8 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+        with:
+          persist-credentials: false
 
       - name: "Setup Python"
         uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,7 +2,8 @@ name: lint
 
 on: [push, pull_request, workflow_dispatch]
 
-permissions: "read-all"
+permissions:
+  contents: "read"
 
 jobs:
   lint:
@@ -12,6 +13,8 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+        with:
+          persist-credentials: false
 
       - name: "Setup Python"
         uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ on:
       - "*"
 
 permissions:
-  contents: read
+  contents: "read"
 
 jobs:
   build:
@@ -26,6 +26,7 @@ jobs:
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
         with:
           fetch-depth: 0 # Needed to fetch the version from git
+          persist-credentials: false
 
       - name: "Setup Python"
         uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
@@ -66,7 +67,7 @@ jobs:
 
   publish-to-pypi-and-github:
     name: "Publish to PyPI"
-    if: startsWith(github.ref, 'refs/tags/')
+    if: ${{ github.ref_type == 'tag' }}
     needs: ["build", "provenance"]
     permissions:
       contents: write # Needed for making GitHub releases

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -6,7 +6,8 @@ on:
   push:
     branches: ["main", "1.26.x"]
 
-permissions: read-all
+permissions:
+  contents: "read"
 
 jobs:
   analysis:


### PR DESCRIPTION
There are still 6 remaining findings. I don't know how to fix them while keeping the functionality.

```bash
$ uvx zizmor --gh-token $(gh auth token) .github/workflows/*.yml
2024-12-13T07:07:50.665504Z  INFO audit: zizmor: 🌈 completed /.../urllib3/.github/workflows/changelog.yml
2024-12-13T07:08:17.811994Z  INFO audit: zizmor: 🌈 completed /.../urllib3/.github/workflows/ci.yml
2024-12-13T07:08:26.465969Z  INFO audit: zizmor: 🌈 completed /.../urllib3/.github/workflows/codeql.yml
2024-12-13T07:08:27.303472Z  INFO audit: zizmor: 🌈 completed /.../urllib3/.github/workflows/downstream.yml
2024-12-13T07:08:31.059292Z  INFO audit: zizmor: 🌈 completed /.../urllib3/.github/workflows/lint.yml
2024-12-13T07:08:38.847244Z  INFO audit: zizmor: 🌈 completed /.../urllib3/.github/workflows/publish.yml
2024-12-13T07:08:42.062256Z  INFO audit: zizmor: 🌈 completed /.../urllib3/.github/workflows/scorecards.yml
info[template-injection]: code injection via template expansion
  --> /Users/quentin/pub/urllib3/.github/workflows/changelog.yml:25:9
   |
25 |         - name: "Check changelog"
   |           ----------------------- info: this step
26 |           if: "!contains(github.event.pull_request.labels.*.name, 'Skip Changelog')"
27 | /         run: |
28 | |           if ! pipx run towncrier check --compare-with origin/${{ github.base_ref }}; then
29 | |           echo "Please see https://github.com/urllib3/urllib3/blob/main/changelog/README.rst for guidance."
30 | |             false
31 | |           fi
   | |_____________- info: github.base_ref may expand into attacker-controllable code
   |
   = note: audit confidence → Low

info[template-injection]: code injection via template expansion
   --> /Users/quentin/pub/urllib3/.github/workflows/ci.yml:122:9
    |
122 |         - name: Force override system chrome
    |           ---------------------------------- info: this step
123 | /         run: |
124 | |           sudo rm -f /usr/bin/google-chrome
...   |
127 | |           sudo ln -s ${{ steps.setup-chrome.outputs.chrome-path }} /usr/bin/chrome
128 | |           google-chrome --version
    | |_________________________________- info: steps.setup-chrome.outputs.chrome-path may expand into attacker-controllable code
    |
    = note: audit confidence → Low

info[template-injection]: code injection via template expansion
   --> /Users/quentin/pub/urllib3/.github/workflows/ci.yml:122:9
    |
122 |         - name: Force override system chrome
    |           ---------------------------------- info: this step
123 | /         run: |
124 | |           sudo rm -f /usr/bin/google-chrome
...   |
127 | |           sudo ln -s ${{ steps.setup-chrome.outputs.chrome-path }} /usr/bin/chrome
128 | |           google-chrome --version
    | |_________________________________- info: steps.setup-chrome.outputs.chrome-path may expand into attacker-controllable code
    |
    = note: audit confidence → Low

error[template-injection]: code injection via template expansion
  --> /Users/quentin/pub/urllib3/.github/workflows/publish.yml:86:7
   |
86 |       - name: "Upload dists to GitHub Release"
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this step
87 |         env:
88 |           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
89 | /       run: |
90 | |         gh release upload ${{ github.ref_name }} dist/* --repo ${{ github.repository }}
   | |_______________________________________________________________________________________^ github.ref_name may expand into attacker-controllable code
   |
   = note: audit confidence → High

6 findings (2 suppressed): 0 unknown, 3 informational, 0 low, 0 medium, 1 high
```