### PR TITLE
Fix a misleading example for `ProxyManager`

### DIFF
--- a/src/urllib3/poolmanager.py
+++ b/src/urllib3/poolmanager.py
@@ -544,15 +544,17 @@ class ProxyManager(PoolManager):
 
         proxy = urllib3.ProxyManager("https://localhost:3128/")
 
-        resp1 = proxy.request("GET", "https://google.com/")
-        resp2 = proxy.request("GET", "https://httpbin.org/")
+        resp1 = proxy.request("GET", "http://google.com/")
+        resp2 = proxy.request("GET", "http://httpbin.org/")
 
+        # One pool was shared by both plain HTTP requests.
         print(len(proxy.pools))
         # 1
 
         resp3 = proxy.request("GET", "https://httpbin.org/")
         resp4 = proxy.request("GET", "https://twitter.com/")
 
+        # A separate pool was added for each HTTPS target.
         print(len(proxy.pools))
         # 3
 


### PR DESCRIPTION
Docstring of `ProxyManager` had been containing an example showing that:
- one pool is shared for all plain-HTTP requests
- a separate pool is created for every HTTPs target

https://github.com/urllib3/urllib3/commit/c55e0840b1e9596941b4279a633264aae976b3e4#diff-2fe80b3f580c0daa9f6a97de561c7fcd92fde02afdfaecdc210b6563817e69bb changed the example, and it is misleading now.