### PR TITLE
Stop using `slsa-framework/slsa-github-generator` in favor of PyPI attestations

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/release.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release.md
@@ -15,7 +15,7 @@
     ```
 * [ ]  The tag will trigger the `publish` GitHub workflow. This requires a review from a maintainer.
 * [ ]  Ensure that all expected artifacts are added to the new GitHub release. Should
-       be one `.whl`, one `.tar.gz`, and one `multiple.intoto.jsonl`. Update the GitHub
+       be one `.whl` and one `.tar.gz`. Update the GitHub
        release to have the content of the release's changelog and any ongoing announcements.
 * [ ]  Announce on:
   * [ ]  Social media

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,21 +54,10 @@ jobs:
           if-no-files-found: error
           retention-days: 5
 
-  provenance:
-    needs: [build]
-    permissions:
-      actions: read
-      contents: write
-      id-token: write # Needed to access the workflow's OIDC identity.
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
-    with:
-      base64-subjects: "${{ needs.build.outputs.hashes }}"
-      upload-assets: true
-
   publish-to-pypi-and-github:
     name: "Publish to PyPI"
     if: ${{ github.ref_type == 'tag' }}
-    needs: ["build", "provenance"]
+    needs: ["build"]
     permissions:
       contents: write # Needed for making GitHub releases
       id-token: write # Needed for trusted publishing to PyPI.
@@ -96,7 +85,7 @@ jobs:
 
   publish-to-test-pypi:
     name: "Publish to Test PyPI"
-    needs: ["build", "provenance"]
+    needs: ["build"]
     permissions:
       id-token: write # Needed for trusted publishing to PyPI.
     runs-on: "ubuntu-latest"

--- a/changelog/3566.removal.rst
+++ b/changelog/3566.removal.rst
@@ -1,0 +1,2 @@
+Removed the ``multiple.intoto.jsonl`` asset from GitHub releases.
+Attestation of release files since v2.3.0 can be found on PyPI.


### PR DESCRIPTION
`slsa-framework/slsa-github-generator` has been helping us to generate provenance for a few years faithfully. Now when attestations became more integrated in Python ecosystem, `pypa/gh-action-pypi-publish` have been putting provenance on Sigstore for us for some time too. Let's avoid excessive entries in Sigstore by dropping `slsa-framework/slsa-github-generator`.