### PR TITLE
Use `nox -s lint` instead of `pre-commit/action` in CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,15 +20,11 @@ jobs:
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
         with:
           python-version: "3.x"
-          cache: pip
-
-      - name: "Run pre-commit"
-        uses: pre-commit/action@646c83fcd040023954eafda54b4db0192ce70507 # v3.0.0
 
       - name: "Install uv"
         uses: astral-sh/setup-uv@05273c154d09957eb9a2377d9c988fbda431d1c5 # v6.4.0
         with:
           version: "0.7.12"
 
-      - name: "Run mypy"
-        run: uvx nox -s mypy
+      - name: "Lint code"
+        run: uvx nox -s lint

--- a/noxfile.py
+++ b/noxfile.py
@@ -186,7 +186,7 @@ def format(session: nox.Session) -> None:
     lint(session)
 
 
-@nox.session(python="3.12")
+@nox.session()
 def lint(session: nox.Session) -> None:
     session.install("pre-commit")
     session.run("pre-commit", "run", "--all-files")


### PR DESCRIPTION
 `pre-commit/action` does not pin `actions/cache` to a SHA and won't do this, see #230.
This prevents us from enabling the following setting for the repository:
<img width="431" height="36" alt="image" src="https://github.com/user-attachments/assets/f41595b3-fa34-49c7-8be4-a7b491b07450" />

Anyway, we can drop the action and use the functionality we already have set up using nox. This not only resolves the issue mentioned above, but also simplifies the set up and we'll have less dependabot PRs.
