### PR TITLE
Release 2.6.2

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,11 @@
+2.6.2 (2025-12-11)
+==================
+
+- Fixed ``HTTPResponse.read_chunked()`` to properly handle leftover data in
+  the decoder's buffer when reading compressed chunked responses.
+  (`#3734 <https://github.com/urllib3/urllib3/issues/3734>`__)
+
+
 2.6.1 (2025-12-08)
 ==================
 

--- a/changelog/3734.bugfix.rst
+++ b/changelog/3734.bugfix.rst
@@ -1,2 +1,0 @@
-Fixed ``HTTPResponse.read_chunked()`` to properly handle leftover data in
-the decoder's buffer when reading compressed chunked responses.


### PR DESCRIPTION
A small release fixing a 2.6.0 regression related to reading larger chunked compressed responses.

* [x]  Draft a social media announcement
* [x]  See if all tests, including downstream, pass
* [ ]  Get the release pull request approved by a [CODEOWNER](https://github.com/urllib3/urllib3/blob/main/.github/CODEOWNERS)
* [x]  Squash merge the release pull request with message "`Release <VERSION>`"
* [x]  Tag with X.Y.Z, push tag on urllib3/urllib3 (not on your fork, update `<REMOTE>` accordingly)
  * Notice that the `<VERSION>` shouldn't have a `v` prefix (Use `2.0.0` instead of `v2.0.0`)
  * ```
    # Ensure the release commit is the latest in the main branch.
    export VERSION=<X.Y.Z>
    export REMOTE=origin
    git checkout main
    git pull $REMOTE main
    git tag -s -a "$VERSION" -m "Release: $VERSION"
    git push $REMOTE --tags
    ```
* [x]  The tag will trigger the `publish` GitHub workflow. This requires a review from a maintainer.
* [x]  Ensure that all expected artifacts are added to the new GitHub release draft. Should
       be one `.whl` and one `.tar.gz`. Publish the GitHub
       release with the content of the release's changelog and any ongoing announcements.
* [ ]  Announce on:
  * [ ]  Social media
  * [x]  Discord
  * [ ]  Open Collective
* [x]  Check [Tidelift security maintenance plan](https://tidelift.com/lifter/package/pypi/urllib3/tasks/packages_have_maintenance_plans>) is still correct