### PR TITLE
Updated docs to reflect change in optional zstd dependency from `zstandard` to `backports.zstd`

### DIFF
--- a/changelog/3721.doc.rst
+++ b/changelog/3721.doc.rst
@@ -1,1 +1,0 @@
-Updated docs to reflect change in optional zstd dependency from ``zstandard`` to ``backports.zstd``.


### PR DESCRIPTION
<!---
Thanks for your contribution! ♥️

If this is your first PR to urllib3 please review the Contributing Guide:
https://urllib3.readthedocs.io/en/latest/contributing.html

Adhering to the Contributing Guide means we can review, merge, and release your change faster! :)
--->

This was done in https://github.com/urllib3/urllib3/commit/93e6ae22ab1b708ca859cfe7f6f219e8de20e015, but the "Advanced Usage" doc was not updated.
