### PR TITLE
Bump browser-actions/setup-firefox to fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,7 @@ jobs:
           google-chrome --version
         if: ${{ matrix.nox-session == 'emscripten(chrome)' }}
       - name: "Install Firefox"
-        uses: browser-actions/setup-firefox@233224b712fc07910ded8c15fb95a555c86da76f # v1.5.0
+        uses: browser-actions/setup-firefox@634a60ccd6599686158cf5a570481b4cd30455a2 # v1.5.4
         if: ${{ matrix.nox-session == 'emscripten(firefox)' }}
       - name: "Install node.js"
         uses: actions/setup-node@v4


### PR DESCRIPTION
Our emscripten(firefox) CI job has recently started [failing](https://github.com/urllib3/urllib3/actions/runs/13138651938/job/36660115824#logs) because the newest [Firefox switched](https://blog.nightly.mozilla.org/2024/11/28/announcing-faster-lighter-firefox-downloads-for-linux-with-tar-xz-packaging/) from `.tar.bz2` to `.tar.xz` packaging. We have to use newer `browser-actions/setup-firefox` to fix the error.

BTW, this is not the only patch-version actions upgrade that we need to do. Newer `pypa/gh-action-pypi-publish` uploads correct license info to PyPI, for example. What do you think about reenabling patch-version dependabot upgrades with possible [grouping](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#groups--) of all actions in a single PR?