### PR TITLE
Remove pieces which may lead to assuming that 1.26.x is maintained

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/release.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release.md
@@ -3,7 +3,7 @@
 * [ ]  Get the release pull request approved by a [CODEOWNER](https://github.com/urllib3/urllib3/blob/main/.github/CODEOWNERS)
 * [ ]  Squash merge the release pull request with message "`Release <VERSION>`"
 * [ ]  Tag with X.Y.Z, push tag on urllib3/urllib3 (not on your fork, update `<REMOTE>` accordingly)
-  * Notice that the `<VERSION>` shouldn't have a `v` prefix (Use `1.26.6` instead of `v.1.26.6`)
+  * Notice that the `<VERSION>` shouldn't have a `v` prefix (Use `2.0.0` instead of `v2.0.0`)
   * ```
     # Ensure the release commit is the latest in the main branch.
     export VERSION=<X.Y.Z>
@@ -22,4 +22,3 @@
   * [ ]  Discord
   * [ ]  Open Collective
 * [ ]  Check [Tidelift security maintenance plan](https://tidelift.com/lifter/package/pypi/urllib3/tasks/packages_have_maintenance_plans>) is still correct
-* [ ]  If this was a 1.26.x release, add changelog to the `main` branch

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,9 +3,6 @@ name: Publish to PyPI
 on:
   push:
     branches:
-      # We don't publish to Test PyPI on pushes to 1.26.x yet because there is
-      # no mechanism to get a dynamic version number in the branch yet.
-      # - "1.26.x"
       - "main"
     tags:
       - "*"

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -4,7 +4,7 @@ on:
   schedule:
     - cron: "0 0 * * 0"
   push:
-    branches: ["main", "1.26.x"]
+    branches: ["main"]
 
 permissions:
   contents: "read"

--- a/docs/v2-migration-guide.rst
+++ b/docs/v2-migration-guide.rst
@@ -52,8 +52,8 @@ urllib3 1.26.x for Python 3.9 and earlier. If your organization would benefit fr
 continued support of urllib3 1.26.x, please contact sethmichaellarson@gmail.com to
 discuss sponsorship or contribution opportunities.
 
-However, upgrading is still recommended as **no new feature developments or non-critical
-bug fixes will be shipped to the 1.26.x release stream**.
+However, upgrading is still recommended as **no new feature developments or
+fixes will be shipped to the 1.26.x release stream**.
 
 **🤔 Common upgrading issues**
 ------------------------------


### PR DESCRIPTION
This drops a few mentions of 1.26.x which may make somebody assume that 1.26.x is still maintained.

Relates to #3410