### PR TITLE
Tests: clarify pooling behavior in test_many_urls

### DIFF
--- a/test/test_poolmanager.py
+++ b/test/test_poolmanager.py
@@ -66,6 +66,7 @@ class TestPoolManager:
             conn = p.connection_from_url(url)
             connections.add(conn)
 
+        #Connections are pooled by scheme, host, and port, not by full URL
         assert len(connections) == 5
 
     def test_manager_clear(self) -> None:


### PR DESCRIPTION
Adds a brief comment explaining why multiple URLs result in five pooled connections. No functional changes.