### PR TITLE
HTTPHeaderDict bytes key handling

### DIFF
--- a/changelog/3653.feature.rst
+++ b/changelog/3653.feature.rst
@@ -1,0 +1,1 @@
+Enabled retrieval, deletion, and membership testing in ``HTTPHeaderDict`` using bytes keys.

--- a/changelog/3653.misc.rst
+++ b/changelog/3653.misc.rst
@@ -1,1 +1,0 @@
-Fixed HTTPHeaderDict so that byte-string header names were decoded, allowing retrieval and deletion via bytes keys.

--- a/changelog/3653.misc.rst
+++ b/changelog/3653.misc.rst
@@ -1,0 +1,1 @@
+Fixed HTTPHeaderDict so that byte-string header names were decoded, allowing retrieval and deletion via bytes keys.

--- a/src/urllib3/_collections.py
+++ b/src/urllib3/_collections.py
@@ -255,6 +255,8 @@ class HTTPHeaderDict(typing.MutableMapping[str, str]):
         self._container[key.lower()] = [key, val]
 
     def __getitem__(self, key: str) -> str:
+        if isinstance(key, bytes):
+            key = key.decode("latin-1")
         val = self._container[key.lower()]
         return ", ".join(val[1:])
 
@@ -264,6 +266,8 @@ class HTTPHeaderDict(typing.MutableMapping[str, str]):
         del self._container[key.lower()]
 
     def __contains__(self, key: object) -> bool:
+        if isinstance(key, bytes):
+            key = key.decode("latin-1")
         if isinstance(key, str):
             return key.lower() in self._container
         return False

--- a/src/urllib3/_collections.py
+++ b/src/urllib3/_collections.py
@@ -259,6 +259,8 @@ class HTTPHeaderDict(typing.MutableMapping[str, str]):
         return ", ".join(val[1:])
 
     def __delitem__(self, key: str) -> None:
+        if isinstance(key, bytes):
+            key = key.decode("latin-1")
         del self._container[key.lower()]
 
     def __contains__(self, key: object) -> bool:
@@ -376,6 +378,8 @@ class HTTPHeaderDict(typing.MutableMapping[str, str]):
     ) -> list[str] | _DT:
         """Returns a list of all the values for the named field. Returns an
         empty list if the key doesn't exist."""
+        if isinstance(key, bytes):
+            key = key.decode("latin-1")
         try:
             vals = self._container[key.lower()]
         except KeyError:

--- a/test/test_collections.py
+++ b/test/test_collections.py
@@ -230,6 +230,10 @@ class TestHTTPHeaderDict:
         assert "cookie" not in d
         assert "COOKIE" not in d
 
+    def test_delitem_with_bytes_key(self, d: HTTPHeaderDict) -> None:
+        del d[b"cookie"]
+        assert "cookie" not in d
+
     def test_add_well_known_multiheader(self, d: HTTPHeaderDict) -> None:
         d.add("COOKIE", "asdf")
         assert d.getlist("cookie") == ["foo", "bar", "asdf"]
@@ -317,6 +321,9 @@ class TestHTTPHeaderDict:
         assert d.getlist("b") == []
         d.add("b", "asdf")
         assert d.getlist("b") == ["asdf"]
+
+    def test_getlist_with_bytes_key(self, d: HTTPHeaderDict) -> None:
+        assert d.getlist(b"cookie") == ["foo", "bar"]
 
     def test_getlist_after_copy(self, d: HTTPHeaderDict) -> None:
         assert d.getlist("cookie") == HTTPHeaderDict(d).getlist("cookie")

--- a/test/test_collections.py
+++ b/test/test_collections.py
@@ -231,7 +231,7 @@ class TestHTTPHeaderDict:
         assert "COOKIE" not in d
 
     def test_delitem_with_bytes_key(self, d: HTTPHeaderDict) -> None:
-        del d[b"cookie"]
+        del d[b"cookie"]  # type: ignore[arg-type]
         assert "cookie" not in d
 
     def test_add_well_known_multiheader(self, d: HTTPHeaderDict) -> None:
@@ -323,7 +323,7 @@ class TestHTTPHeaderDict:
         assert d.getlist("b") == ["asdf"]
 
     def test_getlist_with_bytes_key(self, d: HTTPHeaderDict) -> None:
-        assert d.getlist(b"cookie") == ["foo", "bar"]
+        assert d.getlist(b"cookie") == ["foo", "bar"]  # type: ignore[call-overload]
 
     def test_getlist_after_copy(self, d: HTTPHeaderDict) -> None:
         assert d.getlist("cookie") == HTTPHeaderDict(d).getlist("cookie")

--- a/test/test_collections.py
+++ b/test/test_collections.py
@@ -324,12 +324,15 @@ class TestHTTPHeaderDict:
 
     def test_getlist_with_bytes_key(self, d: HTTPHeaderDict) -> None:
         assert d.getlist(b"cookie") == ["foo", "bar"]  # type: ignore[call-overload]
-    
+
     def test_getitem_with_bytes(self, d: HTTPHeaderDict):
+        d["Content-Type"] = "application/json"
+        d.add("Content-Type", "charset=utf-8")
         result = d[b"Content-Type"]
         assert result == "application/json, charset=utf-8"
 
     def test_contains_with_bytes(self, d: HTTPHeaderDict):
+        d["Content-Type"] = "application/json"
         assert b"Content-Type" in d
         assert b"X-Not-There" not in d
 

--- a/test/test_collections.py
+++ b/test/test_collections.py
@@ -325,16 +325,16 @@ class TestHTTPHeaderDict:
     def test_getlist_with_bytes_key(self, d: HTTPHeaderDict) -> None:
         assert d.getlist(b"cookie") == ["foo", "bar"]  # type: ignore[call-overload]
 
-    def test_getitem_with_bytes(self, d: HTTPHeaderDict):
+    def test_getitem_with_bytes(self, d: HTTPHeaderDict) -> None:
         d["Content-Type"] = "application/json"
         d.add("Content-Type", "charset=utf-8")
-        result = d[b"Content-Type"]
+        result = d[b"Content-Type"]  # type: ignore[index]
         assert result == "application/json, charset=utf-8"
 
-    def test_contains_with_bytes(self, d: HTTPHeaderDict):
+    def test_contains_with_bytes(self, d: HTTPHeaderDict) -> None:
         d["Content-Type"] = "application/json"
-        assert b"Content-Type" in d
-        assert b"X-Not-There" not in d
+        assert b"Content-Type" in d  # type: ignore[comparison-overlap]
+        assert b"X-Not-There" not in d  # type: ignore[comparison-overlap]
 
     def test_getlist_after_copy(self, d: HTTPHeaderDict) -> None:
         assert d.getlist("cookie") == HTTPHeaderDict(d).getlist("cookie")

--- a/test/test_collections.py
+++ b/test/test_collections.py
@@ -324,6 +324,14 @@ class TestHTTPHeaderDict:
 
     def test_getlist_with_bytes_key(self, d: HTTPHeaderDict) -> None:
         assert d.getlist(b"cookie") == ["foo", "bar"]  # type: ignore[call-overload]
+    
+    def test_getitem_with_bytes(self, d: HTTPHeaderDict):
+        result = d[b"Content-Type"]
+        assert result == "application/json, charset=utf-8"
+
+    def test_contains_with_bytes(self, d: HTTPHeaderDict):
+        assert b"Content-Type" in d
+        assert b"X-Not-There" not in d
 
     def test_getlist_after_copy(self, d: HTTPHeaderDict) -> None:
         assert d.getlist("cookie") == HTTPHeaderDict(d).getlist("cookie")


### PR DESCRIPTION
## Summary
- handle bytes keys in HTTPHeaderDict.__delitem__ and getlist
- test bytes key handling in HTTPHeaderDict

## Testing
- `PYTHONPATH=src python -m pytest test/test_collections.py -q`