### PR TITLE
Fix IPv6 tunnel_host when using connection_from_host with python < 3.11.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,11 @@ jobs:
             os: ubuntu-24.04
             experimental: false
             nox-session: test_integration
+          # Test with 3.12.2 for https://github.com/urllib3/urllib3/pull/3620 patch
+          - python-version: "3.12.2"
+            os: ubuntu-24.04
+            experimental: false
+            nox-session: test-3.12
           # pypy
           - python-version: "pypy-3.10"
             os: ubuntu-24.04

--- a/changelog/3615.bugfix.rst
+++ b/changelog/3615.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed incorrect `CONNECT` statement when using an IPv6 proxy with `connection_from_host`. Previously would not be wrapped in `[]`.

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -233,11 +233,16 @@ class HTTPConnection(_HTTPConnection):
         self._tunnel_scheme = scheme
 
     if sys.version_info < (3, 11, 4):
+        # Taken from http.client. When using connection_from_host, host will come without brackets.
+        def _wrap_ipv6(self, ip: bytes) -> bytes:
+            if b":" in ip and ip[0] != b"["[0]:
+                return b"[" + ip + b"]"
+            return ip
 
         def _tunnel(self) -> None:
             _MAXLINE = http.client._MAXLINE  # type: ignore[attr-defined]
             connect = b"CONNECT %s:%d HTTP/1.0\r\n" % (  # type: ignore[str-format]
-                self._tunnel_host.encode("ascii"),  # type: ignore[union-attr]
+                self._wrap_ipv6(self._tunnel_host.encode("idna")),  # type: ignore[union-attr]
                 self._tunnel_port,
             )
             headers = [connect]

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -241,7 +241,9 @@ class HTTPConnection(_HTTPConnection):
             return ip
 
         if sys.version_info < (3, 11, 9):
-            # https://github.com/python/cpython/commit/6fbc61070fda2ffb8889e77e3b24bca4249ab4d1#diff-3cf29d90eb758d0fe5ec013bbfda9b0bb60be4f7d899583bd5f490a7a5a5dc5fR923
+            # `_tunnel` copied from 3.11.13 backporting
+            # https://github.com/python/cpython/commit/0d4026432591d43185568dd31cef6a034c4b9261
+            # and https://github.com/python/cpython/commit/6fbc61070fda2ffb8889e77e3b24bca4249ab4d1
             def _tunnel(self) -> None:
                 _MAXLINE = http.client._MAXLINE  # type: ignore[attr-defined]
                 connect = b"CONNECT %s:%d HTTP/1.0\r\n" % (  # type: ignore[str-format]
@@ -283,8 +285,8 @@ class HTTPConnection(_HTTPConnection):
                     response.close()
 
         elif (3, 12) <= sys.version_info < (3, 12, 3):
-            # https://github.com/python/cpython/commit/23aef575c7629abcd4aaf028ebd226fb41a4b3c8#diff-3cf29d90eb758d0fe5ec013bbfda9b0bb60be4f7d899583bd5f490a7a5a5dc5fR939-R952
-
+            # `_tunnel` copied from 3.12.11 backporting
+            # https://github.com/python/cpython/commit/23aef575c7629abcd4aaf028ebd226fb41a4b3c8
             def _tunnel(self) -> None:  # noqa: F811
                 connect = b"CONNECT %s:%d HTTP/1.1\r\n" % (  # type: ignore[str-format]
                     self._wrap_ipv6(self._tunnel_host.encode("idna")),  # type: ignore[union-attr]
@@ -304,9 +306,7 @@ class HTTPConnection(_HTTPConnection):
                 try:
                     (version, code, message) = response._read_status()  # type: ignore[attr-defined]
 
-                    from http.client import _read_headers  # type: ignore[attr-defined]
-
-                    self._raw_proxy_headers = _read_headers(response.fp)
+                    self._raw_proxy_headers = http.client._read_headers(response.fp)  # type: ignore[attr-defined]
 
                     if self.debuglevel > 0:
                         for header in self._raw_proxy_headers:

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -1334,12 +1334,11 @@ class TestProxyManager(SocketDummyServerTestCase):
             # Try with connection_from_host
             parsed_request_url = urlparse(url)
 
-            host_params = {
-                "scheme": parsed_request_url.scheme.lower(),
-                "host": parsed_request_url.hostname,
-                "port": parsed_request_url.port,
-            }
-            conn = proxy.connection_from_host(**host_params)
+            conn = proxy.connection_from_host(
+                scheme=parsed_request_url.scheme.lower(),
+                host=parsed_request_url.hostname,
+                port=parsed_request_url.port,
+            )
             try:
                 with pytest.warns(InsecureRequestWarning):
                     r = conn.urlopen("GET", url, retries=0)


### PR DESCRIPTION
Fixes #3615 

My first time contributing. Thanks for taking the time to look at this PR. Let me know if there's anything I can do better.

Testing without the `_wrap_ipv6()`, I got a successful failure.
Had to also make sure `/etc/hosts` pointed `::1` to `localhost`
```
====================================== test session starts =======================================
platform linux -- Python 3.9.21, pytest-8.3.4, pluggy-1.5.0 -- /home/dahn/urllib3/.nox/test-3-9/bin/python
cachedir: .pytest_cache
rootdir: /home/dahn/urllib3
configfile: pyproject.toml
plugins: timeout-2.3.1, memray-1.7.0, anyio-4.8.0, socket-0.7.0
collected 1 item                                                                                 

test/with_dummyserver/test_socketlevel.py::TestProxyManager::test_connect_ipv6_addr_from_host FAILED [100%]

============================================ FAILURES ============================================
_______________________ TestProxyManager.test_connect_ipv6_addr_from_host ________________________
urllib3.exceptions.ProtocolError: ('Connection aborted.', RemoteDisconnected('Remote end closed connection without response'))

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/dahn/urllib3/test/with_dummyserver/test_socketlevel.py", line 1345, in test_connect_ipv6_addr_from_host
    r = conn.urlopen("GET", url, retries=0)
  File "/home/dahn/urllib3/src/urllib3/connectionpool.py", line 841, in urlopen
    retries = retries.increment(
  File "/home/dahn/urllib3/src/urllib3/util/retry.py", line 519, in increment
    raise MaxRetryError(_pool, url, reason) from reason  # type: ignore[arg-type]
urllib3.exceptions.MaxRetryError: HTTPSConnectionPool(host='2001:4998:c:a06::2:4008', port=443): Max retries exceeded with url: https://[2001:4998:c:a06::2:4008] (Caused by ProtocolError('Connection aborted.', RemoteDisconnected('Remote end closed connection without response')))

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/dahn/urllib3/.nox/test-3-9/lib/python3.9/site-packages/_pytest/runner.py", line 341, in from_call
    result: TResult | None = func()
  File "/home/dahn/urllib3/.nox/test-3-9/lib/python3.9/site-packages/_pytest/runner.py", line 242, in <lambda>
    lambda: runtest_hook(item=item, **kwds), when=when, reraise=reraise
  File "/home/dahn/urllib3/.nox/test-3-9/lib/python3.9/site-packages/pluggy/_hooks.py", line 513, in __call__
    return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
  File "/home/dahn/urllib3/.nox/test-3-9/lib/python3.9/site-packages/pluggy/_manager.py", line 120, in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
  File "/home/dahn/urllib3/.nox/test-3-9/lib/python3.9/site-packages/pluggy/_callers.py", line 182, in _multicall
    return outcome.get_result()
  File "/home/dahn/urllib3/.nox/test-3-9/lib/python3.9/site-packages/pluggy/_result.py", line 100, in get_result
    raise exc.with_traceback(exc.__traceback__)
  File "/home/dahn/urllib3/.nox/test-3-9/lib/python3.9/site-packages/pluggy/_callers.py", line 167, in _multicall
    teardown.throw(outcome._exception)
  File "/home/dahn/urllib3/.nox/test-3-9/lib/python3.9/site-packages/_pytest/threadexception.py", line 92, in pytest_runtest_call
    yield from thread_exception_runtest_hook()
  File "/home/dahn/urllib3/.nox/test-3-9/lib/python3.9/site-packages/_pytest/threadexception.py", line 68, in thread_exception_runtest_hook
    yield
  File "/home/dahn/urllib3/.nox/test-3-9/lib/python3.9/site-packages/pluggy/_callers.py", line 167, in _multicall
    teardown.throw(outcome._exception)
  File "/home/dahn/urllib3/.nox/test-3-9/lib/python3.9/site-packages/_pytest/unraisableexception.py", line 95, in pytest_runtest_call
    yield from unraisable_exception_runtest_hook()
  File "/home/dahn/urllib3/.nox/test-3-9/lib/python3.9/site-packages/_pytest/unraisableexception.py", line 70, in unraisable_exception_runtest_hook
    yield
  File "/home/dahn/urllib3/.nox/test-3-9/lib/python3.9/site-packages/pluggy/_callers.py", line 167, in _multicall
    teardown.throw(outcome._exception)
  File "/home/dahn/urllib3/.nox/test-3-9/lib/python3.9/site-packages/_pytest/logging.py", line 846, in pytest_runtest_call
    yield from self._runtest_for(item, "call")
  File "/home/dahn/urllib3/.nox/test-3-9/lib/python3.9/site-packages/_pytest/logging.py", line 829, in _runtest_for
    yield
  File "/home/dahn/urllib3/.nox/test-3-9/lib/python3.9/site-packages/pluggy/_callers.py", line 167, in _multicall
    teardown.throw(outcome._exception)
  File "/home/dahn/urllib3/.nox/test-3-9/lib/python3.9/site-packages/_pytest/capture.py", line 880, in pytest_runtest_call
    return (yield)
  File "/home/dahn/urllib3/.nox/test-3-9/lib/python3.9/site-packages/pluggy/_callers.py", line 167, in _multicall
    teardown.throw(outcome._exception)
  File "/home/dahn/urllib3/.nox/test-3-9/lib/python3.9/site-packages/_pytest/skipping.py", line 257, in pytest_runtest_call
    return (yield)
  File "/home/dahn/urllib3/.nox/test-3-9/lib/python3.9/site-packages/pluggy/_callers.py", line 103, in _multicall
    res = hook_impl.function(*args)
  File "/home/dahn/urllib3/.nox/test-3-9/lib/python3.9/site-packages/_pytest/runner.py", line 174, in pytest_runtest_call
    item.runtest()
  File "/home/dahn/urllib3/.nox/test-3-9/lib/python3.9/site-packages/_pytest/python.py", line 1627, in runtest
    self.ihook.pytest_pyfunc_call(pyfuncitem=self)
  File "/home/dahn/urllib3/.nox/test-3-9/lib/python3.9/site-packages/pluggy/_hooks.py", line 513, in __call__
    return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
  File "/home/dahn/urllib3/.nox/test-3-9/lib/python3.9/site-packages/pluggy/_manager.py", line 120, in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
  File "/home/dahn/urllib3/.nox/test-3-9/lib/python3.9/site-packages/pluggy/_callers.py", line 182, in _multicall
    return outcome.get_result()
  File "/home/dahn/urllib3/.nox/test-3-9/lib/python3.9/site-packages/pluggy/_result.py", line 100, in get_result
    raise exc.with_traceback(exc.__traceback__)
  File "/home/dahn/urllib3/.nox/test-3-9/lib/python3.9/site-packages/pluggy/_callers.py", line 103, in _multicall
    res = hook_impl.function(*args)
  File "/home/dahn/urllib3/.nox/test-3-9/lib/python3.9/site-packages/_pytest/python.py", line 159, in pytest_pyfunc_call
    result = testfunction(**testargs)
  File "/home/dahn/urllib3/.nox/test-3-9/lib/python3.9/site-packages/pytest_memray/plugin.py", line 214, in wrapper
    return func(*args, **kwargs)
  File "/home/dahn/urllib3/test/with_dummyserver/test_socketlevel.py", line 1345, in test_connect_ipv6_addr_from_host
    r = conn.urlopen("GET", url, retries=0)
  File "/home/dahn/urllib3/.nox/test-3-9/lib/python3.9/site-packages/_pytest/recwarn.py", line 316, in __exit__
    fail(
  File "/home/dahn/urllib3/.nox/test-3-9/lib/python3.9/site-packages/_pytest/outcomes.py", line 178, in fail
    raise Failed(msg=reason, pytrace=pytrace)
Failed: DID NOT WARN. No warnings of type (<class 'urllib3.exceptions.InsecureRequestWarning'>,) were emitted.
 Emitted warnings: [].
-------------------------------------- Captured stderr call --------------------------------------
Memray WARNING: Correcting symbol for aligned_alloc from 0x70d6b2a57fb0 to 0x70d6b3eae690
--------------------------------------- Captured log call ----------------------------------------
DEBUG    urllib3.util.retry:retry.py:286 Converted retries value: 0 -> Retry(total=0, connect=None, read=None, redirect=None, status=None)
DEBUG    urllib3.connectionpool:connectionpool.py:1049 Starting new HTTPS connection (1): 2001:4998:c:a06::2:4008:443
====================================== slowest 10 durations ======================================
0.02s call     test/with_dummyserver/test_socketlevel.py::TestProxyManager::test_connect_ipv6_addr_from_host

(2 durations < 0.005s hidden.  Use -vv to show these durations.)
==================================== short test summary info =====================================
FAILED test/with_dummyserver/test_socketlevel.py::TestProxyManager::test_connect_ipv6_addr_from_host - Failed: DID NOT WARN. No warnings of type (<class 'urllib3.exceptions.InsecureRequestWarning'...
======================================= 1 failed in 0.32s ========================================
nox > Command python -m coverage run --parallel-mode -m pytest --memray --hide-memray-summary -v -ra --tb=native --durations=10 --strict-config --strict-markers --disable-socket --allow-unix-socket --allow-hosts=localhost,127.0.0.1,::1,127.0.0.0,240.0.0.0 test/with_dummyserver/test_socketlevel.py::TestProxyManager::test_connect_ipv6_addr_from_host failed with exit code 1
nox > Session test-3.9 failed.
```