### PR TITLE
Reject whitespace in HTTP/1.1 header names

### DIFF
--- a/changelog/1362.bugfix.rst
+++ b/changelog/1362.bugfix.rst
@@ -1,0 +1,1 @@
+Reject outbound HTTP/1.1 header names containing whitespace including tabs and newlines.

--- a/src/urllib3/_base_connection.py
+++ b/src/urllib3/_base_connection.py
@@ -46,6 +46,7 @@ if typing.TYPE_CHECKING:
         blocksize: int
         source_address: tuple[str, int] | None
         socket_options: _TYPE_SOCKET_OPTIONS | None
+        assert_header_names: bool
 
         proxy: Url | None
         proxy_config: ProxyConfig | None
@@ -64,6 +65,7 @@ if typing.TYPE_CHECKING:
             socket_options: _TYPE_SOCKET_OPTIONS | None = ...,
             proxy: Url | None = None,
             proxy_config: ProxyConfig | None = None,
+            assert_header_names: bool = True,
         ) -> None: ...
 
         def set_tunnel(
@@ -150,6 +152,7 @@ if typing.TYPE_CHECKING:
             socket_options: _TYPE_SOCKET_OPTIONS | None = ...,
             proxy: Url | None = None,
             proxy_config: ProxyConfig | None = None,
+            assert_header_names: bool = True,
             cert_reqs: int | str | None = None,
             assert_hostname: None | str | typing.Literal[False] = None,
             assert_fingerprint: str | None = None,

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -45,6 +45,7 @@ from ._version import __version__
 from .exceptions import (
     ConnectTimeoutError,
     HeaderParsingError,
+    InvalidHeader,
     NameResolutionError,
     NewConnectionError,
     ProxyError,
@@ -79,6 +80,16 @@ RECENT_DATE = datetime.date(2025, 1, 1)
 _CONTAINS_CONTROL_CHAR_RE = re.compile(r"[^-!#$%&'*+.^_`|~0-9a-zA-Z]")
 
 
+def _validate_http1_header_name(header: str | bytes) -> None:
+    try:
+        header_name = to_str(header, "ascii")
+    except UnicodeDecodeError as e:
+        raise InvalidHeader(f"Invalid header name {header!r}") from e
+
+    if not header_name or _CONTAINS_CONTROL_CHAR_RE.search(header_name):
+        raise InvalidHeader(f"Invalid header name {header!r}")
+
+
 class HTTPConnection(_HTTPConnection):
     """
     Based on :class:`http.client.HTTPConnection` but provides an extra constructor
@@ -102,6 +113,8 @@ class HTTPConnection(_HTTPConnection):
          ]
 
       Or you may want to disable the defaults by passing an empty list (e.g., ``[]``).
+
+    - ``assert_header_names``: Set to ``False`` to allow invalid header names.
     """
 
     default_port: typing.ClassVar[int] = port_by_scheme["http"]  # type: ignore[misc]
@@ -122,6 +135,7 @@ class HTTPConnection(_HTTPConnection):
     blocksize: int
     source_address: tuple[str, int] | None
     socket_options: connection._TYPE_SOCKET_OPTIONS | None
+    assert_header_names: bool
 
     _has_connected_to_proxy: bool
     _response_options: _ResponseOptions | None
@@ -142,6 +156,7 @@ class HTTPConnection(_HTTPConnection):
         ) = default_socket_options,
         proxy: Url | None = None,
         proxy_config: ProxyConfig | None = None,
+        assert_header_names: bool = True,
     ) -> None:
         super().__init__(
             host=host,
@@ -153,6 +168,7 @@ class HTTPConnection(_HTTPConnection):
         self.socket_options = socket_options
         self.proxy = proxy
         self.proxy_config = proxy_config
+        self.assert_header_names = assert_header_names
 
         self._has_connected_to_proxy = False
         self._response_options = None
@@ -235,6 +251,9 @@ class HTTPConnection(_HTTPConnection):
             raise ValueError(
                 f"Invalid proxy scheme for tunneling: {scheme!r}, must be either 'http' or 'https'"
             )
+        if self.assert_header_names and headers:
+            for header in headers:
+                _validate_http1_header_name(header)
         super().set_tunnel(host, port=port, headers=headers)
         self._tunnel_scheme = scheme
 
@@ -410,6 +429,8 @@ class HTTPConnection(_HTTPConnection):
     def putheader(self, header: str, *values: str) -> None:  # type: ignore[override]
         """"""
         if not any(isinstance(v, str) and v == SKIP_HEADER for v in values):
+            if self.assert_header_names:
+                _validate_http1_header_name(header)
             super().putheader(header, *values)
         elif to_str(header.lower()) not in SKIPPABLE_HEADERS:
             skippable_headers = "', '".join(
@@ -631,6 +652,7 @@ class HTTPSConnection(HTTPConnection):
         ) = HTTPConnection.default_socket_options,
         proxy: Url | None = None,
         proxy_config: ProxyConfig | None = None,
+        assert_header_names: bool = True,
         cert_reqs: int | str | None = None,
         assert_hostname: None | str | typing.Literal[False] = None,
         assert_fingerprint: str | None = None,
@@ -655,6 +677,7 @@ class HTTPSConnection(HTTPConnection):
             socket_options=socket_options,
             proxy=proxy,
             proxy_config=proxy_config,
+            assert_header_names=assert_header_names,
         )
 
         self.key_file = key_file

--- a/src/urllib3/contrib/emscripten/connection.py
+++ b/src/urllib3/contrib/emscripten/connection.py
@@ -33,6 +33,7 @@ class EmscriptenHTTPConnection:
     blocksize: int
     source_address: tuple[str, int] | None
     socket_options: _TYPE_SOCKET_OPTIONS | None
+    assert_header_names: bool
 
     proxy: Url | None
     proxy_config: ProxyConfig | None
@@ -54,6 +55,7 @@ class EmscriptenHTTPConnection:
         socket_options: _TYPE_SOCKET_OPTIONS | None = None,
         proxy: Url | None = None,
         proxy_config: ProxyConfig | None = None,
+        assert_header_names: bool = True,
     ) -> None:
         self.host = host
         self.port = port
@@ -68,6 +70,7 @@ class EmscriptenHTTPConnection:
         self.blocksize = blocksize
         self.source_address = None
         self.socket_options = None
+        self.assert_header_names = assert_header_names
         self.is_verified = False
 
     def set_tunnel(
@@ -192,6 +195,7 @@ class EmscriptenHTTPSConnection(EmscriptenHTTPConnection):
         ) = HTTPConnection.default_socket_options,
         proxy: Url | None = None,
         proxy_config: ProxyConfig | None = None,
+        assert_header_names: bool = True,
         cert_reqs: int | str | None = None,
         assert_hostname: None | str | typing.Literal[False] = None,
         assert_fingerprint: str | None = None,
@@ -216,6 +220,7 @@ class EmscriptenHTTPSConnection(EmscriptenHTTPConnection):
             socket_options=socket_options,
             proxy=proxy,
             proxy_config=proxy_config,
+            assert_header_names=assert_header_names,
         )
         self.scheme = "https"
 

--- a/src/urllib3/poolmanager.py
+++ b/src/urllib3/poolmanager.py
@@ -88,6 +88,7 @@ class PoolKey(typing.NamedTuple):
     key__socks_options: frozenset[tuple[str, str]] | None
     key_assert_hostname: bool | str | None
     key_assert_fingerprint: str | None
+    key_assert_header_names: bool | None
     key_server_hostname: str | None
     key_blocksize: int | None
 
@@ -143,6 +144,8 @@ def _default_key_normalizer(
     # Default key_blocksize to _DEFAULT_BLOCKSIZE if missing from the context
     if context.get("key_blocksize") is None:
         context["key_blocksize"] = _DEFAULT_BLOCKSIZE
+    if context.get("key_assert_header_names") is None:
+        context["key_assert_header_names"] = True
 
     return key_class(**context)
 

--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -17,7 +17,7 @@ from urllib3.connection import (  # type: ignore[attr-defined]
     _url_from_connection,
     _wrap_proxy_error,
 )
-from urllib3.exceptions import HTTPError, ProxyError, SSLError
+from urllib3.exceptions import HTTPError, InvalidHeader, ProxyError, SSLError
 from urllib3.util import ssl_
 from urllib3.util.request import SKIP_HEADER
 from urllib3.util.ssl_match_hostname import (
@@ -326,3 +326,50 @@ class TestConnection:
             assert "User-Agent" in request_headers
         else:
             assert user_agent not in request_headers
+
+    @pytest.mark.parametrize(
+        "header",
+        ["Invalid Header", "Invalid\tHeader", "Invalid Header "],
+    )
+    def test_request_rejects_header_names_with_whitespace(self, header: str) -> None:
+        headers = {header: "value"}
+
+        with mock.patch("urllib3.util.connection.create_connection"):
+            conn = HTTPConnection("")
+            with pytest.raises(InvalidHeader, match="Invalid header name"):
+                conn.request("GET", "/headers", headers=headers)
+
+    def test_request_allows_invalid_header_names_when_disabled(self) -> None:
+        headers = {"Invalid Header": "value"}
+
+        with (
+            mock.patch("urllib3.util.connection.create_connection"),
+            mock.patch(
+                "urllib3.connection._HTTPConnection.putheader"
+            ) as http_client_putheader,
+        ):
+            conn = HTTPConnection("", assert_header_names=False)
+            conn.request("GET", "/headers", headers=headers)
+
+        http_client_putheader.assert_any_call("Invalid Header", "value")
+
+    def test_putheader_rejects_non_ascii_bytes_header_name(self) -> None:
+        with mock.patch("urllib3.util.connection.create_connection"):
+            conn = HTTPConnection("")
+            conn.putrequest("GET", "/headers")
+
+            with pytest.raises(InvalidHeader, match="Invalid header name"):
+                conn.putheader(b"\xff", "value")  # type: ignore[arg-type]
+
+    def test_set_tunnel_rejects_header_names_with_whitespace(self) -> None:
+        conn = HTTPConnection("proxy.example")
+
+        with pytest.raises(InvalidHeader, match="Invalid header name"):
+            conn.set_tunnel("target.example", headers={"Proxy Authorization": "value"})
+
+    def test_set_tunnel_allows_invalid_header_names_when_disabled(self) -> None:
+        conn = HTTPConnection("proxy.example", assert_header_names=False)
+
+        conn.set_tunnel("target.example", headers={"Proxy Authorization": "value"})
+
+        assert getattr(conn, "_tunnel_headers")["Proxy Authorization"] == "value"

--- a/test/test_poolmanager.py
+++ b/test/test_poolmanager.py
@@ -98,6 +98,7 @@ class TestPoolManager:
             "block": True,
             "source_address": "127.0.0.1",
             "blocksize": _DEFAULT_BLOCKSIZE + 1,
+            "assert_header_names": False,
         }
         p = PoolManager()
         conn_pools = [
@@ -131,6 +132,7 @@ class TestPoolManager:
             "ca_certs": "/root/path_to_pem",
             "ssl_version": "SSLv23_METHOD",
             "blocksize": _DEFAULT_BLOCKSIZE + 1,
+            "assert_header_names": False,
         }
         p = PoolManager()
         conn_pools = [
@@ -246,6 +248,14 @@ class TestPoolManager:
         assert isinstance(pool, HTTPSConnectionPool)
         assert pool.assert_hostname
         assert fingerprint == pool.assert_fingerprint
+
+    def test_assert_header_names_flag(self) -> None:
+        """Assert that pool manager can disable header name validation."""
+        p = PoolManager(assert_header_names=False)
+        pool = p.connection_from_url("http://example.com/")
+        conn = pool._new_conn()
+
+        assert conn.assert_header_names is False
 
     def test_http_connection_from_context_case_insensitive(self) -> None:
         """Assert scheme case is ignored when getting the https key class."""

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -1154,7 +1154,7 @@ class TestProxyManager(SocketDummyServerTestCase):
         base_url = f"http://{self.host}:{self.port}"
 
         # Define some proxy headers.
-        proxy_headers = HTTPHeaderDict({"For The Proxy": "YEAH!"})
+        proxy_headers = HTTPHeaderDict({"For-The-Proxy": "YEAH!"})
         with proxy_from_url(base_url, proxy_headers=proxy_headers) as proxy:
             conn = proxy.connection_from_url("http://www.google.com/")
 
@@ -1164,7 +1164,7 @@ class TestProxyManager(SocketDummyServerTestCase):
             # FIXME: The order of the headers is not predictable right now. We
             # should fix that someday (maybe when we migrate to
             # OrderedDict/MultiDict).
-            assert b"For The Proxy: YEAH!\r\n" in r.data
+            assert b"For-The-Proxy: YEAH!\r\n" in r.data
 
     def test_retries(self) -> None:
         close_event = Event()


### PR DESCRIPTION
Fixes #1362

This tightens the HTTP/1.1 request path so header field names have to be valid tokens before they are written to the request. That catches names with spaces or tabs from normal request headers and tunnel headers instead of letting them reach the wire.

I left the header collection behavior alone so this only affects outbound serialization.

Tested with:
- python -m pytest test\test_connection.py test\test_http2_connection.py
- python -m pre_commit run black --files src\urllib3\connection.py test\test_connection.py
- python -m pre_commit run isort --files src\urllib3\connection.py test\test_connection.py
- python -m pre_commit run flake8 --files src\urllib3\connection.py test\test_connection.py