### PR TITLE
Fix dynamic default socket options

### DIFF
--- a/changelog/3789.bugfix.rst
+++ b/changelog/3789.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed ``HTTPConnection`` and ``HTTPSConnection`` so new instances respected updated ``default_socket_options`` values.

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -72,6 +72,8 @@ log = logging.getLogger(__name__)
 
 port_by_scheme = {"http": 80, "https": 443}
 
+_DEFAULT_SOCKET_OPTIONS = object()
+
 # When it comes time to update this value as a part of regular maintenance
 # (ie test_recent_date is failing) update it to ~6 months before the current date.
 RECENT_DATE = datetime.date(2025, 1, 1)
@@ -137,9 +139,7 @@ class HTTPConnection(_HTTPConnection):
         timeout: _TYPE_TIMEOUT = _DEFAULT_TIMEOUT,
         source_address: tuple[str, int] | None = None,
         blocksize: int = 16384,
-        socket_options: None | (
-            connection._TYPE_SOCKET_OPTIONS
-        ) = default_socket_options,
+        socket_options: connection._TYPE_SOCKET_OPTIONS | None | object = _DEFAULT_SOCKET_OPTIONS,
         proxy: Url | None = None,
         proxy_config: ProxyConfig | None = None,
     ) -> None:
@@ -150,6 +150,8 @@ class HTTPConnection(_HTTPConnection):
             source_address=source_address,
             blocksize=blocksize,
         )
+        if socket_options is _DEFAULT_SOCKET_OPTIONS:
+            socket_options = type(self).default_socket_options
         self.socket_options = socket_options
         self.proxy = proxy
         self.proxy_config = proxy_config
@@ -626,9 +628,7 @@ class HTTPSConnection(HTTPConnection):
         timeout: _TYPE_TIMEOUT = _DEFAULT_TIMEOUT,
         source_address: tuple[str, int] | None = None,
         blocksize: int = 16384,
-        socket_options: None | (
-            connection._TYPE_SOCKET_OPTIONS
-        ) = HTTPConnection.default_socket_options,
+        socket_options: connection._TYPE_SOCKET_OPTIONS | None | object = _DEFAULT_SOCKET_OPTIONS,
         proxy: Url | None = None,
         proxy_config: ProxyConfig | None = None,
         cert_reqs: int | str | None = None,

--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -214,6 +214,25 @@ class TestConnection:
         assert conn.socket_options == [(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)]
 
     @pytest.mark.parametrize(
+        ("connection_cls", "port"),
+        ((HTTPConnection, 80), (HTTPSConnection, 443)),
+    )
+    def test_default_socket_options_follow_class_variable(
+        self,
+        connection_cls: type[HTTPConnection],
+        port: int,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        socket_options = connection_cls.default_socket_options + [
+            (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
+        ]
+        monkeypatch.setattr(connection_cls, "default_socket_options", socket_options)
+
+        conn = connection_cls("not.a.real.host", port=port)
+
+        assert conn.socket_options == socket_options
+
+    @pytest.mark.parametrize(
         "proxy_scheme, err_part",
         [
             ("http", "Unable to connect to proxy"),


### PR DESCRIPTION
## Summary
- resolve default socket options at connection construction time instead of capturing them in the function signature
- add regression coverage for both `HTTPConnection` and `HTTPSConnection` when `default_socket_options` is updated
- add a changelog fragment for the bugfix

Closes #3789.

## Testing
- `.venv/bin/python -m pytest test/test_connection.py -k default_socket_options_follow_class_variable -q`
- `.venv/bin/python -m pytest test/test_connection.py -k default_socket_options -q`
- `.venv/bin/python -m pytest test/test_http2_connection.py -k default_socket_options -q`
- `.venv/bin/python -m pytest test/test_connection.py -q`
- `.venv/bin/python -m pytest test/test_http2_connection.py -q`
