### PR TITLE
Normalize folded response headers

### DIFF
--- a/changelog/1362.bugfix.rst
+++ b/changelog/1362.bugfix.rst
@@ -1,0 +1,1 @@
+Replaced obsolete folded response headers with spaces before storing them.

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -22,7 +22,7 @@ if typing.TYPE_CHECKING:
 
 from ._collections import HTTPHeaderDict
 from .http2 import probe as http2_probe
-from .util.response import assert_header_parsing
+from .util.response import assert_header_parsing, normalize_header_value
 from .util.timeout import _DEFAULT_TIMEOUT, _TYPE_TIMEOUT, Timeout
 from .util.util import to_str
 from .util.wait import wait_for_read
@@ -580,7 +580,10 @@ class HTTPConnection(_HTTPConnection):
                 exc_info=True,
             )
 
-        headers = HTTPHeaderDict(httplib_response.msg.items())
+        headers = HTTPHeaderDict(
+            (key, normalize_header_value(value))
+            for key, value in httplib_response.msg.items()
+        )
 
         response = HTTPResponse(
             body=httplib_response,

--- a/src/urllib3/util/response.py
+++ b/src/urllib3/util/response.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 import http.client as httplib
+import re
 from email.errors import MultipartInvariantViolationDefect, StartBoundaryNotFoundDefect
 
 from ..exceptions import HeaderParsingError
+
+_OBS_FOLD_RE = re.compile(r"\r\n[ \t]+")
 
 
 def is_fp_closed(obj: object) -> bool:
@@ -86,6 +89,10 @@ def assert_header_parsing(headers: httplib.HTTPMessage) -> None:
 
     if defects or unparsed_data:
         raise HeaderParsingError(defects=defects, unparsed_data=unparsed_data)
+
+
+def normalize_header_value(value: str) -> str:
+    return _OBS_FOLD_RE.sub(" ", value)
 
 
 def is_response_to_head(response: httplib.HTTPResponse) -> bool:

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -27,7 +27,7 @@ from urllib3.util import is_fp_closed
 from urllib3.util.connection import _has_ipv6, allowed_gai_family, create_connection
 from urllib3.util.proxy import connection_requires_http_tunnel
 from urllib3.util.request import _FAILEDTELL, make_headers, rewind_body
-from urllib3.util.response import assert_header_parsing
+from urllib3.util.response import assert_header_parsing, normalize_header_value
 from urllib3.util.ssl_ import (
     _is_has_never_check_common_name_reliable,
     resolve_cert_reqs,
@@ -804,6 +804,9 @@ class TestUtil:
     ) -> None:
         with pytest.raises(TypeError):
             assert_header_parsing(headers)  # type: ignore[arg-type]
+
+    def test_normalize_header_value_replaces_obs_fold(self) -> None:
+        assert normalize_header_value("foo\r\n bar\r\n\tbaz") == "foo bar baz"
 
     def test_connection_requires_http_tunnel_no_proxy(self) -> None:
         assert not connection_requires_http_tunnel(

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -88,6 +88,31 @@ class TestCookies(SocketDummyServerTestCase):
             assert r.headers == {"set-cookie": "foo=1, bar=1"}
             assert r.headers.getlist("set-cookie") == ["foo=1", "bar=1"]
 
+    def test_folded_setcookie_replaces_obs_fold(self) -> None:
+        def folded_cookie_response_handler(listener: socket.socket) -> None:
+            sock = listener.accept()[0]
+
+            buf = b""
+            while not buf.endswith(b"\r\n\r\n"):
+                buf += sock.recv(65536)
+
+            sock.send(
+                b"HTTP/1.1 200 OK\r\n"
+                b"Set-Cookie: ___utmvbtouVBFmB=gZg\r\n"
+                b"    XbNOjalT: Lte; path=/; Max-Age=900\r\n"
+                b"Content-Length: 0\r\n"
+                b"\r\n"
+            )
+            sock.close()
+
+        self._start_server(folded_cookie_response_handler)
+        with HTTPConnectionPool(self.host, self.port) as pool:
+            r = pool.request("GET", "/", retries=0)
+
+        assert r.headers.getlist("set-cookie") == [
+            "___utmvbtouVBFmB=gZg XbNOjalT: Lte; path=/; Max-Age=900"
+        ]
+
 
 class TestSNI(SocketDummyServerTestCase):
     def test_hostname_in_first_request_packet(self) -> None:


### PR DESCRIPTION
Fixes #1362.

## Summary

- Normalize obsolete folded response header values copied from `http.client`.
- Add unit coverage for obs-fold normalization.
- Add socket-level regression coverage for the folded `Set-Cookie` case from the issue.

## Testing

- `python -m pytest test/test_util.py::TestUtil::test_normalize_header_value_replaces_obs_fold test/with_dummyserver/test_socketlevel.py::TestCookies`
