### PR TITLE
Handle null body response in Emscripten

### DIFF
--- a/changelog/4953.bugfix.rst
+++ b/changelog/4953.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed no response body (e.g. from HEAD requests) handling on Emscripten.

--- a/src/urllib3/contrib/emscripten/emscripten_fetch_worker.js
+++ b/src/urllib3/contrib/emscripten/emscripten_fetch_worker.js
@@ -22,6 +22,16 @@ self.addEventListener("message", async function (event) {
     if (!value || curOffset >= value.length) {
       // read another buffer if required
       try {
+        if (reader === null) {
+          // no response body - clear connection and return
+          connections.delete(connectionID);
+          Atomics.store(intBuffer, 0, Status.SUCCESS_EOF);
+          Atomics.notify(intBuffer, 0);
+          // finished reading successfully
+          // return from event handler
+          return;
+        }
+
         let readResponse = await reader.read();
 
         if (readResponse.done) {
@@ -85,7 +95,7 @@ self.addEventListener("message", async function (event) {
       intBuffer[1] = written;
       // make a connection
       connections.set(connectionID, {
-        reader: response.body.getReader(),
+        reader: response.body ? response.body.getReader() : null,
         intBuffer: intBuffer,
         byteBuffer: byteBuffer,
         value: undefined,

--- a/src/urllib3/contrib/emscripten/fetch.py
+++ b/src/urllib3/contrib/emscripten/fetch.py
@@ -47,6 +47,7 @@ from pyodide.ffi import (  # type: ignore[import-not-found]
     JsArray,
     JsException,
     JsProxy,
+    jsnull,
     to_js,
 )
 
@@ -528,7 +529,9 @@ def send_request(request: EmscriptenRequest) -> EmscriptenResponse:
 
         headers = dict(Parser().parsestr(js_xhr.getAllResponseHeaders()))
 
-        if not is_in_browser_main_thread():
+        if js_xhr.response is jsnull:
+            body = b""
+        elif not is_in_browser_main_thread():
             body = js_xhr.response.to_py().tobytes()
         else:
             body = js_xhr.response.encode("ISO-8859-15")
@@ -596,19 +599,20 @@ def send_jspi_request(
         else:
             headers[str(iter_value_js.value[0])] = str(iter_value_js.value[1])
     status_code = response_js.status
-    body: bytes | io.RawIOBase = b""
+    body: bytes | io.RawIOBase
 
     response = EmscriptenResponse(
         status_code=status_code, headers=headers, body=b"", request=request
     )
-    if streaming:
+    if response_js.body is jsnull:
+        body = b""
+    elif streaming:
         # get via inputstream
-        if response_js.body is not None:
-            # get a reader from the fetch response
-            body_stream_js = response_js.body.getReader()
-            body = _JSPIReadStream(
-                body_stream_js, timeout, request, response, js_abort_controller
-            )
+        # get a reader from the fetch response
+        body_stream_js = response_js.body.getReader()
+        body = _JSPIReadStream(
+            body_stream_js, timeout, request, response, js_abort_controller
+        )
     else:
         # get directly via arraybuffer
         # n.b. this is another async JavaScript call.
@@ -618,7 +622,7 @@ def send_jspi_request(
             js_abort_controller,
             request=request,
             response=response,
-        ).to_py()
+        ).to_bytes()
     response.body = body
     return response
 

--- a/test/contrib/emscripten/test_emscripten.py
+++ b/test/contrib/emscripten/test_emscripten.py
@@ -435,6 +435,67 @@ def test_specific_method(
     )
 
 
+def test_null_body_non_streaming(
+    selenium_coverage: typing.Any,
+    testserver_http: PyodideServerInfo,
+) -> None:
+    """A 204 makes ``fetch`` set ``response.body`` to JavaScript ``null``.
+
+    Pyodide converts that to ``JsNull``, which is *not* ``None``, so an
+    ``is not None`` guard lets it through and the reader call then fails with
+    ``AttributeError: 'JsNull' object has no attribute 'getReader'`` (#3723).
+
+    204 is used rather than HEAD because the fetch spec guarantees a null body
+    for it by status, independent of what the server sends.
+    """
+
+    @run_in_pyodide  # type: ignore[untyped-decorator]
+    def pyodide_test(selenium_coverage, host: str, port: int) -> None:  # type: ignore[no-untyped-def]
+        from urllib3 import HTTPSConnectionPool
+
+        with HTTPSConnectionPool(host, port) as pool:
+            response = pool.request("GET", "/status?status=204 NO CONTENT")
+            assert response.status == 204
+            assert response.data == b""
+
+    pyodide_test(
+        selenium_coverage, testserver_http.http_host, testserver_http.https_port
+    )
+
+
+@pytest.mark.webworkers
+def test_null_body_streaming(
+    testserver_http: PyodideServerInfo,
+    run_from_server: ServerRunnerInfo,
+    prefer_jspi: bool,
+) -> None:
+    """Same as above on the streaming path, which is the one #3723 reported.
+
+    Streaming has to run in a webworker, and it reaches ``response.body``
+    through a different branch than the non-streaming path -- ``_JSPIReadStream``
+    under JSPI, the worker's ``getReader()`` otherwise -- so both need covering.
+    """
+    url = (
+        f"http://{testserver_http.http_host}:{testserver_http.http_port}"
+        "/status?status=204 NO CONTENT"
+    )
+    worker_code = f"""
+            import urllib3.contrib.emscripten.fetch
+            await urllib3.contrib.emscripten.fetch.wait_for_streaming_ready()
+            from urllib3.response import BaseHTTPResponse
+            from urllib3.connection import HTTPConnection
+
+            conn = HTTPConnection("{testserver_http.http_host}", {testserver_http.http_port})
+            conn.request("GET", "{url}", preload_content=False)
+            response = conn.getresponse()
+            assert isinstance(response, BaseHTTPResponse)
+            assert(urllib3.contrib.emscripten.fetch.has_jspi() == {prefer_jspi})
+            assert response.status == 204
+            assert response.data == b""
+"""
+    run_from_server.run_webworker(worker_code)
+
+
 @pytest.mark.webworkers
 def test_streaming_download(
     testserver_http: PyodideServerInfo,


### PR DESCRIPTION
JS response body may be null, for instance for HEAD requests, and this was not yet handled in all cases.

cc @hoodmane @joemarshall 

<!---
Thanks for your contribution! ♥️

If this is your first PR to urllib3 please review the Contributing Guide:
https://urllib3.readthedocs.io/en/latest/contributing.html

Adhering to the Contributing Guide means we can review, merge, and release your change faster! :)
--->
