### PR TITLE
Fix three zizmor warnings and add a pre-commit hook

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -25,7 +25,7 @@ jobs:
       - name: "Check changelog"
         if: "!contains(github.event.pull_request.labels.*.name, 'Skip Changelog')"
         run: |
-          if ! pipx run towncrier check --compare-with origin/${{ github.base_ref }}; then
+          if ! pipx run towncrier check --compare-with origin/$GITHUB_BASE_REF; then
           echo "Please see https://github.com/urllib3/urllib3/blob/main/changelog/README.rst for guidance."
             false
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,11 +123,13 @@ jobs:
           install-chromedriver: true
           chrome-version: canary
       - name: Force override system chrome
+        env:
+          CHROME_PATH: ${{ steps.setup-chrome.outputs.chrome-path }}
         run: |
           sudo rm -f /usr/bin/google-chrome
           sudo rm -f /usr/bin/chrome
-          sudo ln -s ${{ steps.setup-chrome.outputs.chrome-path }} /usr/bin/google-chrome
-          sudo ln -s ${{ steps.setup-chrome.outputs.chrome-path }} /usr/bin/chrome
+          sudo ln -s $CHROME_PATH /usr/bin/google-chrome
+          sudo ln -s $CHROME_PATH /usr/bin/chrome
           google-chrome --version
         if: ${{ matrix.nox-session == 'emscripten(chrome)' }}
       - name: "Install Firefox"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,6 +27,11 @@ repos:
     hooks:
       - id: uv-lock
 
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: v1.13.0
+    hooks:
+      - id: zizmor
+
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: "v3.1.0"
     hooks:


### PR DESCRIPTION
The warnings fixed by using env variables:
```
error[template-injection]: code injection via template expansion
  --> .github/workflows/changelog.yml:28:67
   |
27 |         run: |
   |         --- this run block
28 |           if ! pipx run towncrier check --compare-with origin/${{ github.base_ref }}; then
   |                                                                   ^^^^^^^^^^^^^^^ may expand into attacker-controllable code
   |
   = note: audit confidence → High
   = note: this finding has an auto-fix

info[template-injection]: code injection via template expansion
   --> .github/workflows/ci.yml:129:26
    |
126 |         run: |
    |         --- this run block
...
129 |           sudo ln -s ${{ steps.setup-chrome.outputs.chrome-path }} /usr/bin/google-chrome
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ may expand into attacker-controllable code
    |
    = note: audit confidence → Low
    = note: this finding has an auto-fix

info[template-injection]: code injection via template expansion
   --> .github/workflows/ci.yml:130:26
    |
126 |         run: |
    |         --- this run block
...
130 |           sudo ln -s ${{ steps.setup-chrome.outputs.chrome-path }} /usr/bin/chrome
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ may expand into attacker-controllable code
    |
    = note: audit confidence → Low
    = note: this finding has an auto-fix

16 findings (13 suppressed, 3 fixable): 0 unknown, 2 informational, 0 low, 0 medium, 1 high
```