### PR TITLE
Fix request header byte typing

### DIFF
--- a/changelog/3047.bugfix.rst
+++ b/changelog/3047.bugfix.rst
@@ -1,0 +1,1 @@
+Updated request header type annotations to accept ``str`` or ``bytes`` header names and values.

--- a/src/urllib3/__init__.py
+++ b/src/urllib3/__init__.py
@@ -13,7 +13,7 @@ from logging import NullHandler
 
 from . import exceptions
 from ._base_connection import _TYPE_BODY
-from ._collections import HTTPHeaderDict
+from ._collections import _TYPE_HEADER_MAPPING, HTTPHeaderDict
 from ._version import __version__
 from .connectionpool import HTTPConnectionPool, HTTPSConnectionPool, connection_from_url
 from .filepost import _TYPE_FIELDS, encode_multipart_formdata
@@ -120,7 +120,7 @@ def request(
     *,
     body: _TYPE_BODY | None = None,
     fields: _TYPE_FIELDS | None = None,
-    headers: typing.Mapping[str, str] | None = None,
+    headers: _TYPE_HEADER_MAPPING | None = None,
     preload_content: bool | None = True,
     decode_content: bool | None = True,
     redirect: bool | None = True,

--- a/src/urllib3/_base_connection.py
+++ b/src/urllib3/_base_connection.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import typing
 
+from ._collections import _TYPE_HEADER_MAPPING
 from .util.connection import _TYPE_SOCKET_OPTIONS
 from .util.timeout import _DEFAULT_TIMEOUT, _TYPE_TIMEOUT
 from .util.url import Url
@@ -70,7 +71,7 @@ if typing.TYPE_CHECKING:
             self,
             host: str,
             port: int | None = None,
-            headers: typing.Mapping[str, str] | None = None,
+            headers: _TYPE_HEADER_MAPPING | None = None,
             scheme: str = "http",
         ) -> None: ...
 
@@ -81,7 +82,7 @@ if typing.TYPE_CHECKING:
             method: str,
             url: str,
             body: _TYPE_BODY | None = None,
-            headers: typing.Mapping[str, str] | None = None,
+            headers: _TYPE_HEADER_MAPPING | None = None,
             # We know *at least* botocore is depending on the order of the
             # first 3 parameters so to be safe we only mark the later ones
             # as keyword-only to ensure we have space to extend.

--- a/src/urllib3/_collections.py
+++ b/src/urllib3/_collections.py
@@ -28,6 +28,16 @@ _VT = typing.TypeVar("_VT")
 # Default type
 _DT = typing.TypeVar("_DT")
 
+_TYPE_HEADER_KEY = str | bytes
+_TYPE_HEADER_VALUE = str | bytes
+_TYPE_HEADER_MAPPING: typing.TypeAlias = (
+    typing.Mapping[str, str]
+    | typing.Mapping[str, bytes]
+    | typing.Mapping[bytes, str]
+    | typing.Mapping[bytes, bytes]
+    | typing.Mapping[_TYPE_HEADER_KEY, _TYPE_HEADER_VALUE]
+)
+
 ValidHTTPHeaderSource = typing.Union[
     "HTTPHeaderDict",
     typing.Mapping[str, str],

--- a/src/urllib3/_request_methods.py
+++ b/src/urllib3/_request_methods.py
@@ -5,9 +5,10 @@ import typing
 from urllib.parse import urlencode
 
 from ._base_connection import _TYPE_BODY
-from ._collections import HTTPHeaderDict
+from ._collections import _TYPE_HEADER_MAPPING, HTTPHeaderDict, ValidHTTPHeaderSource
 from .filepost import _TYPE_FIELDS, encode_multipart_formdata
 from .response import BaseHTTPResponse
+from .util.util import to_str
 
 __all__ = ["RequestMethods"]
 
@@ -48,7 +49,7 @@ class RequestMethods:
 
     _encode_url_methods = {"DELETE", "GET", "HEAD", "OPTIONS"}
 
-    def __init__(self, headers: typing.Mapping[str, str] | None = None) -> None:
+    def __init__(self, headers: _TYPE_HEADER_MAPPING | None = None) -> None:
         self.headers = headers or {}
 
     def urlopen(
@@ -56,7 +57,7 @@ class RequestMethods:
         method: str,
         url: str,
         body: _TYPE_BODY | None = None,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADER_MAPPING | None = None,
         encode_multipart: bool = True,
         multipart_boundary: str | None = None,
         **kw: typing.Any,
@@ -72,7 +73,7 @@ class RequestMethods:
         url: str,
         body: _TYPE_BODY | None = None,
         fields: _TYPE_FIELDS | None = None,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADER_MAPPING | None = None,
         json: typing.Any | None = None,
         **urlopen_kw: typing.Any,
     ) -> BaseHTTPResponse:
@@ -120,8 +121,8 @@ class RequestMethods:
             if headers is None:
                 headers = self.headers
 
-            if not ("content-type" in map(str.lower, headers.keys())):
-                headers = HTTPHeaderDict(headers)
+            if not ("content-type" in (to_str(key).lower() for key in headers.keys())):
+                headers = HTTPHeaderDict(typing.cast(ValidHTTPHeaderSource, headers))
                 headers["Content-Type"] = "application/json"
 
             body = _json.dumps(json, separators=(",", ":"), ensure_ascii=False).encode(
@@ -149,7 +150,7 @@ class RequestMethods:
         method: str,
         url: str,
         fields: _TYPE_ENCODE_URL_FIELDS | None = None,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADER_MAPPING | None = None,
         **urlopen_kw: str,
     ) -> BaseHTTPResponse:
         """
@@ -186,7 +187,7 @@ class RequestMethods:
         method: str,
         url: str,
         fields: _TYPE_FIELDS | None = None,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADER_MAPPING | None = None,
         encode_multipart: bool = True,
         multipart_boundary: str | None = None,
         **urlopen_kw: str,
@@ -251,7 +252,9 @@ class RequestMethods:
         if headers is None:
             headers = self.headers
 
-        extra_kw: dict[str, typing.Any] = {"headers": HTTPHeaderDict(headers)}
+        extra_kw: dict[str, typing.Any] = {
+            "headers": HTTPHeaderDict(typing.cast(ValidHTTPHeaderSource, headers))
+        }
         body: bytes | str
 
         if fields:

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -20,7 +20,7 @@ if typing.TYPE_CHECKING:
     from .util.ssl_ import _TYPE_PEER_CERT_RET_DICT
     from .util.ssltransport import SSLTransport
 
-from ._collections import HTTPHeaderDict
+from ._collections import _TYPE_HEADER_MAPPING, HTTPHeaderDict
 from .http2 import probe as http2_probe
 from .util.response import assert_header_parsing
 from .util.timeout import _DEFAULT_TIMEOUT, _TYPE_TIMEOUT, Timeout
@@ -228,14 +228,18 @@ class HTTPConnection(_HTTPConnection):
         self,
         host: str,
         port: int | None = None,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADER_MAPPING | None = None,
         scheme: str = "http",
     ) -> None:
         if scheme not in ("http", "https"):
             raise ValueError(
                 f"Invalid proxy scheme for tunneling: {scheme!r}, must be either 'http' or 'https'"
             )
-        super().set_tunnel(host, port=port, headers=headers)
+        super().set_tunnel(
+            host,
+            port=port,
+            headers=typing.cast(typing.Mapping[str, str] | None, headers),
+        )
         self._tunnel_scheme = scheme
 
     if sys.version_info < (3, 11, 9) or ((3, 12) <= sys.version_info < (3, 12, 3)):
@@ -426,7 +430,7 @@ class HTTPConnection(_HTTPConnection):
         method: str,
         url: str,
         body: _TYPE_BODY | None = None,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADER_MAPPING | None = None,
         *,
         chunked: bool = False,
         preload_content: bool = True,
@@ -496,7 +500,7 @@ class HTTPConnection(_HTTPConnection):
         if "user-agent" not in header_keys:
             self.putheader("User-Agent", _get_default_user_agent())
         for header, value in headers.items():
-            self.putheader(header, value)
+            self.putheader(typing.cast(str, header), typing.cast(str, value))
         self.endheaders()
 
         # If we're given a body we start sending that in chunks.
@@ -523,7 +527,7 @@ class HTTPConnection(_HTTPConnection):
         method: str,
         url: str,
         body: _TYPE_BODY | None = None,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADER_MAPPING | None = None,
     ) -> None:
         """
         Alternative to the common request method, which sends the

--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -11,7 +11,7 @@ from socket import timeout as SocketTimeout
 from types import TracebackType
 
 from ._base_connection import _TYPE_BODY
-from ._collections import HTTPHeaderDict
+from ._collections import _TYPE_HEADER_MAPPING, HTTPHeaderDict, ValidHTTPHeaderSource
 from ._request_methods import RequestMethods
 from .connection import (
     BaseSSLError,
@@ -61,6 +61,14 @@ if typing.TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 _TYPE_TIMEOUT = typing.Union[Timeout, float, _TYPE_DEFAULT, None]
+
+
+def _copy_request_headers(
+    headers: _TYPE_HEADER_MAPPING,
+) -> HTTPHeaderDict | dict[str | bytes, str | bytes]:
+    if isinstance(headers, HTTPHeaderDict):
+        return headers.copy()
+    return dict(typing.cast(typing.Mapping[str | bytes, str | bytes], headers))
 
 
 # Pool objects
@@ -179,10 +187,10 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         timeout: _TYPE_TIMEOUT | None = _DEFAULT_TIMEOUT,
         maxsize: int = 1,
         block: bool = False,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADER_MAPPING | None = None,
         retries: Retry | bool | int | None = None,
         _proxy: Url | None = None,
-        _proxy_headers: typing.Mapping[str, str] | None = None,
+        _proxy_headers: _TYPE_HEADER_MAPPING | None = None,
         _proxy_config: ProxyConfig | None = None,
         **conn_kw: typing.Any,
     ):
@@ -380,7 +388,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         method: str,
         url: str,
         body: _TYPE_BODY | None = None,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADER_MAPPING | None = None,
         retries: Retry | None = None,
         timeout: _TYPE_TIMEOUT = _DEFAULT_TIMEOUT,
         chunked: bool = False,
@@ -594,7 +602,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         method: str,
         url: str,
         body: _TYPE_BODY | None = None,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADER_MAPPING | None = None,
         retries: Retry | bool | int | None = None,
         redirect: bool = True,
         assert_same_host: bool = True,
@@ -746,8 +754,10 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         # have to copy the headers dict so we can safely change it without those
         # changes being reflected in anyone else's copy.
         if not http_tunnel_required:
-            headers = headers.copy()  # type: ignore[attr-defined]
-            headers.update(self.proxy_headers)  # type: ignore[union-attr]
+            headers = _copy_request_headers(headers)
+            typing.cast(typing.MutableMapping[typing.Any, typing.Any], headers).update(
+                self.proxy_headers
+            )
 
         # Must keep the exception bound to a separate variable or else Python 3
         # complains about UnboundLocalError.
@@ -895,7 +905,9 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
                 method = "GET"
                 # And lose the body not to transfer anything sensitive.
                 body = None
-                headers = HTTPHeaderDict(headers)._prepare_for_method_change()
+                headers = HTTPHeaderDict(
+                    typing.cast(ValidHTTPHeaderSource, headers)
+                )._prepare_for_method_change()
 
             # Strip headers marked as unsafe to forward to the redirected location.
             # Check remove_headers_on_redirect to avoid a potential network call within
@@ -997,10 +1009,10 @@ class HTTPSConnectionPool(HTTPConnectionPool):
         timeout: _TYPE_TIMEOUT | None = _DEFAULT_TIMEOUT,
         maxsize: int = 1,
         block: bool = False,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADER_MAPPING | None = None,
         retries: Retry | bool | int | None = None,
         _proxy: Url | None = None,
-        _proxy_headers: typing.Mapping[str, str] | None = None,
+        _proxy_headers: _TYPE_HEADER_MAPPING | None = None,
         key_file: str | None = None,
         cert_file: str | None = None,
         cert_reqs: int | str | None = None,

--- a/src/urllib3/contrib/emscripten/connection.py
+++ b/src/urllib3/contrib/emscripten/connection.py
@@ -8,12 +8,14 @@ from http.client import HTTPException as HTTPException  # noqa: F401
 from http.client import ResponseNotReady
 
 from ..._base_connection import _TYPE_BODY
+from ..._collections import _TYPE_HEADER_MAPPING
 from ...connection import HTTPConnection, ProxyConfig, port_by_scheme
 from ...exceptions import TimeoutError
 from ...response import BaseHTTPResponse
 from ...util.connection import _TYPE_SOCKET_OPTIONS
 from ...util.timeout import _DEFAULT_TIMEOUT, _TYPE_TIMEOUT
 from ...util.url import Url
+from ...util.util import to_str
 from .fetch import _RequestError, _TimeoutError, send_request, send_streaming_request
 from .request import EmscriptenRequest
 from .response import EmscriptenHttpResponseWrapper, EmscriptenResponse
@@ -74,7 +76,7 @@ class EmscriptenHTTPConnection:
         self,
         host: str,
         port: int | None = 0,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADER_MAPPING | None = None,
         scheme: str = "http",
     ) -> None:
         pass
@@ -87,7 +89,7 @@ class EmscriptenHTTPConnection:
         method: str,
         url: str,
         body: _TYPE_BODY | None = None,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADER_MAPPING | None = None,
         # We know *at least* botocore is depending on the order of the
         # first 3 parameters so to be safe we only mark the later ones
         # as keyword-only to ensure we have space to extend.
@@ -114,7 +116,7 @@ class EmscriptenHTTPConnection:
         request.set_body(body)
         if headers:
             for k, v in headers.items():
-                request.set_header(k, v)
+                request.set_header(to_str(k, "latin-1"), to_str(v, "latin-1"))
         self._response = None
         try:
             if not preload_content:

--- a/src/urllib3/contrib/socks.py
+++ b/src/urllib3/contrib/socks.py
@@ -60,6 +60,7 @@ except ImportError:
 import typing
 from socket import timeout as SocketTimeout
 
+from .._collections import _TYPE_HEADER_MAPPING
 from ..connection import HTTPConnection, HTTPSConnection
 from ..connectionpool import HTTPConnectionPool, HTTPSConnectionPool
 from ..exceptions import ConnectTimeoutError, NewConnectionError
@@ -187,7 +188,7 @@ class SOCKSProxyManager(PoolManager):
         username: str | None = None,
         password: str | None = None,
         num_pools: int = 10,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADER_MAPPING | None = None,
         **connection_pool_kw: typing.Any,
     ):
         parsed = parse_url(proxy_url)

--- a/src/urllib3/http2/connection.py
+++ b/src/urllib3/http2/connection.py
@@ -11,7 +11,7 @@ import h2.connection
 import h2.events
 
 from .._base_connection import _TYPE_BODY
-from .._collections import HTTPHeaderDict
+from .._collections import _TYPE_HEADER_MAPPING, HTTPHeaderDict
 from ..connection import HTTPSConnection, _get_default_user_agent
 from ..exceptions import ConnectionError
 from ..response import BaseHTTPResponse
@@ -216,7 +216,7 @@ class HTTP2Connection(HTTPSConnection):
         self,
         host: str,
         port: int | None = None,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADER_MAPPING | None = None,
         scheme: str = "http",
     ) -> None:
         raise NotImplementedError(
@@ -270,7 +270,7 @@ class HTTP2Connection(HTTPSConnection):
         method: str,
         url: str,
         body: _TYPE_BODY | None = None,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADER_MAPPING | None = None,
         *,
         preload_content: bool = True,
         decode_content: bool = True,

--- a/src/urllib3/poolmanager.py
+++ b/src/urllib3/poolmanager.py
@@ -7,7 +7,12 @@ import warnings
 from types import TracebackType
 from urllib.parse import urljoin
 
-from ._collections import HTTPHeaderDict, RecentlyUsedContainer
+from ._collections import (
+    _TYPE_HEADER_MAPPING,
+    HTTPHeaderDict,
+    RecentlyUsedContainer,
+    ValidHTTPHeaderSource,
+)
 from ._request_methods import RequestMethods
 from .connection import ProxyConfig
 from .connectionpool import HTTPConnectionPool, HTTPSConnectionPool, port_by_scheme
@@ -199,7 +204,7 @@ class PoolManager(RequestMethods):
     def __init__(
         self,
         num_pools: int = 10,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADER_MAPPING | None = None,
         **connection_pool_kw: typing.Any,
     ) -> None:
         super().__init__(headers)
@@ -468,7 +473,9 @@ class PoolManager(RequestMethods):
             method = "GET"
             # And lose the body not to transfer anything sensitive.
             kw["body"] = None
-            kw["headers"] = HTTPHeaderDict(kw["headers"])._prepare_for_method_change()
+            kw["headers"] = HTTPHeaderDict(
+                typing.cast(ValidHTTPHeaderSource, kw["headers"])
+            )._prepare_for_method_change()
 
         retries = kw.get("retries", response.retries)
         if not isinstance(retries, Retry):
@@ -564,8 +571,8 @@ class ProxyManager(PoolManager):
         self,
         proxy_url: str,
         num_pools: int = 10,
-        headers: typing.Mapping[str, str] | None = None,
-        proxy_headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADER_MAPPING | None = None,
+        proxy_headers: _TYPE_HEADER_MAPPING | None = None,
         proxy_ssl_context: ssl.SSLContext | None = None,
         use_forwarding_for_https: bool = False,
         proxy_assert_hostname: None | str | typing.Literal[False] = None,
@@ -618,20 +625,22 @@ class ProxyManager(PoolManager):
         )
 
     def _set_proxy_headers(
-        self, url: str, headers: typing.Mapping[str, str] | None = None
-    ) -> typing.Mapping[str, str]:
+        self, url: str, headers: _TYPE_HEADER_MAPPING | None = None
+    ) -> _TYPE_HEADER_MAPPING:
         """
         Sets headers needed by proxies: specifically, the Accept and Host
         headers. Only sets headers not provided by the user.
         """
-        headers_ = {"Accept": "*/*"}
+        headers_: dict[str | bytes, str | bytes] = {"Accept": "*/*"}
 
         netloc = parse_url(url).netloc
         if netloc:
             headers_["Host"] = netloc
 
         if headers:
-            headers_.update(headers)
+            headers_.update(
+                typing.cast(typing.Mapping[str | bytes, str | bytes], headers)
+            )
         return headers_
 
     def urlopen(  # type: ignore[override]

--- a/test/test_typing.py
+++ b/test/test_typing.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import typing
+
+import urllib3
+
+if typing.TYPE_CHECKING:
+
+    def check_request_header_types() -> None:
+        string_headers: dict[str, str] = {"accept": "application/json"}
+        bytes_value_headers: dict[str, bytes] = {"x-token": b"abc"}
+        bytes_key_headers: dict[bytes, str] = {b"x-token": "abc"}
+        bytes_headers: dict[bytes, bytes] = {b"x-token": b"abc"}
+        mixed_headers: dict[str | bytes, str | bytes] = {
+            "accept": "application/json",
+            b"x-token": b"abc",
+        }
+        header_dict = urllib3.HTTPHeaderDict({"accept": "application/json"})
+
+        urllib3.request("GET", "https://example.com", headers=string_headers)
+        urllib3.request("GET", "https://example.com", headers=bytes_value_headers)
+        urllib3.request("GET", "https://example.com", headers=bytes_key_headers)
+        urllib3.request("GET", "https://example.com", headers=bytes_headers)
+        urllib3.request("GET", "https://example.com", headers=mixed_headers)
+        urllib3.request("GET", "https://example.com", headers=header_dict)
+
+        pool = urllib3.PoolManager(headers=string_headers)
+        pool.request("GET", "https://example.com", headers=bytes_value_headers)
+        pool.request_encode_url("GET", "https://example.com", headers=bytes_key_headers)
+        pool.request_encode_body("POST", "https://example.com", headers=bytes_headers)
+
+        connection_pool = urllib3.HTTPConnectionPool(
+            "example.com", headers=mixed_headers
+        )
+        connection_pool.request("GET", "/", headers=header_dict)
+
+        proxy = urllib3.ProxyManager(
+            "http://example.com",
+            headers=bytes_key_headers,
+            proxy_headers=bytes_value_headers,
+        )
+        proxy.request("GET", "https://example.com", headers=mixed_headers)


### PR DESCRIPTION
Closes #3047

## Summary
- add a shared request-header mapping type that accepts str or bytes header names and values without rejecting dict[str, str]
- apply the wider request header type across the public request, pool, proxy, connection, SOCKS, emscripten, and HTTP/2 request surfaces
- add a typing regression check for str-only, bytes-only, mixed str/bytes, and HTTPHeaderDict request headers

## Verification
- `uv run --group mypy mypy test/test_typing.py --hide-error-context`
- `uv run --group mypy mypy src/urllib3/__init__.py src/urllib3/_base_connection.py src/urllib3/_collections.py src/urllib3/_request_methods.py src/urllib3/connection.py src/urllib3/connectionpool.py src/urllib3/contrib/emscripten/connection.py src/urllib3/contrib/socks.py src/urllib3/http2/connection.py src/urllib3/poolmanager.py test/test_typing.py --hide-error-context`
- `uv run pytest -q test/test_typing.py test/test_collections.py`
- `git diff --check`