### PR TITLE
docs: fix broken link in HTTPResponse.tell docstring

### DIFF
--- a/src/urllib3/response.py
+++ b/src/urllib3/response.py
@@ -826,7 +826,7 @@ class HTTPResponse(BaseHTTPResponse):
     def tell(self) -> int:
         """
         Obtain the number of bytes pulled over the wire so far. May differ from
-        the amount of content returned by :meth:``urllib3.response.HTTPResponse.read``
+        the amount of content returned by :meth:`HTTPResponse.read`
         if bytes are encoded on the wire (e.g, compressed).
         """
         return self._fp_bytes_read


### PR DESCRIPTION
<!---
Thanks for your contribution! ♥️

If this is your first PR to urllib3 please review the Contributing Guide:
https://urllib3.readthedocs.io/en/latest/contributing.html

Adhering to the Contributing Guide means we can review, merge, and release your change faster! :)
--->

https://urllib3.readthedocs.io/en/latest/reference/urllib3.response.html#urllib3.response.HTTPResponse.tell

The link to the `read()` method was using incorrect syntax. This PR fixes the formatting so the documentation renders correctly.

Before:

<img width="828" height="208" alt="before" src="https://github.com/user-attachments/assets/d72e466d-4acb-4816-a5bb-c34a21857665" />


After (local preview with `nox -rs docs`):

<img width="854" height="189" alt="after" src="https://github.com/user-attachments/assets/d343052e-880c-4b36-bb6d-696d09f09de9" />
