### PR TITLE
Backport 8864ac407 for CVE-2026-21441

### DIFF
--- a/src/urllib3/response.py
+++ b/src/urllib3/response.py
@@ -292,7 +292,11 @@ class HTTPResponse(io.IOBase):
         Unread data in the HTTPResponse connection blocks the connection from being released back to the pool.
         """
         try:
-            self.read()
+            self.read(
+                # Do not spend resources decoding the content unless
+                # decoding has already been initiated.
+                decode_content=self._has_decoded_content,
+            )
         except (HTTPError, SocketError, BaseSSLError, HTTPException):
             pass
 


### PR DESCRIPTION
We currently aren't running 2.x in production and therefore rely on the 1.26.x branch.

This backports the fix for CVE-2026-21441 since I believe it's still present in the 1.x branch.