### PR TITLE
fix: ProxyManager now honors HTTPConnection.default_socket_options

### DIFF
--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -6,6 +6,7 @@ import queue
 import sys
 import typing
 import warnings
+import socket
 import weakref
 from socket import timeout as SocketTimeout
 from types import TracebackType
@@ -216,9 +217,18 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
 
         if self.proxy:
             # Enable Nagle's algorithm for proxies, to avoid packet fragmentation.
-            # Defaulting `socket_options` to an empty list avoids it defaulting to
-            # ``HTTPConnection.default_socket_options``.
-            self.conn_kw.setdefault("socket_options", [])
+            # We start with the connection class's default_socket_options but remove
+            # TCP_NODELAY so that Nagle's algorithm is enabled for proxy connections.
+            # This ensures user-modified default_socket_options (e.g. SO_KEEPALIVE)
+            # are still honored while avoiding the proxy-specific packet fragmentation
+            # issue that originally motivated defaulting to an empty list.
+            default_opts = self.ConnectionCls.default_socket_options
+            proxy_opts = [
+                opt
+                for opt in default_opts
+                if opt != (socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+            ]
+            self.conn_kw.setdefault("socket_options", proxy_opts)
 
             self.conn_kw["proxy"] = self.proxy
             self.conn_kw["proxy_config"] = self.proxy_config

--- a/test/test_connectionpool.py
+++ b/test/test_connectionpool.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import http.client as httplib
+import socket
 import ssl
 import typing
 from http.client import HTTPException
@@ -614,3 +615,23 @@ class TestConnectionPool:
             # Verify the URL isn't mangled
             actual_url = mock_request.call_args[0][2]
             assert actual_url == path
+
+    def test_proxy_pool_honors_default_socket_options(self) -> None:
+        """See https://github.com/urllib3/urllib3/issues/2936."""
+        original_opts = HTTPConnection.default_socket_options.copy()
+        HTTPConnection.default_socket_options = original_opts + [
+            (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1),
+        ]
+        try:
+            proxy_pool = HTTPConnectionPool(
+                "example.com",
+                80,
+                _proxy="http://proxy.example.com:8080",
+            )
+            proxy_opts = proxy_pool.conn_kw.get("socket_options", [])
+            # TCP_NODELAY should be excluded for proxy connections
+            assert (socket.IPPROTO_TCP, socket.TCP_NODELAY, 1) not in proxy_opts
+            # User-added default socket options should be present
+            assert (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1) in proxy_opts
+        finally:
+            HTTPConnection.default_socket_options = original_opts


### PR DESCRIPTION
## Summary

Fixes #2936.

When using , proxy connection pools previously defaulted  to an empty list. This silently discarded any user-modified  (e.g. ), making it impossible to apply global socket options to proxy connections without explicitly passing  to every  instance.

## Changes

- Proxy connection pools now inherit  from the connection class, minus . This preserves the original intent of enabling Nagle's algorithm for proxies (to avoid packet fragmentation) while still honoring custom socket options.
- Added regression test .

## Test Plan



All 396 tests in , , and  pass.