### PR TITLE
Use retrying sockets logic in CI

### DIFF
--- a/dummyserver/hypercornserver.py
+++ b/dummyserver/hypercornserver.py
@@ -24,9 +24,9 @@ class Config(hypercorn.Config):
         assert len(self.bind) == 1
         secure_sockets, insecure_sockets = [], []
         if self.ssl_enabled:
-            secure_sockets = self._create_urllib3_sockets(self.bind[0])
+            secure_sockets = self._retry_create_urllib3_sockets(self.bind[0])
         else:
-            insecure_sockets = self._create_urllib3_sockets(self.bind[0])
+            insecure_sockets = self._retry_create_urllib3_sockets(self.bind[0])
         return hypercorn.config.Sockets(
             secure_sockets, insecure_sockets, quic_sockets=[]
         )


### PR DESCRIPTION
It was not used at all by mistake.

Noticed in https://github.com/urllib3/urllib3/actions/runs/16899401114/job/47875536159?pr=3657 where the setup of `TestHTTPSProxyVerification.test_https_proxy_assert_hostname[::1]` failed with `OSError: [Errno 98] Address already in use`.