### PR TITLE
Add possibility for overriding network address resolution

### DIFF
--- a/changelog/3675.feature.rst
+++ b/changelog/3675.feature.rst
@@ -1,0 +1,7 @@
+Added possibility for overriding network address resolution.
+
+This allows to override CPython's default `getaddrinfo()`_ function
+which can be used to customize the resolution of domain names, hostnames,
+and IP addresses.
+
+.. _getaddrinfo(): https://docs.python.org/3/library/socket.html#socket.getaddrinfo

--- a/docs/reference/urllib3.util.rst
+++ b/docs/reference/urllib3.util.rst
@@ -15,3 +15,5 @@ but can also be used independently.
 .. automodule:: urllib3.util
     :members:
     :show-inheritance:
+
+.. autoclass:: urllib3.util.resolver.Resolver

--- a/src/urllib3/_base_connection.py
+++ b/src/urllib3/_base_connection.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import typing
 
-from .util.connection import _TYPE_SOCKET_OPTIONS, Resolver
+from .util.connection import _TYPE_SOCKET_OPTIONS
+from .util.resolver import Resolver
 from .util.timeout import _DEFAULT_TIMEOUT, _TYPE_TIMEOUT
 from .util.url import Url
 

--- a/src/urllib3/_base_connection.py
+++ b/src/urllib3/_base_connection.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import typing
 
-from .util.connection import _TYPE_SOCKET_OPTIONS
+from .util.connection import _TYPE_SOCKET_OPTIONS, Resolver
 from .util.timeout import _DEFAULT_TIMEOUT, _TYPE_TIMEOUT
 from .util.url import Url
 
@@ -51,6 +51,8 @@ if typing.TYPE_CHECKING:
         is_verified: bool
         proxy_is_verified: bool | None
 
+        resolver: Resolver | None = None
+
         def __init__(
             self,
             host: str,
@@ -62,6 +64,7 @@ if typing.TYPE_CHECKING:
             socket_options: _TYPE_SOCKET_OPTIONS | None = ...,
             proxy: Url | None = None,
             proxy_config: ProxyConfig | None = None,
+            resolver: Resolver | None = None,
         ) -> None: ...
 
         def set_tunnel(
@@ -162,4 +165,5 @@ if typing.TYPE_CHECKING:
             cert_file: str | None = None,
             key_file: str | None = None,
             key_password: str | None = None,
+            resolver: Resolver | None = None,
         ) -> None: ...

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -22,7 +22,7 @@ if typing.TYPE_CHECKING:
 
 from ._collections import HTTPHeaderDict
 from .http2 import probe as http2_probe
-from .util.connection import Resolver
+from .util.resolver import Resolver
 from .util.response import assert_header_parsing
 from .util.timeout import _DEFAULT_TIMEOUT, _TYPE_TIMEOUT, Timeout
 from .util.util import to_str

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -22,6 +22,7 @@ if typing.TYPE_CHECKING:
 
 from ._collections import HTTPHeaderDict
 from .http2 import probe as http2_probe
+from .util.connection import Resolver
 from .util.response import assert_header_parsing
 from .util.timeout import _DEFAULT_TIMEOUT, _TYPE_TIMEOUT, Timeout
 from .util.util import to_str
@@ -142,6 +143,7 @@ class HTTPConnection(_HTTPConnection):
         ) = default_socket_options,
         proxy: Url | None = None,
         proxy_config: ProxyConfig | None = None,
+        resolver: Resolver | None = None,
     ) -> None:
         super().__init__(
             host=host,
@@ -153,6 +155,7 @@ class HTTPConnection(_HTTPConnection):
         self.socket_options = socket_options
         self.proxy = proxy
         self.proxy_config = proxy_config
+        self.resolver = resolver
 
         self._has_connected_to_proxy = False
         self._response_options = None
@@ -206,6 +209,7 @@ class HTTPConnection(_HTTPConnection):
                 self.timeout,
                 source_address=self.source_address,
                 socket_options=self.socket_options,
+                resolver=self.resolver,
             )
         except socket.gaierror as e:
             raise NameResolutionError(self.host, self, e) from e
@@ -645,6 +649,7 @@ class HTTPSConnection(HTTPConnection):
         cert_file: str | None = None,
         key_file: str | None = None,
         key_password: str | None = None,
+        resolver: Resolver | None = None,
     ) -> None:
         super().__init__(
             host,
@@ -655,6 +660,7 @@ class HTTPSConnection(HTTPConnection):
             socket_options=socket_options,
             proxy=proxy,
             proxy_config=proxy_config,
+            resolver=resolver,
         )
 
         self.key_file = key_file

--- a/src/urllib3/contrib/emscripten/connection.py
+++ b/src/urllib3/contrib/emscripten/connection.py
@@ -11,7 +11,8 @@ from ..._base_connection import _TYPE_BODY
 from ...connection import HTTPConnection, ProxyConfig, port_by_scheme
 from ...exceptions import TimeoutError
 from ...response import BaseHTTPResponse
-from ...util.connection import _TYPE_SOCKET_OPTIONS, Resolver
+from ...util.connection import _TYPE_SOCKET_OPTIONS
+from ...util.resolver import Resolver
 from ...util.timeout import _DEFAULT_TIMEOUT, _TYPE_TIMEOUT
 from ...util.url import Url
 from .fetch import _RequestError, _TimeoutError, send_request, send_streaming_request

--- a/src/urllib3/contrib/emscripten/connection.py
+++ b/src/urllib3/contrib/emscripten/connection.py
@@ -11,7 +11,7 @@ from ..._base_connection import _TYPE_BODY
 from ...connection import HTTPConnection, ProxyConfig, port_by_scheme
 from ...exceptions import TimeoutError
 from ...response import BaseHTTPResponse
-from ...util.connection import _TYPE_SOCKET_OPTIONS
+from ...util.connection import _TYPE_SOCKET_OPTIONS, Resolver
 from ...util.timeout import _DEFAULT_TIMEOUT, _TYPE_TIMEOUT
 from ...util.url import Url
 from .fetch import _RequestError, _TimeoutError, send_request, send_streaming_request
@@ -40,6 +40,8 @@ class EmscriptenHTTPConnection:
     is_verified: bool = False
     proxy_is_verified: bool | None = None
 
+    resolver: Resolver | None = None
+
     response_class: type[BaseHTTPResponse] = EmscriptenHttpResponseWrapper
     _response: EmscriptenResponse | None
 
@@ -54,6 +56,7 @@ class EmscriptenHTTPConnection:
         socket_options: _TYPE_SOCKET_OPTIONS | None = None,
         proxy: Url | None = None,
         proxy_config: ProxyConfig | None = None,
+        resolver: Resolver | None = None,
     ) -> None:
         self.host = host
         self.port = port
@@ -69,6 +72,7 @@ class EmscriptenHTTPConnection:
         self.source_address = None
         self.socket_options = None
         self.is_verified = False
+        self.resolver = resolver
 
     def set_tunnel(
         self,
@@ -206,6 +210,7 @@ class EmscriptenHTTPSConnection(EmscriptenHTTPConnection):
         cert_file: str | None = None,
         key_file: str | None = None,
         key_password: str | None = None,
+        resolver: Resolver | None = None,
     ) -> None:
         super().__init__(
             host,
@@ -216,6 +221,7 @@ class EmscriptenHTTPSConnection(EmscriptenHTTPConnection):
             socket_options=socket_options,
             proxy=proxy,
             proxy_config=proxy_config,
+            resolver=resolver,
         )
         self.scheme = "https"
 

--- a/src/urllib3/poolmanager.py
+++ b/src/urllib3/poolmanager.py
@@ -18,7 +18,7 @@ from .exceptions import (
     URLSchemeUnknown,
 )
 from .response import BaseHTTPResponse
-from .util.connection import _TYPE_SOCKET_OPTIONS
+from .util.connection import _TYPE_SOCKET_OPTIONS, Resolver
 from .util.proxy import connection_requires_http_tunnel
 from .util.retry import Retry
 from .util.timeout import Timeout
@@ -90,6 +90,7 @@ class PoolKey(typing.NamedTuple):
     key_assert_fingerprint: str | None
     key_server_hostname: str | None
     key_blocksize: int | None
+    key_resolver: Resolver | None
 
 
 def _default_key_normalizer(

--- a/src/urllib3/poolmanager.py
+++ b/src/urllib3/poolmanager.py
@@ -18,8 +18,9 @@ from .exceptions import (
     URLSchemeUnknown,
 )
 from .response import BaseHTTPResponse
-from .util.connection import _TYPE_SOCKET_OPTIONS, Resolver
+from .util.connection import _TYPE_SOCKET_OPTIONS
 from .util.proxy import connection_requires_http_tunnel
+from .util.resolver import Resolver
 from .util.retry import Retry
 from .util.timeout import Timeout
 from .util.url import Url, parse_url

--- a/src/urllib3/poolmanager.py
+++ b/src/urllib3/poolmanager.py
@@ -91,7 +91,6 @@ class PoolKey(typing.NamedTuple):
     key_assert_fingerprint: str | None
     key_server_hostname: str | None
     key_blocksize: int | None
-    key_resolver: Resolver | None
 
 
 def _default_key_normalizer(
@@ -202,9 +201,12 @@ class PoolManager(RequestMethods):
         self,
         num_pools: int = 10,
         headers: typing.Mapping[str, str] | None = None,
+        resolver: Resolver | None = None,
         **connection_pool_kw: typing.Any,
     ) -> None:
         super().__init__(headers)
+        self.resolver = resolver
+
         # PoolManager handles redirects itself in PoolManager.urlopen().
         # It always passes redirect=False to the underlying connection pool to
         # suppress per-pool redirect handling. If the user supplied a non-Retry
@@ -278,7 +280,7 @@ class PoolManager(RequestMethods):
             for kw in SSL_KEYWORDS:
                 request_context.pop(kw, None)
 
-        return pool_cls(host, port, **request_context)
+        return pool_cls(host, port, resolver=self.resolver, **request_context)
 
     def clear(self) -> None:
         """

--- a/src/urllib3/poolmanager.py
+++ b/src/urllib3/poolmanager.py
@@ -91,6 +91,7 @@ class PoolKey(typing.NamedTuple):
     key_assert_fingerprint: str | None
     key_server_hostname: str | None
     key_blocksize: int | None
+    key_resolver: Resolver | None
 
 
 def _default_key_normalizer(
@@ -201,12 +202,9 @@ class PoolManager(RequestMethods):
         self,
         num_pools: int = 10,
         headers: typing.Mapping[str, str] | None = None,
-        resolver: Resolver | None = None,
         **connection_pool_kw: typing.Any,
     ) -> None:
         super().__init__(headers)
-        self.resolver = resolver
-
         # PoolManager handles redirects itself in PoolManager.urlopen().
         # It always passes redirect=False to the underlying connection pool to
         # suppress per-pool redirect handling. If the user supplied a non-Retry
@@ -280,7 +278,7 @@ class PoolManager(RequestMethods):
             for kw in SSL_KEYWORDS:
                 request_context.pop(kw, None)
 
-        return pool_cls(host, port, resolver=self.resolver, **request_context)
+        return pool_cls(host, port, **request_context)
 
     def clear(self) -> None:
         """

--- a/src/urllib3/util/__init__.py
+++ b/src/urllib3/util/__init__.py
@@ -1,8 +1,9 @@
 # For backwards compatibility, provide imports that used to be here.
 from __future__ import annotations
 
-from .connection import Resolver, is_connection_dropped
+from .connection import is_connection_dropped
 from .request import SKIP_HEADER, SKIPPABLE_HEADERS, make_headers
+from .resolver import Resolver
 from .response import is_fp_closed
 from .retry import Retry
 from .ssl_ import (

--- a/src/urllib3/util/__init__.py
+++ b/src/urllib3/util/__init__.py
@@ -1,7 +1,7 @@
 # For backwards compatibility, provide imports that used to be here.
 from __future__ import annotations
 
-from .connection import is_connection_dropped
+from .connection import Resolver, is_connection_dropped
 from .request import SKIP_HEADER, SKIPPABLE_HEADERS, make_headers
 from .response import is_fp_closed
 from .retry import Retry
@@ -39,4 +39,5 @@ __all__ = (
     "wait_for_write",
     "SKIP_HEADER",
     "SKIPPABLE_HEADERS",
+    "Resolver",
 )

--- a/src/urllib3/util/__init__.py
+++ b/src/urllib3/util/__init__.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 from .connection import is_connection_dropped
 from .request import SKIP_HEADER, SKIPPABLE_HEADERS, make_headers
-from .resolver import Resolver
 from .response import is_fp_closed
 from .retry import Retry
 from .ssl_ import (
@@ -40,5 +39,4 @@ __all__ = (
     "wait_for_write",
     "SKIP_HEADER",
     "SKIPPABLE_HEADERS",
-    "Resolver",
 )

--- a/src/urllib3/util/connection.py
+++ b/src/urllib3/util/connection.py
@@ -2,44 +2,15 @@ from __future__ import annotations
 
 import socket
 import typing
-from typing import Protocol
 
 from ..exceptions import LocationParseError
+from .resolver import Resolver
 from .timeout import _DEFAULT_TIMEOUT, _TYPE_TIMEOUT
 
 _TYPE_SOCKET_OPTIONS = list[tuple[int, int, typing.Union[int, bytes]]]
 
 if typing.TYPE_CHECKING:
     from .._base_connection import BaseHTTPConnection
-
-
-class Resolver(Protocol):
-    """Type stub for the network address resolver.
-
-    This allows to override CPython's default `getaddrinfo()`_ function
-    which can be used to customize the resolution of domain names, hostnames,
-    and IP addresses.
-
-    .. _getaddrinfo(): https://docs.python.org/3/library/socket.html#socket.getaddrinfo
-    """
-
-    def __call__(
-        self,
-        host: bytes | str | None,
-        port: bytes | str | int | None,
-        family: int = 0,
-        type: int = 0,
-        proto: int = 0,
-        flags: int = 0,
-    ) -> list[
-        tuple[
-            socket.AddressFamily,
-            socket.SocketKind,
-            int,
-            str,
-            tuple[str, int] | tuple[str, int, int, int] | tuple[int, bytes],
-        ]
-    ]: ...
 
 
 def is_connection_dropped(conn: BaseHTTPConnection) -> bool:  # Platform-specific

--- a/src/urllib3/util/connection.py
+++ b/src/urllib3/util/connection.py
@@ -59,7 +59,7 @@ def create_connection(
     timeout: _TYPE_TIMEOUT = _DEFAULT_TIMEOUT,
     source_address: tuple[str, int] | None = None,
     socket_options: _TYPE_SOCKET_OPTIONS | None = None,
-    resolver: Resolver | None = socket.getaddrinfo,
+    resolver: Resolver | None = None,
 ) -> socket.socket:
     """Connect to *address* and return the socket object.
 

--- a/src/urllib3/util/resolver.py
+++ b/src/urllib3/util/resolver.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import socket
+import typing
+
+
+class Resolver(typing.Protocol):
+    """Type stub for the network address resolver.
+
+    This allows to override CPython's default `getaddrinfo()`_ function
+    which can be used to customize the resolution of domain names, hostnames,
+    and IP addresses.
+
+    .. _getaddrinfo(): https://docs.python.org/3/library/socket.html#socket.getaddrinfo
+    """
+
+    def __call__(
+        self,
+        host: bytes | str | None,
+        port: bytes | str | int | None,
+        family: int = 0,
+        type: int = 0,
+        proto: int = 0,
+        flags: int = 0,
+    ) -> list[
+        tuple[
+            socket.AddressFamily,
+            socket.SocketKind,
+            int,
+            str,
+            tuple[str, int] | tuple[str, int, int, int] | tuple[int, bytes],
+        ]
+    ]: ...

--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -237,9 +237,8 @@ class TestConnection:
             )
         ]
 
-        HTTPConnection("127.0.0.1", 80, resolver=custom_resolver).connect()
-
         # When passing a custom resolver, it should not call CPython's socket.getaddrinfo
+        HTTPConnection("127.0.0.1", 80, resolver=custom_resolver).connect()
         cpython_getaddrinfo.assert_not_called()
         custom_resolver.assert_has_calls([expected_call])
 
@@ -247,8 +246,6 @@ class TestConnection:
         cpython_getaddrinfo.reset_mock()
         custom_resolver.reset_mock()
         HTTPConnection("127.0.0.1", 80).connect()
-
-        # When passing a custom resolver, it should not call CPython's socket.getaddrinfo
         cpython_getaddrinfo.assert_has_calls([expected_call])
         custom_resolver.assert_not_called()
 
@@ -276,28 +273,24 @@ class TestConnection:
             )
         ]
 
+        # When passing a custom resolver, it should not call CPython's socket.getaddrinfo
         HTTPSConnection(
             "127.0.0.1",
             443,
             resolver=custom_resolver,
             ssl_context=ssl_context,
         ).connect()
-
-        # When passing a custom resolver, it should not call CPython's socket.getaddrinfo
         cpython_getaddrinfo.assert_not_called()
         custom_resolver.assert_has_calls([expected_call])
 
         # Sanity check: when using default resolver, it should call CPython's resolve
         cpython_getaddrinfo.reset_mock()
         custom_resolver.reset_mock()
-
         HTTPSConnection(
             "127.0.0.1",
             443,
             ssl_context=ssl_context,
         ).connect()
-
-        # When passing a custom resolver, it should not call CPython's socket.getaddrinfo
         cpython_getaddrinfo.assert_has_calls([expected_call])
         custom_resolver.assert_not_called()
 

--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -19,6 +19,7 @@ from urllib3.connection import (  # type: ignore[attr-defined]
 )
 from urllib3.exceptions import HTTPError, ProxyError, SSLError
 from urllib3.util import ssl_
+from urllib3.util.connection import allowed_gai_family
 from urllib3.util.request import SKIP_HEADER
 from urllib3.util.ssl_match_hostname import (
     CertificateError as ImplementationCertificateError,
@@ -212,6 +213,93 @@ class TestConnection:
     def test_HTTPSConnection_default_socket_options(self) -> None:
         conn = HTTPSConnection("not.a.real.host", port=443)
         assert conn.socket_options == [(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)]
+
+    @mock.patch("socket.getaddrinfo")
+    @mock.patch("socket.socket")
+    def test_create_http_connection_with_custom_resolver(
+        self,
+        _wrapped_socket: mock.MagicMock,
+        cpython_getaddrinfo: mock.MagicMock,
+    ) -> None:
+        """Passing a custom resolver should never call socket.getaddrinfo."""
+        expected_call = mock.call(
+            "127.0.0.1", 80, allowed_gai_family(), socket.SOCK_STREAM
+        )
+
+        custom_resolver = mock.MagicMock()
+        cpython_getaddrinfo.return_value = custom_resolver.return_value = [
+            (
+                socket.AF_INET,
+                socket.SOCK_STREAM,
+                socket.IPPROTO_TCP,
+                "",
+                ("127.0.0.1", 80),
+            )
+        ]
+
+        HTTPConnection("127.0.0.1", 80, resolver=custom_resolver).connect()
+
+        # When passing a custom resolver, it should not call CPython's socket.getaddrinfo
+        cpython_getaddrinfo.assert_not_called()
+        custom_resolver.assert_has_calls([expected_call])
+
+        # Sanity check: when using default resolver, it should call CPython's resolve
+        cpython_getaddrinfo.reset_mock()
+        custom_resolver.reset_mock()
+        HTTPConnection("127.0.0.1", 80).connect()
+
+        # When passing a custom resolver, it should not call CPython's socket.getaddrinfo
+        cpython_getaddrinfo.assert_has_calls([expected_call])
+        custom_resolver.assert_not_called()
+
+    @mock.patch("socket.getaddrinfo")
+    @mock.patch("socket.socket")
+    def test_create_https_connection_with_custom_resolver(
+        self,
+        _wrapped_socket: mock.MagicMock,
+        cpython_getaddrinfo: mock.MagicMock,
+    ) -> None:
+        """Passing a custom resolver should never call socket.getaddrinfo."""
+        expected_call = mock.call(
+            "127.0.0.1", 443, allowed_gai_family(), socket.SOCK_STREAM
+        )
+        ssl_context = mock.create_autospec(ssl_.SSLContext)
+
+        custom_resolver = mock.MagicMock()
+        cpython_getaddrinfo.return_value = custom_resolver.return_value = [
+            (
+                socket.AF_INET,
+                socket.SOCK_STREAM,
+                socket.IPPROTO_TCP,
+                "",
+                ("127.0.0.1", 443),
+            )
+        ]
+
+        HTTPSConnection(
+            "127.0.0.1",
+            443,
+            resolver=custom_resolver,
+            ssl_context=ssl_context,
+        ).connect()
+
+        # When passing a custom resolver, it should not call CPython's socket.getaddrinfo
+        cpython_getaddrinfo.assert_not_called()
+        custom_resolver.assert_has_calls([expected_call])
+
+        # Sanity check: when using default resolver, it should call CPython's resolve
+        cpython_getaddrinfo.reset_mock()
+        custom_resolver.reset_mock()
+
+        HTTPSConnection(
+            "127.0.0.1",
+            443,
+            ssl_context=ssl_context,
+        ).connect()
+
+        # When passing a custom resolver, it should not call CPython's socket.getaddrinfo
+        cpython_getaddrinfo.assert_has_calls([expected_call])
+        custom_resolver.assert_not_called()
 
     @pytest.mark.parametrize(
         "proxy_scheme, err_part",

--- a/test/test_poolmanager.py
+++ b/test/test_poolmanager.py
@@ -98,6 +98,7 @@ class TestPoolManager:
             "block": True,
             "source_address": "127.0.0.1",
             "blocksize": _DEFAULT_BLOCKSIZE + 1,
+            "resolver": lambda: None,
         }
         p = PoolManager()
         conn_pools = [
@@ -131,6 +132,7 @@ class TestPoolManager:
             "ca_certs": "/root/path_to_pem",
             "ssl_version": "SSLv23_METHOD",
             "blocksize": _DEFAULT_BLOCKSIZE + 1,
+            "resolver": lambda: None,
         }
         p = PoolManager()
         conn_pools = [
@@ -170,6 +172,7 @@ class TestPoolManager:
             "cert_reqs": "CERT_REQUIRED",
             "ca_certs": "/root/path_to_pem",
             "ssl_version": "SSLv23_METHOD",
+            "resolver": lambda: None,
         }
         p = PoolManager(5, **ssl_kw)  # type: ignore[arg-type]
         conns = [p.connection_from_host("example.com", 443, scheme="https")]
@@ -429,6 +432,17 @@ class TestPoolManager:
         )
         assert pool_blocksize.conn_kw["blocksize"] == expected_blocksize
         assert pool_blocksize._get_conn().blocksize == expected_blocksize
+
+    def test_poolmanager_create_http_connection_with_custom_resolver(self) -> None:
+        """Assert PoolManager properly sets the resolver property."""
+
+        resolver = MagicMock()
+        manager = PoolManager()
+
+        pool = manager.connection_from_url("http://example.com", {"resolver": resolver})
+
+        assert pool.conn_kw["resolver"] == resolver
+        assert pool._get_conn().resolver == resolver
 
     @pytest.mark.parametrize(
         "url",

--- a/test/test_poolmanager.py
+++ b/test/test_poolmanager.py
@@ -98,7 +98,6 @@ class TestPoolManager:
             "block": True,
             "source_address": "127.0.0.1",
             "blocksize": _DEFAULT_BLOCKSIZE + 1,
-            "resolver": lambda: None,
         }
         p = PoolManager()
         conn_pools = [
@@ -132,7 +131,6 @@ class TestPoolManager:
             "ca_certs": "/root/path_to_pem",
             "ssl_version": "SSLv23_METHOD",
             "blocksize": _DEFAULT_BLOCKSIZE + 1,
-            "resolver": lambda: None,
         }
         p = PoolManager()
         conn_pools = [
@@ -172,7 +170,6 @@ class TestPoolManager:
             "cert_reqs": "CERT_REQUIRED",
             "ca_certs": "/root/path_to_pem",
             "ssl_version": "SSLv23_METHOD",
-            "resolver": lambda: None,
         }
         p = PoolManager(5, **ssl_kw)  # type: ignore[arg-type]
         conns = [p.connection_from_host("example.com", 443, scheme="https")]
@@ -437,9 +434,9 @@ class TestPoolManager:
         """Assert PoolManager properly sets the resolver property."""
 
         resolver = MagicMock()
-        manager = PoolManager()
+        manager = PoolManager(resolver=resolver)
 
-        pool = manager.connection_from_url("http://example.com", {"resolver": resolver})
+        pool = manager.connection_from_url("http://example.com")
 
         assert pool.conn_kw["resolver"] == resolver
         assert pool._get_conn().resolver == resolver


### PR DESCRIPTION
This allows to override CPython's default [`getaddrinfo()`] function which can be used to customize the resolution of domain names, hostnames, and IP addresses. (closes #3675)

For example, this useful for filtering IP addresses (this being the actual use-case behind the change), as well as the behavior.

Full context: in our instance (#3675) we weren't able to override the network resolution in urllib3 which meant that we had to result to hacks: we were pinning the IP address, e.g., `https://google.com` would become `https://1.2.4.0:443` **before** calling urllib3 which meant that we were only trying 1 IP address and not N addresses, thus this led to two issues:

1. We had a single point of failure (if IP no. 1 is down, then IP no. 2 isn't tried)
2. RFC 8305 (Happy Eyeballs v2) prefers IPv6 over IPv4, which meant resolving `localhost` returned `["::1", "127.0.0.1"]` which means the 1st IP to be tried to connect to is `::1` but some (not all) servers unfortunately only listen on `127.0.0.1` thus leading to being unable to connect to the service (it's easy to mitigate: just put the IP instead of `localhost`, but that's not viable for an OSS project like ours where users have to be told to not put `localhost`). We also cannot change resolution to always return `127.0.0.1` instead of `::1` as it's too case-specific, we prefer having a generic solution.

Note: there is no implementation for emscripten as it uses Node.js thus it's likely not feasible. I initially considered adding such code:

```py
class EmscriptenHTTPConnection:
    ...

    def __init__(..., resolver: Resolver = None):
        ...

        if resolver is not None:
            raise NotImplementedError(
                "Custom resolvers are not supported in emscripten"
            )
```

But I noticed that other parameters are also [already not implemented] thus I followed suite.

[`getaddrinfo()`]: https://docs.python.org/3/library/socket.html#socket.getaddrinfo
[already not implemented]: https://github.com/urllib3/urllib3/blob/fd4dffd2fc544166b76151a2fa3d7b7c0eab540c/src/urllib3/contrib/emscripten/connection.py#L64-L71

<!---
Thanks for your contribution! ♥️

If this is your first PR to urllib3 please review the Contributing Guide:
https://urllib3.readthedocs.io/en/latest/contributing.html

Adhering to the Contributing Guide means we can review, merge, and release your change faster! :)
--->
