### PR TITLE
Fix brotli decompressing handling in HTTPResponse.read_chunked

### DIFF
--- a/src/urllib3/response.py
+++ b/src/urllib3/response.py
@@ -1407,10 +1407,13 @@ class HTTPResponse(BaseHTTPResponse):
                 amt = None
 
             while True:
-                self._update_chunk_length()
-                if self.chunk_left == 0:
-                    break
-                chunk = self._handle_chunk(amt)
+                if self._decoder and self._decoder.has_unconsumed_tail:
+                    chunk = b""
+                else:
+                    self._update_chunk_length()
+                    if self.chunk_left == 0:
+                        break
+                    chunk = self._handle_chunk(amt)
                 decoded = self._decode(
                     chunk,
                     decode_content=decode_content,


### PR DESCRIPTION
Check if brotli decoder is able to accept more data before feeding into it. If not, feed it with empty bytes to consume its internal buffer.

Fixes #3734 
