### PR TITLE
Pin `actions/cache` by SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,7 +139,7 @@ jobs:
         with:
           node-version: 22
       - name: Cache pyodide downloads in nox cache
-        uses: actions/cache@v4
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         if: ${{ startsWith(matrix.nox-session, 'emscripten') }}
         with:
           path: .nox/.cache


### PR DESCRIPTION
This was the only actions not pinned by a SHA.