### PR TITLE
docs: document assert_hostname and assert_fingerprint usage

### DIFF
--- a/changelog/3520.bugfix.rst
+++ b/changelog/3520.bugfix.rst
@@ -1,0 +1,2 @@
+Added documentation for ``assert_hostname`` and ``assert_fingerprint`` in the
+connection API reference and TLS advanced usage guide.

--- a/docs/advanced-usage.rst
+++ b/docs/advanced-usage.rst
@@ -415,6 +415,27 @@ hostname or the SNI hostname, you can use ``assert_hostname``:
     pool.request("GET", "/")
 
 
+.. _assert_fingerprint:
+
+Verifying TLS with certificate fingerprints
+-------------------------------------------
+
+If you need certificate pinning, pass ``assert_fingerprint`` with the expected
+certificate fingerprint. The value can be written with or without colons.
+SHA-256 fingerprints are recommended.
+
+.. code-block:: python
+
+    import urllib3
+
+    expected_fingerprint = "ab" * 32
+    pool = urllib3.HTTPSConnectionPool(
+        "example.com",
+        assert_fingerprint=expected_fingerprint,
+    )
+    pool.request("GET", "/")
+
+
 .. _ssl_client:
 
 Client Certificates

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -604,6 +604,16 @@ class HTTPSConnection(HTTPConnection):
     """
     Many of the parameters to this constructor are passed to the underlying SSL
     socket by means of :py:func:`urllib3.util.ssl_wrap_socket`.
+
+    ``assert_hostname`` controls which hostname is used for certificate
+    verification. By default urllib3 verifies against the requested host (or
+    ``server_hostname`` when it is set). Set this to another hostname when
+    connecting by IP while validating a specific certificate identity, or set
+    it to ``False`` to disable hostname checks.
+
+    ``assert_fingerprint`` enables certificate pinning by verifying that the
+    peer certificate matches the expected fingerprint. SHA-256 is recommended.
+    See :ref:`assert_hostname` and :ref:`assert_fingerprint` for examples.
     """
 
     default_port = port_by_scheme["https"]  # type: ignore[misc]


### PR DESCRIPTION
## Summary
- adds clear usage guidance for `assert_hostname` and `assert_fingerprint`
- expands `HTTPSConnection` API docs so the reference page explains both parameters
- adds an `assert_fingerprint` section to advanced usage with a concrete example

## Why
Issue #3520 reported that these options were listed in the API but lacked practical guidance.

Closes #3520