### PR TITLE
fix(parse_url): decode percent-encoded auth credentials

### DIFF
--- a/src/urllib3/util/url.py
+++ b/src/urllib3/util/url.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import re
 import typing
+from urllib.parse import unquote
 
 from ..exceptions import LocationParseError
 from .util import to_str
@@ -421,8 +422,8 @@ def parse_url(url: str) -> Url:
             auth, _, host_port = authority.rpartition("@")
             auth = auth or None
             host, port = _HOST_PORT_RE.match(host_port).groups()  # type: ignore[union-attr]
-            if auth and normalize_uri:
-                auth = _encode_invalid_chars(auth, _USERINFO_CHARS)
+            if auth:
+                auth = unquote(auth)
             if port == "":
                 port = None
         else:

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -306,6 +306,25 @@ class TestUtil:
     ]
 
     @pytest.mark.parametrize(
+        "url, expected_auth",
+        [
+            ("http://user:pass@example.com", "user:pass"),
+            ("http://u%7Ber:pass%7D%7Dword@example.com", "u{er:pass}}word"),
+            ("http://user%40name:pass%23word@example.com", "user@name:pass#word"),
+            ("http://simple@example.com", "simple"),
+            ("http://example.com", None),
+        ],
+    )
+    def test_parse_url_decodes_percent_encoded_auth(
+        self, url: str, expected_auth: str | None
+    ) -> None:
+        """Assert parse_url decodes percent-encoded auth credentials.
+
+        Regression test for #4945.
+        """
+        assert parse_url(url).auth == expected_auth
+
+    @pytest.mark.parametrize(
         "url, expected_url",
         chain(parse_url_host_map, non_round_tripping_parse_url_host_map),
     )


### PR DESCRIPTION
Fixes #4945

## Problem

`parse_url()` does not decode percent-encoded characters in the auth (userinfo) component of URLs. When a URL contains `http://u%7Ber:pass%7D%7Dword@example.com`, the `auth` property returns `u%7Ber:pass%7D%7Dword` instead of the decoded `u{er:pass}}word`.

This causes authentication failures when the parsed auth is passed to `make_headers(basic_auth=url.auth)`, as the server expects the actual credentials, not their percent-encoded form.

The behavior is inconsistent with other popular HTTP libraries like `yarl` and `httpx` which correctly decode auth components.

## Fix

- Added `from urllib.parse import unquote` import
- Changed the auth processing to decode percent-encoded characters using `unquote()` instead of re-encoding invalid characters with `_encode_invalid_chars()`

## Tests

- Added `test_parse_url_decodes_percent_encoded_auth` with 5 test cases covering:
  - Normal auth (no encoding needed)
  - Curly braces in auth (`%7B`, `%7D`)
  - `@` and `#` characters in auth (`%40`, `%23`)
  - Simple auth string
  - No auth present