### PR TITLE
Changed static annotations of url parameter in __init__ method of RequestError and MaxRetryError class

### DIFF
--- a/src/urllib3/exceptions.py
+++ b/src/urllib3/exceptions.py
@@ -42,7 +42,7 @@ class PoolError(HTTPError):
 class RequestError(PoolError):
     """Base exception for PoolErrors that have associated URLs."""
 
-    def __init__(self, pool: ConnectionPool, url: str, message: str) -> None:
+    def __init__(self, pool: ConnectionPool, url: str | None, message: str) -> None:
         self.url = url
         super().__init__(pool, message)
 
@@ -93,7 +93,7 @@ class MaxRetryError(RequestError):
     """
 
     def __init__(
-        self, pool: ConnectionPool, url: str, reason: Exception | None = None
+        self, pool: ConnectionPool, url: str | None, reason: Exception | None = None
     ) -> None:
         self.reason = reason
 


### PR DESCRIPTION
The static annotation for the url parameter is changed from `str` to `str| None` of the __init__ methods of the RequestError and the MaxRetryError classes since in one of the test cases a `None` value is being passed to this particular parameter. The links of the sequence of argument data passing is mentioned as follows :

https://github.com/urllib3/urllib3/blob/62c9d1b0a4394216b93153b37f4451be3e94bd61/test/test_retry.py#L24
https://github.com/urllib3/urllib3/blob/62c9d1b0a4394216b93153b37f4451be3e94bd61/test/test_retry.py#L30
https://github.com/urllib3/urllib3/blob/62c9d1b0a4394216b93153b37f4451be3e94bd61/src/urllib3/util/retry.py#L431
https://github.com/urllib3/urllib3/blob/62c9d1b0a4394216b93153b37f4451be3e94bd61/src/urllib3/util/retry.py#L519
https://github.com/urllib3/urllib3/blob/62c9d1b0a4394216b93153b37f4451be3e94bd61/src/urllib3/exceptions.py#L95
https://github.com/urllib3/urllib3/blob/62c9d1b0a4394216b93153b37f4451be3e94bd61/src/urllib3/exceptions.py#L45