### PR TITLE
Add support for the new `compression.zstd` module in Python 3.14

### DIFF
--- a/changelog/3610.feature.rst
+++ b/changelog/3610.feature.rst
@@ -1,0 +1,2 @@
+Add support for the ``compression.zstd`` module that is new in Python 3.14.
+See `PEP 784 <https://peps.python.org/pep-0784/>`_ for more information.

--- a/docs/advanced-usage.rst
+++ b/docs/advanced-usage.rst
@@ -561,11 +561,14 @@ Zstandard Encoding
 `Zstandard <https://datatracker.ietf.org/doc/html/rfc8878>`_
 is a compression algorithm created by Facebook with better compression
 than brotli, gzip and deflate (see `benchmarks <https://facebook.github.io/zstd/#benchmarks>`_)
-and is supported by urllib3 if the `zstandard package <https://pypi.org/project/zstandard/>`_ is installed.
+and is supported by urllib3 in Python 3.14+ using the `compression.zstd <https://peps.python.org/pep-0784/>`_ standard library module
+and for Python 3.13 and earlier if the `zstandard package <https://pypi.org/project/zstandard/>`_ is installed.
 You may also request the package be installed via the ``urllib3[zstd]`` extra:
 
 .. code-block:: bash
 
+    # This is only necessary on Python 3.13 and earlier.
+    # Otherwise zstandard support is included in the Python standard library.
     $ python -m pip install urllib3[zstd]
 
 .. note::

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,10 @@ brotli = [
   "brotli>=1.0.9; platform_python_implementation == 'CPython'",
   "brotlicffi>=0.8.0; platform_python_implementation != 'CPython'"
 ]
+# Once we drop support for Python 3.13 this extra can be removed.
+# We'll need a deprecation period for the 'zstandard' module support
+# so that folks using Python without the 'compression.zstd' module
+# compiled will know to start doing so (although it'll likely be rare).
 zstd = [
   "zstandard>=0.18.0",
 ]

--- a/src/urllib3/response.py
+++ b/src/urllib3/response.py
@@ -148,12 +148,12 @@ if brotli is not None:
 
 try:
     # Python 3.14+
-    from compression import zstd
+    from compression import zstd  # type: ignore[import-not-found] # noqa: F401
 
     HAS_ZSTD = True
 
     class ZstdDecoder(ContentDecoder):
-        def __init__(self):
+        def __init__(self) -> None:
             self._obj = zstd.ZstdDecompressor()
 
         def decompress(self, data: bytes) -> bytes:
@@ -190,7 +190,7 @@ except ImportError:
     else:
         HAS_ZSTD = True
 
-        class ZstdDecoder(ContentDecoder):
+        class ZstdDecoder(ContentDecoder):  # type: ignore[no-redef]
             def __init__(self) -> None:
                 self._obj = zstd.ZstdDecompressor().decompressobj()
 
@@ -208,7 +208,7 @@ except ImportError:
                 ret = self._obj.flush()  # note: this is a no-op
                 if not self._obj.eof:
                     raise DecodeError("Zstandard data is incomplete")
-                return ret
+                return ret  # type: ignore[no-any-return]
 
 
 class MultiDecoder(ContentDecoder):

--- a/src/urllib3/util/request.py
+++ b/src/urllib3/util/request.py
@@ -30,7 +30,9 @@ else:
     ACCEPT_ENCODING += ",br"
 
 try:
-    from compression import zstd as _unused_module_zstd  # noqa: F401
+    from compression import (  # type: ignore[import-not-found] # noqa: F401
+        zstd as _unused_module_zstd,
+    )
 
     ACCEPT_ENCODING += ",zstd"
 except ImportError:

--- a/src/urllib3/util/request.py
+++ b/src/urllib3/util/request.py
@@ -28,12 +28,18 @@ except ImportError:
     pass
 else:
     ACCEPT_ENCODING += ",br"
+
 try:
-    import zstandard as _unused_module_zstd  # noqa: F401
-except ImportError:
-    pass
-else:
+    from compression import zstd as _unused_module_zstd  # noqa: F401
+
     ACCEPT_ENCODING += ",zstd"
+except ImportError:
+    try:
+        import zstandard as _unused_module_zstd  # noqa: F401
+
+        ACCEPT_ENCODING += ",zstd"
+    except ImportError:
+        pass
 
 
 class _TYPE_FAILEDTELL(Enum):

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -26,9 +26,16 @@ except ImportError:
     brotli = None
 
 try:
-    import zstandard as _unused_module_zstd  # noqa: F401
+    # Python 3.14
+    from compression import zstd as _unused_module_zstd  # noqa: F401
 except ImportError:
-    HAS_ZSTD = False
+    # Python 3.13 and earlier require the 'zstandard' module.
+    try:
+        import zstandard as _unused_module_zstd  # noqa: F401
+    except ImportError:
+        HAS_ZSTD = False
+    else:
+        HAS_ZSTD = True
 else:
     HAS_ZSTD = True
 

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -134,14 +134,15 @@ def notBrotli() -> typing.Callable[[_TestFuncT], _TestFuncT]:
 
 def onlyZstd() -> typing.Callable[[_TestFuncT], _TestFuncT]:
     return pytest.mark.skipif(
-        not HAS_ZSTD, reason="only run if a python-zstandard library is installed"
+        not HAS_ZSTD,
+        reason="only run if a python-zstandard library is installed or Python 3.14 and later",
     )
 
 
 def notZstd() -> typing.Callable[[_TestFuncT], _TestFuncT]:
     return pytest.mark.skipif(
         HAS_ZSTD,
-        reason="only run if a python-zstandard library is not installed",
+        reason="only run if a python-zstandard library is not installed or Python 3.13 and earlier",
     )
 
 

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -27,7 +27,9 @@ except ImportError:
 
 try:
     # Python 3.14
-    from compression import zstd as _unused_module_zstd  # noqa: F401
+    from compression import (  # type: ignore[import-not-found] # noqa: F401
+        zstd as _unused_module_zstd,
+    )
 except ImportError:
     # Python 3.13 and earlier require the 'zstandard' module.
     try:

--- a/test/test_response.py
+++ b/test/test_response.py
@@ -37,10 +37,10 @@ from urllib3.util.retry import RequestHistory, Retry
 
 def zstd_compress(data: bytes) -> bytes:
     try:
-        from compression import zstd
+        from compression import zstd  # type: ignore[import-not-found] # noqa: F401
     except ImportError:
         import zstandard as zstd
-    return zstd.compress(data)
+    return zstd.compress(data)  # type: ignore[no-any-return]
 
 
 class TestBytesQueueBuffer:

--- a/test/test_response.py
+++ b/test/test_response.py
@@ -35,6 +35,14 @@ from urllib3.util.response import is_fp_closed
 from urllib3.util.retry import RequestHistory, Retry
 
 
+def zstd_compress(data: bytes) -> bytes:
+    try:
+        from compression import zstd
+    except ImportError:
+        import zstandard as zstd
+    return zstd.compress(data)
+
+
 class TestBytesQueueBuffer:
     def test_single_chunk(self) -> None:
         buffer = BytesQueueBuffer()
@@ -411,9 +419,7 @@ class TestResponse:
 
     @onlyZstd()
     def test_decode_zstd(self) -> None:
-        import zstandard as zstd
-
-        data = zstd.compress(b"foo")
+        data = zstd_compress(b"foo")
 
         fp = BytesIO(data)
         r = HTTPResponse(fp, headers={"content-encoding": "zstd"})
@@ -421,11 +427,9 @@ class TestResponse:
 
     @onlyZstd()
     def test_decode_multiframe_zstd(self) -> None:
-        import zstandard as zstd
-
         data = (
             # Zstandard frame
-            zstd.compress(b"foo")
+            zstd_compress(b"foo")
             # skippable frame (must be ignored)
             + bytes.fromhex(
                 "50 2A 4D 18"  # Magic_Number (little-endian)
@@ -433,7 +437,7 @@ class TestResponse:
                 "00 00 00 00 00 00 00"  # User_Data
             )
             # Zstandard frame
-            + zstd.compress(b"bar")
+            + zstd_compress(b"bar")
         )
 
         fp = BytesIO(data)
@@ -442,9 +446,7 @@ class TestResponse:
 
     @onlyZstd()
     def test_chunked_decoding_zstd(self) -> None:
-        import zstandard as zstd
-
-        data = zstd.compress(b"foobarbaz")
+        data = zstd_compress(b"foobarbaz")
 
         fp = BytesIO(data)
         r = HTTPResponse(
@@ -475,9 +477,7 @@ class TestResponse:
     @onlyZstd()
     @pytest.mark.parametrize("data", decode_param_set)
     def test_decode_zstd_incomplete_preload_content(self, data: bytes) -> None:
-        import zstandard as zstd
-
-        data = zstd.compress(data)
+        data = zstd_compress(data)
         fp = BytesIO(data[:-1])
 
         with pytest.raises(DecodeError):
@@ -486,9 +486,7 @@ class TestResponse:
     @onlyZstd()
     @pytest.mark.parametrize("data", decode_param_set)
     def test_decode_zstd_incomplete_read(self, data: bytes) -> None:
-        import zstandard as zstd
-
-        data = zstd.compress(data)
+        data = zstd_compress(data)
         fp = BytesIO(data[:-1])  # shorten the data to trigger DecodeError
 
         # create response object without(!) reading/decoding the content
@@ -503,9 +501,7 @@ class TestResponse:
     @onlyZstd()
     @pytest.mark.parametrize("data", decode_param_set)
     def test_decode_zstd_incomplete_read1(self, data: bytes) -> None:
-        import zstandard as zstd
-
-        data = zstd.compress(data)
+        data = zstd_compress(data)
         fp = BytesIO(data[:-1])
 
         r = HTTPResponse(
@@ -523,9 +519,7 @@ class TestResponse:
     @onlyZstd()
     @pytest.mark.parametrize("data", decode_param_set)
     def test_decode_zstd_read1(self, data: bytes) -> None:
-        import zstandard as zstd
-
-        encoded_data = zstd.compress(data)
+        encoded_data = zstd_compress(data)
         fp = BytesIO(encoded_data)
 
         r = HTTPResponse(


### PR DESCRIPTION
Closes #3610, big thank-you to @emmatyping for adding this module to the Python standard library.