### PR TITLE
Support HTTP/2 forwarding proxies

### DIFF
--- a/changelog/3299.feature.rst
+++ b/changelog/3299.feature.rst
@@ -1,0 +1,1 @@
+Added HTTP/2 support for forwarding proxy requests.

--- a/src/urllib3/http2/connection.py
+++ b/src/urllib3/http2/connection.py
@@ -15,6 +15,7 @@ from .._collections import HTTPHeaderDict
 from ..connection import HTTPSConnection, _get_default_user_agent
 from ..exceptions import ConnectionError
 from ..response import BaseHTTPResponse
+from ..util.url import parse_url
 
 orig_HTTPSConnection = HTTPSConnection
 
@@ -90,9 +91,6 @@ class HTTP2Connection(HTTPSConnection):
         self._h2_stream: int | None = None
         self._headers: list[tuple[bytes, bytes]] = []
 
-        if "proxy" in kwargs or "proxy_config" in kwargs:  # Defensive:
-            raise NotImplementedError("Proxies aren't supported with HTTP/2")
-
         super().__init__(host, port, **kwargs)
 
         if self._tunnel_host is not None:
@@ -127,15 +125,25 @@ class HTTP2Connection(HTTPSConnection):
         self._request_url = url or "/"
         self._validate_path(url)  # type: ignore[attr-defined]
 
-        if ":" in self.host:
+        scheme = "https"
+        request_target = url or "/"
+        parsed_url = parse_url(url)
+
+        if self.proxy_is_forwarding and parsed_url.scheme and parsed_url.host:
+            scheme = parsed_url.scheme
+            authority = parsed_url.netloc
+            request_target = parsed_url.request_uri
+        elif ":" in self.host:
             authority = f"[{self.host}]:{self.port or 443}"
         else:
             authority = f"{self.host}:{self.port or 443}"
 
-        self._headers.append((b":scheme", b"https"))
+        assert authority is not None
+
+        self._headers.append((b":scheme", scheme.encode()))
         self._headers.append((b":method", method.encode()))
         self._headers.append((b":authority", authority.encode()))
-        self._headers.append((b":path", url.encode()))
+        self._headers.append((b":path", request_target.encode()))
 
         with self._h2_conn as conn:
             self._h2_stream = conn.get_next_available_stream_id()

--- a/test/test_http2_connection.py
+++ b/test/test_http2_connection.py
@@ -5,13 +5,14 @@ from unittest import mock
 
 import pytest
 
-from urllib3.connection import _get_default_user_agent
+from urllib3.connection import ProxyConfig, _get_default_user_agent
 from urllib3.exceptions import ConnectionError
 from urllib3.http2.connection import (
     HTTP2Connection,
     _is_illegal_header_value,
     _is_legal_header_name,
 )
+from urllib3.util import parse_url
 
 # [1] https://httpwg.org/specs/rfc9113.html#n-field-validity
 
@@ -264,6 +265,63 @@ class TestHTTP2Connection:
                 (b":method", b"GET"),
                 (b":authority", b"example.com:443"),
                 (b":path", b"/"),
+                (b"user-agent", _get_default_user_agent().encode()),
+            ],
+            end_stream=True,
+        )
+
+        close_connection.assert_called_with()
+
+    @pytest.mark.parametrize(
+        "url, scheme, authority, path",
+        (
+            (
+                "https://target.example:9443/path?query=true",
+                b"https",
+                b"target.example:9443",
+                b"/path?query=true",
+            ),
+            (
+                "http://target.example/path?query=true",
+                b"http",
+                b"target.example",
+                b"/path?query=true",
+            ),
+        ),
+    )
+    def test_forwarding_proxy_request_GET(
+        self, url: str, scheme: bytes, authority: bytes, path: bytes
+    ) -> None:
+        conn = HTTP2Connection(
+            "proxy.example",
+            8443,
+            proxy=parse_url("https://proxy.example:8443"),
+            proxy_config=ProxyConfig(None, True, None, None),
+        )
+        conn.sock = mock.MagicMock(
+            sendall=mock.Mock(return_value=None),
+        )
+        sendall = conn.sock.sendall
+        data_to_send = conn._h2_conn._obj.data_to_send = mock.Mock(return_value=b"foo")  # type: ignore[method-assign]
+        send_headers = conn._h2_conn._obj.send_headers = mock.Mock(return_value=None)  # type: ignore[method-assign]
+        conn._h2_conn._obj.send_data = mock.Mock(return_value=None)  # type: ignore[method-assign]
+        conn._h2_conn._obj.get_next_available_stream_id = mock.Mock(return_value=1)  # type: ignore[method-assign]
+        close_connection = conn._h2_conn._obj.close_connection = mock.Mock(  # type: ignore[method-assign]
+            return_value=None
+        )
+
+        conn.request("GET", url)
+        conn.close()
+
+        data_to_send.assert_called_with()
+        sendall.assert_called_with(b"foo")
+        send_headers.assert_called_with(
+            stream_id=1,
+            headers=[
+                (b":scheme", scheme),
+                (b":method", b"GET"),
+                (b":authority", authority),
+                (b":path", path),
                 (b"user-agent", _get_default_user_agent().encode()),
             ],
             end_stream=True,


### PR DESCRIPTION
## Summary
- allow HTTP/2 connections to be constructed with proxy configuration while keeping CONNECT tunneling unsupported
- build forwarded HTTP/2 pseudo-headers from the destination URL instead of the proxy endpoint
- add coverage for forwarded HTTP and HTTPS target URLs through an HTTPS proxy

Fixes #3299

## Testing
- python -m black --target-version py310 src/urllib3/http2/connection.py test/test_http2_connection.py
- python -m isort src/urllib3/http2/connection.py test/test_http2_connection.py
- python -m flake8 src/urllib3/http2/connection.py test/test_http2_connection.py
- python -m pytest -q test/test_http2_connection.py