### PR TITLE
Prepare Emscripten tests for Chrome 139

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,7 @@ jobs:
         if: ${{ matrix.nox-session == 'emscripten(chrome)' }}
         with:
           install-chromedriver: true
+          chrome-version: canary
       - name: Force override system chrome
         run: |
           sudo rm -f /usr/bin/google-chrome

--- a/noxfile.py
+++ b/noxfile.py
@@ -273,7 +273,6 @@ def emscripten(session: nox.Session, runner: str) -> None:
         session,
         extras="",
         pytest_extra_args=[
-            "-x",
             "--runtime",
             f"{runner}-no-host",
             "--dist-dir",

--- a/noxfile.py
+++ b/noxfile.py
@@ -239,7 +239,7 @@ def emscripten(session: nox.Session, runner: str) -> None:
         dist_dir = Path(os.environ["PYODIDE_ROOT"]) / "dist"
     else:
         # we don't have a build tree
-        pyodide_version = "0.27.1"
+        pyodide_version = "0.28.0"
 
         pyodide_artifacts_path = Path(session.cache_dir) / f"pyodide-{pyodide_version}"
         if not pyodide_artifacts_path.exists():

--- a/test/contrib/emscripten/conftest.py
+++ b/test/contrib/emscripten/conftest.py
@@ -250,26 +250,25 @@ class ServerRunnerInfo:
 # we are at the same origin as web requests to server_host
 @pytest.fixture()
 def run_from_server(
-    selenium_coverage: Any, testserver_http: PyodideServerInfo
+    selenium: Any, testserver_http: PyodideServerInfo, has_jspi: bool
 ) -> Generator[ServerRunnerInfo]:
-    if selenium_coverage.browser != "node":
+    if selenium.browser != "node":
         # on node, we don't need to be on the same origin
         # so we can ignore all this
         addr = f"https://{testserver_http.http_host}:{testserver_http.https_port}/pyodide/test.html"
-        selenium_coverage.goto(addr)
-        selenium_coverage.javascript_setup()
-        selenium_coverage.load_pyodide()
-        selenium_coverage.initialize_pyodide()
-        selenium_coverage.save_state()
-        selenium_coverage.restore_state()
-        selenium_coverage._install_packages()
+        selenium.goto(addr)
+        selenium.javascript_setup()
+        selenium.load_pyodide()
+        selenium.initialize_pyodide()
+        selenium.save_state()
+        selenium.restore_state()
     dist_dir = testserver_http.pyodide_dist_dir
     yield ServerRunnerInfo(
         testserver_http.http_host,
         testserver_http.https_port,
-        selenium_coverage,
+        selenium,
         dist_dir,
-        selenium_coverage.with_jspi,
+        has_jspi,
     )
 
 

--- a/test/contrib/emscripten/conftest.py
+++ b/test/contrib/emscripten/conftest.py
@@ -109,10 +109,10 @@ def _get_jspi_monkeypatch_code(runtime: str, prefer_jspi: bool) -> tuple[str, st
 def selenium_with_jspi_if_possible(
     request: pytest.FixtureRequest, runtime: str, has_jspi: bool
 ) -> Generator[Any]:
-    if runtime.startswith("firefox") or not has_jspi:
-        fixture_name = "selenium"
-    else:
+    if runtime == "node" and has_jspi:
         fixture_name = "selenium_jspi"
+    else:
+        fixture_name = "selenium"
     selenium_obj = request.getfixturevalue(fixture_name)
 
     jspi_monkeypatch_code, jspi_unmonkeypatch_code = _get_jspi_monkeypatch_code(

--- a/test/contrib/emscripten/test_emscripten.py
+++ b/test/contrib/emscripten/test_emscripten.py
@@ -29,15 +29,15 @@ pyodide_config.set_flags(
 
 
 def test_index(
-    selenium_coverage: typing.Any, testserver_http: PyodideServerInfo, has_jspi: bool
+    selenium_coverage: typing.Any, testserver_http: PyodideServerInfo, prefer_jspi: bool
 ) -> None:
     @run_in_pyodide  # type: ignore[misc]
-    def pyodide_test(selenium_coverage, host: str, port: int, has_jspi: bool) -> None:  # type: ignore[no-untyped-def]
+    def pyodide_test(selenium_coverage, host: str, port: int, prefer_jspi: bool) -> None:  # type: ignore[no-untyped-def]
         import urllib3.contrib.emscripten.fetch
         from urllib3.connection import HTTPConnection
         from urllib3.response import BaseHTTPResponse
 
-        assert urllib3.contrib.emscripten.fetch.has_jspi() == has_jspi
+        assert urllib3.contrib.emscripten.fetch.has_jspi() == prefer_jspi
         conn = HTTPConnection(host, port)
         url = f"http://{host}:{port}/"
         conn.request("GET", url)
@@ -59,20 +59,20 @@ def test_index(
         selenium_coverage,
         testserver_http.http_host,
         testserver_http.http_port,
-        has_jspi,
+        prefer_jspi,
     )
 
 
 def test_pool_requests(
-    selenium_coverage: typing.Any, testserver_http: PyodideServerInfo, has_jspi: bool
+    selenium_coverage: typing.Any, testserver_http: PyodideServerInfo, prefer_jspi: bool
 ) -> None:
     @run_in_pyodide  # type: ignore[misc]
-    def pyodide_test(selenium_coverage, host: str, port: int, https_port: int, has_jspi: bool) -> None:  # type: ignore[no-untyped-def]
+    def pyodide_test(selenium_coverage, host: str, port: int, https_port: int, prefer_jspi: bool) -> None:  # type: ignore[no-untyped-def]
         # first with PoolManager
         import urllib3
         import urllib3.contrib.emscripten.fetch
 
-        assert urllib3.contrib.emscripten.fetch.has_jspi() == has_jspi
+        assert urllib3.contrib.emscripten.fetch.has_jspi() == prefer_jspi
 
         http = urllib3.PoolManager()
         resp = http.request("GET", f"http://{host}:{port}/")
@@ -127,13 +127,13 @@ def test_pool_requests(
         testserver_http.http_host,
         testserver_http.http_port,
         testserver_http.https_port,
-        has_jspi,
+        prefer_jspi,
     )
 
 
 # wrong protocol / protocol error etc. should raise an exception of http.client.HTTPException
 def test_wrong_protocol(
-    selenium_coverage: typing.Any, testserver_http: PyodideServerInfo, has_jspi: bool
+    selenium_coverage: typing.Any, testserver_http: PyodideServerInfo
 ) -> None:
     @run_in_pyodide  # type: ignore[misc]
     def pyodide_test(selenium_coverage, host: str, port: int) -> None:  # type: ignore[no-untyped-def]
@@ -154,7 +154,7 @@ def test_wrong_protocol(
 
 # wrong protocol / protocol error etc. should raise an exception of http.client.HTTPException
 def test_bad_method(
-    selenium_coverage: typing.Any, testserver_http: PyodideServerInfo, has_jspi: bool
+    selenium_coverage: typing.Any, testserver_http: PyodideServerInfo
 ) -> None:
     @run_in_pyodide  # type: ignore[misc]
     def pyodide_test(selenium_coverage, host: str, port: int) -> None:  # type: ignore[no-untyped-def]
@@ -175,7 +175,7 @@ def test_bad_method(
 
 # no connection - should raise
 def test_no_response(
-    selenium_coverage: typing.Any, testserver_http: PyodideServerInfo, has_jspi: bool
+    selenium_coverage: typing.Any, testserver_http: PyodideServerInfo
 ) -> None:
     @run_in_pyodide  # type: ignore[misc]
     def pyodide_test(selenium_coverage, host: str, port: int) -> None:  # type: ignore[no-untyped-def]
@@ -193,9 +193,7 @@ def test_no_response(
     pyodide_test(selenium_coverage, testserver_http.http_host, find_unused_port())
 
 
-def test_404(
-    selenium_coverage: typing.Any, testserver_http: PyodideServerInfo, has_jspi: bool
-) -> None:
+def test_404(selenium_coverage: typing.Any, testserver_http: PyodideServerInfo) -> None:
     @run_in_pyodide  # type: ignore[misc]
     def pyodide_test(selenium_coverage, host: str, port: int) -> None:  # type: ignore[no-untyped-def]
         from urllib3.connection import HTTPConnection
@@ -253,7 +251,6 @@ def test_timeout_warning(
 def test_timeout_in_worker_non_streaming(
     testserver_http: PyodideServerInfo,
     run_from_server: ServerRunnerInfo,
-    has_jspi: bool,
 ) -> None:
     worker_code = f"""
         from urllib3.exceptions import TimeoutError
@@ -284,7 +281,6 @@ def test_timeout_in_worker_non_streaming(
 def test_timeout_in_worker_streaming(
     testserver_http: PyodideServerInfo,
     run_from_server: ServerRunnerInfo,
-    has_jspi: bool,
 ) -> None:
     worker_code = f"""
         import urllib3.contrib.emscripten.fetch
@@ -307,7 +303,7 @@ def test_timeout_in_worker_streaming(
 
 
 def test_index_https(
-    selenium_coverage: typing.Any, testserver_http: PyodideServerInfo, has_jspi: bool
+    selenium_coverage: typing.Any, testserver_http: PyodideServerInfo
 ) -> None:
     @run_in_pyodide  # type: ignore[misc]
     def pyodide_test(selenium_coverage, host: str, port: int) -> None:  # type: ignore[no-untyped-def]
@@ -413,7 +409,6 @@ def test_streaming_fallback_warning(
 def test_specific_method(
     selenium_coverage: typing.Any,
     testserver_http: PyodideServerInfo,
-    has_jspi: bool,
 ) -> None:
     @run_in_pyodide  # type: ignore[misc]
     def pyodide_test(selenium_coverage, host: str, port: int) -> None:  # type: ignore[no-untyped-def]
@@ -436,7 +431,7 @@ def test_specific_method(
 def test_streaming_download(
     testserver_http: PyodideServerInfo,
     run_from_server: ServerRunnerInfo,
-    has_jspi: bool,
+    prefer_jspi: bool,
 ) -> None:
     # test streaming download, which must be in a webworker
     # as you can't do it on main thread
@@ -457,7 +452,7 @@ def test_streaming_download(
             response = conn.getresponse()
             assert isinstance(response, BaseHTTPResponse)
             assert urllib3.contrib.emscripten.fetch._SHOWN_STREAMING_WARNING==False
-            assert(urllib3.contrib.emscripten.fetch.has_jspi() == {has_jspi})
+            assert(urllib3.contrib.emscripten.fetch.has_jspi() == {prefer_jspi})
             data=response.data.decode('utf-8')
             assert len(data) == 17825792
 """
@@ -468,7 +463,7 @@ def test_streaming_download(
 def test_streaming_close(
     testserver_http: PyodideServerInfo,
     run_from_server: ServerRunnerInfo,
-    has_jspi: bool,
+    prefer_jspi: bool,
 ) -> None:
     # test streaming download, which must be in a webworker
     # as you can't do it on main thread
@@ -492,7 +487,7 @@ def test_streaming_close(
             assert(body_internal.writable() is False)
             assert(body_internal.seekable() is False)
             assert(body_internal.readable() is True)
-            assert(urllib3.contrib.emscripten.fetch.has_jspi() == {has_jspi})
+            assert(urllib3.contrib.emscripten.fetch.has_jspi() == {prefer_jspi})
 
             response.drain_conn()
             x=response.read()
@@ -512,7 +507,6 @@ def test_streaming_close(
 def test_streaming_bad_url(
     testserver_http: PyodideServerInfo,
     run_from_server: ServerRunnerInfo,
-    has_jspi: bool,
 ) -> None:
     # this should cause an error
     # because the protocol is bad
@@ -538,7 +532,6 @@ def test_streaming_bad_url(
 def test_streaming_bad_method(
     testserver_http: PyodideServerInfo,
     run_from_server: ServerRunnerInfo,
-    has_jspi: bool,
 ) -> None:
     # this should cause an error
     # because the protocol is bad
@@ -599,7 +592,7 @@ def test_streaming_notready_warning(
 
 
 def test_post_receive_json(
-    selenium_coverage: typing.Any, testserver_http: PyodideServerInfo, has_jspi: bool
+    selenium_coverage: typing.Any, testserver_http: PyodideServerInfo
 ) -> None:
     @run_in_pyodide  # type: ignore[misc]
     def pyodide_test(selenium_coverage, host: str, port: int) -> None:  # type: ignore[no-untyped-def]
@@ -1024,26 +1017,26 @@ def test_insecure_requests_warning(
 def test_has_jspi_worker(
     testserver_http: PyodideServerInfo,
     run_from_server: ServerRunnerInfo,
-    has_jspi: bool,
+    prefer_jspi: bool,
 ) -> None:
     worker_code = f"""
     import urllib3.contrib.emscripten.fetch
-    assert(urllib3.contrib.emscripten.fetch.has_jspi() == {has_jspi})
+    assert(urllib3.contrib.emscripten.fetch.has_jspi() == {prefer_jspi})
     """
 
     run_from_server.run_webworker(worker_code)
 
 
 def test_has_jspi(
-    selenium_coverage: typing.Any, testserver_http: PyodideServerInfo, has_jspi: bool
+    selenium_coverage: typing.Any, testserver_http: PyodideServerInfo, prefer_jspi: bool
 ) -> None:
     @run_in_pyodide
-    def pyodide_test(selenium, has_jspi):  # type: ignore[no-untyped-def]
+    def pyodide_test(selenium, prefer_jspi):  # type: ignore[no-untyped-def]
         import urllib3.contrib.emscripten.fetch
 
-        assert urllib3.contrib.emscripten.fetch.has_jspi() == has_jspi
+        assert urllib3.contrib.emscripten.fetch.has_jspi() == prefer_jspi
 
-    pyodide_test(selenium_coverage, has_jspi)
+    pyodide_test(selenium_coverage, prefer_jspi)
 
 
 @pytest.mark.with_jspi

--- a/test/contrib/emscripten/test_emscripten.py
+++ b/test/contrib/emscripten/test_emscripten.py
@@ -251,7 +251,6 @@ def test_timeout_warning(
 
 @pytest.mark.webworkers
 def test_timeout_in_worker_non_streaming(
-    selenium_coverage: typing.Any,
     testserver_http: PyodideServerInfo,
     run_from_server: ServerRunnerInfo,
     has_jspi: bool,
@@ -283,7 +282,6 @@ def test_timeout_in_worker_non_streaming(
 
 @pytest.mark.webworkers
 def test_timeout_in_worker_streaming(
-    selenium_coverage: typing.Any,
     testserver_http: PyodideServerInfo,
     run_from_server: ServerRunnerInfo,
     has_jspi: bool,
@@ -415,7 +413,6 @@ def test_streaming_fallback_warning(
 def test_specific_method(
     selenium_coverage: typing.Any,
     testserver_http: PyodideServerInfo,
-    run_from_server: ServerRunnerInfo,
     has_jspi: bool,
 ) -> None:
     @run_in_pyodide  # type: ignore[misc]
@@ -437,7 +434,6 @@ def test_specific_method(
 
 @pytest.mark.webworkers
 def test_streaming_download(
-    selenium_coverage: typing.Any,
     testserver_http: PyodideServerInfo,
     run_from_server: ServerRunnerInfo,
     has_jspi: bool,
@@ -470,7 +466,6 @@ def test_streaming_download(
 
 @pytest.mark.webworkers
 def test_streaming_close(
-    selenium_coverage: typing.Any,
     testserver_http: PyodideServerInfo,
     run_from_server: ServerRunnerInfo,
     has_jspi: bool,
@@ -515,7 +510,6 @@ def test_streaming_close(
 
 @pytest.mark.webworkers
 def test_streaming_bad_url(
-    selenium_coverage: typing.Any,
     testserver_http: PyodideServerInfo,
     run_from_server: ServerRunnerInfo,
     has_jspi: bool,
@@ -542,7 +536,6 @@ def test_streaming_bad_url(
 
 @pytest.mark.webworkers
 def test_streaming_bad_method(
-    selenium_coverage: typing.Any,
     testserver_http: PyodideServerInfo,
     run_from_server: ServerRunnerInfo,
     has_jspi: bool,
@@ -572,7 +565,6 @@ def test_streaming_bad_method(
 @pytest.mark.webworkers
 @pytest.mark.without_jspi
 def test_streaming_notready_warning(
-    selenium_coverage: typing.Any,
     testserver_http: PyodideServerInfo,
     run_from_server: ServerRunnerInfo,
 ) -> None:
@@ -680,7 +672,6 @@ def test_streaming_not_ready_in_browser(
 def test_requests_with_micropip(
     selenium_coverage: typing.Any,
     testserver_http: PyodideServerInfo,
-    run_from_server: ServerRunnerInfo,
 ) -> None:
     @run_in_pyodide(packages=["micropip"])  # type: ignore[misc]
     async def test_fn(
@@ -751,7 +742,6 @@ def test_open_close(
 @pytest.mark.webworkers
 @pytest.mark.without_jspi
 def test_break_worker_streaming(
-    selenium_coverage: typing.Any,
     testserver_http: PyodideServerInfo,
     run_from_server: ServerRunnerInfo,
 ) -> None:
@@ -1032,7 +1022,6 @@ def test_insecure_requests_warning(
 
 @pytest.mark.webworkers
 def test_has_jspi_worker(
-    selenium_coverage: typing.Any,
     testserver_http: PyodideServerInfo,
     run_from_server: ServerRunnerInfo,
     has_jspi: bool,
@@ -1061,7 +1050,6 @@ def test_has_jspi(
 def test_timeout_jspi(
     selenium_coverage: typing.Any,
     testserver_http: PyodideServerInfo,
-    run_from_server: ServerRunnerInfo,
 ) -> None:
     @run_in_pyodide
     def pyodide_test(selenium, host, port):  # type: ignore[no-untyped-def]

--- a/uv.lock
+++ b/uv.lock
@@ -87,6 +87,15 @@ wheels = [
 ]
 
 [[package]]
+name = "backports-asyncio-runner"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/ff/70dca7d7cb1cbc0edb2c6cc0c38b65cba36cccc491eca64cabd5fe7f8670/backports_asyncio_runner-1.2.0.tar.gz", hash = "sha256:a5aa7b2b7d8f8bfcaa2b57313f70792df84e32a2a746f585213373f900b42162", size = 69893, upload-time = "2025-07-02T02:27:15.685Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/59/76ab57e3fe74484f48a53f8e337171b4a2349e506eabe136d7e01d059086/backports_asyncio_runner-1.2.0-py3-none-any.whl", hash = "sha256:0da0a936a8aeb554eccb426dc55af3ba63bcdc69fa1a600b5bb305413a4477b5", size = 12313, upload-time = "2025-07-02T02:27:14.263Z" },
+]
+
+[[package]]
 name = "beautifulsoup4"
 version = "4.12.3"
 source = { registry = "https://pypi.org/simple" }
@@ -755,16 +764,16 @@ wheels = [
 
 [[package]]
 name = "hypothesis"
-version = "6.123.17"
+version = "6.135.33"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs", marker = "python_full_version >= '3.10'" },
     { name = "exceptiongroup", marker = "python_full_version == '3.10.*'" },
     { name = "sortedcontainers", marker = "python_full_version >= '3.10'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/15/a7/695b2bcb4e8438e1d4683efa6877fc95be293a11251471d4552d6dd08259/hypothesis-6.123.17.tar.gz", hash = "sha256:5850893975b4f08e893ddc10f1d468bc7e011d59703f70fe06a10161e426e602", size = 418572, upload-time = "2025-01-13T20:36:14.851Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/08/4a5d8b03010a20810a5920f8102f68b54baa097495eff6a0c97277845caa/hypothesis-6.135.33.tar.gz", hash = "sha256:661cad8d12ffc94a58e5ed30f9713ed3c562c2db725f8e4de9a244b7fed4bd4f", size = 456414, upload-time = "2025-07-18T17:18:31.695Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/11/8a/f1c166f048df4b314d0d38e9530b7af516a16160873d724bb416084d6990/hypothesis-6.123.17-py3-none-any.whl", hash = "sha256:5c949fb44935e32c61c64abfcc3975eec41f8205ade2223073ba074c1e078ead", size = 480880, upload-time = "2025-01-13T20:36:11.335Z" },
+    { url = "https://files.pythonhosted.org/packages/04/fc/1e45703b2e744a8e2cfd8579f8fc73923a8f5b70c448620db9a8b4065afc/hypothesis-6.135.33-py3-none-any.whl", hash = "sha256:34b69c00d961bd73ac2cb234eede95ac2a956d6c0ec4fbb74c665b8dc4a4a9a1", size = 523429, upload-time = "2025-07-18T17:18:28.513Z" },
 ]
 
 [[package]]
@@ -1128,20 +1137,21 @@ wheels = [
 
 [[package]]
 name = "playwright"
-version = "1.49.1"
+version = "1.53.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "greenlet", marker = "python_full_version >= '3.10'" },
     { name = "pyee", marker = "python_full_version >= '3.10'" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ab/be/01025581052e43eb698092c4328d7497ca62bcb5c83f15a611d4a71b4b92/playwright-1.49.1-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:1041ffb45a0d0bc44d698d3a5aa3ac4b67c9bd03540da43a0b70616ad52592b8", size = 39559859, upload-time = "2024-12-10T17:32:14.907Z" },
-    { url = "https://files.pythonhosted.org/packages/79/25/ef1010a42cc7d576282015d983c5451d73e369b198b6eb32a177fae281f8/playwright-1.49.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:9f38ed3d0c1f4e0a6d1c92e73dd9a61f8855133249d6f0cec28648d38a7137be", size = 38808973, upload-time = "2024-12-10T17:32:22.516Z" },
-    { url = "https://files.pythonhosted.org/packages/70/4b/3930cf10f303a10d493a382e4448aaff898b4065698b3b8d92f902e53e08/playwright-1.49.1-py3-none-macosx_11_0_universal2.whl", hash = "sha256:3be48c6d26dc819ca0a26567c1ae36a980a0303dcd4249feb6f59e115aaddfb8", size = 39559863, upload-time = "2024-12-10T17:32:29.12Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/c1/ea765e72a746dc7ec2ce155ffea29d454e7171db78f3c09185e888387246/playwright-1.49.1-py3-none-manylinux1_x86_64.whl", hash = "sha256:753ca90ee31b4b03d165cfd36e477309ebf2b4381953f2a982ff612d85b147d2", size = 44163300, upload-time = "2024-12-10T17:32:35.647Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/52/95efac704bf36b770a2522d88a6dee298042845d10bfb35f7ca0fcc36d91/playwright-1.49.1-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cd9bc8dab37aa25198a01f555f0a2e2c3813fe200fef018ac34dfe86b34994b9", size = 43744353, upload-time = "2024-12-10T17:32:43.189Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/97/a3fccc9aaa6da83890772e9980703b0ea6b1e1ad42042fb50df3aef6c641/playwright-1.49.1-py3-none-win32.whl", hash = "sha256:43b304be67f096058e587dac453ece550eff87b8fbed28de30f4f022cc1745bb", size = 34060663, upload-time = "2024-12-10T17:32:49.904Z" },
-    { url = "https://files.pythonhosted.org/packages/71/a9/bd88ac0bd498c91aab3aba2e393d1fa59f72a7243e9265ccbf4861ca4f64/playwright-1.49.1-py3-none-win_amd64.whl", hash = "sha256:47b23cb346283278f5b4d1e1990bcb6d6302f80c0aa0ca93dd0601a1400191df", size = 34060667, upload-time = "2024-12-10T17:32:56.459Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/e2/2f107be74419280749723bd1197c99351f4b8a0a25e974b9764affb940b2/playwright-1.53.0-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:48a1a15ce810f0ffe512b6050de9871ea193b41dd3cc1bbed87b8431012419ba", size = 40392498, upload-time = "2025-06-25T21:48:34.17Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/d5/e8c57a4f6fd46059fb2d51da2d22b47afc886b42400f06b742cd4a9ba131/playwright-1.53.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:a701f9498a5b87e3f929ec01cea3109fbde75821b19c7ba4bba54f6127b94f76", size = 38647035, upload-time = "2025-06-25T21:48:38.414Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/f3/da18cd7c22398531316e58fd131243fd9156fe7765aae239ae542a5d07d2/playwright-1.53.0-py3-none-macosx_11_0_universal2.whl", hash = "sha256:f765498341c4037b4c01e742ae32dd335622f249488ccd77ca32d301d7c82c61", size = 40392502, upload-time = "2025-06-25T21:48:42.293Z" },
+    { url = "https://files.pythonhosted.org/packages/92/32/5d871c3753fbee5113eefc511b9e44c0006a27f2301b4c6bffa4346fbd94/playwright-1.53.0-py3-none-manylinux1_x86_64.whl", hash = "sha256:db19cb5b58f3b15cad3e2419f4910c053e889202fc202461ee183f1530d1db60", size = 45848364, upload-time = "2025-06-25T21:48:45.849Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/6b/9942f86661ff41332f9299db4950623123e60ca71e4fb6e6942fc0212624/playwright-1.53.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9276c9c935fc062f51f4f5107e56420afd6d9a524348dc437793dc2e34c742e3", size = 45235174, upload-time = "2025-06-25T21:48:49.579Z" },
+    { url = "https://files.pythonhosted.org/packages/51/63/28b3f2d36e6a95e88f033d2aa7af06083f6f4aa0d9764759d96033cd053e/playwright-1.53.0-py3-none-win32.whl", hash = "sha256:36eedec101724ff5a000cddab87dd9a72a39f9b3e65a687169c465484e667c06", size = 35415131, upload-time = "2025-06-25T21:48:53.403Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/b5/4ca25974a90d16cfd4a9a953ee5a666cf484a0bdacb4eed484e5cab49e66/playwright-1.53.0-py3-none-win_amd64.whl", hash = "sha256:d68975807a0fd997433537f1dcf2893cda95884a39dc23c6f591b8d5f691e9e8", size = 35415138, upload-time = "2025-06-25T21:48:57.082Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/81/b42ff2116df5d07ccad2dc4eeb20af92c975a1fbc7cd3ed37b678468b813/playwright-1.53.0-py3-none-win_arm64.whl", hash = "sha256:fcfd481f76568d7b011571160e801b47034edd9e2383c43d83a5fb3f35c67885", size = 31188568, upload-time = "2025-06-25T21:49:00.194Z" },
 ]
 
 [[package]]
@@ -1182,14 +1192,14 @@ wheels = [
 
 [[package]]
 name = "pyee"
-version = "12.0.0"
+version = "13.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions", marker = "python_full_version >= '3.10'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d2/a7/8faaa62a488a2a1e0d56969757f087cbd2729e9bcfa508c230299f366b4c/pyee-12.0.0.tar.gz", hash = "sha256:c480603f4aa2927d4766eb41fa82793fe60a82cbfdb8d688e0d08c55a534e145", size = 29675, upload-time = "2024-08-30T19:40:43.555Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/95/03/1fd98d5841cd7964a27d729ccf2199602fe05eb7a405c1462eb7277945ed/pyee-13.0.0.tar.gz", hash = "sha256:b391e3c5a434d1f5118a25615001dbc8f669cf410ab67d04c4d4e07c55481c37", size = 31250, upload-time = "2025-03-17T18:53:15.955Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1d/0d/95993c08c721ec68892547f2117e8f9dfbcef2ca71e098533541b4a54d5f/pyee-12.0.0-py3-none-any.whl", hash = "sha256:7b14b74320600049ccc7d0e0b1becd3b4bd0a03c745758225e31a59f4095c990", size = 14831, upload-time = "2024-08-30T19:40:42.132Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/4d/b9add7c84060d4c1906abe9a7e5359f2a60f7a9a4f67268b2766673427d8/pyee-13.0.0-py3-none-any.whl", hash = "sha256:48195a3cddb3b1515ce0695ed76036b5ccc2ef3a9f963ff9f77aec0139845498", size = 15730, upload-time = "2025-03-17T18:53:14.532Z" },
 ]
 
 [[package]]
@@ -1251,14 +1261,15 @@ wheels = [
 
 [[package]]
 name = "pytest-asyncio"
-version = "0.25.2"
+version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "backports-asyncio-runner", marker = "python_full_version == '3.10.*'" },
     { name = "pytest", marker = "python_full_version >= '3.10'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/72/df/adcc0d60f1053d74717d21d58c0048479e9cab51464ce0d2965b086bd0e2/pytest_asyncio-0.25.2.tar.gz", hash = "sha256:3f8ef9a98f45948ea91a0ed3dc4268b5326c0e7bce73892acc654df4262ad45f", size = 53950, upload-time = "2025-01-08T06:20:29.31Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/51/f8794af39eeb870e87a8c8068642fc07bce0c854d6865d7dd0f2a9d338c2/pytest_asyncio-1.1.0.tar.gz", hash = "sha256:796aa822981e01b68c12e4827b8697108f7205020f24b5793b3c41555dab68ea", size = 46652, upload-time = "2025-07-16T04:29:26.393Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/61/d8/defa05ae50dcd6019a95527200d3b3980043df5aa445d40cb0ef9f7f98ab/pytest_asyncio-0.25.2-py3-none-any.whl", hash = "sha256:0d0bb693f7b99da304a0634afc0a4b19e49d5e0de2d670f38dc4bfa5727c5075", size = 19400, upload-time = "2025-01-08T06:20:27.862Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/9d/bf86eddabf8c6c9cb1ea9a869d6873b46f105a5d292d3a6f7071f5b07935/pytest_asyncio-1.1.0-py3-none-any.whl", hash = "sha256:5fe2d69607b0bd75c656d1211f969cadba035030156745ee09e7d71740e58ecf", size = 15157, upload-time = "2025-07-16T04:29:24.929Z" },
 ]
 
 [[package]]
@@ -1276,7 +1287,7 @@ wheels = [
 
 [[package]]
 name = "pytest-pyodide"
-version = "0.58.4"
+version = "0.58.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "hypothesis", marker = "python_full_version >= '3.10'" },
@@ -1287,9 +1298,9 @@ dependencies = [
     { name = "selenium", marker = "python_full_version >= '3.10'" },
     { name = "tblib", marker = "python_full_version >= '3.10'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/85/2b/d959d17f5a544d4cd74d06833b63da9760dfc2a20a792fc67bef50ee433f/pytest_pyodide-0.58.4.tar.gz", hash = "sha256:653f460e514cae6038cee821c592b05a0a2a4a22dab77929603126921f7d70f1", size = 162282, upload-time = "2024-11-23T04:41:41.043Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/77/841ad56a6b60b9dbe8d131d82d677ecd9829338444bb87ff8a649d8993ae/pytest_pyodide-0.58.6.tar.gz", hash = "sha256:f9aacc6b916dd585eeb496bdcc111b776a2922e5b7faf4a46b7345dfb999e122", size = 164794, upload-time = "2025-06-12T22:13:54.625Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a6/9f/e24389ffe2b703194c36c2763d8c1402cb6c8ac84be8fe1bd16f9315b444/pytest_pyodide-0.58.4-py3-none-any.whl", hash = "sha256:e8799464f0db5c8c281a1e9b4b8a4b38f015183679d47f09e140c4004a8d2ccc", size = 49710, upload-time = "2024-11-23T04:41:39.386Z" },
+    { url = "https://files.pythonhosted.org/packages/21/1a/9ba3235b1f06bbbabc5e63b863bea22d5f8c239d1cc916bd3055702ca505/pytest_pyodide-0.58.6-py3-none-any.whl", hash = "sha256:4e4d25c2eb2e6689da8dd0f6aa59f8053fe21b17c5aa597733fd3fc9191d2900", size = 50112, upload-time = "2025-06-12T22:13:53.343Z" },
 ]
 
 [[package]]
@@ -1384,7 +1395,7 @@ wheels = [
 
 [[package]]
 name = "selenium"
-version = "4.27.1"
+version = "4.32.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -1394,9 +1405,9 @@ dependencies = [
     { name = "urllib3", extra = ["socks"] },
     { name = "websocket-client" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/44/8c/62c47c91072aa03af1c3b7d7f1c59b987db41c9fec0f158fb03a0da51aa6/selenium-4.27.1.tar.gz", hash = "sha256:5296c425a75ff1b44d0d5199042b36a6d1ef76c04fb775b97b40be739a9caae2", size = 973526, upload-time = "2024-11-26T14:56:47.893Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/2d/fafffe946099033ccf22bf89e12eede14c1d3c5936110c5f6f2b9830722c/selenium-4.32.0.tar.gz", hash = "sha256:b9509bef4056f4083772abb1ae19ff57247d617a29255384b26be6956615b206", size = 870997, upload-time = "2025-05-02T20:35:27.325Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a6/1e/5f1a5dd2a28528c4b3ec6e076b58e4c035810c805328f9936123283ca14e/selenium-4.27.1-py3-none-any.whl", hash = "sha256:b89b1f62b5cfe8025868556fe82360d6b649d464f75d2655cb966c8f8447ea18", size = 9707007, upload-time = "2024-11-26T14:56:45.191Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/37/d07ed9d13e571b2115d4ed6956d156c66816ceec0b03b2e463e80d09f572/selenium-4.32.0-py3-none-any.whl", hash = "sha256:c4d9613f8a45693d61530c9660560fadb52db7d730237bc788ddedf442391f97", size = 9369668, upload-time = "2025-05-02T20:35:24.726Z" },
 ]
 
 [[package]]
@@ -1606,11 +1617,11 @@ wheels = [
 
 [[package]]
 name = "tblib"
-version = "3.0.0"
+version = "3.1.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1a/df/4f2cd7eaa6d41a7994d46527349569d46e34d9cdd07590b5c5b0dcf53de3/tblib-3.0.0.tar.gz", hash = "sha256:93622790a0a29e04f0346458face1e144dc4d32f493714c6c3dff82a4adb77e6", size = 30616, upload-time = "2023-10-22T00:35:48.554Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/95/4b3044ec4bf248186769629bbfb495a458deb6e4c1f9eff7f298ae1e336e/tblib-3.1.0.tar.gz", hash = "sha256:06404c2c9f07f66fee2d7d6ad43accc46f9c3361714d9b8426e7f47e595cd652", size = 30766, upload-time = "2025-03-31T12:58:27.473Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9b/87/ce70db7cae60e67851eb94e1a2127d4abb573d3866d2efd302ceb0d4d2a5/tblib-3.0.0-py3-none-any.whl", hash = "sha256:80a6c77e59b55e83911e1e607c649836a69c103963c5f28a46cbeef44acf8129", size = 12478, upload-time = "2023-10-22T00:35:46.515Z" },
+    { url = "https://files.pythonhosted.org/packages/27/44/aa5c8b10b2cce7a053018e0d132bd58e27527a0243c4985383d5b6fd93e9/tblib-3.1.0-py3-none-any.whl", hash = "sha256:670bb4582578134b3d81a84afa1b016128b429f3d48e6cbbaecc9d15675e984e", size = 12552, upload-time = "2025-03-31T12:58:26.142Z" },
 ]
 
 [[package]]
@@ -1703,16 +1714,17 @@ wheels = [
 
 [[package]]
 name = "trio-websocket"
-version = "0.11.1"
+version = "0.12.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "outcome" },
     { name = "trio" },
     { name = "wsproto" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/dd/36/abad2385853077424a11b818d9fd8350d249d9e31d583cb9c11cd4c85eda/trio-websocket-0.11.1.tar.gz", hash = "sha256:18c11793647703c158b1f6e62de638acada927344d534e3c7628eedcb746839f", size = 26511, upload-time = "2023-09-26T23:24:58.753Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d1/3c/8b4358e81f2f2cfe71b66a267f023a91db20a817b9425dd964873796980a/trio_websocket-0.12.2.tar.gz", hash = "sha256:22c72c436f3d1e264d0910a3951934798dcc5b00ae56fc4ee079d46c7cf20fae", size = 33549, upload-time = "2025-02-25T05:16:58.947Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/48/be/a9ae5f50cad5b6f85bd2574c2c923730098530096e170c1ce7452394d7aa/trio_websocket-0.11.1-py3-none-any.whl", hash = "sha256:520d046b0d030cf970b8b2b2e00c4c2245b3807853ecd44214acd33d74581638", size = 17408, upload-time = "2023-09-26T23:24:56.788Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/19/eb640a397bba49ba49ef9dbe2e7e5c04202ba045b6ce2ec36e9cadc51e04/trio_websocket-0.12.2-py3-none-any.whl", hash = "sha256:df605665f1db533f4a386c94525870851096a223adcb97f72a07e8b4beba45b6", size = 21221, upload-time = "2025-02-25T05:16:57.545Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This pull request addresses the upcoming change in Chrome 139, which we've already seen in failing CI jobs. It migrates our Emscripten tests to exclusively use the `selenium` fixture, rather than a combination of `selenium` and `selenium_jspi`. Thanks @hoodmane for the suggestion in https://github.com/pyodide/pytest-pyodide/issues/163#issuecomment-3088631178.

Initial attempts at this switch revealed underlying issues. Consequently, this branch evolved to include a series of necessary fixes and related refactorings. Please review the individual commits for detailed changes, I'm describing a few of the more complex ones below.

* ad2dfb53c51aa947c0dbade7497d2db5fab6a0cd Stop using fixtures `selenium_coverage` and `run_from_server` together
This commit stops the combined use of `selenium_coverage` and `run_from_server` fixtures.
Previously, `run_from_server` depended on `selenium_coverage`, and some tests unnecessarily requested both. This combination created conflicts with upcoming monkey patching cleanup. Decoupling them resolves this interference.

* 5f89c1874c1e98d0000ebec1d1903d78643c65ae Share the same code monkey patching JSPI availability
This commit extracts and centralizes the JSPI monkey patching logic into a shared function, now including a crucial cleanup step.
Previously, separate Selenium fixtures for JSPI and non-JSPI paths in Chrome meant no cleanup was needed after monkey patching. With the switch to a single Chrome fixture, any subsequent JSPI-dependent tests would fail if the monkey patch persisted. The added cleanup resolves this, preventing test failures and eliminating code duplication.

* 8316ef0a4204dc179b5f1c5b1a0074f52ce1bed0 Rename `has_jspi` fixture to `prefer_jspi`
The original `has_jspi` fixture provides a boolean value indicating whether a test should use JSPI or XHR. A `False` value doesn't necessarily mean the runtime lacks JSPI support. For instance, the same test against Chrome can have two versions, `test_index[chrome-False]` and `test_index[chrome-True]`, where the boolean reflects `has_jspi`. This has been confusing.
Renaming it to `prefer_jspi` will clarify the fixture's meaning, as it's more easily understood as a characteristic of the test method rather than the runtime itself.

* 22e25c4119ef5585e9689066b02a7143593956dc Deselect and parametrize Emscripten tests properly
This commit refactors Emscripten test management by separating parametrization and deselection into distinct pytest hooks.