### PR TITLE
bug: artifact path issues

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -73,6 +73,7 @@ jobs:
       with:
         artifact-ids: ${{ needs.build.outputs.artifact-id }}
         path: "dist/"
+        merge-multiple: true
 
     - name: "Upload dists to a new GitHub Release Draft"
       env:
@@ -106,6 +107,7 @@ jobs:
       with:
         artifact-ids: ${{ needs.build.outputs.artifact-id }}
         path: "dist/"
+        merge-multiple: true
 
     - name: "Publish dists to Test PyPI"
       uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4


### PR DESCRIPTION
# Summary

Fix artifact extraction path when downloading a single artifact by `artifact-ids`.  
Previously, the artifact was extracted to a subdirectory (e.g., `dist/dist`). This PR sets `merge-multiple: true` so the artifact is extracted directly to the target folder, matching the behavior when downloading by name.

## Details

- When using `artifact-ids` with a single artifact, the default behavior created a nested folder (e.g., `dist/dist`).
- Setting `merge-multiple: true` ensures the artifact contents are placed directly in the specified directory (e.g., `dist/`), keeping behavior consistent with single artifact downloads by name.

This change prevents unwanted extra directory nesting and makes the download experience the same whether using `name` or `artifact-ids` for a single artifact.

---

related: https://github.com/urllib3/urllib3/pull/3648