### PR TITLE
Fix PyPI publish with Core metadata 2.4

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -90,7 +90,7 @@ jobs:
         gh release upload ${{ github.ref_name }} dist/* --repo ${{ github.repository }}
 
     - name: "Publish dists to PyPI"
-      uses: pypa/gh-action-pypi-publish@15c56dba361d8335944d31a2ecd17d700fc7bcbc # v1.12.2
+      uses: pypa/gh-action-pypi-publish@67339c736fd9354cd4f8cb0b744f2b82a74b5c70 # v1.12.3
       with:
         attestations: true
 
@@ -111,7 +111,7 @@ jobs:
         path: "dist/"
 
     - name: "Publish dists to Test PyPI"
-      uses: pypa/gh-action-pypi-publish@15c56dba361d8335944d31a2ecd17d700fc7bcbc # v1.12.2
+      uses: pypa/gh-action-pypi-publish@67339c736fd9354cd4f8cb0b744f2b82a74b5c70 # v1.12.3
       with:
         repository-url: https://test.pypi.org/legacy/
         attestations: true


### PR DESCRIPTION
The latest PyPI push failed because the versions of twine and pkginfo did not support Core metadata 2.4; see https://github.com/urllib3/urllib3/actions/runs/12354192811/job/34475229840.

With twine 6, Core metadata 2.4 is ignored but does not prevent uploads. (This means the new license metadata discussed in #3522 won't be supported now.)