### PR TITLE
Reject invalid outgoing header names

### DIFF
--- a/changelog/1362.bugfix.rst
+++ b/changelog/1362.bugfix.rst
@@ -1,0 +1,1 @@
+Rejected outgoing HTTP header names containing characters outside the RFC token grammar.

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -79,6 +79,16 @@ RECENT_DATE = datetime.date(2025, 1, 1)
 _CONTAINS_CONTROL_CHAR_RE = re.compile(r"[^-!#$%&'*+.^_`|~0-9a-zA-Z]")
 
 
+def _validate_header_name(header: str | bytes) -> None:
+    header_name = to_str(header)
+    match = _CONTAINS_CONTROL_CHAR_RE.search(header_name)
+    if not header_name or match:
+        bad_char = "" if not header_name else f" (found at least {match.group()!r})"
+        raise ValueError(
+            f"Header name cannot contain non-token characters {header_name!r}{bad_char}"
+        )
+
+
 class HTTPConnection(_HTTPConnection):
     """
     Based on :class:`http.client.HTTPConnection` but provides an extra constructor
@@ -235,6 +245,9 @@ class HTTPConnection(_HTTPConnection):
             raise ValueError(
                 f"Invalid proxy scheme for tunneling: {scheme!r}, must be either 'http' or 'https'"
             )
+        if headers is not None:
+            for header in headers:
+                _validate_header_name(header)
         super().set_tunnel(host, port=port, headers=headers)
         self._tunnel_scheme = scheme
 
@@ -409,6 +422,7 @@ class HTTPConnection(_HTTPConnection):
 
     def putheader(self, header: str, *values: str) -> None:  # type: ignore[override]
         """"""
+        _validate_header_name(header)
         if not any(isinstance(v, str) and v == SKIP_HEADER for v in values):
             super().putheader(header, *values)
         elif to_str(header.lower()) not in SKIPPABLE_HEADERS:

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -82,10 +82,14 @@ _CONTAINS_CONTROL_CHAR_RE = re.compile(r"[^-!#$%&'*+.^_`|~0-9a-zA-Z]")
 def _validate_header_name(header: str | bytes) -> None:
     header_name = to_str(header)
     match = _CONTAINS_CONTROL_CHAR_RE.search(header_name)
-    if not header_name or match:
-        bad_char = "" if not header_name else f" (found at least {match.group()!r})"
+    if not header_name:
         raise ValueError(
-            f"Header name cannot contain non-token characters {header_name!r}{bad_char}"
+            f"Header name cannot contain non-token characters {header_name!r}"
+        )
+    if match:
+        raise ValueError(
+            f"Header name cannot contain non-token characters {header_name!r} "
+            f"(found at least {match.group()!r})"
         )
 
 

--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -241,6 +241,48 @@ class TestConnection:
         with pytest.raises(ResponseNotReady):
             conn.getresponse()
 
+    @pytest.mark.parametrize(
+        "header_name",
+        [
+            "",
+            "Header ",
+            "Header\t",
+            b"Header ",
+        ],
+    )
+    def test_putheader_rejects_invalid_header_names(
+        self, header_name: str | bytes
+    ) -> None:
+        conn = HTTPConnection("google.com", port=80)
+        conn.putrequest("GET", "/")
+
+        with pytest.raises(
+            ValueError, match="Header name cannot contain non-token characters"
+        ):
+            conn.putheader(header_name, "value")  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize(
+        "header_name",
+        [
+            "",
+            "Header ",
+            "Header\t",
+            b"Header ",
+        ],
+    )
+    def test_set_tunnel_rejects_invalid_header_names(
+        self, header_name: str | bytes
+    ) -> None:
+        conn = HTTPConnection("google.com", port=80)
+
+        with pytest.raises(
+            ValueError, match="Header name cannot contain non-token characters"
+        ):
+            conn.set_tunnel(
+                "example.com",
+                headers={header_name: "value"},  # type: ignore[dict-item]
+            )
+
     def test_assert_fingerprint_closes_socket(self) -> None:
         context = mock.create_autospec(ssl_.SSLContext)
         context.wrap_socket.return_value.getpeercert.return_value = b"fake cert"

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -1154,7 +1154,7 @@ class TestProxyManager(SocketDummyServerTestCase):
         base_url = f"http://{self.host}:{self.port}"
 
         # Define some proxy headers.
-        proxy_headers = HTTPHeaderDict({"For The Proxy": "YEAH!"})
+        proxy_headers = HTTPHeaderDict({"For-The-Proxy": "YEAH!"})
         with proxy_from_url(base_url, proxy_headers=proxy_headers) as proxy:
             conn = proxy.connection_from_url("http://www.google.com/")
 
@@ -1164,7 +1164,7 @@ class TestProxyManager(SocketDummyServerTestCase):
             # FIXME: The order of the headers is not predictable right now. We
             # should fix that someday (maybe when we migrate to
             # OrderedDict/MultiDict).
-            assert b"For The Proxy: YEAH!\r\n" in r.data
+            assert b"For-The-Proxy: YEAH!\r\n" in r.data
 
     def test_retries(self) -> None:
         close_event = Event()


### PR DESCRIPTION
## Summary

- validate outgoing request header names against the HTTP token grammar before emitting them
- apply the same validation to tunnel proxy headers before they are formatted into CONNECT requests
- add regression coverage for empty names and names with trailing space/tab

Fixes #1362
/claim #1362

## Testing

- `python3 -m py_compile src/urllib3/connection.py test/test_connection.py`
- Manual validation in a local checkout with generated `_version.py`: `HTTPConnection.putheader()` and `HTTPConnection.set_tunnel()` now reject `"Header "`, `"Header\t"`, `b"Header "`, and `""`.