### PR TITLE
[1.26] Update .readthedocs.yml addressing a deprecation

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,9 +1,9 @@
 version: 2
 
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
-    python: "3.11"
+    python: "3.13"
 
 python:
   install:
@@ -16,4 +16,5 @@ python:
     - requirements: docs/requirements.txt
 
 sphinx:
+  configuration: docs/conf.py
   fail_on_warning: true


### PR DESCRIPTION
Backport of #3534 to 1.26.x