### PR TITLE
Improve release process

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,6 +3,6 @@
 
 .github/workflows/          @sethmlarson @pquentin @shazow @illia-v
 .github/CODEOWNERS          @sethmlarson @pquentin @shazow @illia-v
-src/urllib3/_version.py     @sethmlarson @pquentin @shazow @illia-v
+CHANGES.rst                 @sethmlarson @pquentin @shazow @illia-v
 pyproject.toml              @sethmlarson @pquentin @shazow @illia-v
 ci/                         @sethmlarson @pquentin @shazow @illia-v

--- a/.github/PULL_REQUEST_TEMPLATE/release.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release.md
@@ -1,3 +1,4 @@
+* [ ]  Draft a social media announcement
 * [ ]  See if all tests, including downstream, pass
 * [ ]  Get the release pull request approved by a [CODEOWNER](https://github.com/urllib3/urllib3/blob/main/.github/CODEOWNERS)
 * [ ]  Squash merge the release pull request with message "`Release <VERSION>`"
@@ -5,18 +6,20 @@
   * Notice that the `<VERSION>` shouldn't have a `v` prefix (Use `1.26.6` instead of `v.1.26.6`)
   * ```
     # Ensure the release commit is the latest in the main branch.
+    export VERSION=<X.Y.Z>
+    export REMOTE=origin
     git checkout main
-    git pull origin main
-    git tag -s -a '<VERSION>' -m 'Release: <VERSION>'
-    git push <REMOTE> --tags
+    git pull $REMOTE main
+    git tag -s -a "$VERSION" -m "Release: $VERSION"
+    git push $REMOTE --tags
     ```
-* [ ]  Execute the `publish` GitHub workflow. This requires a review from a maintainer.
+* [ ]  The tag will trigger the `publish` GitHub workflow. This requires a review from a maintainer.
 * [ ]  Ensure that all expected artifacts are added to the new GitHub release. Should
        be one `.whl`, one `.tar.gz`, and one `multiple.intoto.jsonl`. Update the GitHub
-       release to have the content of the release's changelog.
+       release to have the content of the release's changelog and any ongoing announcements.
 * [ ]  Announce on:
-  * [ ]  Twitter
+  * [ ]  Social media
   * [ ]  Discord
-  * [ ]  OpenCollective
-* [ ]  Update Tidelift metadata
+  * [ ]  Open Collective
+* [ ]  Check [Tidelift security maintenance plan](https://tidelift.com/lifter/package/pypi/urllib3/tasks/packages_have_maintenance_plans>) is still correct
 * [ ]  If this was a 1.26.x release, add changelog to the `main` branch


### PR DESCRIPTION
The release process is excellent and involves little stress. Still, here are a few things that would help me:

 * Agree on the social media announcement before merging the pull request. Summarizing pull requests you haven't worked on is not always easy, and this is what I spend the most time doing today when releasing a new version.
 * Make the git commands easy to copy/paste to avoid typos.
 * Clarify that pushing the tag will trigger the publish workflow; it does not need to be done manually.
 * Link the exact Tidelift page that needs to be checked
 * Use `CHANGES.rst` as a trigger for CODEOWNERS review since we no longer have a version file.