### PR TITLE
Upgrade download-artifact action to v5.0.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -69,11 +69,10 @@ jobs:
 
     steps:
     - name: "Download dists"
-      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+      uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
       with:
         artifact-ids: ${{ needs.build.outputs.artifact-id }}
         path: "dist/"
-        merge-multiple: true
 
     - name: "Upload dists to a new GitHub Release Draft"
       env:
@@ -103,11 +102,10 @@ jobs:
 
     steps:
     - name: "Download dists"
-      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+      uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
       with:
         artifact-ids: ${{ needs.build.outputs.artifact-id }}
         path: "dist/"
-        merge-multiple: true
 
     - name: "Publish dists to Test PyPI"
       uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4


### PR DESCRIPTION
This pull request updates the `download-artifact` Action to `v5.0.0` which removes the need for the `merge-multiple: true` workaround related to artifact path issues.

Sorry for the churn on PRs here but this should be the last PR needed to have the `publish.yml` workflow all cleaned up! Glad I opened the original PR here because it also led me to an inconsistency in some earlier code I wrote with the Actions team and it directly led to a fix! 🎉 

The issue with artifact paths we found earlier today led me to land this PR which resolves the issue -> https://github.com/actions/download-artifact/pull/416.

---

related: https://github.com/urllib3/urllib3/pull/3650, https://github.com/urllib3/urllib3/pull/3648