### PR TITLE
Pin Quart to 0.20.0 instead of a Git commit

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -11,8 +11,7 @@ cryptography==43.0.1
 towncrier==23.6.0
 pytest-memray==1.7.0;python_version<"3.14" and sys_platform!="win32" and implementation_name=="cpython"
 trio==0.26.2
-# https://github.com/pallets/quart/pull/369
-Quart @ git+https://github.com/pallets/quart@67110bf383d8973bce1619e957b4b6ea088ad9f2
+Quart==0.20.0
 quart-trio==0.11.1
 # https://github.com/pgjones/hypercorn/issues/62
 # https://github.com/pgjones/hypercorn/issues/168


### PR DESCRIPTION
https://github.com/pallets/quart/releases/tag/0.20.0 includes a change we needed for testing with Python 3.14.