### PR TITLE
Handle HTTP/2 StreamReset and ConnectionTerminated events

### DIFF
--- a/changelog/3291.bugfix.rst
+++ b/changelog/3291.bugfix.rst
@@ -1,0 +1,1 @@
+Handled HTTP/2 stream reset and GOAWAY termination events by raising connection errors instead of hanging and by retiring terminated connections before reuse.

--- a/src/urllib3/http2/connection.py
+++ b/src/urllib3/http2/connection.py
@@ -8,6 +8,7 @@ import typing
 
 import h2.config
 import h2.connection
+import h2.errors
 import h2.events
 
 from .._base_connection import _TYPE_BODY
@@ -49,6 +50,44 @@ def _is_illegal_header_value(value: bytes) -> bool:
     0x20 or 0x09)." (https://httpwg.org/specs/rfc9113.html#n-field-validity)
     """
     return bool(RE_IS_ILLEGAL_HEADER_VALUE.search(value))
+
+
+def _format_http2_error_code(
+    error_code: h2.errors.ErrorCodes | int | None,
+) -> str:
+    if error_code is None:
+        return "unknown error code"
+    if isinstance(error_code, h2.errors.ErrorCodes):
+        return error_code.name
+    try:
+        return h2.errors.ErrorCodes(error_code).name
+    except ValueError:
+        return str(error_code)
+
+
+def _stream_reset_error(event: h2.events.StreamReset) -> ConnectionError:
+    error_code = _format_http2_error_code(event.error_code)
+    if event.remote_reset:
+        return ConnectionError(
+            f"HTTP/2 stream {event.stream_id} was reset: {error_code}"
+        )
+    return ConnectionError(
+        f"HTTP/2 stream {event.stream_id} was reset locally: {error_code}"
+    )
+
+
+def _connection_terminated_error(
+    event: h2.events.ConnectionTerminated,
+) -> ConnectionError:
+    message = (
+        "HTTP/2 connection was terminated: "
+        f"{_format_http2_error_code(event.error_code)}"
+    )
+    if event.last_stream_id is not None:
+        message += f" (last_stream_id={event.last_stream_id})"
+    if event.additional_data:
+        message += f" ({event.additional_data!r})"
+    return ConnectionError(message)
 
 
 class _LockedObject(typing.Generic[T]):
@@ -101,6 +140,24 @@ class HTTP2Connection(HTTPSConnection):
     def _new_h2_conn(self) -> _LockedObject[h2.connection.H2Connection]:
         config = h2.config.H2Configuration(client_side=True)
         return _LockedObject(h2.connection.H2Connection(config=config))
+
+    def _reset_h2_state(self) -> None:
+        self._h2_conn = self._new_h2_conn()
+        self._h2_stream = None
+        self._headers = []
+
+    def _close_http2_connection(self, *, send_goaway: bool) -> None:
+        if send_goaway:
+            with self._h2_conn as conn:
+                try:
+                    conn.close_connection()
+                    if data := conn.data_to_send():
+                        self.sock.sendall(data)
+                except Exception:
+                    pass
+
+        self._reset_h2_state()
+        super().close()
 
     def connect(self) -> None:
         super().connect()
@@ -227,35 +284,71 @@ class HTTP2Connection(HTTPSConnection):
         self,
     ) -> HTTP2Response:
         status = None
+        headers = HTTPHeaderDict()
         data = bytearray()
+        close_connection = False
+        error: ConnectionError | None = None
+        connection_terminated = None
         with self._h2_conn as conn:
             end_stream = False
             while not end_stream:
                 # TODO: Arbitrary read value.
-                if received_data := self.sock.recv(65535):
-                    events = conn.receive_data(received_data)
-                    for event in events:
-                        if isinstance(event, h2.events.ResponseReceived):
-                            headers = HTTPHeaderDict()
-                            for header, value in event.headers:
-                                if header == b":status":
-                                    status = int(value.decode())
-                                else:
-                                    headers.add(
-                                        header.decode("ascii"), value.decode("ascii")
-                                    )
+                received_data = self.sock.recv(65535)
+                if not received_data:
+                    close_connection = True
+                    if connection_terminated is not None:
+                        error = _connection_terminated_error(connection_terminated)
+                    else:
+                        error = ConnectionError("HTTP/2 connection closed unexpectedly")
+                    break
 
-                        elif isinstance(event, h2.events.DataReceived):
-                            data += event.data
-                            conn.acknowledge_received_data(
-                                event.flow_controlled_length, event.stream_id
-                            )
+                events = conn.receive_data(received_data)
+                for event in events:
+                    if isinstance(event, h2.events.ResponseReceived):
+                        headers = HTTPHeaderDict()
+                        for header, value in event.headers:
+                            if header == b":status":
+                                status = int(value.decode())
+                            else:
+                                headers.add(
+                                    header.decode("ascii"), value.decode("ascii")
+                                )
 
-                        elif isinstance(event, h2.events.StreamEnded):
-                            end_stream = True
+                    elif isinstance(event, h2.events.DataReceived):
+                        data += event.data
+                        conn.acknowledge_received_data(
+                            event.flow_controlled_length, event.stream_id
+                        )
+
+                    elif isinstance(event, h2.events.StreamEnded):
+                        end_stream = True
+
+                    elif isinstance(event, h2.events.StreamReset):
+                        error = _stream_reset_error(event)
+                        break
+
+                    elif isinstance(event, h2.events.ConnectionTerminated):
+                        connection_terminated = event
+                        close_connection = True
+                        if (
+                            self._h2_stream is not None
+                            and event.last_stream_id is not None
+                            and self._h2_stream > event.last_stream_id
+                        ):
+                            error = _connection_terminated_error(event)
+                            break
 
                 if data_to_send := conn.data_to_send():
                     self.sock.sendall(data_to_send)
+
+                if error is not None:
+                    break
+
+        if close_connection:
+            self._close_http2_connection(send_goaway=connection_terminated is None)
+
+        if error is not None:
+            raise error
 
         assert status is not None
         return HTTP2Response(
@@ -305,20 +398,7 @@ class HTTP2Connection(HTTPSConnection):
             self.endheaders()
 
     def close(self) -> None:
-        with self._h2_conn as conn:
-            try:
-                conn.close_connection()
-                if data := conn.data_to_send():
-                    self.sock.sendall(data)
-            except Exception:
-                pass
-
-        # Reset all our HTTP/2 connection state.
-        self._h2_conn = self._new_h2_conn()
-        self._h2_stream = None
-        self._headers = []
-
-        super().close()
+        self._close_http2_connection(send_goaway=True)
 
 
 class HTTP2Response(BaseHTTPResponse):

--- a/test/test_http2_connection.py
+++ b/test/test_http2_connection.py
@@ -384,6 +384,29 @@ class TestHTTP2Connection:
         ):
             conn.getresponse()
 
+    def test_getresponse_raises_on_local_stream_reset_with_unknown_error_code(
+        self,
+    ) -> None:
+        conn = HTTP2Connection("example.com")
+        conn.sock = mock.MagicMock(
+            recv=mock.Mock(return_value=b"event-data"),
+            sendall=mock.Mock(return_value=None),
+        )
+        conn._h2_conn._obj.receive_data = mock.Mock(  # type: ignore[method-assign]
+            return_value=[
+                h2.events.StreamReset(stream_id=1, error_code=123, remote_reset=False)
+            ]
+        )
+        conn._h2_conn._obj.data_to_send = mock.Mock(return_value=b"")  # type: ignore[method-assign]
+        conn._h2_conn._obj.get_next_available_stream_id = mock.Mock(return_value=1)  # type: ignore[method-assign]
+
+        conn.putrequest("GET", "/")
+
+        with pytest.raises(
+            ConnectionError, match=r"HTTP/2 stream 1 was reset locally: 123"
+        ):
+            conn.getresponse()
+
     def test_getresponse_raises_on_connection_terminated(self) -> None:
         conn = HTTP2Connection("example.com")
         conn.sock = mock.MagicMock(
@@ -405,6 +428,57 @@ class TestHTTP2Connection:
         with pytest.raises(
             ConnectionError,
             match=r"HTTP/2 connection was terminated: NO_ERROR \(last_stream_id=0\)",
+        ):
+            conn.getresponse()
+
+        old_h2_conn.close_connection.assert_not_called()
+        assert conn.sock is None
+        assert conn._h2_conn._obj is not old_h2_conn
+        assert conn._h2_stream is None
+
+    def test_getresponse_raises_on_unexpected_eof(self) -> None:
+        conn = HTTP2Connection("example.com")
+        conn.sock = mock.MagicMock(
+            recv=mock.Mock(return_value=b""),
+            sendall=mock.Mock(return_value=None),
+        )
+        old_h2_conn = conn._h2_conn._obj
+        old_h2_conn.data_to_send = mock.Mock(return_value=b"")  # type: ignore[method-assign]
+        old_h2_conn.get_next_available_stream_id = mock.Mock(return_value=1)  # type: ignore[method-assign]
+        old_h2_conn.close_connection = mock.Mock(return_value=None)  # type: ignore[method-assign]
+
+        conn.putrequest("GET", "/")
+
+        with pytest.raises(
+            ConnectionError, match="HTTP/2 connection closed unexpectedly"
+        ):
+            conn.getresponse()
+
+        old_h2_conn.close_connection.assert_called_once_with()
+        assert conn.sock is None
+        assert conn._h2_conn._obj is not old_h2_conn
+        assert conn._h2_stream is None
+
+    def test_getresponse_raises_on_connection_terminated_after_eof(self) -> None:
+        conn = HTTP2Connection("example.com")
+        conn.sock = mock.MagicMock(
+            recv=mock.Mock(side_effect=[b"event-data", b""]),
+            sendall=mock.Mock(return_value=None),
+        )
+        old_h2_conn = conn._h2_conn._obj
+        old_h2_conn.data_to_send = mock.Mock(return_value=b"")  # type: ignore[method-assign]
+        old_h2_conn.get_next_available_stream_id = mock.Mock(return_value=1)  # type: ignore[method-assign]
+        old_h2_conn.close_connection = mock.Mock(return_value=None)  # type: ignore[method-assign]
+
+        event = h2.events.ConnectionTerminated()
+        event.additional_data = b"bye"
+        old_h2_conn.receive_data = mock.Mock(return_value=[event])  # type: ignore[method-assign]
+
+        conn.putrequest("GET", "/")
+
+        with pytest.raises(
+            ConnectionError,
+            match=r"HTTP/2 connection was terminated: unknown error code \(b'bye'\)",
         ):
             conn.getresponse()
 

--- a/test/test_http2_connection.py
+++ b/test/test_http2_connection.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import socket
 from unittest import mock
 
+import h2.errors
+import h2.events
 import pytest
 
 from urllib3.connection import _get_default_user_agent
@@ -358,3 +360,100 @@ class TestHTTP2Connection:
         )
 
         close_connection.assert_called_with()
+
+    def test_getresponse_raises_on_stream_reset(self) -> None:
+        conn = HTTP2Connection("example.com")
+        conn.sock = mock.MagicMock(
+            recv=mock.Mock(return_value=b"event-data"),
+            sendall=mock.Mock(return_value=None),
+        )
+        conn._h2_conn._obj.receive_data = mock.Mock(  # type: ignore[method-assign]
+            return_value=[
+                h2.events.StreamReset(
+                    stream_id=1, error_code=h2.errors.ErrorCodes.REFUSED_STREAM
+                )
+            ]
+        )
+        conn._h2_conn._obj.data_to_send = mock.Mock(return_value=b"")  # type: ignore[method-assign]
+        conn._h2_conn._obj.get_next_available_stream_id = mock.Mock(return_value=1)  # type: ignore[method-assign]
+
+        conn.putrequest("GET", "/")
+
+        with pytest.raises(
+            ConnectionError, match="HTTP/2 stream 1 was reset: REFUSED_STREAM"
+        ):
+            conn.getresponse()
+
+    def test_getresponse_raises_on_connection_terminated(self) -> None:
+        conn = HTTP2Connection("example.com")
+        conn.sock = mock.MagicMock(
+            recv=mock.Mock(return_value=b"event-data"),
+            sendall=mock.Mock(return_value=None),
+        )
+        old_h2_conn = conn._h2_conn._obj
+        old_h2_conn.data_to_send = mock.Mock(return_value=b"")  # type: ignore[method-assign]
+        old_h2_conn.get_next_available_stream_id = mock.Mock(return_value=1)  # type: ignore[method-assign]
+        old_h2_conn.close_connection = mock.Mock(return_value=None)  # type: ignore[method-assign]
+
+        event = h2.events.ConnectionTerminated()
+        event.error_code = h2.errors.ErrorCodes.NO_ERROR
+        event.last_stream_id = 0
+        old_h2_conn.receive_data = mock.Mock(return_value=[event])  # type: ignore[method-assign]
+
+        conn.putrequest("GET", "/")
+
+        with pytest.raises(
+            ConnectionError,
+            match=r"HTTP/2 connection was terminated: NO_ERROR \(last_stream_id=0\)",
+        ):
+            conn.getresponse()
+
+        old_h2_conn.close_connection.assert_not_called()
+        assert conn.sock is None
+        assert conn._h2_conn._obj is not old_h2_conn
+        assert conn._h2_stream is None
+
+    def test_getresponse_closes_connection_after_graceful_goaway(self) -> None:
+        conn = HTTP2Connection("example.com")
+        conn.sock = mock.MagicMock(
+            recv=mock.Mock(return_value=b"event-data"),
+            sendall=mock.Mock(return_value=None),
+        )
+        old_h2_conn = conn._h2_conn._obj
+        old_h2_conn.data_to_send = mock.Mock(return_value=b"")  # type: ignore[method-assign]
+        old_h2_conn.get_next_available_stream_id = mock.Mock(return_value=1)  # type: ignore[method-assign]
+        old_h2_conn.close_connection = mock.Mock(return_value=None)  # type: ignore[method-assign]
+
+        event = h2.events.ConnectionTerminated()
+        event.error_code = h2.errors.ErrorCodes.NO_ERROR
+        event.last_stream_id = 1
+        old_h2_conn.receive_data = mock.Mock(  # type: ignore[method-assign]
+            return_value=[
+                h2.events.ResponseReceived(
+                    stream_id=1,
+                    headers=[
+                        (b":status", b"200"),
+                        (b"server", b"hypercorn-h2"),
+                    ],
+                ),
+                h2.events.DataReceived(
+                    stream_id=1,
+                    data=b"foo",
+                    flow_controlled_length=3,
+                ),
+                event,
+                h2.events.StreamEnded(stream_id=1),
+            ]
+        )
+        old_h2_conn.acknowledge_received_data = mock.Mock(return_value=None)  # type: ignore[method-assign]
+
+        conn.putrequest("GET", "/")
+        response = conn.getresponse()
+
+        assert response.status == 200
+        assert response.data == b"foo"
+        assert response.headers["server"] == "hypercorn-h2"
+        old_h2_conn.close_connection.assert_not_called()
+        assert conn.sock is None
+        assert conn._h2_conn._obj is not old_h2_conn
+        assert conn._h2_stream is None


### PR DESCRIPTION
## Checklist

- [x] I have read the repository contribution guidelines.
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue

Closes #3291.

## Description of Changes

`HTTP2Connection.getresponse()` handled successful response events but ignored `h2`'s `StreamReset` and `ConnectionTerminated` error events. That could leave the receive loop waiting for more socket data instead of raising a urllib3 error, and it could also leave a GOAWAYed connection reusable.

This change translates those event types into `ConnectionError`s, allows a fully buffered response to complete only when GOAWAY still covers the active stream via `last_stream_id`, and retires the connection afterward. It also avoids sending a second local GOAWAY when the peer has already terminated the connection.

Manual validation performed:
- `uvx nox -rs format`
- `uvx nox -rs lint`
- `uvx nox -rs test-3.14 -- test/test_http2_connection.py -q`
- `uvx nox -rs test-3.14 -- test/with_dummyserver/test_https.py -k 'test_simple and h2' -q`

## Screenshot

N/A (backend/API change)
