### PR TITLE
Reject whitespace in request header names

### DIFF
--- a/changelog/1362.bugfix.rst
+++ b/changelog/1362.bugfix.rst
@@ -1,0 +1,1 @@
+Rejected HTTP request header names with leading or trailing whitespace, control characters, or colons.

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -77,6 +77,7 @@ port_by_scheme = {"http": 80, "https": 443}
 RECENT_DATE = datetime.date(2025, 1, 1)
 
 _CONTAINS_CONTROL_CHAR_RE = re.compile(r"[^-!#$%&'*+.^_`|~0-9a-zA-Z]")
+_CONTAINS_INVALID_HEADER_NAME_RE = re.compile(r"[:\x00-\x1f\x7f]")
 
 
 class HTTPConnection(_HTTPConnection):
@@ -407,8 +408,18 @@ class HTTPConnection(_HTTPConnection):
             method, url, skip_host=skip_host, skip_accept_encoding=skip_accept_encoding
         )
 
-    def putheader(self, header: str, *values: str) -> None:  # type: ignore[override]
+    def putheader(self, header: str | bytes, *values: str) -> None:  # type: ignore[override]
         """"""
+        header_str = to_str(header)
+        header_stripped = header_str.strip(" \t")
+        match = _CONTAINS_INVALID_HEADER_NAME_RE.search(header_stripped)
+        if match or header_str != header_stripped:
+            raise ValueError(
+                f"Header name cannot contain leading/trailing whitespace, "
+                f"control characters, or ':' {header!r} "
+                f"(found at least {(match.group() if match else ' ')!r})"
+            )
+
         if not any(isinstance(v, str) and v == SKIP_HEADER for v in values):
             super().putheader(header, *values)
         elif to_str(header.lower()) not in SKIPPABLE_HEADERS:

--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -326,3 +326,24 @@ class TestConnection:
             assert "User-Agent" in request_headers
         else:
             assert user_agent not in request_headers
+
+    @pytest.mark.parametrize("header", ["Header ", " Header", "Header\t", "Header:"])
+    def test_rejects_invalid_header_names(self, header: str) -> None:
+        conn = HTTPConnection("example.com")
+
+        with pytest.raises(ValueError, match="Header name cannot contain"):
+            conn.putheader(header, "value")
+
+    def test_allows_internal_whitespace_in_header_names(self) -> None:
+        conn = HTTPConnection("example.com")
+
+        with mock.patch("urllib3.connection._HTTPConnection.putheader") as putheader:
+            conn.putheader("For The Proxy", "value")
+
+        putheader.assert_called_once_with("For The Proxy", "value")
+
+    def test_rejects_invalid_header_names_before_skip_header(self) -> None:
+        conn = HTTPConnection("example.com")
+
+        with pytest.raises(ValueError, match="Header name cannot contain"):
+            conn.putheader("Header ", SKIP_HEADER)


### PR DESCRIPTION
Fixes #1362.

## Summary

- Reject outbound HTTP/1.1 request header names with leading/trailing space or tab characters, control characters, or `:` before they are serialized by `http.client`.
- Validate before `SKIP_HEADER` handling so invalid names can't bypass the check.
- Add regression coverage for whitespace adjacent to the header-name delimiter, colon characters, and the existing proxy-header compatibility case.
- Add a changelog fragment for issue 1362.

## Testing

- `uv run pytest test/test_connection.py -k 'header_names or skip_header'`
- `NPM_CONFIG_CACHE=/private/tmp/urllib3-npm-cache uvx nox -s lint`
