### PR TITLE
Honor dynamic default socket options

### DIFF
--- a/changelog/2936.bugfix.rst
+++ b/changelog/2936.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed ``HTTPConnection.default_socket_options`` updates not being honored by new connections and proxied connection pools.

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -10,6 +10,7 @@ import sys
 import threading
 import typing
 import warnings
+from enum import Enum
 from http.client import HTTPConnection as _HTTPConnection
 from http.client import HTTPException as HTTPException  # noqa: F401
 from http.client import ResponseNotReady
@@ -71,6 +72,18 @@ BrokenPipeError = BrokenPipeError
 log = logging.getLogger(__name__)
 
 port_by_scheme = {"http": 80, "https": 443}
+
+
+class _TYPE_DEFAULT_SOCKET_OPTIONS(Enum):
+    token = 0
+
+
+_DEFAULT_SOCKET_OPTIONS: typing.Final[_TYPE_DEFAULT_SOCKET_OPTIONS] = (
+    _TYPE_DEFAULT_SOCKET_OPTIONS.token
+)
+_TYPE_SOCKET_OPTIONS = typing.Union[
+    connection._TYPE_SOCKET_OPTIONS, None, _TYPE_DEFAULT_SOCKET_OPTIONS
+]
 
 # When it comes time to update this value as a part of regular maintenance
 # (ie test_recent_date is failing) update it to ~6 months before the current date.
@@ -137,9 +150,7 @@ class HTTPConnection(_HTTPConnection):
         timeout: _TYPE_TIMEOUT = _DEFAULT_TIMEOUT,
         source_address: tuple[str, int] | None = None,
         blocksize: int = 16384,
-        socket_options: None | (
-            connection._TYPE_SOCKET_OPTIONS
-        ) = default_socket_options,
+        socket_options: _TYPE_SOCKET_OPTIONS = _DEFAULT_SOCKET_OPTIONS,
         proxy: Url | None = None,
         proxy_config: ProxyConfig | None = None,
     ) -> None:
@@ -150,6 +161,8 @@ class HTTPConnection(_HTTPConnection):
             source_address=source_address,
             blocksize=blocksize,
         )
+        if socket_options is _DEFAULT_SOCKET_OPTIONS:
+            socket_options = self.default_socket_options
         self.socket_options = socket_options
         self.proxy = proxy
         self.proxy_config = proxy_config
@@ -626,9 +639,7 @@ class HTTPSConnection(HTTPConnection):
         timeout: _TYPE_TIMEOUT = _DEFAULT_TIMEOUT,
         source_address: tuple[str, int] | None = None,
         blocksize: int = 16384,
-        socket_options: None | (
-            connection._TYPE_SOCKET_OPTIONS
-        ) = HTTPConnection.default_socket_options,
+        socket_options: _TYPE_SOCKET_OPTIONS = _DEFAULT_SOCKET_OPTIONS,
         proxy: Url | None = None,
         proxy_config: ProxyConfig | None = None,
         cert_reqs: int | str | None = None,

--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import errno
 import logging
 import queue
+import socket
 import sys
 import typing
 import warnings
@@ -40,7 +41,7 @@ from .exceptions import (
     TimeoutError,
 )
 from .response import BaseHTTPResponse
-from .util.connection import is_connection_dropped
+from .util.connection import _TYPE_SOCKET_OPTIONS, is_connection_dropped
 from .util.proxy import connection_requires_http_tunnel
 from .util.request import _TYPE_BODY_POSITION, set_file_position
 from .util.retry import Retry
@@ -115,6 +116,20 @@ class ConnectionPool:
 
 # This is taken from http://hg.python.org/cpython/file/7aaba721ebc0/Lib/socket.py#l252
 _blocking_errnos = {errno.EAGAIN, errno.EWOULDBLOCK}
+
+
+def _proxy_default_socket_options(
+    connection_cls: type[BaseHTTPConnection] | type[BaseHTTPSConnection],
+) -> _TYPE_SOCKET_OPTIONS:
+    socket_options = getattr(connection_cls, "default_socket_options", None)
+    if socket_options is None:
+        return []
+
+    return [
+        option
+        for option in socket_options
+        if option != (socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+    ]
 
 
 class HTTPConnectionPool(ConnectionPool, RequestMethods):
@@ -216,9 +231,11 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
 
         if self.proxy:
             # Enable Nagle's algorithm for proxies, to avoid packet fragmentation.
-            # Defaulting `socket_options` to an empty list avoids it defaulting to
-            # ``HTTPConnection.default_socket_options``.
-            self.conn_kw.setdefault("socket_options", [])
+            # Preserve user-added default socket options while omitting urllib3's
+            # TCP_NODELAY default.
+            self.conn_kw.setdefault(
+                "socket_options", _proxy_default_socket_options(self.ConnectionCls)
+            )
 
             self.conn_kw["proxy"] = self.proxy
             self.conn_kw["proxy_config"] = self.proxy_config

--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -213,6 +213,34 @@ class TestConnection:
         conn = HTTPSConnection("not.a.real.host", port=443)
         assert conn.socket_options == [(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)]
 
+    def test_HTTPConnection_default_socket_options_updates_are_honored(self) -> None:
+        original_socket_options = HTTPConnection.default_socket_options
+        custom_socket_options = original_socket_options + [
+            (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
+        ]
+        try:
+            HTTPConnection.default_socket_options = custom_socket_options
+            conn = HTTPConnection("not.a.real.host", port=80)
+            assert conn.socket_options == custom_socket_options
+        finally:
+            HTTPConnection.default_socket_options = original_socket_options
+
+    def test_HTTPSConnection_default_socket_options_updates_are_honored(self) -> None:
+        had_https_default = "default_socket_options" in HTTPSConnection.__dict__
+        original_socket_options = HTTPSConnection.default_socket_options
+        custom_socket_options = original_socket_options + [
+            (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
+        ]
+        try:
+            HTTPSConnection.default_socket_options = custom_socket_options
+            conn = HTTPSConnection("not.a.real.host", port=443)
+            assert conn.socket_options == custom_socket_options
+        finally:
+            if had_https_default:
+                HTTPSConnection.default_socket_options = original_socket_options
+            else:
+                del HTTPSConnection.default_socket_options
+
     @pytest.mark.parametrize(
         "proxy_scheme, err_part",
         [

--- a/test/test_poolmanager.py
+++ b/test/test_poolmanager.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import gc
 import socket
+import typing
 from test import resolvesLocalhostFQDN
 from unittest import mock
 from unittest.mock import MagicMock, patch
@@ -9,12 +10,14 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from urllib3 import connection_from_url
-from urllib3.connectionpool import HTTPSConnectionPool
+from urllib3.connection import HTTPConnection
+from urllib3.connectionpool import HTTPSConnectionPool, _proxy_default_socket_options
 from urllib3.exceptions import LocationValueError
 from urllib3.poolmanager import (
     _DEFAULT_BLOCKSIZE,
     PoolKey,
     PoolManager,
+    ProxyManager,
     key_fn_by_scheme,
 )
 from urllib3.util import retry, timeout
@@ -376,6 +379,53 @@ class TestPoolManager:
 
         assert default_pool.conn_kw["socket_options"] == []
         assert override_pool.conn_kw["socket_options"] == override_opts
+
+    def test_proxy_pool_uses_proxy_default_socket_options(self) -> None:
+        p = ProxyManager("http://proxy.example:3128")
+        pool = p.connection_from_host("example.com", scheme="http")
+        assert pool.conn_kw["socket_options"] == []
+
+    def test_proxy_pool_preserves_custom_default_socket_options(self) -> None:
+        original_socket_options = HTTPConnection.default_socket_options
+        custom_socket_option = (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
+
+        try:
+            HTTPConnection.default_socket_options = original_socket_options + [
+                custom_socket_option
+            ]
+            p = ProxyManager("http://proxy.example:3128")
+            pool = p.connection_from_host("example.com", scheme="http")
+            assert pool.conn_kw["socket_options"] == [custom_socket_option]
+        finally:
+            HTTPConnection.default_socket_options = original_socket_options
+
+    def test_proxy_pool_socket_options_override_custom_defaults(self) -> None:
+        original_socket_options = HTTPConnection.default_socket_options
+        custom_socket_option = (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
+        override_socket_options = [(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)]
+
+        try:
+            HTTPConnection.default_socket_options = original_socket_options + [
+                custom_socket_option
+            ]
+            p = ProxyManager(
+                "http://proxy.example:3128", socket_options=override_socket_options
+            )
+            pool = p.connection_from_host("example.com", scheme="http")
+            assert pool.conn_kw["socket_options"] == override_socket_options
+        finally:
+            HTTPConnection.default_socket_options = original_socket_options
+
+    def test_proxy_default_socket_options_without_class_default(self) -> None:
+        class ConnectionWithoutDefaultSocketOptions:
+            pass
+
+        assert (
+            _proxy_default_socket_options(
+                typing.cast(type[typing.Any], ConnectionWithoutDefaultSocketOptions)
+            )
+            == []
+        )
 
     def test_merge_pool_kwargs(self) -> None:
         """Assert _merge_pool_kwargs works in the happy case"""


### PR DESCRIPTION
## Summary
- resolve omitted `socket_options` at connection construction time so updates to `HTTPConnection.default_socket_options` and `HTTPSConnection.default_socket_options` are honored
- preserve proxy behavior that avoids urllib3's default TCP_NODELAY option while allowing user-added default socket options through proxied pools
- add regression coverage for direct HTTP/HTTPS connections and ProxyManager socket option defaults/overrides

Closes #2936.
Closes #3789.

## Testing
- `.venv/bin/python -m pytest test/test_connection.py -k 'default_socket_options' -q`
- `.venv/bin/python -m pytest test/test_poolmanager.py -k 'socket_options' -q`
- `.venv/bin/python -m pytest test/test_connection.py test/test_poolmanager.py -q`
- `.venv/bin/python -m mypy src/urllib3/connection.py src/urllib3/connectionpool.py test/test_connection.py test/test_poolmanager.py`
- `git diff --check`