### PR TITLE
The QUERY method is retryable too as idempotent

### DIFF
--- a/changelog/3549.feature.rst
+++ b/changelog/3549.feature.rst
@@ -1,0 +1,1 @@
+Added support for the `QUERY HTTP method (Proposed Standard) <https://datatracker.ietf.org/doc/draft-ietf-httpbis-safe-method-w-body/>`_. As urllib3 already allows making requests with arbitrary methods, this only means that QUERY is now another retryable by default method.

--- a/src/urllib3/util/retry.py
+++ b/src/urllib3/util/retry.py
@@ -182,7 +182,7 @@ class Retry:
 
     #: Default methods to be used for ``allowed_methods``
     DEFAULT_ALLOWED_METHODS = frozenset(
-        ["HEAD", "GET", "PUT", "DELETE", "OPTIONS", "TRACE"]
+        ["HEAD", "GET", "PUT", "DELETE", "OPTIONS", "TRACE", "QUERY"]
     )
 
     #: Default status codes to be used for ``status_forcelist``


### PR DESCRIPTION
according to its description in the Internet-Draft https://datatracker.ietf.org/doc/draft-ietf-httpbis-safe-method-w-body/

Fixes #3548