### PR TITLE
Upgrade the publishing action to get correct licensing info on PyPI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -79,7 +79,7 @@ jobs:
         gh release upload ${{ github.ref_name }} dist/* --repo ${{ github.repository }}
 
     - name: "Publish dists to PyPI"
-      uses: pypa/gh-action-pypi-publish@67339c736fd9354cd4f8cb0b744f2b82a74b5c70 # v1.12.3
+      uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
       with:
         attestations: true
 
@@ -100,7 +100,7 @@ jobs:
         path: "dist/"
 
     - name: "Publish dists to Test PyPI"
-      uses: pypa/gh-action-pypi-publish@67339c736fd9354cd4f8cb0b744f2b82a74b5c70 # v1.12.3
+      uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
       with:
         repository-url: https://test.pypi.org/legacy/
         attestations: true


### PR DESCRIPTION
PyPI provides no licence data for previous releases of urllib3 via API because of an issue which was fixed by pypa/gh-action-pypi-publish [v1.12.4](https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.12.4).

https://pypi.org/pypi/urllib3/2.3.0/json
![](https://github.com/user-attachments/assets/f825b3d4-cf01-488d-b655-7d57bd7dfd3b)


I'm upgrading the action to get correct license info for the next release.