### PR TITLE
Use stable Chrome in CI for now

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,8 @@ jobs:
         if: ${{ matrix.nox-session == 'emscripten(chrome)' }}
         with:
           install-chromedriver: true
+          # Use stable until https://github.com/urllib3/urllib3/issues/3598 is fixed.
+          chrome-version: stable
       - name: Force override system chrome
         run: |
           sudo rm -f /usr/bin/google-chrome


### PR DESCRIPTION
Chrome Canary has enabled JSPI by default which breaks our CI #3598

There is a pull request with a possible fix #3599: only tests are changed, package code stays the same.
But I'm not ready to merge it, I want to consider refactoring the tests a bit next week and use the stable Chrome channel in the meantime to get tests passing.