### PR TITLE
pyproject.toml: change setuptools-scm upper limit

### DIFF
--- a/changelog/3652.misc.rst
+++ b/changelog/3652.misc.rst
@@ -1,0 +1,1 @@
+Allowed building the urllib3 package with newer setuptools-scm v9.x.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 # This file is protected via CODEOWNERS
 
 [build-system]
-requires = ["hatchling>=1.27.0,<2", "hatch-vcs>=0.4.0,<0.6.0", "setuptools-scm>=8,<9"]
+requires = ["hatchling>=1.27.0,<2", "hatch-vcs>=0.4.0,<0.6.0", "setuptools-scm>=8,<10"]
 build-backend = "hatchling.build"
 
 [project]


### PR DESCRIPTION
Fixes: #3652

setuptools-scm version 9.2.0 is now available, so CHANGE the upper limit specified in dependencies.