### PR TITLE
Add a Python 3.14 classifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",


### PR DESCRIPTION
Python 3.14.0rc1 has recently been released with [a call to action](https://www.python.org/downloads/release/python-3140rc1/#:~:text=changes%20as%20possible.-,Call%20to%20action,-We%20strongly%20encourage) for package maintainers to prepare their projects for 3.14.

I believe we can add the classifier now.

Also, we'll have to remove the experimental flag for CI in some time:
https://github.com/urllib3/urllib3/blob/4f7f39fd296fb7d36d769ef971ddd00878103c02/.github/workflows/ci.yml#L92-L93