### PR TITLE
Fix header typing for bytes mappings

### DIFF
--- a/changelog/3047.bugfix.rst
+++ b/changelog/3047.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed request header type hints to accept mappings with ``str`` or ``bytes`` keys and values.

--- a/src/urllib3/__init__.py
+++ b/src/urllib3/__init__.py
@@ -13,7 +13,7 @@ from logging import NullHandler
 
 from . import exceptions
 from ._base_connection import _TYPE_BODY
-from ._collections import HTTPHeaderDict
+from ._collections import _TYPE_HTTP_HEADER_MAPPING, HTTPHeaderDict
 from ._version import __version__
 from .connectionpool import HTTPConnectionPool, HTTPSConnectionPool, connection_from_url
 from .filepost import _TYPE_FIELDS, encode_multipart_formdata
@@ -120,7 +120,7 @@ def request(
     *,
     body: _TYPE_BODY | None = None,
     fields: _TYPE_FIELDS | None = None,
-    headers: typing.Mapping[str, str] | None = None,
+    headers: _TYPE_HTTP_HEADER_MAPPING | None = None,
     preload_content: bool | None = True,
     decode_content: bool | None = True,
     redirect: bool | None = True,

--- a/src/urllib3/_base_connection.py
+++ b/src/urllib3/_base_connection.py
@@ -32,6 +32,7 @@ if typing.TYPE_CHECKING:
     import ssl
     from typing import Protocol
 
+    from ._collections import _TYPE_HTTP_HEADER_MAPPING
     from .response import BaseHTTPResponse
 
     class BaseHTTPConnection(Protocol):
@@ -70,7 +71,7 @@ if typing.TYPE_CHECKING:
             self,
             host: str,
             port: int | None = None,
-            headers: typing.Mapping[str, str] | None = None,
+            headers: _TYPE_HTTP_HEADER_MAPPING | None = None,
             scheme: str = "http",
         ) -> None: ...
 
@@ -81,7 +82,7 @@ if typing.TYPE_CHECKING:
             method: str,
             url: str,
             body: _TYPE_BODY | None = None,
-            headers: typing.Mapping[str, str] | None = None,
+            headers: _TYPE_HTTP_HEADER_MAPPING | None = None,
             # We know *at least* botocore is depending on the order of the
             # first 3 parameters so to be safe we only mark the later ones
             # as keyword-only to ensure we have space to extend.

--- a/src/urllib3/_collections.py
+++ b/src/urllib3/_collections.py
@@ -12,10 +12,10 @@ if typing.TYPE_CHECKING:
 
     from typing_extensions import Self
 
-    class HasGettableStringKeys(Protocol):
-        def keys(self) -> typing.Iterator[str]: ...
+    class HasGettableStrOrBytesKeys(Protocol):
+        def keys(self) -> typing.Iterator[str | bytes]: ...
 
-        def __getitem__(self, key: str) -> str: ...
+        def __getitem__(self, key: str | bytes) -> str | bytes: ...
 
 
 __all__ = ["RecentlyUsedContainer", "HTTPHeaderDict"]
@@ -31,8 +31,21 @@ _DT = typing.TypeVar("_DT")
 ValidHTTPHeaderSource = typing.Union[
     "HTTPHeaderDict",
     typing.Mapping[str, str],
+    typing.Mapping[str, bytes],
+    typing.Mapping[bytes, str],
+    typing.Mapping[bytes, bytes],
+    typing.Mapping[str | bytes, str | bytes],
     typing.Iterable[tuple[str, str]],
-    "HasGettableStringKeys",
+    typing.Iterable[tuple[str | bytes, str | bytes]],
+    "HasGettableStrOrBytesKeys",
+]
+
+_TYPE_HTTP_HEADER_MAPPING = typing.Union[
+    typing.Mapping[str, str],
+    typing.Mapping[str, bytes],
+    typing.Mapping[bytes, str],
+    typing.Mapping[bytes, bytes],
+    typing.Mapping[str | bytes, str | bytes],
 ]
 
 
@@ -48,14 +61,14 @@ def ensure_can_construct_http_header_dict(
     elif isinstance(potential, typing.Mapping):
         # Full runtime checking of the contents of a Mapping is expensive, so for the
         # purposes of typechecking, we assume that any Mapping is the right shape.
-        return typing.cast(typing.Mapping[str, str], potential)
+        return typing.cast(_TYPE_HTTP_HEADER_MAPPING, potential)
     elif isinstance(potential, typing.Iterable):
         # Similarly to Mapping, full runtime checking of the contents of an Iterable is
         # expensive, so for the purposes of typechecking, we assume that any Iterable
         # is the right shape.
-        return typing.cast(typing.Iterable[tuple[str, str]], potential)
+        return typing.cast(typing.Iterable[tuple[str | bytes, str | bytes]], potential)
     elif hasattr(potential, "keys") and hasattr(potential, "__getitem__"):
-        return typing.cast("HasGettableStringKeys", potential)
+        return typing.cast("HasGettableStrOrBytesKeys", potential)
     else:
         return None
 
@@ -248,19 +261,21 @@ class HTTPHeaderDict(typing.MutableMapping[str, str]):
         if kwargs:
             self.extend(kwargs)
 
-    def __setitem__(self, key: str, val: str) -> None:
+    def __setitem__(self, key: str | bytes, val: str | bytes) -> None:
         # avoid a bytes/str comparison by decoding before httplib
         if isinstance(key, bytes):
             key = key.decode("latin-1")
+        if isinstance(val, bytes):
+            val = val.decode("latin-1")
         self._container[key.lower()] = [key, val]
 
-    def __getitem__(self, key: str) -> str:
+    def __getitem__(self, key: str | bytes) -> str:
         if isinstance(key, bytes):
             key = key.decode("latin-1")
         val = self._container[key.lower()]
         return ", ".join(val[1:])
 
-    def __delitem__(self, key: str) -> None:
+    def __delitem__(self, key: str | bytes) -> None:
         if isinstance(key, bytes):
             key = key.decode("latin-1")
         del self._container[key.lower()]
@@ -272,8 +287,14 @@ class HTTPHeaderDict(typing.MutableMapping[str, str]):
             return key.lower() in self._container
         return False
 
-    def setdefault(self, key: str, default: str = "") -> str:
-        return super().setdefault(key, default)
+    def setdefault(self, key: str | bytes, default: str | bytes = "") -> str:
+        if isinstance(default, bytes):
+            default = default.decode("latin-1")
+        try:
+            return self[key]
+        except KeyError:
+            self[key] = default
+            return default
 
     def __eq__(self, other: object) -> bool:
         maybe_constructable = ensure_can_construct_http_header_dict(other)
@@ -297,13 +318,13 @@ class HTTPHeaderDict(typing.MutableMapping[str, str]):
         for vals in self._container.values():
             yield vals[0]
 
-    def discard(self, key: str) -> None:
+    def discard(self, key: str | bytes) -> None:
         try:
             del self[key]
         except KeyError:
             pass
 
-    def add(self, key: str, val: str, *, combine: bool = False) -> None:
+    def add(self, key: str | bytes, val: str | bytes, *, combine: bool = False) -> None:
         """Adds a (name, value) pair, doesn't overwrite the value if it already
         exists.
 
@@ -325,6 +346,8 @@ class HTTPHeaderDict(typing.MutableMapping[str, str]):
         # avoid a bytes/str comparison by decoding before httplib
         if isinstance(key, bytes):
             key = key.decode("latin-1")
+        if isinstance(val, bytes):
+            val = val.decode("latin-1")
         key_lower = key.lower()
         new_vals = [key, val]
         # Keep the common case aka no item present as fast as possible
@@ -353,31 +376,31 @@ class HTTPHeaderDict(typing.MutableMapping[str, str]):
             for key, val in other.iteritems():
                 self.add(key, val)
         elif isinstance(other, typing.Mapping):
-            for key, val in other.items():
-                self.add(key, val)
+            for mapping_key, mapping_val in other.items():
+                self.add(mapping_key, mapping_val)
         elif isinstance(other, typing.Iterable):
-            for key, value in other:
-                self.add(key, value)
+            for iterable_key, iterable_value in other:
+                self.add(iterable_key, iterable_value)
         elif hasattr(other, "keys") and hasattr(other, "__getitem__"):
             # THIS IS NOT A TYPESAFE BRANCH
             # In this branch, the object has a `keys` attr but is not a Mapping or any of
             # the other types indicated in the method signature. We do some stuff with
             # it as though it partially implements the Mapping interface, but we're not
             # doing that stuff safely AT ALL.
-            for key in other.keys():
-                self.add(key, other[key])
+            for gettable_key in other.keys():
+                self.add(gettable_key, other[gettable_key])
 
         for key, value in kwargs.items():
             self.add(key, value)
 
     @typing.overload
-    def getlist(self, key: str) -> list[str]: ...
+    def getlist(self, key: str | bytes) -> list[str]: ...
 
     @typing.overload
-    def getlist(self, key: str, default: _DT) -> list[str] | _DT: ...
+    def getlist(self, key: str | bytes, default: _DT) -> list[str] | _DT: ...
 
     def getlist(
-        self, key: str, default: _Sentinel | _DT = _Sentinel.not_passed
+        self, key: str | bytes, default: _Sentinel | _DT = _Sentinel.not_passed
     ) -> list[str] | _DT:
         """Returns a list of all the values for the named field. Returns an
         empty list if the key doesn't exist."""

--- a/src/urllib3/_request_methods.py
+++ b/src/urllib3/_request_methods.py
@@ -5,7 +5,7 @@ import typing
 from urllib.parse import urlencode
 
 from ._base_connection import _TYPE_BODY
-from ._collections import HTTPHeaderDict
+from ._collections import _TYPE_HTTP_HEADER_MAPPING, HTTPHeaderDict
 from .filepost import _TYPE_FIELDS, encode_multipart_formdata
 from .response import BaseHTTPResponse
 
@@ -48,7 +48,7 @@ class RequestMethods:
 
     _encode_url_methods = {"DELETE", "GET", "HEAD", "OPTIONS"}
 
-    def __init__(self, headers: typing.Mapping[str, str] | None = None) -> None:
+    def __init__(self, headers: _TYPE_HTTP_HEADER_MAPPING | None = None) -> None:
         self.headers = headers or {}
 
     def urlopen(
@@ -56,7 +56,7 @@ class RequestMethods:
         method: str,
         url: str,
         body: _TYPE_BODY | None = None,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HTTP_HEADER_MAPPING | None = None,
         encode_multipart: bool = True,
         multipart_boundary: str | None = None,
         **kw: typing.Any,
@@ -72,7 +72,7 @@ class RequestMethods:
         url: str,
         body: _TYPE_BODY | None = None,
         fields: _TYPE_FIELDS | None = None,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HTTP_HEADER_MAPPING | None = None,
         json: typing.Any | None = None,
         **urlopen_kw: typing.Any,
     ) -> BaseHTTPResponse:
@@ -120,8 +120,8 @@ class RequestMethods:
             if headers is None:
                 headers = self.headers
 
-            if not ("content-type" in map(str.lower, headers.keys())):
-                headers = HTTPHeaderDict(headers)
+            headers = HTTPHeaderDict(headers)
+            if "content-type" not in headers:
                 headers["Content-Type"] = "application/json"
 
             body = _json.dumps(json, separators=(",", ":"), ensure_ascii=False).encode(
@@ -149,7 +149,7 @@ class RequestMethods:
         method: str,
         url: str,
         fields: _TYPE_ENCODE_URL_FIELDS | None = None,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HTTP_HEADER_MAPPING | None = None,
         **urlopen_kw: str,
     ) -> BaseHTTPResponse:
         """
@@ -186,7 +186,7 @@ class RequestMethods:
         method: str,
         url: str,
         fields: _TYPE_FIELDS | None = None,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HTTP_HEADER_MAPPING | None = None,
         encode_multipart: bool = True,
         multipart_boundary: str | None = None,
         **urlopen_kw: str,

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -20,7 +20,7 @@ if typing.TYPE_CHECKING:
     from .util.ssl_ import _TYPE_PEER_CERT_RET_DICT
     from .util.ssltransport import SSLTransport
 
-from ._collections import HTTPHeaderDict
+from ._collections import _TYPE_HTTP_HEADER_MAPPING, HTTPHeaderDict
 from .http2 import probe as http2_probe
 from .util.response import assert_header_parsing
 from .util.timeout import _DEFAULT_TIMEOUT, _TYPE_TIMEOUT, Timeout
@@ -228,14 +228,18 @@ class HTTPConnection(_HTTPConnection):
         self,
         host: str,
         port: int | None = None,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HTTP_HEADER_MAPPING | None = None,
         scheme: str = "http",
     ) -> None:
         if scheme not in ("http", "https"):
             raise ValueError(
                 f"Invalid proxy scheme for tunneling: {scheme!r}, must be either 'http' or 'https'"
             )
-        super().set_tunnel(host, port=port, headers=headers)
+        super().set_tunnel(
+            host,
+            port=port,
+            headers=HTTPHeaderDict(headers) if headers is not None else None,
+        )
         self._tunnel_scheme = scheme
 
     if sys.version_info < (3, 11, 9) or ((3, 12) <= sys.version_info < (3, 12, 3)):
@@ -426,7 +430,7 @@ class HTTPConnection(_HTTPConnection):
         method: str,
         url: str,
         body: _TYPE_BODY | None = None,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HTTP_HEADER_MAPPING | None = None,
         *,
         chunked: bool = False,
         preload_content: bool = True,
@@ -456,6 +460,7 @@ class HTTPConnection(_HTTPConnection):
 
         if headers is None:
             headers = {}
+        headers = HTTPHeaderDict(headers)
         header_keys = frozenset(to_str(k.lower()) for k in headers)
         skip_accept_encoding = "accept-encoding" in header_keys
         skip_host = "host" in header_keys
@@ -523,7 +528,7 @@ class HTTPConnection(_HTTPConnection):
         method: str,
         url: str,
         body: _TYPE_BODY | None = None,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HTTP_HEADER_MAPPING | None = None,
     ) -> None:
         """
         Alternative to the common request method, which sends the

--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -11,7 +11,7 @@ from socket import timeout as SocketTimeout
 from types import TracebackType
 
 from ._base_connection import _TYPE_BODY
-from ._collections import HTTPHeaderDict
+from ._collections import _TYPE_HTTP_HEADER_MAPPING, HTTPHeaderDict
 from ._request_methods import RequestMethods
 from .connection import (
     BaseSSLError,
@@ -179,10 +179,10 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         timeout: _TYPE_TIMEOUT | None = _DEFAULT_TIMEOUT,
         maxsize: int = 1,
         block: bool = False,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HTTP_HEADER_MAPPING | None = None,
         retries: Retry | bool | int | None = None,
         _proxy: Url | None = None,
-        _proxy_headers: typing.Mapping[str, str] | None = None,
+        _proxy_headers: _TYPE_HTTP_HEADER_MAPPING | None = None,
         _proxy_config: ProxyConfig | None = None,
         **conn_kw: typing.Any,
     ):
@@ -380,7 +380,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         method: str,
         url: str,
         body: _TYPE_BODY | None = None,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HTTP_HEADER_MAPPING | None = None,
         retries: Retry | None = None,
         timeout: _TYPE_TIMEOUT = _DEFAULT_TIMEOUT,
         chunked: bool = False,
@@ -594,7 +594,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         method: str,
         url: str,
         body: _TYPE_BODY | None = None,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HTTP_HEADER_MAPPING | None = None,
         retries: Retry | bool | int | None = None,
         redirect: bool = True,
         assert_same_host: bool = True,
@@ -714,6 +714,8 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
 
         if headers is None:
             headers = self.headers
+        if not isinstance(headers, HTTPHeaderDict):
+            headers = HTTPHeaderDict(headers)
 
         if not isinstance(retries, Retry):
             retries = Retry.from_int(retries, redirect=redirect, default=self.retries)
@@ -746,8 +748,8 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         # have to copy the headers dict so we can safely change it without those
         # changes being reflected in anyone else's copy.
         if not http_tunnel_required:
-            headers = headers.copy()  # type: ignore[attr-defined]
-            headers.update(self.proxy_headers)  # type: ignore[union-attr]
+            headers = headers.copy()
+            headers.update(HTTPHeaderDict(self.proxy_headers))
 
         # Must keep the exception bound to a separate variable or else Python 3
         # complains about UnboundLocalError.
@@ -903,7 +905,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
             if retries.remove_headers_on_redirect and not self.is_same_host(
                 redirect_location
             ):
-                new_headers = headers.copy()  # type: ignore[union-attr]
+                new_headers = headers.copy()
                 for header in headers:
                     if header.lower() in retries.remove_headers_on_redirect:
                         new_headers.pop(header, None)
@@ -997,10 +999,10 @@ class HTTPSConnectionPool(HTTPConnectionPool):
         timeout: _TYPE_TIMEOUT | None = _DEFAULT_TIMEOUT,
         maxsize: int = 1,
         block: bool = False,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HTTP_HEADER_MAPPING | None = None,
         retries: Retry | bool | int | None = None,
         _proxy: Url | None = None,
-        _proxy_headers: typing.Mapping[str, str] | None = None,
+        _proxy_headers: _TYPE_HTTP_HEADER_MAPPING | None = None,
         key_file: str | None = None,
         cert_file: str | None = None,
         cert_reqs: int | str | None = None,

--- a/src/urllib3/contrib/emscripten/connection.py
+++ b/src/urllib3/contrib/emscripten/connection.py
@@ -8,6 +8,7 @@ from http.client import HTTPException as HTTPException  # noqa: F401
 from http.client import ResponseNotReady
 
 from ..._base_connection import _TYPE_BODY
+from ..._collections import _TYPE_HTTP_HEADER_MAPPING, HTTPHeaderDict
 from ...connection import HTTPConnection, ProxyConfig, port_by_scheme
 from ...exceptions import TimeoutError
 from ...response import BaseHTTPResponse
@@ -74,7 +75,7 @@ class EmscriptenHTTPConnection:
         self,
         host: str,
         port: int | None = 0,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HTTP_HEADER_MAPPING | None = None,
         scheme: str = "http",
     ) -> None:
         pass
@@ -87,7 +88,7 @@ class EmscriptenHTTPConnection:
         method: str,
         url: str,
         body: _TYPE_BODY | None = None,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HTTP_HEADER_MAPPING | None = None,
         # We know *at least* botocore is depending on the order of the
         # first 3 parameters so to be safe we only mark the later ones
         # as keyword-only to ensure we have space to extend.
@@ -113,7 +114,7 @@ class EmscriptenHTTPConnection:
         )
         request.set_body(body)
         if headers:
-            for k, v in headers.items():
+            for k, v in HTTPHeaderDict(headers).items():
                 request.set_header(k, v)
         self._response = None
         try:

--- a/src/urllib3/contrib/socks.py
+++ b/src/urllib3/contrib/socks.py
@@ -60,6 +60,7 @@ except ImportError:
 import typing
 from socket import timeout as SocketTimeout
 
+from .._collections import _TYPE_HTTP_HEADER_MAPPING
 from ..connection import HTTPConnection, HTTPSConnection
 from ..connectionpool import HTTPConnectionPool, HTTPSConnectionPool
 from ..exceptions import ConnectTimeoutError, NewConnectionError
@@ -187,7 +188,7 @@ class SOCKSProxyManager(PoolManager):
         username: str | None = None,
         password: str | None = None,
         num_pools: int = 10,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HTTP_HEADER_MAPPING | None = None,
         **connection_pool_kw: typing.Any,
     ):
         parsed = parse_url(proxy_url)

--- a/src/urllib3/http2/connection.py
+++ b/src/urllib3/http2/connection.py
@@ -11,7 +11,7 @@ import h2.connection
 import h2.events
 
 from .._base_connection import _TYPE_BODY
-from .._collections import HTTPHeaderDict
+from .._collections import _TYPE_HTTP_HEADER_MAPPING, HTTPHeaderDict
 from ..connection import HTTPSConnection, _get_default_user_agent
 from ..exceptions import ConnectionError
 from ..response import BaseHTTPResponse
@@ -216,7 +216,7 @@ class HTTP2Connection(HTTPSConnection):
         self,
         host: str,
         port: int | None = None,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HTTP_HEADER_MAPPING | None = None,
         scheme: str = "http",
     ) -> None:
         raise NotImplementedError(
@@ -270,7 +270,7 @@ class HTTP2Connection(HTTPSConnection):
         method: str,
         url: str,
         body: _TYPE_BODY | None = None,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HTTP_HEADER_MAPPING | None = None,
         *,
         preload_content: bool = True,
         decode_content: bool = True,

--- a/src/urllib3/poolmanager.py
+++ b/src/urllib3/poolmanager.py
@@ -7,7 +7,11 @@ import warnings
 from types import TracebackType
 from urllib.parse import urljoin
 
-from ._collections import HTTPHeaderDict, RecentlyUsedContainer
+from ._collections import (
+    _TYPE_HTTP_HEADER_MAPPING,
+    HTTPHeaderDict,
+    RecentlyUsedContainer,
+)
 from ._request_methods import RequestMethods
 from .connection import ProxyConfig
 from .connectionpool import HTTPConnectionPool, HTTPSConnectionPool, port_by_scheme
@@ -199,7 +203,7 @@ class PoolManager(RequestMethods):
     def __init__(
         self,
         num_pools: int = 10,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HTTP_HEADER_MAPPING | None = None,
         **connection_pool_kw: typing.Any,
     ) -> None:
         super().__init__(headers)
@@ -564,8 +568,8 @@ class ProxyManager(PoolManager):
         self,
         proxy_url: str,
         num_pools: int = 10,
-        headers: typing.Mapping[str, str] | None = None,
-        proxy_headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HTTP_HEADER_MAPPING | None = None,
+        proxy_headers: _TYPE_HTTP_HEADER_MAPPING | None = None,
         proxy_ssl_context: ssl.SSLContext | None = None,
         use_forwarding_for_https: bool = False,
         proxy_assert_hostname: None | str | typing.Literal[False] = None,
@@ -618,21 +622,21 @@ class ProxyManager(PoolManager):
         )
 
     def _set_proxy_headers(
-        self, url: str, headers: typing.Mapping[str, str] | None = None
+        self, url: str, headers: _TYPE_HTTP_HEADER_MAPPING | None = None
     ) -> typing.Mapping[str, str]:
         """
         Sets headers needed by proxies: specifically, the Accept and Host
         headers. Only sets headers not provided by the user.
         """
-        headers_ = {"Accept": "*/*"}
+        headers_ = HTTPHeaderDict({"Accept": "*/*"})
 
         netloc = parse_url(url).netloc
         if netloc:
             headers_["Host"] = netloc
 
         if headers:
-            headers_.update(headers)
-        return headers_
+            headers_.extend(headers)
+        return dict(headers_.items())
 
     def urlopen(  # type: ignore[override]
         self, method: str, url: str, redirect: bool = True, **kw: typing.Any

--- a/src/urllib3/response.py
+++ b/src/urllib3/response.py
@@ -478,7 +478,7 @@ class BaseHTTPResponse(io.IOBase):
         if isinstance(headers, HTTPHeaderDict):
             self.headers = headers
         else:
-            self.headers = HTTPHeaderDict(headers)  # type: ignore[arg-type]
+            self.headers = HTTPHeaderDict(headers)
         self.status = status
         self.version = version
         self.version_string = version_string

--- a/test/test_collections.py
+++ b/test/test_collections.py
@@ -137,10 +137,12 @@ class NonMappingHeaderContainer:
         self._data = {}
         self._data.update(kwargs)
 
-    def keys(self) -> typing.Iterator[str]:
+    def keys(self) -> typing.Iterator[str | bytes]:
         return iter(self._data)
 
-    def __getitem__(self, key: str) -> str:
+    def __getitem__(self, key: str | bytes) -> str:
+        if isinstance(key, bytes):
+            key = key.decode("latin-1")
         return self._data[key]
 
 
@@ -161,9 +163,11 @@ class TestHTTPHeaderDict:
         h = HTTPHeaderDict(a="1")
         assert h.setdefault("A", "3") == "1"
         assert h.setdefault("b", "2") == "2"
+        assert h.setdefault(b"d", b"4") == "4"
         assert h.setdefault("c") == ""
         assert h["c"] == ""
         assert h["b"] == "2"
+        assert h["d"] == "4"
 
     def test_create_from_dict(self) -> None:
         h = HTTPHeaderDict(dict(ab="1", cd="2", ef="3", gh="4"))
@@ -212,12 +216,17 @@ class TestHTTPHeaderDict:
 
     def test_setitem(self, d: HTTPHeaderDict) -> None:
         d["Cookie"] = "foo"
-        # The bytes value gets converted to str. The API is typed for str only,
-        # but the implementation continues supports bytes.
-        d[b"Cookie"] = "bar"  # type: ignore[index]
+        # The bytes value gets converted to str.
+        d[b"Cookie"] = "bar"
         assert d["cookie"] == "bar"
         d["cookie"] = "with, comma"
         assert d.getlist("cookie") == ["with, comma"]
+
+    def test_setitem_with_bytes_value(self) -> None:
+        h = HTTPHeaderDict()
+        h["X-Bytes"] = b"value"
+        assert h["x-bytes"] == "value"
+        assert list(h.items()) == [("X-Bytes", "value")]
 
     def test_update(self, d: HTTPHeaderDict) -> None:
         d.update(dict(Cookie="foo"))
@@ -231,7 +240,7 @@ class TestHTTPHeaderDict:
         assert "COOKIE" not in d
 
     def test_delitem_with_bytes_key(self, d: HTTPHeaderDict) -> None:
-        del d[b"cookie"]  # type: ignore[arg-type]
+        del d[b"cookie"]
         assert "cookie" not in d
 
     def test_add_well_known_multiheader(self, d: HTTPHeaderDict) -> None:
@@ -241,12 +250,23 @@ class TestHTTPHeaderDict:
 
     def test_add_comma_separated_multiheader(self, d: HTTPHeaderDict) -> None:
         d.add("bar", "foo")
-        # The bytes value gets converted to str. The API is typed for str only,
-        # but the implementation continues supports bytes.
-        d.add(b"BAR", "bar")  # type: ignore[arg-type]
+        # The bytes value gets converted to str.
+        d.add(b"BAR", "bar")
         d.add("Bar", "asdf")
         assert d.getlist("bar") == ["foo", "bar", "asdf"]
         assert d["bar"] == "foo, bar, asdf"
+
+    def test_add_with_bytes_value(self) -> None:
+        h = HTTPHeaderDict()
+        h.add(b"X-Bytes", b"value")
+        assert h["x-bytes"] == "value"
+        assert list(h.items()) == [("X-Bytes", "value")]
+
+    def test_create_from_bytes_mapping(self) -> None:
+        h = HTTPHeaderDict({b"X-Bytes": b"value"})
+        assert h["x-bytes"] == "value"
+        assert h.getlist(b"x-bytes") == ["value"]
+        assert list(h.items()) == [("X-Bytes", "value")]
 
     def test_extend_from_list(self, d: HTTPHeaderDict) -> None:
         d.extend([("set-cookie", "100"), ("set-cookie", "200"), ("set-cookie", "300")])
@@ -323,12 +343,12 @@ class TestHTTPHeaderDict:
         assert d.getlist("b") == ["asdf"]
 
     def test_getlist_with_bytes_key(self, d: HTTPHeaderDict) -> None:
-        assert d.getlist(b"cookie") == ["foo", "bar"]  # type: ignore[call-overload]
+        assert d.getlist(b"cookie") == ["foo", "bar"]
 
     def test_getitem_with_bytes(self, d: HTTPHeaderDict) -> None:
         d["Content-Type"] = "application/json"
         d.add("Content-Type", "charset=utf-8")
-        result = d[b"Content-Type"]  # type: ignore[index]
+        result = d[b"Content-Type"]
         assert result == "application/json, charset=utf-8"
 
     def test_contains_with_bytes(self, d: HTTPHeaderDict) -> None:

--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -326,3 +326,28 @@ class TestConnection:
             assert "User-Agent" in request_headers
         else:
             assert user_agent not in request_headers
+
+    def test_request_normalizes_mixed_bytes_headers(self) -> None:
+        headers: dict[str | bytes, str | bytes] = {
+            b"X-Bytes": b"value",
+            "X-Other": b"other",
+        }
+        with (
+            mock.patch("urllib3.util.connection.create_connection"),
+            mock.patch(
+                "urllib3.connection._HTTPConnection.putheader"
+            ) as http_client_putheader,
+        ):
+            conn = HTTPConnection("")
+            conn.request(
+                "GET",
+                "/headers",
+                headers=headers,
+            )
+
+        assert ("X-Bytes", "value") in [
+            call.args for call in http_client_putheader.call_args_list
+        ]
+        assert ("X-Other", "other") in [
+            call.args for call in http_client_putheader.call_args_list
+        ]

--- a/test/test_typing.py
+++ b/test/test_typing.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+import urllib3
+
+
+def _check_request_headers_accept_str_and_bytes() -> None:
+    headers: dict[str | bytes, str | bytes] = {
+        "User-Agent": "urllib3-typing-test",
+        b"X-Bytes": b"value",
+    }
+
+    urllib3.request("GET", "https://example.com", headers=headers)
+    urllib3.PoolManager().request("GET", "https://example.com", headers=headers)
+    urllib3.HTTPConnectionPool("example.com").request("GET", "/", headers=headers)


### PR DESCRIPTION
## Summary
- broaden request-facing header annotations to accept str/bytes keys and values
- normalize bytes header values through HTTPHeaderDict before forwarding to lower-level APIs
- add runtime and mypy coverage for mixed str/bytes header mappings

/claim #3047

## Testing
- uv run --frozen pytest test/test_collections.py -q
- uv run --frozen pytest test/test_connection.py test/test_connectionpool.py test/test_poolmanager.py test/test_http2_connection.py -q
- uv run --frozen --group mypy mypy src/urllib3/_collections.py src/urllib3/_request_methods.py src/urllib3/__init__.py src/urllib3/_base_connection.py src/urllib3/connection.py src/urllib3/connectionpool.py src/urllib3/poolmanager.py src/urllib3/contrib/socks.py src/urllib3/contrib/emscripten/connection.py src/urllib3/http2/connection.py src/urllib3/response.py test/test_collections.py test/test_typing.py
- uvx pre-commit run --files src/urllib3/__init__.py src/urllib3/_base_connection.py src/urllib3/_collections.py src/urllib3/_request_methods.py src/urllib3/connection.py src/urllib3/connectionpool.py src/urllib3/contrib/emscripten/connection.py src/urllib3/contrib/socks.py src/urllib3/http2/connection.py src/urllib3/poolmanager.py src/urllib3/response.py test/test_collections.py test/test_typing.py
- git diff --check