### PR TITLE
Emscripten: Fix connection pool when used without an explicit port

### DIFF
--- a/changelog/3664.bugfix.rst
+++ b/changelog/3664.bugfix.rst
@@ -1,1 +1,1 @@
-Fixed HTTPConnectionPool when used in Emscripten with no explicit port.
+Fixed ``HTTPConnectionPool`` when used in Emscripten with no explicit port.

--- a/changelog/3664.bugfix.rst
+++ b/changelog/3664.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed HTTPConnectionPool when used in Emscripten with no explicit port.

--- a/src/urllib3/contrib/emscripten/connection.py
+++ b/src/urllib3/contrib/emscripten/connection.py
@@ -98,8 +98,12 @@ class EmscriptenHTTPConnection:
     ) -> None:
         self._closed = False
         if url.startswith("/"):
+            if self.port is not None:
+                main = f"{self.host}:{self.port}"
+            else:
+                main = self.host
             # no scheme / host / port included, make a full url
-            url = f"{self.scheme}://{self.host}:{self.port}" + url
+            url = f"{self.scheme}://{main}{url}"
         request = EmscriptenRequest(
             url=url,
             method=method,

--- a/src/urllib3/contrib/emscripten/connection.py
+++ b/src/urllib3/contrib/emscripten/connection.py
@@ -99,11 +99,11 @@ class EmscriptenHTTPConnection:
         self._closed = False
         if url.startswith("/"):
             if self.port is not None:
-                main = f"{self.host}:{self.port}"
+                port = f":{self.port}"
             else:
-                main = self.host
+                port = ""
             # no scheme / host / port included, make a full url
-            url = f"{self.scheme}://{main}{url}"
+            url = f"{self.scheme}://{self.host}{port}{url}"
         request = EmscriptenRequest(
             url=url,
             method=method,

--- a/test/contrib/emscripten/test_emscripten.py
+++ b/test/contrib/emscripten/test_emscripten.py
@@ -1272,14 +1272,15 @@ def test_has_jspi_exception(
     )
 
 
-@run_in_pyodide  # type: ignore[misc]
+@run_in_pyodide
 def test_pool_no_port(selenium_coverage):
     from unittest.mock import patch
 
     from urllib3 import HTTPConnectionPool
-    from urllib3.contrib.emscripten.fetch import EmscriptenResponse
+    from urllib3.contrib.emscripten.request import EmscriptenRequest
+    from urllib3.contrib.emscripten.response import EmscriptenResponse
 
-    def send_request(request):
+    def send_request(request: EmscriptenRequest) -> EmscriptenResponse:
         assert request.url == "http://example.com/"
         return EmscriptenResponse(
             status_code=200, headers={}, body=b"", request=request

--- a/test/contrib/emscripten/test_emscripten.py
+++ b/test/contrib/emscripten/test_emscripten.py
@@ -1272,7 +1272,7 @@ def test_has_jspi_exception(
     )
 
 
-@run_in_pyodide
+@run_in_pyodide  # type: ignore[misc]
 def test_pool_no_port(selenium_coverage: typing.Any) -> None:
     from unittest.mock import patch
 

--- a/test/contrib/emscripten/test_emscripten.py
+++ b/test/contrib/emscripten/test_emscripten.py
@@ -1270,3 +1270,22 @@ def test_has_jspi_exception(
     pyodide_test(
         selenium_coverage, testserver_http.http_host, testserver_http.http_port
     )
+
+
+@run_in_pyodide  # type: ignore[misc]
+def test_pool_no_port(selenium_coverage):
+    from unittest.mock import patch
+
+    from urllib3 import HTTPConnectionPool
+    from urllib3.contrib.emscripten.fetch import EmscriptenResponse
+
+    def send_request(request):
+        assert request.url == "http://example.com/"
+        return EmscriptenResponse(
+            status_code=200, headers={}, body=b"", request=request
+        )
+
+    with patch("urllib3.contrib.emscripten.connection.send_request", new=send_request):
+        pool = HTTPConnectionPool("example.com", maxsize=10, block=True)
+
+        pool.request("GET", "/")

--- a/test/contrib/emscripten/test_emscripten.py
+++ b/test/contrib/emscripten/test_emscripten.py
@@ -1273,7 +1273,7 @@ def test_has_jspi_exception(
 
 
 @run_in_pyodide
-def test_pool_no_port(selenium_coverage):
+def test_pool_no_port(selenium_coverage: typing.Any) -> None:
     from unittest.mock import patch
 
     from urllib3 import HTTPConnectionPool


### PR DESCRIPTION
Without this change it inserts `None` as the port. In that case, the following code:
```py
import urllib3
pool = urllib3.HTTPConnectionPool("example.com", maxsize=10, block=True)

print(pool.request("GET", "/"))
```
fails with:
```
TypeError: Failed to parse URL from http://example.com:None/
```
In our tests we always use a test server on localhost with an explicit port.