### PR TITLE
Avoid repeated SSL verify location loads

### DIFF
--- a/src/urllib3/util/ssl_.py
+++ b/src/urllib3/util/ssl_.py
@@ -8,6 +8,7 @@ import sys
 import typing
 import warnings
 from binascii import unhexlify
+from weakref import WeakKeyDictionary
 
 from ..exceptions import ProxySchemeUnsupported, SSLError
 from .url import _BRACELESS_IPV6_ADDRZ_RE, _IPV4_RE
@@ -360,6 +361,45 @@ def ssl_wrap_socket(
 ) -> ssl.SSLSocket | SSLTransportType: ...
 
 
+_VerifyLocations = tuple[str | None, str | None, str | bytes | None]
+_context_verify_locations_cache: WeakKeyDictionary[
+    typing.Any, set[_VerifyLocations]
+] = WeakKeyDictionary()
+
+
+def _load_verify_locations_once(
+    context: ssl.SSLContext,
+    ca_certs: str | None,
+    ca_cert_dir: str | None,
+    ca_cert_data: str | bytes | None,
+) -> None:
+    verify_locations = (ca_certs, ca_cert_dir, ca_cert_data)
+
+    try:
+        loaded_verify_locations = _context_verify_locations_cache.setdefault(
+            context, set()
+        )
+    except TypeError:
+        # Fall back for custom SSLContext implementations that don't support
+        # weak references.
+        try:
+            context.load_verify_locations(ca_certs, ca_cert_dir, ca_cert_data)
+        except OSError as e:
+            raise SSLError(e) from e
+
+        return
+
+    if verify_locations in loaded_verify_locations:
+        return
+
+    try:
+        context.load_verify_locations(ca_certs, ca_cert_dir, ca_cert_data)
+    except OSError as e:
+        raise SSLError(e) from e
+
+    loaded_verify_locations.add(verify_locations)
+
+
 def ssl_wrap_socket(
     sock: socket.socket,
     keyfile: str | None = None,
@@ -407,11 +447,7 @@ def ssl_wrap_socket(
         context = create_urllib3_context(ssl_version, cert_reqs, ciphers=ciphers)
 
     if ca_certs or ca_cert_dir or ca_cert_data:
-        try:
-            context.load_verify_locations(ca_certs, ca_cert_dir, ca_cert_data)
-        except OSError as e:
-            raise SSLError(e) from e
-
+        _load_verify_locations_once(context, ca_certs, ca_cert_dir, ca_cert_data)
     elif ssl_context is None and hasattr(context, "load_default_certs"):
         # try to load OS default certs; works well on Windows.
         context.load_default_certs()

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -1017,6 +1017,39 @@ class TestUtilSSL:
             "/path/to/pem", None, None
         )
 
+    def test_ssl_wrap_socket_loads_verify_locations_once_per_context(self) -> None:
+        socket = Mock()
+        loaded_verify_locations = []
+
+        class Context:
+            def load_verify_locations(self, *args: object) -> None:
+                loaded_verify_locations.append(args)
+
+            def set_alpn_protocols(self, protocols: object) -> None:
+                pass
+
+            def wrap_socket(self, *args: object, **kwargs: object) -> Mock:
+                return Mock()
+
+        context = Context()
+
+        ssl_wrap_socket(ssl_context=context, ca_certs="/path/to/pem", sock=socket)
+        ssl_wrap_socket(ssl_context=context, ca_certs="/path/to/pem", sock=socket)
+
+        assert loaded_verify_locations == [("/path/to/pem", None, None)]
+
+    def test_ssl_wrap_socket_loads_distinct_verify_locations(self) -> None:
+        socket = Mock()
+        mock_context = Mock()
+
+        ssl_wrap_socket(ssl_context=mock_context, ca_certs="/path/to/one", sock=socket)
+        ssl_wrap_socket(ssl_context=mock_context, ca_certs="/path/to/two", sock=socket)
+
+        assert mock_context.load_verify_locations.call_args_list == [
+            mock.call("/path/to/one", None, None),
+            mock.call("/path/to/two", None, None),
+        ]
+
     def test_ssl_wrap_socket_loads_certificate_directories(self) -> None:
         socket = Mock()
         mock_context = Mock()


### PR DESCRIPTION
Fixes #3623.

When callers pass the same `SSLContext` and the same CA certificate locations to `ssl_wrap_socket`, urllib3 currently calls `SSLContext.load_verify_locations()` on every wrap. This can repeatedly reload the same certificates into the same context and is expensive for high-volume clients.

This caches loaded verify locations per context using a `WeakKeyDictionary`, so the same `(ca_certs, ca_cert_dir, ca_cert_data)` tuple is only loaded once for a given context. Custom context implementations that cannot be weak-referenced fall back to the previous behavior.

Validation:
- repo-local virtualenv in disposable checkout
- `PYTHONPATH=src .venv/bin/python -m pytest test/test_util.py -q` -> 326 passed, 6 skipped
- `PYTHONPATH=src .venv/bin/python -m pytest test/test_ssl.py test/test_util.py -q` -> 371 passed, 6 skipped
- Tenfold Docker eval for urllib3 #3623: 0.003423s
