### PR TITLE
Update SECURITY.md

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -5,7 +5,8 @@
 To report a security vulnerability, please use the [Tidelift security contact](https://tidelift.com/security).
 Tidelift will coordinate the fix and disclosure with maintainers.
 
-> [!WARNING] Please do **not** file a public GitHub issue for security reports.
+> [!WARNING]
+> Please do **not** file a public GitHub issue for security reports.
 
 When reporting, if possible, include:
 - A clear description of the issue and potential impact


### PR DESCRIPTION
Updated SECURITY.md keeps Tidelift as our security contact, but also:
- asks reporters not to open public issues
- mentions what urllib3 versions are maintained
- describes our process briefly
- mentions that advisories are published through GitHub and the way people can stay notified
