### PR TITLE
Normalize folded response header values

### DIFF
--- a/changelog/1362.bugfix.rst
+++ b/changelog/1362.bugfix.rst
@@ -1,0 +1,1 @@
+Normalized obsolete folded response header values before storing them in response headers.

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -22,7 +22,7 @@ if typing.TYPE_CHECKING:
 
 from ._collections import HTTPHeaderDict
 from .http2 import probe as http2_probe
-from .util.response import assert_header_parsing
+from .util.response import assert_header_parsing, normalize_header_value
 from .util.timeout import _DEFAULT_TIMEOUT, _TYPE_TIMEOUT, Timeout
 from .util.util import to_str
 from .util.wait import wait_for_read
@@ -580,7 +580,10 @@ class HTTPConnection(_HTTPConnection):
                 exc_info=True,
             )
 
-        headers = HTTPHeaderDict(httplib_response.msg.items())
+        headers = HTTPHeaderDict(
+            (key, normalize_header_value(value))
+            for key, value in httplib_response.msg.items()
+        )
 
         response = HTTPResponse(
             body=httplib_response,

--- a/src/urllib3/util/response.py
+++ b/src/urllib3/util/response.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 import http.client as httplib
+import re
 from email.errors import MultipartInvariantViolationDefect, StartBoundaryNotFoundDefect
 
 from ..exceptions import HeaderParsingError
+
+_OBS_FOLD_RE = re.compile(r"(?:\r\n|\r|\n)[ \t]+")
 
 
 def is_fp_closed(obj: object) -> bool:
@@ -86,6 +89,17 @@ def assert_header_parsing(headers: httplib.HTTPMessage) -> None:
 
     if defects or unparsed_data:
         raise HeaderParsingError(defects=defects, unparsed_data=unparsed_data)
+
+
+def normalize_header_value(value: str) -> str:
+    """
+    Replace obsolete line folding with spaces per RFC 9112.
+
+    ``http.client`` preserves folded response header values as embedded newlines
+    with leading whitespace. Normalizing here prevents those bytes from leaking
+    into urllib3's header mapping and downstream generated request headers.
+    """
+    return _OBS_FOLD_RE.sub(" ", value)
 
 
 def is_response_to_head(response: httplib.HTTPResponse) -> bool:

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -27,7 +27,7 @@ from urllib3.util import is_fp_closed
 from urllib3.util.connection import _has_ipv6, allowed_gai_family, create_connection
 from urllib3.util.proxy import connection_requires_http_tunnel
 from urllib3.util.request import _FAILEDTELL, make_headers, rewind_body
-from urllib3.util.response import assert_header_parsing
+from urllib3.util.response import assert_header_parsing, normalize_header_value
 from urllib3.util.ssl_ import (
     _is_has_never_check_common_name_reliable,
     resolve_cert_reqs,
@@ -851,6 +851,18 @@ class TestUtil:
         )
         header_msg.seek(0)
         assert_header_parsing(client.parse_headers(header_msg))
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "name=value\r\n continued",
+            "name=value\r\n\tcontinued",
+            "name=value\n\tcontinued",
+            "name=value\r\tcontinued",
+        ],
+    )
+    def test_normalize_header_value_replaces_folded_lines(self, value: str) -> None:
+        assert normalize_header_value(value) == "name=value continued"
 
     @pytest.mark.parametrize("host", [".localhost", "...", "t" * 64])
     def test_create_connection_with_invalid_idna_labels(self, host: str) -> None:

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -88,6 +88,32 @@ class TestCookies(SocketDummyServerTestCase):
             assert r.headers == {"set-cookie": "foo=1, bar=1"}
             assert r.headers.getlist("set-cookie") == ["foo=1", "bar=1"]
 
+    def test_folded_setcookie_header_is_normalized(self) -> None:
+        def folded_setcookie_response_handler(listener: socket.socket) -> None:
+            sock = listener.accept()[0]
+
+            buf = b""
+            while not buf.endswith(b"\r\n\r\n"):
+                buf += sock.recv(65536)
+
+            sock.send(
+                b"HTTP/1.1 200 OK\r\n"
+                b"Set-Cookie: ___utmvbtouVBFmB=gZg\r\n"
+                b"\tXbNOjalT: Lte; path=/; Max-Age=900\r\n"
+                b"\r\n"
+            )
+            sock.close()
+
+        self._start_server(folded_setcookie_response_handler)
+        with HTTPConnectionPool(self.host, self.port) as pool:
+            r = pool.request("GET", "/", retries=0)
+            assert (
+                r.headers["set-cookie"]
+                == "___utmvbtouVBFmB=gZg XbNOjalT: Lte; path=/; Max-Age=900"
+            )
+            assert "\r" not in r.headers["set-cookie"]
+            assert "\n" not in r.headers["set-cookie"]
+
 
 class TestSNI(SocketDummyServerTestCase):
     def test_hostname_in_first_request_packet(self) -> None:


### PR DESCRIPTION
## Summary
- Normalize obsolete folded response header values from http.client before storing them in urllib3 response headers
- Add a socket-level regression test for folded Set-Cookie headers
- Add unit coverage for folded header normalization
- Add a changelog fragment for #1362

Fixes #1362.

## Testing
- UV_CACHE_DIR=/private/tmp/uv-cache uv run --group dev python -m pytest test/with_dummyserver/test_socketlevel.py::TestCookies::test_folded_setcookie_header_is_normalized test/with_dummyserver/test_socketlevel.py::TestCookies::test_multi_setcookie test/test_util.py::TestUtil::test_normalize_header_value_replaces_folded_lines test/test_util.py::TestUtil::test_assert_header_parsing_no_error_on_multipart
- UV_CACHE_DIR=/private/tmp/uv-cache uv run --group dev python -m pytest test/test_util.py::TestUtil
- git diff --check