### PR TITLE
security: update actions for artifact handling only by `id`

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,6 +20,7 @@ jobs:
     runs-on: "ubuntu-latest"
     outputs:
       hashes: ${{ steps.hash.outputs.hashes }}
+      artifact-id: ${{ steps.upload-artifact.outputs.artifact-id }}
 
     steps:
       - name: "Checkout repository"
@@ -47,7 +48,8 @@ jobs:
           cd dist && echo "hashes=$(sha256sum * | base64 -w0)" >> $GITHUB_OUTPUT
 
       - name: "Upload dists"
-        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+        uses: actions/upload-artifact@4.6.2 # immutable release
+        id: upload-artifact
         with:
           name: "dist"
           path: "dist/"
@@ -67,9 +69,9 @@ jobs:
 
     steps:
     - name: "Download dists"
-      uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
+      uses: actions/download-artifact@4.3.0 # immutable release
       with:
-        name: "dist"
+        artifact-ids: ${{ needs.build.outputs.artifact-id }}
         path: "dist/"
 
     - name: "Upload dists to a new GitHub Release Draft"
@@ -100,9 +102,9 @@ jobs:
 
     steps:
     - name: "Download dists"
-      uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
+      uses: actions/download-artifact@4.3.0 # immutable release
       with:
-        name: "dist"
+        artifact-ids: ${{ needs.build.outputs.artifact-id }}
         path: "dist/"
 
     - name: "Publish dists to Test PyPI"


### PR DESCRIPTION
This pull request updates the `publish.yml` workflow to explicitly use `artifact-ids` instead of the `name` input option when handling artifacts. This is important because artifacts produced by GitHub Actions can be completely overwritten by other workflow runs if they use the same `name`. To avoid potential TOCTOU issues/vulnerabilities where an artifact might be replaced between upload and download, the new `artifact-ids` input allows you to download artifacts by their specific ID rather than by name.

In the context of this repo, this is especially important as the SLSA L3 badge is present on this project, but in order to be truly at SLSA L3, you cannot use `name` for artifacts as it could be replaced between the `build` and `release...` stages of this workflow. This means that another workflow could potentially change the artifact being used by this `publish.yml` job and release a malicious package to `pypi.org`.

---

The pull request where I originally implemented this feature in `actions/download-artifact` does a pretty good job at summarizing why this is important in the context of security in general: https://github.com/actions/download-artifact/pull/401

