### PR TITLE
Update .readthedocs.yml addressing a deprecation

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,9 +1,9 @@
 version: 2
 
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
-    python: "3.11"
+    python: "3.13"
 
 python:
   install:
@@ -17,4 +17,5 @@ python:
         - zstd
 
 sphinx:
+  configuration: docs/conf.py
   fail_on_warning: true


### PR DESCRIPTION
Read the Docs sent us a message about a deprecation of projects without explicit Sphinx configuration
https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/

We have to set a path to the Sphinx configuration file in .readthedocs.yml explicitly to prevent failing builds in the future

In addition to the required change, I bumped OS and Python versions for the docs