### PR TITLE
Fix full read with `amt=None` after a partial read

### DIFF
--- a/changelog/3636.bugfix.rst
+++ b/changelog/3636.bugfix.rst
@@ -1,0 +1,4 @@
+Fixed a bug where ``HTTPResponse.read(amt=None)`` ignored decompressed data
+buffered from previous partial reads. Also prevented ``HTTPResponse.read()``
+from caching only a chunk of data after a partial read when
+``cache_content=True``.

--- a/changelog/3636.bugfix.rst
+++ b/changelog/3636.bugfix.rst
@@ -1,4 +1,2 @@
-Fixed a bug where ``HTTPResponse.read(amt=None)`` ignored decompressed data
-buffered from previous partial reads. Also prevented ``HTTPResponse.read()``
-from caching only a chunk of data after a partial read when
-``cache_content=True``.
+Fixed a bug where ``HTTPResponse.read(amt=None)`` was ignoring decompressed data
+buffered from previous partial reads.

--- a/src/urllib3/response.py
+++ b/src/urllib3/response.py
@@ -485,7 +485,6 @@ class BaseHTTPResponse(io.IOBase):
         self.reason = reason
         self.decode_content = decode_content
         self._has_decoded_content = False
-        self._uncached_read_occured = False
         self._request_url: str | None = request_url
         self.retries = retries
 
@@ -1090,7 +1089,6 @@ class HTTPResponse(BaseHTTPResponse):
             amt = None
         elif amt is not None:
             cache_content = False
-            self._uncached_read_occured = True
 
             if self._decoder and self._decoder.has_unconsumed_tail:
                 decoded_data = self._decode(
@@ -1122,7 +1120,7 @@ class HTTPResponse(BaseHTTPResponse):
                 self._decoded_buffer.put(data)
                 data = self._decoded_buffer.get_all()
 
-            if cache_content and not self._uncached_read_occured:
+            if cache_content:
                 self._body = data
         else:
             # do not waste memory on buffer when not decoding
@@ -1175,7 +1173,6 @@ class HTTPResponse(BaseHTTPResponse):
             If True, will attempt to decode the body based on the
             'content-encoding' header.
         """
-        self._uncached_read_occured = True
         if decode_content is None:
             decode_content = self.decode_content
         if amt and amt < 0:
@@ -1385,7 +1382,6 @@ class HTTPResponse(BaseHTTPResponse):
             If True, will attempt to decode the body based on the
             'content-encoding' header.
         """
-        self._uncached_read_occured = True
         self._init_decoder()
         # FIXME: Rewrite this method and make it a class with a better structured logic.
         if not self.chunked:

--- a/src/urllib3/response.py
+++ b/src/urllib3/response.py
@@ -485,6 +485,7 @@ class BaseHTTPResponse(io.IOBase):
         self.reason = reason
         self.decode_content = decode_content
         self._has_decoded_content = False
+        self._uncached_read_occured = False
         self._request_url: str | None = request_url
         self.retries = retries
 
@@ -1089,6 +1090,7 @@ class HTTPResponse(BaseHTTPResponse):
             amt = None
         elif amt is not None:
             cache_content = False
+            self._uncached_read_occured = True
 
             if self._decoder and self._decoder.has_unconsumed_tail:
                 decoded_data = self._decode(
@@ -1114,7 +1116,13 @@ class HTTPResponse(BaseHTTPResponse):
 
         if amt is None:
             data = self._decode(data, decode_content, flush_decoder)
-            if cache_content:
+            # It's possible that there is buffered decoded data after a
+            # partial read.
+            if decode_content and len(self._decoded_buffer) > 0:
+                self._decoded_buffer.put(data)
+                data = self._decoded_buffer.get_all()
+
+            if cache_content and not self._uncached_read_occured:
                 self._body = data
         else:
             # do not waste memory on buffer when not decoding
@@ -1167,6 +1175,7 @@ class HTTPResponse(BaseHTTPResponse):
             If True, will attempt to decode the body based on the
             'content-encoding' header.
         """
+        self._uncached_read_occured = True
         if decode_content is None:
             decode_content = self.decode_content
         if amt and amt < 0:
@@ -1376,6 +1385,7 @@ class HTTPResponse(BaseHTTPResponse):
             If True, will attempt to decode the body based on the
             'content-encoding' header.
         """
+        self._uncached_read_occured = True
         self._init_decoder()
         # FIXME: Rewrite this method and make it a class with a better structured logic.
         if not self.chunked:

--- a/test/test_response.py
+++ b/test/test_response.py
@@ -219,6 +219,47 @@ class TestResponse:
         assert r._body == b"foo"  # type: ignore[comparison-overlap]
         assert r.data == b"foo"
 
+    def test_cache_content_with_explicit_read_call(self) -> None:
+        fp = BytesIO(b"foo")
+        r = HTTPResponse(fp, preload_content=False)
+        assert r.read(cache_content=True) == b"foo"
+        assert r._body == b"foo"
+        assert r.data == b"foo"
+
+    @pytest.mark.parametrize(
+        "initial_read_method", ("read", "read1", "read_chunked", "stream")
+    )
+    def test_cache_content_ignored_during_and_after_partial_read(
+        self, initial_read_method: str
+    ) -> None:
+        data = b"foo"
+        initial_limit = 1
+        if initial_read_method in ("read_chunked", "stream"):
+            httplib_r = httplib.HTTPResponse(MockSock)  # type: ignore[arg-type]
+            httplib_r.chunked = True
+            httplib_r.fp = MockChunkedEncodingResponse([data])  # type: ignore[assignment]
+            r = HTTPResponse(
+                httplib_r,
+                preload_content=False,
+                headers={"transfer-encoding": "chunked"},
+            )
+            # Partial read.
+            next(getattr(r, initial_read_method)(initial_limit))
+            httplib_r.chunk_left = len(data) - initial_limit
+        else:
+            fp = BytesIO(data)
+            r = HTTPResponse(fp, preload_content=False)
+            # Partial read.
+            if initial_read_method == "read":
+                r.read(initial_limit, cache_content=True)
+            else:
+                getattr(r, initial_read_method)(initial_limit)
+        assert r._body is None
+        # Full read (remaining content).
+        r.read(cache_content=True)
+        assert r._body is None
+        assert r.data == b""
+
     def test_default(self) -> None:
         r = HTTPResponse()
         assert r.data is None
@@ -897,6 +938,35 @@ class TestResponse:
                 fp,
                 headers={"content-encoding": "gzip, deflate, br, zstd, gzip, deflate"},
             )
+
+    def test_full_read_after_partial_read_with_buffered_decoded_data(self) -> None:
+        data = zlib.compress(b"foobarbaz")
+        fp = BytesIO(data)
+        r = HTTPResponse(
+            fp, headers={"content-encoding": "deflate"}, preload_content=False
+        )
+        assert r.read(3) == b"foo"
+        # Force putting some decoded data in the buffer as the buffer
+        # is normally empty unless decoder has issues like not
+        # respecting `max_length` https://github.com/google/brotli/issues/1396
+        middle_part = r._decode(
+            r._raw_read(), decode_content=True, flush_decoder=False, max_length=3
+        )
+        assert middle_part == b"bar"
+        r._decoded_buffer.put(middle_part)
+        # Here we expect data from `_decoded_buffer` to be joined with
+        # the remaining part.
+        assert r.read() == b"barbaz"
+
+    def test_full_read_after_partial_read_without_buffered_decoded_data(self) -> None:
+        data = zlib.compress(b"foobarbaz")
+        fp = BytesIO(data)
+        r = HTTPResponse(
+            fp, headers={"content-encoding": "deflate"}, preload_content=False
+        )
+        assert r.read(3) == b"foo"
+        assert len(r._decoded_buffer) == 0
+        assert r.read() == b"barbaz"
 
     def test_body_blob(self) -> None:
         resp = HTTPResponse(b"foo")
@@ -1969,8 +2039,8 @@ class MockChunkedEncodingResponse:
                 self.cur_chunk = self.cur_chunk[amt:]
             return chunk_part
 
-    def readline(self) -> bytes:
-        return self.pop_current_chunk(till_crlf=True)
+    def readline(self, amt: int = -1) -> bytes:
+        return self.pop_current_chunk(amt, till_crlf=amt < 0)
 
     def read(self, amt: int = -1) -> bytes:
         return self.pop_current_chunk(amt)

--- a/test/test_response.py
+++ b/test/test_response.py
@@ -219,47 +219,6 @@ class TestResponse:
         assert r._body == b"foo"  # type: ignore[comparison-overlap]
         assert r.data == b"foo"
 
-    def test_cache_content_with_explicit_read_call(self) -> None:
-        fp = BytesIO(b"foo")
-        r = HTTPResponse(fp, preload_content=False)
-        assert r.read(cache_content=True) == b"foo"
-        assert r._body == b"foo"
-        assert r.data == b"foo"
-
-    @pytest.mark.parametrize(
-        "initial_read_method", ("read", "read1", "read_chunked", "stream")
-    )
-    def test_cache_content_ignored_during_and_after_partial_read(
-        self, initial_read_method: str
-    ) -> None:
-        data = b"foo"
-        initial_limit = 1
-        if initial_read_method in ("read_chunked", "stream"):
-            httplib_r = httplib.HTTPResponse(MockSock)  # type: ignore[arg-type]
-            httplib_r.chunked = True
-            httplib_r.fp = MockChunkedEncodingResponse([data])  # type: ignore[assignment]
-            r = HTTPResponse(
-                httplib_r,
-                preload_content=False,
-                headers={"transfer-encoding": "chunked"},
-            )
-            # Partial read.
-            next(getattr(r, initial_read_method)(initial_limit))
-            httplib_r.chunk_left = len(data) - initial_limit
-        else:
-            fp = BytesIO(data)
-            r = HTTPResponse(fp, preload_content=False)
-            # Partial read.
-            if initial_read_method == "read":
-                r.read(initial_limit, cache_content=True)
-            else:
-                getattr(r, initial_read_method)(initial_limit)
-        assert r._body is None
-        # Full read (remaining content).
-        r.read(cache_content=True)
-        assert r._body is None
-        assert r.data == b""
-
     def test_default(self) -> None:
         r = HTTPResponse()
         assert r.data is None
@@ -2039,8 +1998,8 @@ class MockChunkedEncodingResponse:
                 self.cur_chunk = self.cur_chunk[amt:]
             return chunk_part
 
-    def readline(self, amt: int = -1) -> bytes:
-        return self.pop_current_chunk(amt, till_crlf=amt < 0)
+    def readline(self) -> bytes:
+        return self.pop_current_chunk(till_crlf=True)
 
     def read(self, amt: int = -1) -> bytes:
         return self.pop_current_chunk(amt)


### PR DESCRIPTION
Fixes #3636

A partial read could leave some data inside `_decoded_buffer`, this buffered data was ignored during the next full read with `amt=None`.