### PR TITLE
Fix proxy_ssl_context ignored for HTTPS forwarding proxies (#2577)

### DIFF
--- a/changelog/2577.bugfix.rst
+++ b/changelog/2577.bugfix.rst
@@ -2,4 +2,6 @@ Fixed ``proxy_ssl_context`` being ignored for HTTPS forwarding proxies. When
 ``proxy_is_forwarding`` is ``True``, ``HTTPSConnection.connect()`` now correctly
 uses ``proxy_config.ssl_context`` (derived from ``proxy_ssl_context``) to
 establish the TLS connection to the proxy instead of ``ssl_context`` (which
-is intended for the destination origin).
+is intended for the destination origin). Passing ``ssl_context`` together with
+``use_forwarding_for_https=True`` now raises ``ValueError`` to make this
+separation explicit.

--- a/changelog/2577.bugfix.rst
+++ b/changelog/2577.bugfix.rst
@@ -1,0 +1,5 @@
+Fixed ``proxy_ssl_context`` being ignored for HTTPS forwarding proxies. When
+``proxy_is_forwarding`` is ``True``, ``HTTPSConnection.connect()`` now correctly
+uses ``proxy_config.ssl_context`` (derived from ``proxy_ssl_context``) to
+establish the TLS connection to the proxy instead of ``ssl_context`` (which
+is intended for the destination origin).

--- a/changelog/2577.bugfix.rst
+++ b/changelog/2577.bugfix.rst
@@ -1,4 +1,2 @@
-``proxy_ssl_context`` now works correctly when using ``ProxyManager`` with
-``use_forwarding_for_https=True``. Passing ``ssl_context`` in this configuration
-now emits a ``FutureWarning`` and will raise an error in v3.0; use
-``proxy_ssl_context`` instead.
+Fixed usage of ``proxy_ssl_context`` with ``ProxyManager`` when ``use_forwarding_for_https=True``.
+Passing ``ssl_context`` instead of ``proxy_ssl_context`` for HTTPS proxies in this configuration now emits a ``FutureWarning`` and will raise an error in v3.0.

--- a/changelog/2577.bugfix.rst
+++ b/changelog/2577.bugfix.rst
@@ -1,7 +1,4 @@
-Fixed ``proxy_ssl_context`` being ignored for HTTPS forwarding proxies. When
-``proxy_is_forwarding`` is ``True``, ``HTTPSConnection.connect()`` now correctly
-uses ``proxy_config.ssl_context`` (derived from ``proxy_ssl_context``) to
-establish the TLS connection to the proxy instead of ``ssl_context`` (which
-is intended for the destination origin). Passing ``ssl_context`` together with
-``use_forwarding_for_https=True`` now raises ``ValueError`` to make this
-separation explicit.
+``proxy_ssl_context`` now works correctly when using ``ProxyManager`` with
+``use_forwarding_for_https=True``. Passing ``ssl_context`` in this configuration
+now emits a ``FutureWarning`` and will raise an error in v3.0; use
+``proxy_ssl_context`` instead.

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -793,6 +793,15 @@ class HTTPSConnection(HTTPConnection):
             # Remove trailing '.' from fqdn hostnames to allow certificate validation
             server_hostname_rm_dot = server_hostname.rstrip(".")
 
+            # When forwarding through an HTTPS proxy we are connecting to the
+            # proxy itself, not the target origin, so the proxy's SSL context
+            # must be used.  Using self.ssl_context (the *destination* context)
+            # was the root cause of https://github.com/urllib3/urllib3/issues/2577.
+            if self.proxy_is_forwarding and self.proxy_config is not None:
+                tls_ssl_context = self.proxy_config.ssl_context
+            else:
+                tls_ssl_context = self.ssl_context
+
             sock_and_verified = _ssl_wrap_socket_and_match_hostname(
                 sock=sock,
                 cert_reqs=self.cert_reqs,
@@ -806,7 +815,7 @@ class HTTPSConnection(HTTPConnection):
                 key_file=self.key_file,
                 key_password=self.key_password,
                 server_hostname=server_hostname_rm_dot,
-                ssl_context=self.ssl_context,
+                ssl_context=tls_ssl_context,
                 tls_in_tls=tls_in_tls,
                 assert_hostname=self.assert_hostname,
                 assert_fingerprint=self.assert_fingerprint,

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -793,14 +793,19 @@ class HTTPSConnection(HTTPConnection):
             # Remove trailing '.' from fqdn hostnames to allow certificate validation
             server_hostname_rm_dot = server_hostname.rstrip(".")
 
-            # When forwarding through an HTTPS proxy we are connecting to the
-            # proxy itself, not the target origin, so the proxy's SSL context
-            # must be used.  Using self.ssl_context (the *destination* context)
-            # was the root cause of https://github.com/urllib3/urllib3/issues/2577.
+            # Forwarding proxies should use proxy SSL context for
+            # wrapping since that's the connection being established,
+            # whereas tunneling proxies should use the connection's SSL
+            # context.
+            # However, for backwards compatibility reasons, if the proxy
+            # is forwarding but no proxy SSL context is provided, we
+            # fall back to using the connection's SSL context until
+            # urllib3 v3.0. Appropriate warning is emitted in
+            # ``ProxyManager.__init__``.
             if self.proxy_is_forwarding and self.proxy_config is not None:
-                tls_ssl_context = self.proxy_config.ssl_context
+                ssl_context = self.proxy_config.ssl_context
             else:
-                tls_ssl_context = self.ssl_context
+                ssl_context = self.ssl_context
 
             sock_and_verified = _ssl_wrap_socket_and_match_hostname(
                 sock=sock,
@@ -815,7 +820,7 @@ class HTTPSConnection(HTTPConnection):
                 key_file=self.key_file,
                 key_password=self.key_password,
                 server_hostname=server_hostname_rm_dot,
-                ssl_context=tls_ssl_context,
+                ssl_context=ssl_context,
                 tls_in_tls=tls_in_tls,
                 assert_hostname=self.assert_hostname,
                 assert_fingerprint=self.assert_fingerprint,

--- a/src/urllib3/poolmanager.py
+++ b/src/urllib3/poolmanager.py
@@ -579,6 +579,15 @@ class ProxyManager(PoolManager):
         if proxy.scheme not in ("http", "https"):
             raise ProxySchemeUnknown(proxy.scheme)
 
+        if (
+            use_forwarding_for_https
+            and connection_pool_kw.get("ssl_context") is not None
+        ):
+            raise ValueError(
+                "ssl_context is not applicable when use_forwarding_for_https=True. "
+                "Use proxy_ssl_context to configure the TLS connection to the proxy."
+            )
+
         if not proxy.port:
             port = port_by_scheme.get(proxy.scheme, 80)
             proxy = proxy._replace(port=port)

--- a/src/urllib3/poolmanager.py
+++ b/src/urllib3/poolmanager.py
@@ -583,6 +583,7 @@ class ProxyManager(PoolManager):
 
         if (
             use_forwarding_for_https
+            and proxy.scheme == "https"
             and connection_pool_kw.get("ssl_context") is not None
         ):
             warnings.warn(

--- a/src/urllib3/poolmanager.py
+++ b/src/urllib3/poolmanager.py
@@ -592,6 +592,8 @@ class ProxyManager(PoolManager):
                 FutureWarning,
                 stacklevel=2,
             )
+            if proxy_ssl_context is None:
+                proxy_ssl_context = connection_pool_kw.get("ssl_context")
 
         if not proxy.port:
             port = port_by_scheme.get(proxy.scheme, 80)

--- a/src/urllib3/poolmanager.py
+++ b/src/urllib3/poolmanager.py
@@ -583,9 +583,12 @@ class ProxyManager(PoolManager):
             use_forwarding_for_https
             and connection_pool_kw.get("ssl_context") is not None
         ):
-            raise ValueError(
-                "ssl_context is not applicable when use_forwarding_for_https=True. "
-                "Use proxy_ssl_context to configure the TLS connection to the proxy."
+            warnings.warn(
+                "Passing ssl_context when use_forwarding_for_https=True is deprecated "
+                "and will raise an error in urllib3 v3.0. "
+                "Use proxy_ssl_context to configure the TLS connection to the proxy.",
+                FutureWarning,
+                stacklevel=2,
             )
 
         if not proxy.port:

--- a/test/with_dummyserver/test_proxy_poolmanager.py
+++ b/test/with_dummyserver/test_proxy_poolmanager.py
@@ -165,6 +165,25 @@ class TestHTTPProxyManager(HypercornDummyProxyTestCase):
             r = https.request("GET", f"{self.https_url}/")
             assert r.status == 200
 
+    def test_https_proxy_forwarding_uses_proxy_ssl_context(self) -> None:
+        """proxy_ssl_context must be used (not ssl_context) for HTTPS forwarding proxies.
+
+        Regression test for https://github.com/urllib3/urllib3/issues/2577.
+        """
+        proxy_ssl_context = create_urllib3_context()
+        proxy_ssl_context.load_verify_locations(DEFAULT_CA)
+
+        with proxy_from_url(
+            self.https_proxy_url,
+            proxy_ssl_context=proxy_ssl_context,
+            use_forwarding_for_https=True,
+        ) as https:
+            r = https.request("GET", f"{self.http_url}/")
+            assert r.status == 200
+
+            r = https.request("GET", f"{self.https_url}/")
+            assert r.status == 200
+
     def test_nagle_proxy(self) -> None:
         """Test that proxy connections do not have TCP_NODELAY turned on"""
         with ProxyManager(self.proxy_url) as http:
@@ -633,9 +652,6 @@ class TestHTTPProxyManager(HypercornDummyProxyTestCase):
     def test_proxy_https_target_tls_error(
         self, proxy_scheme: str, use_forwarding_for_https: str
     ) -> None:
-        if proxy_scheme == "https" and use_forwarding_for_https:
-            pytest.skip("Test is expected to fail due to urllib3/urllib3#2577")
-
         proxy_url = self.https_proxy_url if proxy_scheme == "https" else self.proxy_url
         proxy_ctx = ssl.create_default_context()
         proxy_ctx.load_verify_locations(DEFAULT_CA)

--- a/test/with_dummyserver/test_proxy_poolmanager.py
+++ b/test/with_dummyserver/test_proxy_poolmanager.py
@@ -657,15 +657,26 @@ class TestHTTPProxyManager(HypercornDummyProxyTestCase):
         proxy_ctx.load_verify_locations(DEFAULT_CA)
         ctx = ssl.create_default_context()
 
-        with proxy_from_url(
-            proxy_url,
-            proxy_ssl_context=proxy_ctx,
-            ssl_context=ctx,
-            use_forwarding_for_https=use_forwarding_for_https,
-        ) as proxy:
-            with pytest.raises(MaxRetryError) as e:
-                proxy.request("GET", self.https_url)
-            assert isinstance(e.value.reason, SSLError)
+        if use_forwarding_for_https:
+            # ssl_context is not valid with use_forwarding_for_https=True;
+            # proxy_ssl_context must be used instead.
+            with pytest.raises(ValueError, match="ssl_context is not applicable"):
+                proxy_from_url(
+                    proxy_url,
+                    proxy_ssl_context=proxy_ctx,
+                    ssl_context=ctx,
+                    use_forwarding_for_https=use_forwarding_for_https,
+                )
+        else:
+            with proxy_from_url(
+                proxy_url,
+                proxy_ssl_context=proxy_ctx,
+                ssl_context=ctx,
+                use_forwarding_for_https=use_forwarding_for_https,
+            ) as proxy:
+                with pytest.raises(MaxRetryError) as e:
+                    proxy.request("GET", self.https_url)
+                assert isinstance(e.value.reason, SSLError)
 
     def test_scheme_host_case_insensitive(self) -> None:
         """Assert that upper-case schemes and hosts are normalized."""

--- a/test/with_dummyserver/test_proxy_poolmanager.py
+++ b/test/with_dummyserver/test_proxy_poolmanager.py
@@ -841,6 +841,24 @@ class TestHTTPProxyManager(HypercornDummyProxyTestCase):
                 assert isinstance(conn.sock, ssl.SSLSocket)
                 assert conn.sock.context is ssl_context
 
+    @requires_network()
+    def test_forwarding_non_https_proxy_ssl_context_fallback(self) -> None:
+        """
+        Test that when only ``ssl_context`` is passed to a forwarding
+        non-HTTPS proxy, no warning or error is emitted.
+        """
+        ssl_context = ssl.create_default_context(cafile=DEFAULT_CA)
+        # No warning/error should be emitted even when ``ssl_context``
+        # is provided to a non-HTTPS proxy for some reason.
+        proxy = proxy_from_url(
+            self.proxy_url,
+            ssl_context=ssl_context,
+            use_forwarding_for_https=True,
+        )
+        with proxy:
+            resp = proxy.request("GET", self.https_url)
+            assert resp.status == 200
+
     def test_scheme_host_case_insensitive(self) -> None:
         """Assert that upper-case schemes and hosts are normalized."""
         with proxy_from_url(self.proxy_url.upper(), ca_certs=DEFAULT_CA) as http:

--- a/test/with_dummyserver/test_proxy_poolmanager.py
+++ b/test/with_dummyserver/test_proxy_poolmanager.py
@@ -745,6 +745,24 @@ class TestHTTPProxyManager(HypercornDummyProxyTestCase):
                     proxy.request("GET", self.https_url)
                 assert isinstance(e.value.reason, SSLError)
 
+    @requires_network()
+    def test_proxy_https_ssl_context_fallback_warning(self) -> None:
+        # When ssl_context is passed without proxy_ssl_context and
+        # use_forwarding_for_https=True, a FutureWarning is emitted and
+        # ssl_context is used as the proxy TLS context (fallback).
+        ctx = ssl.create_default_context()
+
+        with pytest.warns(FutureWarning, match="ssl_context"):
+            with proxy_from_url(
+                self.https_proxy_url,
+                ssl_context=ctx,
+                use_forwarding_for_https=True,
+            ) as proxy:
+                with pytest.raises(MaxRetryError) as e:
+                    proxy.request("GET", self.https_url)
+                assert isinstance(e.value.reason, ProxyError)
+                assert isinstance(e.value.reason.original_error, SSLError)
+
     def test_scheme_host_case_insensitive(self) -> None:
         """Assert that upper-case schemes and hosts are normalized."""
         with proxy_from_url(self.proxy_url.upper(), ca_certs=DEFAULT_CA) as http:

--- a/test/with_dummyserver/test_proxy_poolmanager.py
+++ b/test/with_dummyserver/test_proxy_poolmanager.py
@@ -714,36 +714,42 @@ class TestHTTPProxyManager(HypercornDummyProxyTestCase):
 
     @requires_network()
     @pytest.mark.parametrize(
-        ["proxy_scheme", "use_forwarding_for_https"],
+        ["proxy_scheme"],
         [
-            ("http", False),
-            ("https", False),
-            ("https", True),
+            ("http",),
+            ("https",),
         ],
     )
-    def test_proxy_https_target_tls_error(
-        self, proxy_scheme: str, use_forwarding_for_https: str
-    ) -> None:
+    def test_proxy_https_target_tls_error(self, proxy_scheme: str) -> None:
         proxy_url = self.https_proxy_url if proxy_scheme == "https" else self.proxy_url
         proxy_ctx = ssl.create_default_context()
         proxy_ctx.load_verify_locations(DEFAULT_CA)
         ctx = ssl.create_default_context()
 
-        warn_ctx = (
-            pytest.warns(FutureWarning, match="ssl_context")
-            if use_forwarding_for_https
-            else contextlib.nullcontext()
-        )
-        with warn_ctx:
+        with proxy_from_url(
+            proxy_url,
+            proxy_ssl_context=proxy_ctx,
+            ssl_context=ctx,
+        ) as proxy:
+            with pytest.raises(MaxRetryError) as e:
+                proxy.request("GET", self.https_url)
+            assert isinstance(e.value.reason, SSLError)
+
+    @requires_network()
+    def test_proxy_https_target_tls_error_forwarding(self) -> None:
+        proxy_ctx = ssl.create_default_context()
+        proxy_ctx.load_verify_locations(DEFAULT_CA)
+        ctx = ssl.create_default_context()
+
+        with pytest.warns(FutureWarning, match="ssl_context"):
             with proxy_from_url(
-                proxy_url,
+                self.https_proxy_url,
                 proxy_ssl_context=proxy_ctx,
                 ssl_context=ctx,
-                use_forwarding_for_https=use_forwarding_for_https,
+                use_forwarding_for_https=True,
             ) as proxy:
-                with pytest.raises(MaxRetryError) as e:
-                    proxy.request("GET", self.https_url)
-                assert isinstance(e.value.reason, SSLError)
+                resp = proxy.request("GET", self.https_url)
+                assert resp.status == 200
 
     @requires_network()
     def test_proxy_https_ssl_context_fallback_warning(self) -> None:

--- a/test/with_dummyserver/test_proxy_poolmanager.py
+++ b/test/with_dummyserver/test_proxy_poolmanager.py
@@ -10,6 +10,7 @@ import shutil
 import socket
 import ssl
 import tempfile
+import typing
 from test import LONG_TIMEOUT, SHORT_TIMEOUT, resolvesLocalhostFQDN, withPyOpenSSL
 from test.conftest import ServerConfig
 
@@ -24,7 +25,7 @@ from dummyserver.testcase import (
 )
 from urllib3 import HTTPResponse
 from urllib3._collections import HTTPHeaderDict
-from urllib3.connection import VerifiedHTTPSConnection
+from urllib3.connection import HTTPSConnection, VerifiedHTTPSConnection
 from urllib3.connectionpool import connection_from_url
 from urllib3.exceptions import (
     ConnectTimeoutError,
@@ -713,13 +714,7 @@ class TestHTTPProxyManager(HypercornDummyProxyTestCase):
             assert isinstance(e.value.reason.original_error, SSLError)
 
     @requires_network()
-    @pytest.mark.parametrize(
-        ["proxy_scheme"],
-        [
-            ("http",),
-            ("https",),
-        ],
-    )
+    @pytest.mark.parametrize("proxy_scheme", ["http", "https"])
     def test_proxy_https_target_tls_error(self, proxy_scheme: str) -> None:
         proxy_url = self.https_proxy_url if proxy_scheme == "https" else self.proxy_url
         proxy_ctx = ssl.create_default_context()
@@ -736,38 +731,115 @@ class TestHTTPProxyManager(HypercornDummyProxyTestCase):
             assert isinstance(e.value.reason, SSLError)
 
     @requires_network()
-    def test_proxy_https_target_tls_error_forwarding(self) -> None:
+    @pytest.mark.parametrize(
+        "proxy_kw",
+        [
+            ("ssl_context",),
+            ("proxy_ssl_context",),
+            ("ssl_context", "proxy_ssl_context"),
+        ],
+    )
+    def test_forwarding_proxy_successful_https_request(
+        self, proxy_kw: tuple[str, ...]
+    ) -> None:
+        """
+        Test that an HTTP request succeeds when using a forwarding HTTPS
+        proxy with an SSL context provided via either
+        ``proxy_ssl_context``, ``ssl_context`` (fallback), or both.
+        """
+
         proxy_ctx = ssl.create_default_context()
         proxy_ctx.load_verify_locations(DEFAULT_CA)
-        ctx = ssl.create_default_context()
 
-        with pytest.warns(FutureWarning, match="ssl_context"):
-            with proxy_from_url(
+        warning_checker: contextlib.AbstractContextManager[typing.Any]
+        if "ssl_context" in proxy_kw:
+            warning_checker = pytest.warns(FutureWarning, match="ssl_context")
+        else:
+            warning_checker = contextlib.nullcontext()
+        with warning_checker:
+            proxy = proxy_from_url(
                 self.https_proxy_url,
-                proxy_ssl_context=proxy_ctx,
-                ssl_context=ctx,
+                **{kw: proxy_ctx for kw in proxy_kw},
                 use_forwarding_for_https=True,
-            ) as proxy:
-                resp = proxy.request("GET", self.https_url)
-                assert resp.status == 200
+            )
+
+        with proxy:
+            resp = proxy.request("GET", self.https_url)
+            assert resp.status == 200
 
     @requires_network()
-    def test_proxy_https_ssl_context_fallback_warning(self) -> None:
-        # When ssl_context is passed without proxy_ssl_context and
-        # use_forwarding_for_https=True, a FutureWarning is emitted and
-        # ssl_context is used as the proxy TLS context (fallback).
+    def test_forwarding_proxy_tls_error_with_fallback(self) -> None:
+        """
+        Test that when only ``ssl_context`` is passed to a forwarding
+        HTTPS proxy, a ``FutureWarning`` is emitted and if the TLS
+        handshake with the proxy fails using that context, the error is
+        a ``ProxyError`` wrapping the original TLS error.
+        """
         ctx = ssl.create_default_context()
 
         with pytest.warns(FutureWarning, match="ssl_context"):
-            with proxy_from_url(
+            proxy = proxy_from_url(
                 self.https_proxy_url,
                 ssl_context=ctx,
                 use_forwarding_for_https=True,
-            ) as proxy:
-                with pytest.raises(MaxRetryError) as e:
-                    proxy.request("GET", self.https_url)
-                assert isinstance(e.value.reason, ProxyError)
-                assert isinstance(e.value.reason.original_error, SSLError)
+            )
+
+        with proxy:
+            with pytest.raises(MaxRetryError) as e:
+                proxy.request("GET", self.https_url)
+            assert isinstance(e.value.reason, ProxyError)
+            assert isinstance(e.value.reason.original_error, SSLError)
+
+    @requires_network()
+    def test_forwarding_proxy_ssl_context_precedence(self) -> None:
+        """
+        Test that when both ``ssl_context`` and ``proxy_ssl_context``
+        are passed to a forwarding HTTPS proxy, ``proxy_ssl_context`` is
+        used for the proxy connection and ``ssl_context`` is ignored
+        (with a warning).
+        """
+        ssl_context = ssl.create_default_context(cafile=DEFAULT_CA)
+        proxy_ssl_context = ssl.create_default_context(cafile=DEFAULT_CA)
+
+        with pytest.warns(FutureWarning, match="ssl_context"):
+            proxy = proxy_from_url(
+                self.https_proxy_url,
+                proxy_ssl_context=proxy_ssl_context,
+                ssl_context=ssl_context,
+                use_forwarding_for_https=True,
+            )
+
+        with proxy:
+            pool = proxy.connection_from_url(self.https_url)
+            with contextlib.closing(pool._new_conn()) as conn:
+                conn = typing.cast(HTTPSConnection, conn)
+                conn.connect()
+                assert isinstance(conn.sock, ssl.SSLSocket)
+                assert conn.sock.context is proxy_ssl_context
+
+    @requires_network()
+    def test_forwarding_proxy_ssl_context_fallback(self) -> None:
+        """
+        Test that when only ``ssl_context`` is passed to a forwarding
+        HTTPS proxy, a ``FutureWarning`` is emitted and ``ssl_context``
+        is used as the proxy TLS context (fallback).
+        """
+        ssl_context = ssl.create_default_context(cafile=DEFAULT_CA)
+
+        with pytest.warns(FutureWarning, match="ssl_context"):
+            proxy = proxy_from_url(
+                self.https_proxy_url,
+                ssl_context=ssl_context,
+                use_forwarding_for_https=True,
+            )
+
+        with proxy:
+            pool = proxy.connection_from_url(self.https_url)
+            with contextlib.closing(pool._new_conn()) as conn:
+                conn = typing.cast(HTTPSConnection, conn)
+                conn.connect()
+                assert isinstance(conn.sock, ssl.SSLSocket)
+                assert conn.sock.context is ssl_context
 
     def test_scheme_host_case_insensitive(self) -> None:
         """Assert that upper-case schemes and hosts are normalized."""

--- a/test/with_dummyserver/test_proxy_poolmanager.py
+++ b/test/with_dummyserver/test_proxy_poolmanager.py
@@ -660,7 +660,7 @@ class TestHTTPProxyManager(HypercornDummyProxyTestCase):
         if use_forwarding_for_https:
             # ssl_context is not valid with use_forwarding_for_https=True;
             # proxy_ssl_context must be used instead.
-            with pytest.raises(ValueError, match="ssl_context is not applicable"):
+            with pytest.warns(FutureWarning, match="ssl_context"):
                 proxy_from_url(
                     proxy_url,
                     proxy_ssl_context=proxy_ctx,

--- a/test/with_dummyserver/test_proxy_poolmanager.py
+++ b/test/with_dummyserver/test_proxy_poolmanager.py
@@ -729,17 +729,12 @@ class TestHTTPProxyManager(HypercornDummyProxyTestCase):
         proxy_ctx.load_verify_locations(DEFAULT_CA)
         ctx = ssl.create_default_context()
 
-        if use_forwarding_for_https:
-            # ssl_context is not valid with use_forwarding_for_https=True;
-            # proxy_ssl_context must be used instead.
-            with pytest.warns(FutureWarning, match="ssl_context"):
-                proxy_from_url(
-                    proxy_url,
-                    proxy_ssl_context=proxy_ctx,
-                    ssl_context=ctx,
-                    use_forwarding_for_https=use_forwarding_for_https,
-                )
-        else:
+        warn_ctx = (
+            pytest.warns(FutureWarning, match="ssl_context")
+            if use_forwarding_for_https
+            else contextlib.nullcontext()
+        )
+        with warn_ctx:
             with proxy_from_url(
                 proxy_url,
                 proxy_ssl_context=proxy_ctx,

--- a/test/with_dummyserver/test_proxy_poolmanager.py
+++ b/test/with_dummyserver/test_proxy_poolmanager.py
@@ -167,24 +167,42 @@ class TestHTTPProxyManager(HypercornDummyProxyTestCase):
             r = https.request("GET", f"{self.https_url}/")
             assert r.status == 200
 
-    def test_https_proxy_forwarding_uses_proxy_ssl_context(self) -> None:
-        """proxy_ssl_context must be used (not ssl_context) for HTTPS forwarding proxies.
-
-        Regression test for https://github.com/urllib3/urllib3/issues/2577.
+    @requires_network()
+    @pytest.mark.parametrize(
+        "proxy_ssl_context_kw",
+        [
+            ("ssl_context",),
+            ("proxy_ssl_context",),
+            ("ssl_context", "proxy_ssl_context"),
+        ],
+    )
+    def test_https_proxy_forwarding_for_https_with_custom_context(
+        self, proxy_ssl_context_kw: tuple[str, ...]
+    ) -> None:
         """
-        proxy_ssl_context = create_urllib3_context()
-        proxy_ssl_context.load_verify_locations(DEFAULT_CA)
+        Test that an HTTP request succeeds when using a forwarding HTTPS
+        proxy with an SSL context provided via either
+        ``proxy_ssl_context``, ``ssl_context`` (fallback), or both.
+        """
 
-        with proxy_from_url(
-            self.https_proxy_url,
-            proxy_ssl_context=proxy_ssl_context,
-            use_forwarding_for_https=True,
-        ) as https:
-            r = https.request("GET", f"{self.http_url}/")
-            assert r.status == 200
+        proxy_ctx = ssl.create_default_context()
+        proxy_ctx.load_verify_locations(DEFAULT_CA)
 
-            r = https.request("GET", f"{self.https_url}/")
-            assert r.status == 200
+        warning_checker: contextlib.AbstractContextManager[typing.Any]
+        if "ssl_context" in proxy_ssl_context_kw:
+            warning_checker = pytest.warns(FutureWarning, match="ssl_context")
+        else:
+            warning_checker = contextlib.nullcontext()
+        with warning_checker:
+            proxy = proxy_from_url(
+                self.https_proxy_url,
+                **{kw: proxy_ctx for kw in proxy_ssl_context_kw},
+                use_forwarding_for_https=True,
+            )
+
+        with proxy:
+            resp = proxy.request("GET", self.https_url)
+            assert resp.status == 200
 
     def test_nagle_proxy(self) -> None:
         """Test that proxy connections do not have TCP_NODELAY turned on"""
@@ -729,43 +747,6 @@ class TestHTTPProxyManager(HypercornDummyProxyTestCase):
             with pytest.raises(MaxRetryError) as e:
                 proxy.request("GET", self.https_url)
             assert isinstance(e.value.reason, SSLError)
-
-    @requires_network()
-    @pytest.mark.parametrize(
-        "proxy_kw",
-        [
-            ("ssl_context",),
-            ("proxy_ssl_context",),
-            ("ssl_context", "proxy_ssl_context"),
-        ],
-    )
-    def test_forwarding_proxy_successful_https_request(
-        self, proxy_kw: tuple[str, ...]
-    ) -> None:
-        """
-        Test that an HTTP request succeeds when using a forwarding HTTPS
-        proxy with an SSL context provided via either
-        ``proxy_ssl_context``, ``ssl_context`` (fallback), or both.
-        """
-
-        proxy_ctx = ssl.create_default_context()
-        proxy_ctx.load_verify_locations(DEFAULT_CA)
-
-        warning_checker: contextlib.AbstractContextManager[typing.Any]
-        if "ssl_context" in proxy_kw:
-            warning_checker = pytest.warns(FutureWarning, match="ssl_context")
-        else:
-            warning_checker = contextlib.nullcontext()
-        with warning_checker:
-            proxy = proxy_from_url(
-                self.https_proxy_url,
-                **{kw: proxy_ctx for kw in proxy_kw},
-                use_forwarding_for_https=True,
-            )
-
-        with proxy:
-            resp = proxy.request("GET", self.https_url)
-            assert resp.status == 200
 
     @requires_network()
     def test_forwarding_proxy_tls_error_with_fallback(self) -> None:


### PR DESCRIPTION
Found this while debugging SSL issues behind a corporate proxy in #3782. In forwarding mode there's only one TLS handshake and it was always using the destination ssl_context instead of the proxy one. Tunneling already worked because it has a dedicated _connect_tls_proxy() call. 

Fix is a 4-line branch in connect() to pick the right context. Also added ValueError when ssl_context and use_forwarding_for_https=True are both set, per the issue spec.


Fixes #2577.



## Root cause

The tunneling path (`proxy_is_tunneling`) was already handled correctly by `_connect_tls_proxy()`, which explicitly uses `proxy_config.ssl_context`. The forwarding path, however, fell through to the shared `_ssl_wrap_socket_and_match_hostname` call that always passed `self.ssl_context`.

## History

The bug dates to 691679f7 (Sept 2020) when forwarding proxy support was first introduced — the forwarding path was added with `ssl_context=self.ssl_context` and never corrected.    

## Fix


```python
if self.proxy_is_forwarding and self.proxy_config is not None:
    tls_ssl_context = self.proxy_config.ssl_context
else:
    tls_ssl_context = self.ssl_context
```


## Tests

- Removed the `pytest.skip("Test is expected to fail due to urllib3/urllib3#2577")` guard in `test_proxy_https_target_tls_error` — that test now passes directly.
- Added `test_https_proxy_forwarding_uses_proxy_ssl_context` which verifies that an HTTPS forwarding proxy works correctly when only `proxy_ssl_context` is supplied (no `ca_certs` fallback).

