### PR TITLE
Remove unneeded coverage pragma in  HTTP2Connection.send

### DIFF
--- a/src/urllib3/http2/connection.py
+++ b/src/urllib3/http2/connection.py
@@ -185,7 +185,7 @@ class HTTP2Connection(HTTPSConnection):
                     if not chunk:
                         break
                     if isinstance(chunk, str):
-                        chunk = chunk.encode()  # pragma: no cover
+                        chunk = chunk.encode()
                     conn.send_data(self._h2_stream, chunk, end_stream=False)
                     if data_to_send := conn.data_to_send():
                         self.sock.sendall(data_to_send)


### PR DESCRIPTION
<!---
Thanks for your contribution! ♥️

If this is your first PR to urllib3 please review the Contributing Guide:
https://urllib3.readthedocs.io/en/latest/contributing.html

Adhering to the Contributing Guide means we can review, merge, and release your change faster! :)
--->

I ran this following issue. https://github.com/urllib3/urllib3/issues/3661

It shows single unneeded coverage pragma.

```
nox > Ran multiple sessions:
nox > * test-3.9: failed
nox > * test-3.10: success
nox > * test-3.11: success
nox > * test-3.12: success
nox > * test-3.13: success
nox > * test-3.14: failed
nox > * test-pypy3.10: success
nox > * test-pypy3.11: success
yevgeny@brownie:~/projects/contributing/urllib3/urllib3$ for cov in .coverage.brownie.* ;do  python3.12 warn_executed.py $cov warn.toml ;done
/home/yevgeny/projects/contributing/urllib3/urllib3/src/urllib3/http2/connection.py:188:                         chunk = chunk.encode()  # pragma: no cover
/home/yevgeny/projects/contributing/urllib3/urllib3/src/urllib3/http2/connection.py:188:                         chunk = chunk.encode()  # pragma: no cover
/home/yevgeny/projects/contributing/urllib3/urllib3/src/urllib3/http2/connection.py:188:                         chunk = chunk.encode()  # pragma: no cover
/home/yevgeny/projects/contributing/urllib3/urllib3/src/urllib3/http2/connection.py:188:                         chunk = chunk.encode()  # pragma: no cover
/home/yevgeny/projects/contributing/urllib3/urllib3/src/urllib3/http2/connection.py:188:                         chunk = chunk.encode()  # pragma: no cover
/home/yevgeny/projects/contributing/urllib3/urllib3/src/urllib3/http2/connection.py:188:                         chunk = chunk.encode()  # pragma: no cover

```
I ran the test on the latest version of code, and it failed in 3.9 and 3.14. I wonder if there's a problem with my development environment.

I used following warn.toml

```
# Regexes that identify excluded lines:
warn-executed = [
    "pragma: no cover",
    "raise AssertionError",
    "pragma: cant happen",
    "pragma: never called",
    ]

# Regexes that identify partial branch lines:
warn-not-partial = [
    "pragma: no branch",
    ]
```