### PR TITLE
Restore `getheaders()` and `getheader()`

### DIFF
--- a/changelog/3731.feature.rst
+++ b/changelog/3731.feature.rst
@@ -1,0 +1,2 @@
+Restore previously removed ``HTTPResponse.getheaders()`` and
+``HTTPResponse.getheader()`` methods.

--- a/docs/v2-migration-guide.rst
+++ b/docs/v2-migration-guide.rst
@@ -30,8 +30,6 @@ Here's a short summary of which changes in urllib3 2.x are most important:
 - Removed the ``urllib3.contrib.ntlmpool`` module.
 - Removed the ``urllib3.contrib.securetransport`` module.
 - Removed the ``urllib3[secure]`` extra.
-- Removed the ``HTTPResponse.getheaders()`` method in favor of ``HTTPResponse.headers``.
-- Removed the ``HTTPResponse.getheader(name, default)`` method in favor of ``HTTPResponse.headers.get(name, default)``.
 - Deprecated URLs without a scheme (ie 'https://') and will be raising an error in a future version of urllib3.
 - Changed the default minimum TLS version to TLS 1.2 (previously was TLS 1.0).
 - Changed the default request body encoding from 'ISO-8859-1' to 'UTF-8'.

--- a/src/urllib3/response.py
+++ b/src/urllib3/response.py
@@ -671,6 +671,13 @@ class BaseHTTPResponse(io.IOBase):
             b[: len(temp)] = temp
             return len(temp)
 
+    # Methods used by dependent libraries
+    def getheaders(self) -> HTTPHeaderDict:
+        return self.headers
+
+    def getheader(self, name: str, default: str | None = None) -> str | None:
+        return self.headers.get(name, default)
+
     # Compatibility method for http.cookiejar
     def info(self) -> HTTPHeaderDict:
         return self.headers

--- a/test/test_response.py
+++ b/test/test_response.py
@@ -1698,11 +1698,16 @@ class TestResponse:
             continue
         resp.release_conn.assert_called_once_with()  # type: ignore[attr-defined]
 
+    def test_getheaders(self) -> None:
+        headers = {"host": "example.com"}
+        r = HTTPResponse(headers=headers)
+        assert r.getheaders() is r.headers
+
     def test_get_case_insensitive_headers(self) -> None:
         headers = {"host": "example.com"}
         r = HTTPResponse(headers=headers)
-        assert r.headers.get("host") == "example.com"
-        assert r.headers.get("Host") == "example.com"
+        assert r.headers.get("host") == r.getheader("host") == "example.com"
+        assert r.headers.get("Host") == r.getheader("Host") == "example.com"
 
     def test_retries(self) -> None:
         fp = BytesIO(b"")


### PR DESCRIPTION
Closes #3731