### PR TITLE
Resolve connection pool queue class lazily

### DIFF
--- a/changelog/3289.bugfix.rst
+++ b/changelog/3289.bugfix.rst
@@ -1,0 +1,1 @@
+Changed connection pools to resolve the default ``queue.LifoQueue`` class when a pool is constructed, allowing late monkey-patching to affect newly-created pools.

--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -76,7 +76,11 @@ class ConnectionPool:
     """
 
     scheme: str | None = None
-    QueueCls = queue.LifoQueue
+    QueueCls: type[queue.LifoQueue[typing.Any]] | None = None
+
+    def _new_pool_queue(self, maxsize: int) -> queue.LifoQueue[typing.Any]:
+        queue_cls = self.QueueCls or queue.LifoQueue
+        return queue_cls(maxsize)
 
     def __init__(self, host: str, port: int | None = None) -> None:
         if not host:
@@ -198,7 +202,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         self.timeout = timeout
         self.retries = retries
 
-        self.pool: queue.LifoQueue[typing.Any] | None = self.QueueCls(maxsize)
+        self.pool: queue.LifoQueue[typing.Any] | None = self._new_pool_queue(maxsize)
         self.block = block
 
         self.proxy = _proxy

--- a/test/test_queue_monkeypatch.py
+++ b/test/test_queue_monkeypatch.py
@@ -15,6 +15,18 @@ class BadError(Exception):
     """
 
 
+class CustomLifoQueue(queue.LifoQueue[int]):
+    pass
+
+
+class OtherLifoQueue(queue.LifoQueue[int]):
+    pass
+
+
+class CustomQueueHTTPConnectionPool(HTTPConnectionPool):
+    QueueCls = CustomLifoQueue
+
+
 class TestMonkeypatchResistance:
     """
     Test that connection pool works even with a monkey patched Queue module,
@@ -27,3 +39,13 @@ class TestMonkeypatchResistance:
                 http._get_conn()
                 with pytest.raises(EmptyPoolError):
                     http._get_conn(timeout=0)
+
+    def test_default_queue_class_resolves_lazily(self) -> None:
+        with mock.patch("urllib3.connectionpool.queue.LifoQueue", CustomLifoQueue):
+            with HTTPConnectionPool(host="localhost", block=True) as http:
+                assert isinstance(http.pool, CustomLifoQueue)
+
+    def test_custom_queue_class_overrides_lazy_default(self) -> None:
+        with mock.patch("urllib3.connectionpool.queue.LifoQueue", OtherLifoQueue):
+            with CustomQueueHTTPConnectionPool(host="localhost", block=True) as http:
+                assert isinstance(http.pool, CustomLifoQueue)


### PR DESCRIPTION
## Summary
- resolve the default `queue.LifoQueue` class when each connection pool is constructed instead of storing an import-time reference
- keep `ConnectionPool.QueueCls` as an explicit override hook for subclasses
- add regression coverage for late monkey-patching and explicit queue-class overrides

Closes #3289.

## Testing
- `.venv/bin/python -m pytest test/test_queue_monkeypatch.py -q`
- `.venv/bin/python -m pytest test/test_connectionpool.py test/test_queue_monkeypatch.py -q`
- `.venv/bin/python -m mypy src/urllib3/connectionpool.py test/test_queue_monkeypatch.py`
- `.venv/bin/python -m nox -rs lint`
- `git diff --check`