### PR TITLE
Specify JS and GitHub Actions in the CodeQL workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -31,7 +31,7 @@ jobs:
       uses: github/codeql-action/init@f1f6e5f6af878fb37288ce1c627459e94dbf7d01 # v3.30.1
       with:
         config-file: "./.github/codeql.yml"
-        languages: "python"
+        languages: "python,javascript-typescript,actions"
 
     - name: "Run CodeQL autobuild"
       uses: github/codeql-action/autobuild@f1f6e5f6af878fb37288ce1c627459e94dbf7d01 # v3.30.1


### PR DESCRIPTION
A follow-up to #3672.

It looks like CodeQL still scanned only Python and JS files, so I'm trying this change
https://github.com/urllib3/urllib3/actions/runs/17591775500/job/49974059426
<img width="1545" height="808" src="https://github.com/user-attachments/assets/5a5da8bc-82a2-4589-805c-4a8e6f802769" />
