### PR TITLE
Emscripten: Only load streaming worker code when it is actually needed

### DIFF
--- a/src/urllib3/contrib/emscripten/fetch.py
+++ b/src/urllib3/contrib/emscripten/fetch.py
@@ -67,12 +67,6 @@ SUCCESS_EOF = -2
 ERROR_TIMEOUT = -3
 ERROR_EXCEPTION = -4
 
-_STREAMING_WORKER_CODE = (
-    files(__package__)
-    .joinpath("emscripten_fetch_worker.js")
-    .read_text(encoding="utf-8")
-)
-
 
 class _RequestError(Exception):
     def __init__(
@@ -207,9 +201,13 @@ class _StreamingFetcher:
     def __init__(self) -> None:
         # make web-worker and data buffer on startup
         self.streaming_ready = False
-
+        streaming_worker_code = (
+            files(__package__)
+            .joinpath("emscripten_fetch_worker.js")
+            .read_text(encoding="utf-8")
+        )
         js_data_blob = js.Blob.new(
-            to_js([_STREAMING_WORKER_CODE], create_pyproxies=False),
+            to_js([streaming_worker_code], create_pyproxies=False),
             _obj_from_dict({"type": "application/javascript"}),
         )
 


### PR DESCRIPTION
We only instantiate _StreamingFetcher at most once, so we can just load this in the constructor.

