### PR TITLE
Enable CodeQL for GitHub Actions workflows

### DIFF
--- a/.github/codeql.yml
+++ b/.github/codeql.yml
@@ -1,3 +1,3 @@
 paths:
 - "src/"
-
+- ".github/workflows/"


### PR DESCRIPTION
CodeQL was enabled just for our `src/` directory missing GitHub Actions workflows.