### PR TITLE
Fix queue class resolution with monkey-patched queue modules

### DIFF
--- a/changelog/3289.bugfix.rst
+++ b/changelog/3289.bugfix.rst
@@ -1,0 +1,1 @@
+Resolved connection pool queue classes at construction time so monkey-patched queue implementations are honored.

--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -61,6 +61,7 @@ if typing.TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 _TYPE_TIMEOUT = typing.Union[Timeout, float, _TYPE_DEFAULT, None]
+_DEFAULT_QUEUE_CLASS = queue.LifoQueue
 
 
 # Pool objects
@@ -198,7 +199,10 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         self.timeout = timeout
         self.retries = retries
 
-        self.pool: queue.LifoQueue[typing.Any] | None = self.QueueCls(maxsize)
+        queue_cls = (
+            queue.LifoQueue if self.QueueCls is _DEFAULT_QUEUE_CLASS else self.QueueCls
+        )
+        self.pool: queue.LifoQueue[typing.Any] | None = queue_cls(maxsize)
         self.block = block
 
         self.proxy = _proxy

--- a/test/test_queue_monkeypatch.py
+++ b/test/test_queue_monkeypatch.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import queue
+import typing
 from unittest import mock
 
 import pytest
@@ -29,7 +30,7 @@ class TestMonkeypatchResistance:
                     http._get_conn(timeout=0)
 
     def test_lifo_queue_monkeypatching(self) -> None:
-        class PatchedLifoQueue(queue.LifoQueue):
+        class PatchedLifoQueue(queue.LifoQueue[object]):
             pass
 
         with mock.patch.object(queue, "LifoQueue", PatchedLifoQueue):
@@ -37,14 +38,14 @@ class TestMonkeypatchResistance:
                 assert isinstance(http.pool, PatchedLifoQueue)
 
     def test_custom_queue_cls_ignores_lifo_queue_monkeypatching(self) -> None:
-        class CustomLifoQueue(queue.LifoQueue):
+        class CustomLifoQueue(queue.LifoQueue[object]):
             pass
 
-        class PatchedLifoQueue(queue.LifoQueue):
+        class PatchedLifoQueue(queue.LifoQueue[object]):
             pass
 
         class CustomQueueConnectionPool(HTTPConnectionPool):
-            QueueCls = CustomLifoQueue
+            QueueCls: typing.Any = CustomLifoQueue
 
         with mock.patch.object(queue, "LifoQueue", PatchedLifoQueue):
             with CustomQueueConnectionPool(host="localhost") as http:

--- a/test/test_queue_monkeypatch.py
+++ b/test/test_queue_monkeypatch.py
@@ -27,3 +27,25 @@ class TestMonkeypatchResistance:
                 http._get_conn()
                 with pytest.raises(EmptyPoolError):
                     http._get_conn(timeout=0)
+
+    def test_lifo_queue_monkeypatching(self) -> None:
+        class PatchedLifoQueue(queue.LifoQueue):
+            pass
+
+        with mock.patch.object(queue, "LifoQueue", PatchedLifoQueue):
+            with HTTPConnectionPool(host="localhost") as http:
+                assert isinstance(http.pool, PatchedLifoQueue)
+
+    def test_custom_queue_cls_ignores_lifo_queue_monkeypatching(self) -> None:
+        class CustomLifoQueue(queue.LifoQueue):
+            pass
+
+        class PatchedLifoQueue(queue.LifoQueue):
+            pass
+
+        class CustomQueueConnectionPool(HTTPConnectionPool):
+            QueueCls = CustomLifoQueue
+
+        with mock.patch.object(queue, "LifoQueue", PatchedLifoQueue):
+            with CustomQueueConnectionPool(host="localhost") as http:
+                assert isinstance(http.pool, CustomLifoQueue)


### PR DESCRIPTION
This fixes #3289 by resolving the default connection-pool queue class at pool construction time instead of always using the `QueueCls` reference captured when `urllib3.connectionpool` is imported.

Explicit custom `QueueCls` subclasses are still honored, but the default path now uses the current `queue.LifoQueue`, which allows gevent-style monkey-patching to work as expected.

Tested with:

- `python -m pytest test/test_queue_monkeypatch.py test/test_connectionpool.py::TestConnectionPool::test_pool_size test/test_connectionpool.py::TestConnectionPool::test_put_conn_when_pool_is_full_nonblocking test/test_connectionpool.py::TestConnectionPool::test_put_conn_when_pool_is_full_blocking`
- `python -m pytest test/test_connectionpool.py test/test_queue_monkeypatch.py`
- `python -m black --check --target-version py310 src/urllib3/connectionpool.py test/test_queue_monkeypatch.py`
- `python -m mypy --ignore-missing-imports --no-warn-unused-ignores test/test_queue_monkeypatch.py`