### PR TITLE
docs: describe Retry backoff_max and backoff_jitter parameters

### DIFF
--- a/src/urllib3/util/retry.py
+++ b/src/urllib3/util/retry.py
@@ -157,6 +157,14 @@ class Retry:
 
         By default, backoff is disabled (factor set to 0).
 
+    :param float backoff_max:
+        The maximum backoff time (in seconds) between retry attempts.
+        This value caps the computed backoff from `backoff_factor`.
+
+    :param float backoff_jitter:
+        Random jitter amount (in seconds) added to the computed backoff.
+        Jitter is sampled uniformly from `0` to `backoff_jitter`.
+
     :param bool raise_on_redirect: Whether, if the number of redirects is
         exhausted, to raise a MaxRetryError, or to return a response with a
         response code in the 3xx range.


### PR DESCRIPTION
## Summary
- add missing parameter descriptions for `backoff_max` and `backoff_jitter` in `Retry` class docstring
- clarify that `backoff_max` caps computed backoff and `backoff_jitter` is sampled uniformly

Closes #3510