### PR TITLE
TLS 1.3 post-handshake auth fix for kodi - dazn addon

### DIFF
--- a/src/urllib3/util/ssl_.py
+++ b/src/urllib3/util/ssl_.py
@@ -324,7 +324,10 @@ def create_urllib3_context(
     # necessary for conditional client cert authentication with TLS 1.3.
     # The attribute is None for OpenSSL <= 1.1.0 or does not exist when using
     # an SSLContext created by pyOpenSSL.
-    if getattr(context, "post_handshake_auth", None) is not None:
+    if (
+            cert_reqs == ssl.CERT_REQUIRED
+            and getattr(context, "post_handshake_auth", None) is not None
+    ):
         context.post_handshake_auth = True
 
     # The order of the below lines setting verify_mode and check_hostname


### PR DESCRIPTION
Old if-statemant necessary again, otherwise for example Dazn-Addon in Kodi does not work probably and gives only following as answer:
{'odata.error': {'code': 10000, 'message': {'lang': 'en-US', 'value': 'Playback not allowed'}}}

If-statemant was changed with following commit:
https://github.com/urllib3/urllib3/commit/d7bb83b48c23d8dd429c20a43ac3da74ea6e9df0

(cc @jborean93 )

<!---
Thanks for your contribution! ♥️

If this is your first PR to urllib3 please review the Contributing Guide:
https://urllib3.readthedocs.io/en/latest/contributing.html

Adhering to the Contributing Guide means we can review, merge, and release your change faster! :)
--->
