### PR TITLE
Fix proxy_ssl_context mutation when target uses cert_reqs='CERT_NONE'

### DIFF
--- a/changelog/4961.bugfix.rst
+++ b/changelog/4961.bugfix.rst
@@ -1,0 +1,4 @@
+Fixed ``proxy_ssl_context`` being mutated when ``cert_reqs='CERT_NONE'`` was
+set for the target connection. The target's ``cert_reqs`` no longer leaks into
+the proxy TLS handshake, and user-provided ``ssl_context`` objects passed to
+``_ssl_wrap_socket_and_match_hostname()`` are no longer modified in place.

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -865,9 +865,19 @@ class HTTPSConnection(HTTPConnection):
         # `_connect_tls_proxy` is called when self._tunnel_host is truthy.
         proxy_config = typing.cast(ProxyConfig, self.proxy_config)
         ssl_context = proxy_config.ssl_context
+
+        # When a proxy_ssl_context is provided, derive cert_reqs from the
+        # proxy's own context rather than using the target connection's
+        # cert_reqs. Otherwise the target's CERT_NONE can leak into the
+        # proxy handshake, and the caller's context object gets mutated.
+        if ssl_context is not None:
+            proxy_cert_reqs = ssl_context.verify_mode
+        else:
+            proxy_cert_reqs = None
+
         sock_and_verified = _ssl_wrap_socket_and_match_hostname(
             sock,
-            cert_reqs=self.cert_reqs,
+            cert_reqs=proxy_cert_reqs,
             ssl_version=self.ssl_version,
             ssl_minimum_version=self.ssl_minimum_version,
             ssl_maximum_version=self.ssl_maximum_version,
@@ -934,7 +944,10 @@ def _ssl_wrap_socket_and_match_hostname(
     else:
         context = ssl_context
 
-    context.verify_mode = resolve_cert_reqs(cert_reqs)
+    # Only override verify_mode on contexts we created ourselves.
+    # User-provided ssl_context objects must not be mutated.
+    if default_ssl_context:
+        context.verify_mode = resolve_cert_reqs(cert_reqs)
 
     # In some cases, we want to verify hostnames ourselves
     if (

--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -8,12 +8,14 @@ from unittest import mock
 
 import pytest
 
+from urllib3._base_connection import ProxyConfig
 from urllib3.connection import (  # type: ignore[attr-defined]
     RECENT_DATE,
     CertificateError,
     HTTPConnection,
     HTTPSConnection,
     _match_hostname,
+    _ssl_wrap_socket_and_match_hostname,
     _url_from_connection,
     _wrap_proxy_error,
 )
@@ -326,3 +328,77 @@ class TestConnection:
             assert "User-Agent" in request_headers
         else:
             assert user_agent not in request_headers
+
+    @pytest.mark.skipif(ssl_ is None, reason="requires ssl")
+    def test_ssl_wrap_socket_does_not_mutate_user_context(self) -> None:
+        import ssl
+
+        context = ssl_.create_urllib3_context()
+        context.check_hostname = False
+        context.verify_mode = ssl.CERT_REQUIRED
+
+        original_verify_mode = context.verify_mode
+        original_check_hostname = context.check_hostname
+
+        sock = mock.MagicMock(spec=socket.socket)
+        try:
+            _ssl_wrap_socket_and_match_hostname(
+                sock=sock,
+                cert_reqs=ssl.CERT_NONE,
+                ssl_version=None,
+                ssl_minimum_version=None,
+                ssl_maximum_version=None,
+                ca_certs=None,
+                ca_cert_dir=None,
+                ca_cert_data=None,
+                cert_file=None,
+                key_file=None,
+                key_password=None,
+                server_hostname="example.com",
+                ssl_context=context,
+                assert_hostname=None,
+                assert_fingerprint=None,
+            )
+        except Exception:
+            pass
+
+        assert context.verify_mode == original_verify_mode
+        assert context.check_hostname == original_check_hostname
+
+    @pytest.mark.skipif(ssl_ is None, reason="requires ssl")
+    def test_connect_tls_proxy_does_not_use_target_cert_reqs(self) -> None:
+        import ssl
+
+        proxy_ssl_context = ssl_.create_urllib3_context()
+        proxy_ssl_context.check_hostname = False
+        proxy_ssl_context.verify_mode = ssl.CERT_REQUIRED
+
+        proxy_config = ProxyConfig(
+            ssl_context=proxy_ssl_context,
+            use_forwarding_for_https=False,
+            assert_hostname=None,
+            assert_fingerprint=None,
+        )
+
+        conn = HTTPSConnection(
+            "target.example.com",
+            port=443,
+            cert_reqs="CERT_NONE",
+            proxy=mock.MagicMock(),
+            proxy_config=proxy_config,
+        )
+
+        sock = mock.MagicMock(spec=socket.socket)
+
+        with mock.patch(
+            "urllib3.connection._ssl_wrap_socket_and_match_hostname"
+        ) as mock_wrap:
+            mock_wrap.return_value = mock.MagicMock(
+                socket=mock.MagicMock(spec=ssl.SSLSocket),
+                is_verified=True,
+            )
+            conn._connect_tls_proxy("proxy.example.com", sock)
+
+        call_kwargs = mock_wrap.call_args
+        assert call_kwargs[1]["cert_reqs"] == ssl.CERT_REQUIRED
+        assert proxy_ssl_context.verify_mode == ssl.CERT_REQUIRED

--- a/test/with_dummyserver/test_proxy_poolmanager.py
+++ b/test/with_dummyserver/test_proxy_poolmanager.py
@@ -10,6 +10,7 @@ import shutil
 import socket
 import ssl
 import tempfile
+import warnings
 from test import LONG_TIMEOUT, SHORT_TIMEOUT, resolvesLocalhostFQDN, withPyOpenSSL
 from test.conftest import ServerConfig
 
@@ -141,6 +142,26 @@ class TestHTTPProxyManager(HypercornDummyProxyTestCase):
 
             r = https.request("GET", f"{self.http_url}/")
             assert r.status == 200
+
+    def test_https_proxy_ssl_context_not_mutated(self) -> None:
+        proxy_ssl_context = create_urllib3_context()
+        proxy_ssl_context.load_verify_locations(DEFAULT_CA)
+        proxy_ssl_context.check_hostname = False
+        proxy_ssl_context.verify_mode = ssl.CERT_REQUIRED
+
+        with proxy_from_url(
+            self.https_proxy_url,
+            proxy_ssl_context=proxy_ssl_context,
+            cert_reqs="CERT_NONE",
+        ) as https:
+            with warnings.catch_warnings():
+                warnings.simplefilter(
+                    "ignore", urllib3.exceptions.InsecureRequestWarning
+                )
+                r = https.request("GET", f"{self.https_url}/")
+                assert r.status == 200
+
+        assert proxy_ssl_context.verify_mode == ssl.CERT_REQUIRED
 
     @withPyOpenSSL
     def test_https_proxy_pyopenssl_not_supported(self) -> None:


### PR DESCRIPTION
_connect_tls_proxy() was passing the target connection's cert_reqs to _ssl_wrap_socket_and_match_hostname(), which then unconditionally overwrote verify_mode on the user-provided proxy_ssl_context. This caused the proxy context to permanently inherit the target's CERT_NONE setting.

Two changes:
- _connect_tls_proxy() now derives cert_reqs from the proxy context's own verify_mode when a proxy_ssl_context is provided.
- _ssl_wrap_socket_and_match_hostname() no longer mutates verify_mode on user-provided ssl_context objects.

Fixes #4961

<!---
Thanks for your contribution! ♥️

If this is your first PR to urllib3 please review the Contributing Guide:
https://urllib3.readthedocs.io/en/latest/contributing.html

Adhering to the Contributing Guide means we can review, merge, and release your change faster! :)
--->
