### PR TITLE
Fix nonexistent wheel and CORS errors in the Pyodide console

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -238,7 +238,7 @@ def emscripten(session: nox.Session, runner: str) -> None:
         dist_dir = Path(os.environ["PYODIDE_ROOT"]) / "dist"
     else:
         # we don't have a build tree
-        pyodide_version = "0.26.3"
+        pyodide_version = "0.27.1"
 
         pyodide_artifacts_path = Path(session.cache_dir) / f"pyodide-{pyodide_version}"
         if not pyodide_artifacts_path.exists():

--- a/test/contrib/emscripten/templates/pyodide-console.html
+++ b/test/contrib/emscripten/templates/pyodide-console.html
@@ -6,6 +6,7 @@
 <html>
   <head>
     <meta charset="UTF-8" />
+    <title>Pyodide — urllib3</title>
     <script src="https://cdn.jsdelivr.net/npm/jquery"></script>
     <script src="https://cdn.jsdelivr.net/npm/jquery.terminal@2.35.2/js/jquery.terminal.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/jquery.terminal@2.35.2/js/unix_formatting.min.js"></script>
@@ -260,7 +261,7 @@
         await term.ready;
         await term.exec("import micropip\n");
         await term.exec("micropip.list()\n");
-        await term.exec('await micropip.install("http://localhost:8000/urllib3-2.2.0-py3-none-any.whl")')
+        await term.exec('await micropip.install("http://localhost:8000/{urllib3_wheel_name}.whl")')
         await term.exec("micropip.list()");
         await term.exec("import urllib3");
         await term.exec("urllib3.__version__");

--- a/test/contrib/emscripten/templates/pyodide-console.html
+++ b/test/contrib/emscripten/templates/pyodide-console.html
@@ -77,7 +77,7 @@
       }
 
       async function main() {
-        let indexURL = "https://cdn.jsdelivr.net/pyodide/v0.25.0/full/";
+        let indexURL = "https://cdn.jsdelivr.net/pyodide/v0.27.1/full/";
         const urlParams = new URLSearchParams(window.location.search);
         const buildParam = urlParams.get("build");
         if (buildParam) {


### PR DESCRIPTION
I noticed that the Pyodide console displays an error right after it's loaded because it has a previous version of urllib3 hard-coded, here I'm making it dynamic