### PR TITLE
Stop using Ubuntu 20.04 and 22.04 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
         os:
           - macos-15
           - windows-latest
-          - ubuntu-latest
+          - ubuntu-24.04
         nox-session: ['']
         include:
           - experimental: false
@@ -51,44 +51,44 @@ jobs:
           # 3.9 has a known issue with large SSL requests that we work around:
           # https://github.com/urllib3/urllib3/pull/3181#issuecomment-1794830698
           - python-version: "3.9"
-            os: ubuntu-latest
+            os: ubuntu-24.04
             experimental: false
             nox-session: test_integration
           - python-version: "3.12"
-            os: ubuntu-latest
+            os: ubuntu-24.04
             experimental: false
             nox-session: test_integration
           # pypy
           - python-version: "pypy-3.10"
-            os: ubuntu-latest
+            os: ubuntu-24.04
             experimental: false
             nox-session: test-pypy3.10
           - python-version: "pypy-3.11"
-            os: ubuntu-latest
+            os: ubuntu-24.04
             experimental: false
             nox-session: test-pypy3.11
           - python-version: "3.x"
           # brotli
-            os: ubuntu-latest
+            os: ubuntu-24.04
             experimental: false
             nox-session: test_brotlipy
           - python-version: "3.12"
-            os: ubuntu-latest
+            os: ubuntu-24.04
             nox-session: emscripten(node)
             experimental: true
           - python-version: "3.12"
-            os: ubuntu-latest
+            os: ubuntu-24.04
             nox-session: emscripten(firefox)
             experimental: true
           - python-version: "3.12"
-            os: ubuntu-latest
+            os: ubuntu-24.04
             nox-session: emscripten(chrome)
             experimental: true
           - python-version: 3.14
             experimental: true
 
     runs-on: ${{ matrix.os }}
-    name: ${{ fromJson('{"macos-15":"macOS","windows-latest":"Windows","ubuntu-latest":"Ubuntu"}')[matrix.os] }} ${{ matrix.python-version }} ${{ matrix.nox-session}}
+    name: ${{ fromJson('{"macos-15":"macOS","windows-latest":"Windows","ubuntu-24.04":"Ubuntu"}')[matrix.os] }} ${{ matrix.python-version }} ${{ matrix.nox-session}}
     continue-on-error: ${{ matrix.experimental }}
     timeout-minutes: 10
     steps:
@@ -156,7 +156,7 @@ jobs:
 
   coverage:
     if: always()
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-24.04"
     needs: test
     steps:
       - name: "Checkout repository"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
         os:
           - macos-15
           - windows-latest
-          - ubuntu-22.04
+          - ubuntu-latest
         nox-session: ['']
         include:
           - experimental: false
@@ -94,7 +94,7 @@ jobs:
             experimental: true
 
     runs-on: ${{ matrix.os }}
-    name: ${{ fromJson('{"macos-15":"macOS","windows-latest":"Windows","ubuntu-latest":"Ubuntu","ubuntu-20.04":"Ubuntu 20.04 (OpenSSL 1.1.1)","ubuntu-22.04":"Ubuntu 22.04 (OpenSSL 3.0)"}')[matrix.os] }} ${{ matrix.python-version }} ${{ matrix.nox-session}}
+    name: ${{ fromJson('{"macos-15":"macOS","windows-latest":"Windows","ubuntu-latest":"Ubuntu","ubuntu-20.04":"Ubuntu 20.04 (OpenSSL 1.1.1)"}')[matrix.os] }} ${{ matrix.python-version }} ${{ matrix.nox-session}}
     continue-on-error: ${{ matrix.experimental }}
     timeout-minutes: 10
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,11 +58,6 @@ jobs:
             os: ubuntu-latest
             experimental: false
             nox-session: test_integration
-          # OpenSSL 1.1.1
-          - python-version: "3.9"
-            os: ubuntu-20.04
-            experimental: false
-            nox-session: test-3.9
           # pypy
           - python-version: "pypy-3.10"
             os: ubuntu-latest
@@ -73,11 +68,6 @@ jobs:
             os: ubuntu-latest
             experimental: false
             nox-session: test_brotlipy
-          # Test CPython with a broken hostname_checks_common_name (the fix is in 3.9.3)
-          - python-version: "3.9.2"
-            os: ubuntu-20.04  # CPython 3.9.2 is not available for ubuntu-22.04.
-            experimental: false
-            nox-session: test-3.9
           - python-version: "3.12"
             os: ubuntu-latest
             nox-session: emscripten(node)
@@ -94,7 +84,7 @@ jobs:
             experimental: true
 
     runs-on: ${{ matrix.os }}
-    name: ${{ fromJson('{"macos-15":"macOS","windows-latest":"Windows","ubuntu-latest":"Ubuntu","ubuntu-20.04":"Ubuntu 20.04 (OpenSSL 1.1.1)"}')[matrix.os] }} ${{ matrix.python-version }} ${{ matrix.nox-session}}
+    name: ${{ fromJson('{"macos-15":"macOS","windows-latest":"Windows","ubuntu-latest":"Ubuntu"}')[matrix.os] }} ${{ matrix.python-version }} ${{ matrix.nox-session}}
     continue-on-error: ${{ matrix.experimental }}
     timeout-minutes: 10
     steps:

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         downstream: [botocore, requests]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     timeout-minutes: 30
 
     steps:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,7 +7,7 @@ permissions:
 
 jobs:
   lint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     timeout-minutes: 10
 
     steps:

--- a/src/urllib3/util/ssl_.py
+++ b/src/urllib3/util/ssl_.py
@@ -117,7 +117,7 @@ try:  # Do we have ssl at all?
         sys.implementation.name,
         sys.version_info,
         sys.pypy_version_info if sys.implementation.name == "pypy" else None,  # type: ignore[attr-defined]
-    ):
+    ):  # Defensive:
         HAS_NEVER_CHECK_COMMON_NAME = False
 
     # Need to be careful here in case old TLS versions get

--- a/src/urllib3/util/ssl_.py
+++ b/src/urllib3/util/ssl_.py
@@ -117,7 +117,7 @@ try:  # Do we have ssl at all?
         sys.implementation.name,
         sys.version_info,
         sys.pypy_version_info if sys.implementation.name == "pypy" else None,  # type: ignore[attr-defined]
-    ):  # Defensive:
+    ):  # Defensive: for Python < 3.9.3
         HAS_NEVER_CHECK_COMMON_NAME = False
 
     # Need to be careful here in case old TLS versions get

--- a/src/urllib3/util/ssl_match_hostname.py
+++ b/src/urllib3/util/ssl_match_hostname.py
@@ -146,7 +146,7 @@ def match_hostname(
                 if key == "commonName":
                     if _dnsname_match(value, hostname):
                         return
-                    dnsnames.append(value)
+                    dnsnames.append(value)  # Defensive:
 
     if len(dnsnames) > 1:
         raise CertificateError(

--- a/src/urllib3/util/ssl_match_hostname.py
+++ b/src/urllib3/util/ssl_match_hostname.py
@@ -146,7 +146,7 @@ def match_hostname(
                 if key == "commonName":
                     if _dnsname_match(value, hostname):
                         return
-                    dnsnames.append(value)  # Defensive:
+                    dnsnames.append(value)  # Defensive: for Python < 3.9.3
 
     if len(dnsnames) > 1:
         raise CertificateError(


### PR DESCRIPTION
A couple of our actions use Ubuntu 20.04 which is deprecated as a GitHub Actions runner image and will be fully unsupported by April 1 https://github.com/actions/runner-images/issues/11101.
We cannot run tests with Python 3.9.2 and OpenSSL 1.1.1 in newer Ubuntu releases, so I have to drop the two jobs from the matrix.

The rest of the tests are upgraded to `ubuntu-latest` which is Ubuntu 24.04 as of today.