### PR TITLE
Avoid infinite loop in `HTTPResponse.read_chunked` when `amt` is zero

### DIFF
--- a/changelog/3793.bugfix.rst
+++ b/changelog/3793.bugfix.rst
@@ -1,1 +1,1 @@
-Fixed ``HTTPResponse.stream()`` to handle ``amt=0``.
+Fixed ``HTTPResponse.stream()`` and ``HTTPResponse.read_chunked()`` to handle ``amt=0``.

--- a/src/urllib3/response.py
+++ b/src/urllib3/response.py
@@ -1400,7 +1400,9 @@ class HTTPResponse(BaseHTTPResponse):
             if self._fp.fp is None:  # type: ignore[union-attr]
                 return None
 
-            if amt and amt < 0:
+            if amt == 0:
+                return
+            elif amt and amt < 0:
                 # Negative numbers and `None` should be treated the same,
                 # but httplib handles only `None` correctly.
                 amt = None

--- a/test/test_response.py
+++ b/test/test_response.py
@@ -1430,6 +1430,16 @@ class TestResponse:
         data = list(resp.stream(0))
         assert data == []
 
+    def test_read_chunked_zero_amt(self) -> None:
+        r = httplib.HTTPResponse(MockSock)  # type: ignore[arg-type]
+        r.fp = MockChunkedEncodingResponse([b"hello"])  # type: ignore[assignment]
+        r.chunked = True
+        r.chunk_left = None
+        resp = HTTPResponse(
+            r, preload_content=False, headers={"transfer-encoding": "chunked"}
+        )
+        assert len(list(resp.read_chunked(0))) == 0
+
     @pytest.mark.parametrize(
         "preload_content, amt, read_meth",
         [


### PR DESCRIPTION
#3797 didn't cover the `HTTPResponse.read_chunked`. `read_chunked(0)` still runs into infinite loop.

Fixes #3793 
