### PR TITLE
Prevent content caching after a partial read

### DIFF
--- a/changelog/4967.bugfix.rst
+++ b/changelog/4967.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed a bug where ``HTTPResponse.read()`` could cache only part of the response
+after a partial read when ``cache_content=True``.

--- a/src/urllib3/contrib/emscripten/response.py
+++ b/src/urllib3/contrib/emscripten/response.py
@@ -36,6 +36,7 @@ class EmscriptenHttpResponseWrapper(BaseHTTPResponse):
     ):
         self._pool = None  # set by pool class
         self._body = None
+        self._uncached_read_occured = False
         self._response = internal_response
         self._url = url
         self._connection = connection
@@ -160,10 +161,13 @@ class EmscriptenHttpResponseWrapper(BaseHTTPResponse):
                 # don't cache partial content
                 cache_content = False
                 data = self._response.body.read(amt)
+                self._uncached_read_occured = True
             else:  # read all we can (and cache it)
                 data = self._response.body.read()
-                if cache_content:
+                if cache_content and not self._uncached_read_occured:
                     self._body = data
+                else:
+                    self._uncached_read_occured = True
             if self.length_remaining is not None:
                 self.length_remaining = max(self.length_remaining - len(data), 0)
             if len(data) == 0 or (

--- a/src/urllib3/contrib/emscripten/response.py
+++ b/src/urllib3/contrib/emscripten/response.py
@@ -36,7 +36,7 @@ class EmscriptenHttpResponseWrapper(BaseHTTPResponse):
     ):
         self._pool = None  # set by pool class
         self._body = None
-        self._uncached_read_occured = False
+        self._uncached_read_occurred = False
         self._response = internal_response
         self._url = url
         self._connection = connection
@@ -161,13 +161,13 @@ class EmscriptenHttpResponseWrapper(BaseHTTPResponse):
                 # don't cache partial content
                 cache_content = False
                 data = self._response.body.read(amt)
-                self._uncached_read_occured = True
+                self._uncached_read_occurred = True
             else:  # read all we can (and cache it)
                 data = self._response.body.read()
-                if cache_content and not self._uncached_read_occured:
+                if cache_content and not self._uncached_read_occurred:
                     self._body = data
                 else:
-                    self._uncached_read_occured = True
+                    self._uncached_read_occurred = True
             if self.length_remaining is not None:
                 self.length_remaining = max(self.length_remaining - len(data), 0)
             if len(data) == 0 or (

--- a/src/urllib3/response.py
+++ b/src/urllib3/response.py
@@ -755,6 +755,7 @@ class HTTPResponse(BaseHTTPResponse):
         self.auto_close = auto_close
 
         self._body = None
+        self._uncached_read_occured = False
         self._fp: _HttplibHTTPResponse | None = None
         self._original_response = original_response
         self._fp_bytes_read = 0
@@ -1102,6 +1103,8 @@ class HTTPResponse(BaseHTTPResponse):
                 return self._decoded_buffer.get(amt)
 
         data = self._raw_read(amt)
+        if not cache_content:
+            self._uncached_read_occured = True
 
         flush_decoder = amt is None or (amt != 0 and not data)
 
@@ -1114,7 +1117,7 @@ class HTTPResponse(BaseHTTPResponse):
 
         if amt is None:
             data = self._decode(data, decode_content, flush_decoder)
-            if cache_content:
+            if cache_content and not self._uncached_read_occured:
                 self._body = data
         else:
             # do not waste memory on buffer when not decoding
@@ -1202,6 +1205,7 @@ class HTTPResponse(BaseHTTPResponse):
 
         # FIXME, this method's type doesn't say returning None is possible
         data = self._raw_read(amt, read1=True)
+        self._uncached_read_occured = True
         if not decode_content or data is None:
             return data
 
@@ -1411,6 +1415,7 @@ class HTTPResponse(BaseHTTPResponse):
                     chunk = b""
                 else:
                     self._update_chunk_length()
+                    self._uncached_read_occured = True
                     if self.chunk_left == 0:
                         break
                     chunk = self._handle_chunk(amt)

--- a/src/urllib3/response.py
+++ b/src/urllib3/response.py
@@ -755,7 +755,7 @@ class HTTPResponse(BaseHTTPResponse):
         self.auto_close = auto_close
 
         self._body = None
-        self._uncached_read_occured = False
+        self._uncached_read_occurred = False
         self._fp: _HttplibHTTPResponse | None = None
         self._original_response = original_response
         self._fp_bytes_read = 0
@@ -1104,7 +1104,7 @@ class HTTPResponse(BaseHTTPResponse):
 
         data = self._raw_read(amt)
         if not cache_content:
-            self._uncached_read_occured = True
+            self._uncached_read_occurred = True
 
         flush_decoder = amt is None or (amt != 0 and not data)
 
@@ -1123,7 +1123,7 @@ class HTTPResponse(BaseHTTPResponse):
                 self._decoded_buffer.put(data)
                 data = self._decoded_buffer.get_all()
 
-            if cache_content and not self._uncached_read_occured:
+            if cache_content and not self._uncached_read_occurred:
                 self._body = data
         else:
             # do not waste memory on buffer when not decoding
@@ -1211,7 +1211,7 @@ class HTTPResponse(BaseHTTPResponse):
 
         # FIXME, this method's type doesn't say returning None is possible
         data = self._raw_read(amt, read1=True)
-        self._uncached_read_occured = True
+        self._uncached_read_occurred = True
         if not decode_content or data is None:
             return data
 
@@ -1421,7 +1421,7 @@ class HTTPResponse(BaseHTTPResponse):
                     chunk = b""
                 else:
                     self._update_chunk_length()
-                    self._uncached_read_occured = True
+                    self._uncached_read_occurred = True
                     if self.chunk_left == 0:
                         break
                     chunk = self._handle_chunk(amt)

--- a/test/contrib/emscripten/test_emscripten.py
+++ b/test/contrib/emscripten/test_emscripten.py
@@ -76,7 +76,9 @@ def test_pool_requests(
 
         http = urllib3.PoolManager()
         resp = http.request("GET", f"http://{host}:{port}/")
-        assert resp.data.decode("utf-8") == "Dummy server!"
+        # ensure that the response is cached and can be read multiple times
+        for _ in range(2):
+            assert resp.data.decode("utf-8") == "Dummy server!"
 
         resp2 = http.request("GET", f"http://{host}:{port}/index")
         assert resp2.data.decode("utf-8") == "Dummy server!"
@@ -1100,6 +1102,9 @@ def test_streaming_jspi(
         # by checking that it took greater than the timeout
         assert time.time() - start_time > 2
         assert len(all_data.decode("utf-8")) == 17825792
+        # ensure that the content is not cached
+        assert response._body is None
+        assert response.data == b""
 
     pyodide_test(
         selenium_coverage,
@@ -1144,6 +1149,34 @@ def test_streaming2_jspi(
         testserver_http.http_host,
         testserver_http.http_port,
         bigfile_url,
+    )
+
+
+def test_cache_content_ignored_during_and_after_partial_read(
+    selenium_coverage: typing.Any, testserver_http: PyodideServerInfo
+) -> None:
+    @run_in_pyodide
+    def pyodide_test(selenium, host, port):  # type: ignore[no-untyped-def]
+        from urllib3.connection import HTTPConnection
+        from urllib3.response import BaseHTTPResponse
+
+        conn = HTTPConnection(host, port)
+        conn.request("GET", f"http://{host}:{port}/dripfeed", preload_content=False)
+        response = conn.getresponse()
+        assert isinstance(response, BaseHTTPResponse)
+        # read some of the data but not all of it
+        data = response.read(32768, cache_content=True)
+        assert len(data) == 32768
+        # check that the cached content is empty
+        assert response._body is None
+        # ensure the rest of the data is not cached either
+        data += response.read(cache_content=True)
+        assert len(data) == 17825792
+        assert response._body is None
+        assert response.data == b""
+
+    pyodide_test(
+        selenium_coverage, testserver_http.http_host, testserver_http.http_port
     )
 
 

--- a/test/test_response.py
+++ b/test/test_response.py
@@ -219,6 +219,47 @@ class TestResponse:
         assert r._body == b"foo"  # type: ignore[comparison-overlap]
         assert r.data == b"foo"
 
+    def test_cache_content_with_explicit_read_call(self) -> None:
+        fp = BytesIO(b"foo")
+        r = HTTPResponse(fp, preload_content=False)
+        assert r.read(cache_content=True) == b"foo"
+        assert r._body == b"foo"
+        assert r.data == b"foo"
+
+    @pytest.mark.parametrize(
+        "initial_read_method", ("read", "read1", "read_chunked", "stream")
+    )
+    def test_cache_content_ignored_during_and_after_partial_read(
+        self, initial_read_method: str
+    ) -> None:
+        data = b"foo"
+        initial_limit = 1
+        if initial_read_method in ("read_chunked", "stream"):
+            httplib_r = httplib.HTTPResponse(MockSock)  # type: ignore[arg-type]
+            httplib_r.chunked = True
+            httplib_r.fp = MockChunkedEncodingResponse([data])  # type: ignore[assignment]
+            r = HTTPResponse(
+                httplib_r,
+                preload_content=False,
+                headers={"transfer-encoding": "chunked"},
+            )
+            # Partial read.
+            next(getattr(r, initial_read_method)(initial_limit))
+            httplib_r.chunk_left = len(data) - initial_limit
+        else:
+            fp = BytesIO(data)
+            r = HTTPResponse(fp, preload_content=False)
+            # Partial read.
+            if initial_read_method == "read":
+                r.read(initial_limit, cache_content=True)
+            else:
+                getattr(r, initial_read_method)(initial_limit)
+        assert r._body is None
+        # Full read (remaining content).
+        r.read(cache_content=True)
+        assert r._body is None
+        assert r.data == b""
+
     def test_default(self) -> None:
         r = HTTPResponse()
         assert r.data is None
@@ -1969,8 +2010,8 @@ class MockChunkedEncodingResponse:
                 self.cur_chunk = self.cur_chunk[amt:]
             return chunk_part
 
-    def readline(self) -> bytes:
-        return self.pop_current_chunk(till_crlf=True)
+    def readline(self, amt: int = -1) -> bytes:
+        return self.pop_current_chunk(amt, till_crlf=amt < 0)
 
     def read(self, amt: int = -1) -> bytes:
         return self.pop_current_chunk(amt)

--- a/test/test_response.py
+++ b/test/test_response.py
@@ -219,10 +219,13 @@ class TestResponse:
         assert r._body == b"foo"  # type: ignore[comparison-overlap]
         assert r.data == b"foo"
 
-    def test_cache_content_with_explicit_read_call(self) -> None:
+    @pytest.mark.parametrize("read_args", ((), (None,), (-1,)))
+    def test_cache_content_with_explicit_read_call(
+        self, read_args: tuple[typing.Any, ...]
+    ) -> None:
         fp = BytesIO(b"foo")
         r = HTTPResponse(fp, preload_content=False)
-        assert r.read(cache_content=True) == b"foo"
+        assert r.read(*read_args, cache_content=True) == b"foo"
         assert r._body == b"foo"
         assert r.data == b"foo"
 

--- a/test/test_response.py
+++ b/test/test_response.py
@@ -225,7 +225,7 @@ class TestResponse:
     ) -> None:
         fp = BytesIO(b"foo")
         r = HTTPResponse(fp, preload_content=False)
-        assert r.read(*read_args, cache_content=True) == b"foo"
+        assert r.read(*read_args, cache_content=True) == b"foo"  # type: ignore[misc]
         assert r._body == b"foo"
         assert r.data == b"foo"
 


### PR DESCRIPTION
#4960 fixes `read(amt=None)` calls after a partial read. This PR addresses a related issue where only a portion of content could be cached.