### PR TITLE
Remove unnecessary response decoder flushing

### DIFF
--- a/changelog/2799.bugfix.rst
+++ b/changelog/2799.bugfix.rst
@@ -1,0 +1,1 @@
+Removed unnecessary response decoder flushing during decompression.

--- a/src/urllib3/response.py
+++ b/src/urllib3/response.py
@@ -59,8 +59,8 @@ class ContentDecoder:
     def has_unconsumed_tail(self) -> bool:
         raise NotImplementedError()
 
-    def flush(self) -> bytes:
-        raise NotImplementedError()
+    def finish(self) -> None:
+        return None
 
 
 class DeflateDecoder(ContentDecoder):
@@ -117,9 +117,6 @@ class DeflateDecoder(ContentDecoder):
         return bool(self._unfed_data) or (
             bool(self._obj.unconsumed_tail) and not self._first_try
         )
-
-    def flush(self) -> bytes:
-        return self._obj.flush()
 
 
 class GzipDecoderState:
@@ -188,9 +185,6 @@ class GzipDecoder(ContentDecoder):
     def has_unconsumed_tail(self) -> bool:
         return bool(self._unconsumed_tail)
 
-    def flush(self) -> bytes:
-        return self._obj.flush()
-
 
 if brotli is not None:
 
@@ -230,11 +224,6 @@ if brotli is not None:
                 return not self._obj.can_accept_more_data()
             except AttributeError:
                 return False
-
-        def flush(self) -> bytes:
-            if hasattr(self._obj, "flush"):
-                return self._obj.flush()  # type: ignore[no-any-return]
-            return b""
 
 
 try:
@@ -291,10 +280,9 @@ else:
                 self._obj.unused_data
             )
 
-        def flush(self) -> bytes:
+        def finish(self) -> None:
             if not self._obj.eof:
                 raise DecodeError("Zstandard data is incomplete")
-            return b""
 
 
 class MultiDecoder(ContentDecoder):
@@ -318,9 +306,6 @@ class MultiDecoder(ContentDecoder):
                 f"{len(encodings)} > {self.max_decode_links}"
             )
         self._decoders = [_get_decoder(e) for e in encodings]
-
-    def flush(self) -> bytes:
-        return self._decoders[0].flush()
 
     def decompress(self, data: bytes, max_length: int = -1) -> bytes:
         if max_length <= 0:
@@ -351,6 +336,10 @@ class MultiDecoder(ContentDecoder):
     @property
     def has_unconsumed_tail(self) -> bool:
         return any(d.has_unconsumed_tail for d in self._decoders)
+
+    def finish(self) -> None:
+        for d in self._decoders:
+            d.finish()
 
 
 def _get_decoder(mode: str) -> ContentDecoder:
@@ -620,11 +609,11 @@ class BaseHTTPResponse(io.IOBase):
         self,
         data: bytes,
         decode_content: bool | None,
-        flush_decoder: bool,
         max_length: int | None = None,
+        end_of_stream: bool = False,
     ) -> bytes:
         """
-        Decode the data passed in and potentially flush the decoder.
+        Decode the data passed in.
         """
         if not decode_content:
             if self._has_decoded_content:
@@ -634,12 +623,14 @@ class BaseHTTPResponse(io.IOBase):
                 )
             return data
 
-        if max_length is None or flush_decoder:
+        if max_length is None:
             max_length = -1
 
         try:
             if self._decoder:
                 data = self._decoder.decompress(data, max_length=max_length)
+                if end_of_stream and not self._decoder.has_unconsumed_tail:
+                    self._decoder.finish()
                 self._has_decoded_content = True
         except self.DECODER_ERROR_CLASSES as e:
             content_encoding = self.headers.get("content-encoding", "").lower()
@@ -648,19 +639,8 @@ class BaseHTTPResponse(io.IOBase):
                 "failed to decode it." % content_encoding,
                 e,
             ) from e
-        if flush_decoder:
-            data += self._flush_decoder()
 
         return data
-
-    def _flush_decoder(self) -> bytes:
-        """
-        Flushes the decoder. Should only be called if the decoder is actually
-        being used.
-        """
-        if self._decoder:
-            return self._decoder.decompress(b"") + self._decoder.flush()
-        return b""
 
     # Compatibility methods for `io` module
     def readinto(self, b: bytearray | memoryview[int]) -> int:
@@ -1100,7 +1080,6 @@ class HTTPResponse(BaseHTTPResponse):
                 decoded_data = self._decode(
                     b"",
                     decode_content,
-                    flush_decoder=False,
                     max_length=amt - len(self._decoded_buffer),
                 )
                 self._decoded_buffer.put(decoded_data)
@@ -1111,7 +1090,7 @@ class HTTPResponse(BaseHTTPResponse):
         if not cache_content:
             self._uncached_read_occurred = True
 
-        flush_decoder = amt is None or (amt != 0 and not data)
+        end_of_stream = amt is None or (amt != 0 and not data)
 
         if (
             not data
@@ -1121,7 +1100,7 @@ class HTTPResponse(BaseHTTPResponse):
             return data
 
         if amt is None:
-            data = self._decode(data, decode_content, flush_decoder)
+            data = self._decode(data, decode_content, end_of_stream=end_of_stream)
             # It's possible that there is buffered decoded data after a
             # partial read.
             if decode_content and len(self._decoded_buffer) > 0:
@@ -1143,8 +1122,8 @@ class HTTPResponse(BaseHTTPResponse):
             decoded_data = self._decode(
                 data,
                 decode_content,
-                flush_decoder,
                 max_length=amt - len(self._decoded_buffer),
+                end_of_stream=end_of_stream,
             )
             self._decoded_buffer.put(decoded_data)
 
@@ -1153,11 +1132,12 @@ class HTTPResponse(BaseHTTPResponse):
                 # For example, the GZ file header takes 10 bytes, we don't want to read
                 # it one byte at a time
                 data = self._raw_read(amt)
+                end_of_stream = not data
                 decoded_data = self._decode(
                     data,
                     decode_content,
-                    flush_decoder,
                     max_length=amt - len(self._decoded_buffer),
+                    end_of_stream=end_of_stream,
                 )
                 self._decoded_buffer.put(decoded_data)
             data = self._decoded_buffer.get(amt)
@@ -1201,7 +1181,6 @@ class HTTPResponse(BaseHTTPResponse):
                 decoded_data = self._decode(
                     b"",
                     decode_content,
-                    flush_decoder=False,
                     max_length=(
                         amt - len(self._decoded_buffer) if amt is not None else None
                     ),
@@ -1222,12 +1201,12 @@ class HTTPResponse(BaseHTTPResponse):
 
         self._init_decoder()
         while True:
-            flush_decoder = not data
+            end_of_stream = not data
             decoded_data = self._decode(
-                data, decode_content, flush_decoder, max_length=amt
+                data, decode_content, max_length=amt, end_of_stream=end_of_stream
             )
             self._decoded_buffer.put(decoded_data)
-            if decoded_data or flush_decoder:
+            if decoded_data or end_of_stream:
                 break
             data = self._raw_read(8192, read1=True)
 
@@ -1435,19 +1414,13 @@ class HTTPResponse(BaseHTTPResponse):
                 decoded = self._decode(
                     chunk,
                     decode_content=decode_content,
-                    flush_decoder=False,
                     max_length=amt,
                 )
                 if decoded:
                     yield decoded
 
-            if decode_content:
-                # On CPython and PyPy, we should never need to flush the
-                # decoder. However, on Jython we *might* need to, so
-                # lets defensively do it anyway.
-                decoded = self._flush_decoder()
-                if decoded:  # Platform-specific: Jython.
-                    yield decoded
+            if decode_content and self._decoder:
+                self._decoder.finish()
 
             # Chunk content ends with \r\n: discard it.
             while self._fp is not None:

--- a/test/test_response.py
+++ b/test/test_response.py
@@ -29,6 +29,7 @@ from urllib3.exceptions import (
 from urllib3.response import (  # type: ignore[attr-defined]
     BaseHTTPResponse,
     BytesQueueBuffer,
+    ContentDecoder,
     HTTPResponse,
     brotli,
 )
@@ -62,6 +63,18 @@ try:
     _zstd_available = True
 except ModuleNotFoundError:
     _zstd_available = False
+
+
+class NoFlushDecoder(ContentDecoder):
+    def decompress(self, data: bytes, max_length: int = -1) -> bytes:
+        return data
+
+    @property
+    def has_unconsumed_tail(self) -> bool:
+        return False
+
+    def flush(self) -> bytes:
+        raise AssertionError("decoder should not be flushed")
 
 
 class TestBytesQueueBuffer:
@@ -970,14 +983,28 @@ class TestResponse:
         # Force putting some decoded data in the buffer as the buffer
         # is normally empty unless decoder has issues like not
         # respecting `max_length` https://github.com/google/brotli/issues/1396
-        middle_part = r._decode(
-            r._raw_read(), decode_content=True, flush_decoder=False, max_length=3
-        )
+        middle_part = r._decode(r._raw_read(), decode_content=True, max_length=3)
         assert middle_part == b"bar"
         r._decoded_buffer.put(middle_part)
         # Here we expect data from `_decoded_buffer` to be joined with
         # the remaining part.
         assert r.read() == b"barbaz"
+
+    def test_read_does_not_flush_decoder(self) -> None:
+        fp = BytesIO(b"foo")
+        r = HTTPResponse(fp, preload_content=False)
+        r._decoder = NoFlushDecoder()
+
+        assert r.read(decode_content=True) == b"foo"
+        assert r.read(decode_content=True) == b""
+
+    def test_read1_does_not_flush_decoder(self) -> None:
+        fp = BytesIO(b"foo")
+        r = HTTPResponse(fp, preload_content=False)
+        r._decoder = NoFlushDecoder()
+
+        assert r.read1(decode_content=True) == b"foo"
+        assert r.read1(decode_content=True) == b""
 
     def test_full_read_after_partial_read_without_buffered_decoded_data(self) -> None:
         data = zlib.compress(b"foobarbaz")
@@ -1708,6 +1735,19 @@ class TestResponse:
             data += c
 
         assert b"foobar" == data
+
+    def test_read_chunked_does_not_flush_decoder(self) -> None:
+        fp = MockChunkedEncodingResponse([b"foo"])
+        r = httplib.HTTPResponse(MockSock)  # type: ignore[arg-type]
+        r.fp = fp  # type: ignore[assignment]
+        resp = HTTPResponse(
+            r,
+            preload_content=False,
+            headers={"transfer-encoding": "chunked"},
+        )
+        resp._decoder = NoFlushDecoder()
+
+        assert list(resp.read_chunked(decode_content=True)) == [b"foo"]
 
     def test_mock_transfer_encoding_chunked_custom_read(self) -> None:
         stream = [b"foooo", b"bbbbaaaaar"]


### PR DESCRIPTION
﻿Fixes #2799

## Summary
- remove response decoder output flushing now that Jython is no longer supported
- keep zstd end-of-stream validation through a finish hook so incomplete zstd data still raises DecodeError
- add regression coverage ensuring read(), read1(), and read_chunked() do not flush decoders

## Testing
- python -m pytest test/test_response.py
- python -m pytest test/with_dummyserver/test_connectionpool.py -k "decode or chunked or gzip"
- python -m pre_commit run pyupgrade --files src/urllib3/response.py test/test_response.py
- python -m pre_commit run black --files src/urllib3/response.py test/test_response.py
- python -m pre_commit run isort --files src/urllib3/response.py test/test_response.py
- python -m pre_commit run flake8 --files src/urllib3/response.py test/test_response.py