### PR TITLE
Bump httpcore to fix Python 3.14 tests

### DIFF
--- a/changelog/3576.bugfix.rst
+++ b/changelog/3576.bugfix.rst
@@ -1,1 +1,0 @@
-Bumped httpcore to fix Python 3.14 tests.

--- a/changelog/3576.bugfix.rst
+++ b/changelog/3576.bugfix.rst
@@ -1,0 +1,1 @@
+Bumped httpcore to fix Python 3.14 tests.

--- a/uv.lock
+++ b/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.9"
 resolution-markers = [
     "python_full_version >= '3.10'",
@@ -698,15 +699,15 @@ wheels = [
 
 [[package]]
 name = "httpcore"
-version = "1.0.7"
+version = "1.0.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
     { name = "h11" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6a/41/d7d0a89eb493922c37d343b607bc1b5da7f5be7e383740b4753ad8943e90/httpcore-1.0.7.tar.gz", hash = "sha256:8551cb62a169ec7162ac7be8d4817d561f60e08eaa485234898414bb5a8a0b4c", size = 85196 }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/45/ad3e1b4d448f22c0cff4f5692f5ed0666658578e358b8d58a19846048059/httpcore-1.0.8.tar.gz", hash = "sha256:86e94505ed24ea06514883fd44d2bc02d90e77e7979c8eb71b90f41d364a1bad", size = 85385 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/87/f5/72347bc88306acb359581ac4d52f23c0ef445b57157adedb9aee0cd689d2/httpcore-1.0.7-py3-none-any.whl", hash = "sha256:a3fff8f43dc260d5bd363d9f9cf1830fa3a458b332856f34282de498ed420edd", size = 78551 },
+    { url = "https://files.pythonhosted.org/packages/18/8d/f052b1e336bb2c1fc7ed1aaed898aa570c0b61a09707b108979d9fc6e308/httpcore-1.0.8-py3-none-any.whl", hash = "sha256:5254cf149bcb5f75e9d1b2b9f729ea4a4b883d1ad7379fc632b727cec23674be", size = 78732 },
 ]
 
 [[package]]
@@ -1826,6 +1827,7 @@ requires-dist = [
     { name = "pysocks", marker = "extra == 'socks'", specifier = ">=1.5.6,!=1.5.7,<2.0" },
     { name = "zstandard", marker = "extra == 'zstd'", specifier = ">=0.18.0" },
 ]
+provides-extras = ["brotli", "h2", "socks", "zstd"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
<!---
Thanks for your contribution! ♥️

If this is your first PR to urllib3 please review the Contributing Guide:
https://urllib3.readthedocs.io/en/latest/contributing.html

Adhering to the Contributing Guide means we can review, merge, and release your change faster! :)
--->

Fixes https://github.com/urllib3/urllib3/issues/3576.

This is now fixed and released in httpcore 1.0.8:

* https://github.com/encode/httpcore/pull/1005
* https://github.com/encode/httpcore/pull/1006
* https://github.com/encode/httpcore/releases/tag/1.0.8

Updated in the lockfile by running `uv lock --upgrade-package httpcore`.
