### PR TITLE
Fix redirect handling when an integer is passed to a pool manager

### DIFF
--- a/changelog/3649.bugfix.rst
+++ b/changelog/3649.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed redirect handling in ``urllib3.PoolManager`` when an integer is passed
+for the retries parameter.

--- a/src/urllib3/poolmanager.py
+++ b/src/urllib3/poolmanager.py
@@ -203,20 +203,18 @@ class PoolManager(RequestMethods):
         **connection_pool_kw: typing.Any,
     ) -> None:
         super().__init__(headers)
+        # PoolManager handles redirects itself in PoolManager.urlopen().
+        # It always passes redirect=False to the underlying connection pool to
+        # suppress per-pool redirect handling. If the user supplied a non-Retry
+        # value (int/bool/etc) for retries and we let the pool normalize it
+        # while redirect=False, the resulting Retry object would have redirect
+        # handling disabled, which can interfere with PoolManager's own
+        # redirect logic. Normalize here so redirects remain governed solely by
+        # PoolManager logic.
         if "retries" in connection_pool_kw:
             retries = connection_pool_kw["retries"]
             if not isinstance(retries, Retry):
-                # When Retry is initialized, raise_on_redirect is based
-                # on a redirect boolean value.
-                # But requests made via a pool manager always set
-                # redirect to False, and raise_on_redirect always ends
-                # up being False consequently.
-                # Here we fix the issue by setting raise_on_redirect to
-                # a value needed by the pool manager without considering
-                # the redirect boolean.
-                raise_on_redirect = retries is not False
-                retries = Retry.from_int(retries, redirect=False)
-                retries.raise_on_redirect = raise_on_redirect
+                retries = Retry.from_int(retries)
                 connection_pool_kw = connection_pool_kw.copy()
                 connection_pool_kw["retries"] = retries
         self.connection_pool_kw = connection_pool_kw

--- a/test/with_dummyserver/test_poolmanager.py
+++ b/test/with_dummyserver/test_poolmanager.py
@@ -26,8 +26,12 @@ class TestPoolManager(HypercornDummyServerTestCase):
         cls.base_url = f"http://{cls.host}:{cls.port}"
         cls.base_url_alt = f"http://{cls.host_alt}:{cls.port}"
 
-    def test_redirect(self) -> None:
-        with PoolManager() as http:
+    @pytest.mark.parametrize(
+        "pool_manager_kwargs",
+        ({}, {"retries": None}, {"retries": 1}, {"retries": Retry(1)}),
+    )
+    def test_redirect(self, pool_manager_kwargs: dict[str, typing.Any]) -> None:
+        with PoolManager(**pool_manager_kwargs) as http:
             r = http.request(
                 "GET",
                 f"{self.base_url}/redirect",
@@ -46,8 +50,12 @@ class TestPoolManager(HypercornDummyServerTestCase):
             assert r.status == 200
             assert r.data == b"Dummy server!"
 
-    def test_redirect_twice(self) -> None:
-        with PoolManager() as http:
+    @pytest.mark.parametrize(
+        "pool_manager_kwargs",
+        ({}, {"retries": None}, {"retries": 2}, {"retries": Retry(2)}),
+    )
+    def test_redirect_twice(self, pool_manager_kwargs: dict[str, typing.Any]) -> None:
+        with PoolManager(**pool_manager_kwargs) as http:
             r = http.request(
                 "GET",
                 f"{self.base_url}/redirect",


### PR DESCRIPTION
Fixes #3649

While investigating the issue I found out that `Retry` doesn't need to created with `redirect=False`.
I believe I passed it [previously](https://github.com/urllib3/urllib3/commit/f05b1329126d5be6de501f9d1e3e36738bc08857#diff-2fe80b3f580c0daa9f6a97de561c7fcd92fde02afdfaecdc210b6563817e69bb) to keep `Retry` instances more similar to what an underlying pool would create, but tests prove it's not necessary and leads to the reported bug.