### PR TITLE
Fix header typing for bytes values

### DIFF
--- a/changelog/3047.bugfix.rst
+++ b/changelog/3047.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed request header type annotations to accept bytes header names and values where supported.

--- a/src/urllib3/__init__.py
+++ b/src/urllib3/__init__.py
@@ -13,7 +13,7 @@ from logging import NullHandler
 
 from . import exceptions
 from ._base_connection import _TYPE_BODY
-from ._collections import HTTPHeaderDict
+from ._collections import _TYPE_HEADER_MAPPING, HTTPHeaderDict
 from ._version import __version__
 from .connectionpool import HTTPConnectionPool, HTTPSConnectionPool, connection_from_url
 from .filepost import _TYPE_FIELDS, encode_multipart_formdata
@@ -120,7 +120,7 @@ def request(
     *,
     body: _TYPE_BODY | None = None,
     fields: _TYPE_FIELDS | None = None,
-    headers: typing.Mapping[str, str] | None = None,
+    headers: _TYPE_HEADER_MAPPING | None = None,
     preload_content: bool | None = True,
     decode_content: bool | None = True,
     redirect: bool | None = True,

--- a/src/urllib3/_base_connection.py
+++ b/src/urllib3/_base_connection.py
@@ -32,6 +32,7 @@ if typing.TYPE_CHECKING:
     import ssl
     from typing import Protocol
 
+    from ._collections import _TYPE_HEADER_MAPPING
     from .response import BaseHTTPResponse
 
     class BaseHTTPConnection(Protocol):
@@ -70,7 +71,7 @@ if typing.TYPE_CHECKING:
             self,
             host: str,
             port: int | None = None,
-            headers: typing.Mapping[str, str] | None = None,
+            headers: _TYPE_HEADER_MAPPING | None = None,
             scheme: str = "http",
         ) -> None: ...
 
@@ -81,7 +82,7 @@ if typing.TYPE_CHECKING:
             method: str,
             url: str,
             body: _TYPE_BODY | None = None,
-            headers: typing.Mapping[str, str] | None = None,
+            headers: _TYPE_HEADER_MAPPING | None = None,
             # We know *at least* botocore is depending on the order of the
             # first 3 parameters so to be safe we only mark the later ones
             # as keyword-only to ensure we have space to extend.

--- a/src/urllib3/_collections.py
+++ b/src/urllib3/_collections.py
@@ -21,6 +21,15 @@ if typing.TYPE_CHECKING:
 __all__ = ["RecentlyUsedContainer", "HTTPHeaderDict"]
 
 
+_TYPE_HEADER_KEY = typing.Union[str, bytes]
+_TYPE_HEADER_VALUE = typing.Union[str, bytes]
+_TYPE_HEADER_MAPPING = typing.Union[
+    typing.Mapping[str, _TYPE_HEADER_VALUE],
+    typing.Mapping[bytes, _TYPE_HEADER_VALUE],
+    typing.Mapping[_TYPE_HEADER_KEY, _TYPE_HEADER_VALUE],
+]
+_TYPE_HEADER_SEQUENCE = typing.Iterable[tuple[_TYPE_HEADER_KEY, _TYPE_HEADER_VALUE]]
+
 # Key type
 _KT = typing.TypeVar("_KT")
 # Value type
@@ -30,10 +39,22 @@ _DT = typing.TypeVar("_DT")
 
 ValidHTTPHeaderSource = typing.Union[
     "HTTPHeaderDict",
-    typing.Mapping[str, str],
-    typing.Iterable[tuple[str, str]],
+    _TYPE_HEADER_MAPPING,
+    _TYPE_HEADER_SEQUENCE,
     "HasGettableStringKeys",
 ]
+
+
+def _normalize_header_key(key: _TYPE_HEADER_KEY) -> str:
+    if isinstance(key, bytes):
+        return key.decode("latin-1")
+    return key
+
+
+def _normalize_header_value(value: _TYPE_HEADER_VALUE) -> str:
+    if isinstance(value, bytes):
+        return value.decode("latin-1")
+    return value
 
 
 class _Sentinel(Enum):
@@ -48,12 +69,12 @@ def ensure_can_construct_http_header_dict(
     elif isinstance(potential, typing.Mapping):
         # Full runtime checking of the contents of a Mapping is expensive, so for the
         # purposes of typechecking, we assume that any Mapping is the right shape.
-        return typing.cast(typing.Mapping[str, str], potential)
+        return typing.cast(_TYPE_HEADER_MAPPING, potential)
     elif isinstance(potential, typing.Iterable):
         # Similarly to Mapping, full runtime checking of the contents of an Iterable is
         # expensive, so for the purposes of typechecking, we assume that any Iterable
         # is the right shape.
-        return typing.cast(typing.Iterable[tuple[str, str]], potential)
+        return typing.cast(_TYPE_HEADER_SEQUENCE, potential)
     elif hasattr(potential, "keys") and hasattr(potential, "__getitem__"):
         return typing.cast("HasGettableStringKeys", potential)
     else:
@@ -237,7 +258,9 @@ class HTTPHeaderDict(typing.MutableMapping[str, str]):
 
     _container: typing.MutableMapping[str, list[str]]
 
-    def __init__(self, headers: ValidHTTPHeaderSource | None = None, **kwargs: str):
+    def __init__(
+        self, headers: ValidHTTPHeaderSource | None = None, **kwargs: _TYPE_HEADER_VALUE
+    ):
         super().__init__()
         self._container = {}  # 'dict' is insert-ordered
         if headers is not None:
@@ -248,21 +271,18 @@ class HTTPHeaderDict(typing.MutableMapping[str, str]):
         if kwargs:
             self.extend(kwargs)
 
-    def __setitem__(self, key: str, val: str) -> None:
-        # avoid a bytes/str comparison by decoding before httplib
-        if isinstance(key, bytes):
-            key = key.decode("latin-1")
+    def __setitem__(self, key: _TYPE_HEADER_KEY, val: _TYPE_HEADER_VALUE) -> None:
+        key = _normalize_header_key(key)
+        val = _normalize_header_value(val)
         self._container[key.lower()] = [key, val]
 
-    def __getitem__(self, key: str) -> str:
-        if isinstance(key, bytes):
-            key = key.decode("latin-1")
+    def __getitem__(self, key: _TYPE_HEADER_KEY) -> str:
+        key = _normalize_header_key(key)
         val = self._container[key.lower()]
         return ", ".join(val[1:])
 
-    def __delitem__(self, key: str) -> None:
-        if isinstance(key, bytes):
-            key = key.decode("latin-1")
+    def __delitem__(self, key: _TYPE_HEADER_KEY) -> None:
+        key = _normalize_header_key(key)
         del self._container[key.lower()]
 
     def __contains__(self, key: object) -> bool:
@@ -272,8 +292,14 @@ class HTTPHeaderDict(typing.MutableMapping[str, str]):
             return key.lower() in self._container
         return False
 
-    def setdefault(self, key: str, default: str = "") -> str:
-        return super().setdefault(key, default)
+    def setdefault(
+        self, key: _TYPE_HEADER_KEY, default: _TYPE_HEADER_VALUE = ""
+    ) -> str:
+        try:
+            return self[key]
+        except KeyError:
+            self[key] = default
+            return self[key]
 
     def __eq__(self, other: object) -> bool:
         maybe_constructable = ensure_can_construct_http_header_dict(other)
@@ -297,13 +323,15 @@ class HTTPHeaderDict(typing.MutableMapping[str, str]):
         for vals in self._container.values():
             yield vals[0]
 
-    def discard(self, key: str) -> None:
+    def discard(self, key: _TYPE_HEADER_KEY) -> None:
         try:
             del self[key]
         except KeyError:
             pass
 
-    def add(self, key: str, val: str, *, combine: bool = False) -> None:
+    def add(
+        self, key: _TYPE_HEADER_KEY, val: _TYPE_HEADER_VALUE, *, combine: bool = False
+    ) -> None:
         """Adds a (name, value) pair, doesn't overwrite the value if it already
         exists.
 
@@ -322,9 +350,8 @@ class HTTPHeaderDict(typing.MutableMapping[str, str]):
         >>> list(headers.items())
         [('foo', 'bar, baz, quz')]
         """
-        # avoid a bytes/str comparison by decoding before httplib
-        if isinstance(key, bytes):
-            key = key.decode("latin-1")
+        key = _normalize_header_key(key)
+        val = _normalize_header_value(val)
         key_lower = key.lower()
         new_vals = [key, val]
         # Keep the common case aka no item present as fast as possible
@@ -338,7 +365,9 @@ class HTTPHeaderDict(typing.MutableMapping[str, str]):
             else:
                 vals.append(val)
 
-    def extend(self, *args: ValidHTTPHeaderSource, **kwargs: str) -> None:
+    def extend(
+        self, *args: ValidHTTPHeaderSource, **kwargs: _TYPE_HEADER_VALUE
+    ) -> None:
         """Generic import function for any type of header-like object.
         Adapted version of MutableMapping.update in order to insert items
         with self.add instead of self.__setitem__
@@ -353,11 +382,11 @@ class HTTPHeaderDict(typing.MutableMapping[str, str]):
             for key, val in other.iteritems():
                 self.add(key, val)
         elif isinstance(other, typing.Mapping):
-            for key, val in other.items():
-                self.add(key, val)
+            for header_key, header_val in other.items():
+                self.add(header_key, header_val)
         elif isinstance(other, typing.Iterable):
-            for key, value in other:
-                self.add(key, value)
+            for header_key, header_val in other:
+                self.add(header_key, header_val)
         elif hasattr(other, "keys") and hasattr(other, "__getitem__"):
             # THIS IS NOT A TYPESAFE BRANCH
             # In this branch, the object has a `keys` attr but is not a Mapping or any of
@@ -371,18 +400,17 @@ class HTTPHeaderDict(typing.MutableMapping[str, str]):
             self.add(key, value)
 
     @typing.overload
-    def getlist(self, key: str) -> list[str]: ...
+    def getlist(self, key: _TYPE_HEADER_KEY) -> list[str]: ...
 
     @typing.overload
-    def getlist(self, key: str, default: _DT) -> list[str] | _DT: ...
+    def getlist(self, key: _TYPE_HEADER_KEY, default: _DT) -> list[str] | _DT: ...
 
     def getlist(
-        self, key: str, default: _Sentinel | _DT = _Sentinel.not_passed
+        self, key: _TYPE_HEADER_KEY, default: _Sentinel | _DT = _Sentinel.not_passed
     ) -> list[str] | _DT:
         """Returns a list of all the values for the named field. Returns an
         empty list if the key doesn't exist."""
-        if isinstance(key, bytes):
-            key = key.decode("latin-1")
+        key = _normalize_header_key(key)
         try:
             vals = self._container[key.lower()]
         except KeyError:

--- a/src/urllib3/_request_methods.py
+++ b/src/urllib3/_request_methods.py
@@ -5,7 +5,7 @@ import typing
 from urllib.parse import urlencode
 
 from ._base_connection import _TYPE_BODY
-from ._collections import HTTPHeaderDict
+from ._collections import _TYPE_HEADER_MAPPING, HTTPHeaderDict, _normalize_header_key
 from .filepost import _TYPE_FIELDS, encode_multipart_formdata
 from .response import BaseHTTPResponse
 
@@ -48,7 +48,7 @@ class RequestMethods:
 
     _encode_url_methods = {"DELETE", "GET", "HEAD", "OPTIONS"}
 
-    def __init__(self, headers: typing.Mapping[str, str] | None = None) -> None:
+    def __init__(self, headers: _TYPE_HEADER_MAPPING | None = None) -> None:
         self.headers = headers or {}
 
     def urlopen(
@@ -56,7 +56,7 @@ class RequestMethods:
         method: str,
         url: str,
         body: _TYPE_BODY | None = None,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADER_MAPPING | None = None,
         encode_multipart: bool = True,
         multipart_boundary: str | None = None,
         **kw: typing.Any,
@@ -72,7 +72,7 @@ class RequestMethods:
         url: str,
         body: _TYPE_BODY | None = None,
         fields: _TYPE_FIELDS | None = None,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADER_MAPPING | None = None,
         json: typing.Any | None = None,
         **urlopen_kw: typing.Any,
     ) -> BaseHTTPResponse:
@@ -120,7 +120,9 @@ class RequestMethods:
             if headers is None:
                 headers = self.headers
 
-            if not ("content-type" in map(str.lower, headers.keys())):
+            if not (
+                "content-type" in (_normalize_header_key(k).lower() for k in headers)
+            ):
                 headers = HTTPHeaderDict(headers)
                 headers["Content-Type"] = "application/json"
 
@@ -149,7 +151,7 @@ class RequestMethods:
         method: str,
         url: str,
         fields: _TYPE_ENCODE_URL_FIELDS | None = None,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADER_MAPPING | None = None,
         **urlopen_kw: str,
     ) -> BaseHTTPResponse:
         """
@@ -186,7 +188,7 @@ class RequestMethods:
         method: str,
         url: str,
         fields: _TYPE_FIELDS | None = None,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADER_MAPPING | None = None,
         encode_multipart: bool = True,
         multipart_boundary: str | None = None,
         **urlopen_kw: str,

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -20,7 +20,7 @@ if typing.TYPE_CHECKING:
     from .util.ssl_ import _TYPE_PEER_CERT_RET_DICT
     from .util.ssltransport import SSLTransport
 
-from ._collections import HTTPHeaderDict
+from ._collections import _TYPE_HEADER_MAPPING, HTTPHeaderDict
 from .http2 import probe as http2_probe
 from .util.response import assert_header_parsing
 from .util.timeout import _DEFAULT_TIMEOUT, _TYPE_TIMEOUT, Timeout
@@ -228,13 +228,15 @@ class HTTPConnection(_HTTPConnection):
         self,
         host: str,
         port: int | None = None,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADER_MAPPING | None = None,
         scheme: str = "http",
     ) -> None:
         if scheme not in ("http", "https"):
             raise ValueError(
                 f"Invalid proxy scheme for tunneling: {scheme!r}, must be either 'http' or 'https'"
             )
+        if headers is not None:
+            headers = HTTPHeaderDict(headers)
         super().set_tunnel(host, port=port, headers=headers)
         self._tunnel_scheme = scheme
 
@@ -407,11 +409,13 @@ class HTTPConnection(_HTTPConnection):
             method, url, skip_host=skip_host, skip_accept_encoding=skip_accept_encoding
         )
 
-    def putheader(self, header: str, *values: str) -> None:  # type: ignore[override]
+    def putheader(  # type: ignore[override]
+        self, header: str | bytes, *values: str | bytes
+    ) -> None:
         """"""
         if not any(isinstance(v, str) and v == SKIP_HEADER for v in values):
             super().putheader(header, *values)
-        elif to_str(header.lower()) not in SKIPPABLE_HEADERS:
+        elif to_str(header.lower(), "latin-1") not in SKIPPABLE_HEADERS:
             skippable_headers = "', '".join(
                 [str.title(header) for header in sorted(SKIPPABLE_HEADERS)]
             )
@@ -426,7 +430,7 @@ class HTTPConnection(_HTTPConnection):
         method: str,
         url: str,
         body: _TYPE_BODY | None = None,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADER_MAPPING | None = None,
         *,
         chunked: bool = False,
         preload_content: bool = True,
@@ -456,7 +460,7 @@ class HTTPConnection(_HTTPConnection):
 
         if headers is None:
             headers = {}
-        header_keys = frozenset(to_str(k.lower()) for k in headers)
+        header_keys = frozenset(to_str(k.lower(), "latin-1") for k in headers)
         skip_accept_encoding = "accept-encoding" in header_keys
         skip_host = "host" in header_keys
         self.putrequest(
@@ -523,7 +527,7 @@ class HTTPConnection(_HTTPConnection):
         method: str,
         url: str,
         body: _TYPE_BODY | None = None,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADER_MAPPING | None = None,
     ) -> None:
         """
         Alternative to the common request method, which sends the

--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -11,7 +11,7 @@ from socket import timeout as SocketTimeout
 from types import TracebackType
 
 from ._base_connection import _TYPE_BODY
-from ._collections import HTTPHeaderDict
+from ._collections import _TYPE_HEADER_MAPPING, HTTPHeaderDict
 from ._request_methods import RequestMethods
 from .connection import (
     BaseSSLError,
@@ -179,10 +179,10 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         timeout: _TYPE_TIMEOUT | None = _DEFAULT_TIMEOUT,
         maxsize: int = 1,
         block: bool = False,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADER_MAPPING | None = None,
         retries: Retry | bool | int | None = None,
         _proxy: Url | None = None,
-        _proxy_headers: typing.Mapping[str, str] | None = None,
+        _proxy_headers: _TYPE_HEADER_MAPPING | None = None,
         _proxy_config: ProxyConfig | None = None,
         **conn_kw: typing.Any,
     ):
@@ -380,7 +380,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         method: str,
         url: str,
         body: _TYPE_BODY | None = None,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADER_MAPPING | None = None,
         retries: Retry | None = None,
         timeout: _TYPE_TIMEOUT = _DEFAULT_TIMEOUT,
         chunked: bool = False,
@@ -594,7 +594,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         method: str,
         url: str,
         body: _TYPE_BODY | None = None,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADER_MAPPING | None = None,
         retries: Retry | bool | int | None = None,
         redirect: bool = True,
         assert_same_host: bool = True,
@@ -746,8 +746,8 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         # have to copy the headers dict so we can safely change it without those
         # changes being reflected in anyone else's copy.
         if not http_tunnel_required:
-            headers = headers.copy()  # type: ignore[attr-defined]
-            headers.update(self.proxy_headers)  # type: ignore[union-attr]
+            headers = HTTPHeaderDict(headers)
+            headers.extend(self.proxy_headers)
 
         # Must keep the exception bound to a separate variable or else Python 3
         # complains about UnboundLocalError.
@@ -905,7 +905,10 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
             ):
                 new_headers = headers.copy()  # type: ignore[union-attr]
                 for header in headers:
-                    if header.lower() in retries.remove_headers_on_redirect:
+                    if (
+                        to_str(header.lower(), "latin-1")
+                        in retries.remove_headers_on_redirect
+                    ):
                         new_headers.pop(header, None)
                 headers = new_headers
 
@@ -997,10 +1000,10 @@ class HTTPSConnectionPool(HTTPConnectionPool):
         timeout: _TYPE_TIMEOUT | None = _DEFAULT_TIMEOUT,
         maxsize: int = 1,
         block: bool = False,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADER_MAPPING | None = None,
         retries: Retry | bool | int | None = None,
         _proxy: Url | None = None,
-        _proxy_headers: typing.Mapping[str, str] | None = None,
+        _proxy_headers: _TYPE_HEADER_MAPPING | None = None,
         key_file: str | None = None,
         cert_file: str | None = None,
         cert_reqs: int | str | None = None,

--- a/src/urllib3/contrib/emscripten/connection.py
+++ b/src/urllib3/contrib/emscripten/connection.py
@@ -8,6 +8,11 @@ from http.client import HTTPException as HTTPException  # noqa: F401
 from http.client import ResponseNotReady
 
 from ..._base_connection import _TYPE_BODY
+from ..._collections import (
+    _TYPE_HEADER_MAPPING,
+    _normalize_header_key,
+    _normalize_header_value,
+)
 from ...connection import HTTPConnection, ProxyConfig, port_by_scheme
 from ...exceptions import TimeoutError
 from ...response import BaseHTTPResponse
@@ -74,7 +79,7 @@ class EmscriptenHTTPConnection:
         self,
         host: str,
         port: int | None = 0,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADER_MAPPING | None = None,
         scheme: str = "http",
     ) -> None:
         pass
@@ -87,7 +92,7 @@ class EmscriptenHTTPConnection:
         method: str,
         url: str,
         body: _TYPE_BODY | None = None,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADER_MAPPING | None = None,
         # We know *at least* botocore is depending on the order of the
         # first 3 parameters so to be safe we only mark the later ones
         # as keyword-only to ensure we have space to extend.
@@ -114,7 +119,7 @@ class EmscriptenHTTPConnection:
         request.set_body(body)
         if headers:
             for k, v in headers.items():
-                request.set_header(k, v)
+                request.set_header(_normalize_header_key(k), _normalize_header_value(v))
         self._response = None
         try:
             if not preload_content:

--- a/src/urllib3/contrib/socks.py
+++ b/src/urllib3/contrib/socks.py
@@ -60,6 +60,7 @@ except ImportError:
 import typing
 from socket import timeout as SocketTimeout
 
+from .._collections import _TYPE_HEADER_MAPPING
 from ..connection import HTTPConnection, HTTPSConnection
 from ..connectionpool import HTTPConnectionPool, HTTPSConnectionPool
 from ..exceptions import ConnectTimeoutError, NewConnectionError
@@ -187,7 +188,7 @@ class SOCKSProxyManager(PoolManager):
         username: str | None = None,
         password: str | None = None,
         num_pools: int = 10,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADER_MAPPING | None = None,
         **connection_pool_kw: typing.Any,
     ):
         parsed = parse_url(proxy_url)

--- a/src/urllib3/fields.py
+++ b/src/urllib3/fields.py
@@ -4,6 +4,12 @@ import email.utils
 import mimetypes
 import typing
 
+from ._collections import (
+    _TYPE_HEADER_MAPPING,
+    _normalize_header_key,
+    _normalize_header_value,
+)
+
 _TYPE_FIELD_VALUE = typing.Union[str, bytes]
 _TYPE_FIELD_VALUE_TUPLE = typing.Union[
     _TYPE_FIELD_VALUE,
@@ -173,7 +179,7 @@ class RequestField:
         name: str,
         data: _TYPE_FIELD_VALUE,
         filename: str | None = None,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADER_MAPPING | None = None,
         header_formatter: typing.Callable[[str, _TYPE_FIELD_VALUE], str] | None = None,
     ):
         self._name = name
@@ -181,7 +187,10 @@ class RequestField:
         self.data = data
         self.headers: dict[str, str | None] = {}
         if headers:
-            self.headers = dict(headers)
+            self.headers = {
+                _normalize_header_key(k): _normalize_header_value(v)
+                for k, v in headers.items()
+            }
 
         if header_formatter is not None:
             import warnings

--- a/src/urllib3/http2/connection.py
+++ b/src/urllib3/http2/connection.py
@@ -11,7 +11,12 @@ import h2.connection
 import h2.events
 
 from .._base_connection import _TYPE_BODY
-from .._collections import HTTPHeaderDict
+from .._collections import (
+    _TYPE_HEADER_MAPPING,
+    HTTPHeaderDict,
+    _normalize_header_key,
+    _normalize_header_value,
+)
 from ..connection import HTTPSConnection, _get_default_user_agent
 from ..exceptions import ConnectionError
 from ..response import BaseHTTPResponse
@@ -216,7 +221,7 @@ class HTTP2Connection(HTTPSConnection):
         self,
         host: str,
         port: int | None = None,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADER_MAPPING | None = None,
         scheme: str = "http",
     ) -> None:
         raise NotImplementedError(
@@ -270,7 +275,7 @@ class HTTP2Connection(HTTPSConnection):
         method: str,
         url: str,
         body: _TYPE_BODY | None = None,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADER_MAPPING | None = None,
         *,
         preload_content: bool = True,
         decode_content: bool = True,
@@ -290,7 +295,10 @@ class HTTP2Connection(HTTPSConnection):
 
         headers = headers or {}
         for k, v in headers.items():
-            if k.lower() == "transfer-encoding" and v == "chunked":
+            if (
+                _normalize_header_key(k).lower() == "transfer-encoding"
+                and _normalize_header_value(v) == "chunked"
+            ):
                 continue
             else:
                 self.putheader(k, v)

--- a/src/urllib3/poolmanager.py
+++ b/src/urllib3/poolmanager.py
@@ -7,7 +7,7 @@ import warnings
 from types import TracebackType
 from urllib.parse import urljoin
 
-from ._collections import HTTPHeaderDict, RecentlyUsedContainer
+from ._collections import _TYPE_HEADER_MAPPING, HTTPHeaderDict, RecentlyUsedContainer
 from ._request_methods import RequestMethods
 from .connection import ProxyConfig
 from .connectionpool import HTTPConnectionPool, HTTPSConnectionPool, port_by_scheme
@@ -23,6 +23,7 @@ from .util.proxy import connection_requires_http_tunnel
 from .util.retry import Retry
 from .util.timeout import Timeout
 from .util.url import Url, parse_url
+from .util.util import to_str
 
 if typing.TYPE_CHECKING:
     import ssl
@@ -199,7 +200,7 @@ class PoolManager(RequestMethods):
     def __init__(
         self,
         num_pools: int = 10,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADER_MAPPING | None = None,
         **connection_pool_kw: typing.Any,
     ) -> None:
         super().__init__(headers)
@@ -482,7 +483,10 @@ class PoolManager(RequestMethods):
         ):
             new_headers = kw["headers"].copy()
             for header in kw["headers"]:
-                if header.lower() in retries.remove_headers_on_redirect:
+                if (
+                    to_str(header.lower(), "latin-1")
+                    in retries.remove_headers_on_redirect
+                ):
                     new_headers.pop(header, None)
             kw["headers"] = new_headers
 
@@ -564,8 +568,8 @@ class ProxyManager(PoolManager):
         self,
         proxy_url: str,
         num_pools: int = 10,
-        headers: typing.Mapping[str, str] | None = None,
-        proxy_headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADER_MAPPING | None = None,
+        proxy_headers: _TYPE_HEADER_MAPPING | None = None,
         proxy_ssl_context: ssl.SSLContext | None = None,
         use_forwarding_for_https: bool = False,
         proxy_assert_hostname: None | str | typing.Literal[False] = None,
@@ -618,20 +622,21 @@ class ProxyManager(PoolManager):
         )
 
     def _set_proxy_headers(
-        self, url: str, headers: typing.Mapping[str, str] | None = None
-    ) -> typing.Mapping[str, str]:
+        self, url: str, headers: _TYPE_HEADER_MAPPING | None = None
+    ) -> _TYPE_HEADER_MAPPING:
         """
         Sets headers needed by proxies: specifically, the Accept and Host
         headers. Only sets headers not provided by the user.
         """
-        headers_ = {"Accept": "*/*"}
+        headers_: dict[str | bytes, str | bytes] = {"Accept": "*/*"}
 
         netloc = parse_url(url).netloc
         if netloc:
             headers_["Host"] = netloc
 
         if headers:
-            headers_.update(headers)
+            for key, value in headers.items():
+                headers_[key] = value
         return headers_
 
     def urlopen(  # type: ignore[override]

--- a/src/urllib3/response.py
+++ b/src/urllib3/response.py
@@ -27,7 +27,7 @@ except ImportError:
 
 from . import util
 from ._base_connection import _TYPE_BODY
-from ._collections import HTTPHeaderDict
+from ._collections import _TYPE_HEADER_MAPPING, HTTPHeaderDict
 from .connection import BaseSSLError, HTTPConnection, HTTPException
 from .exceptions import (
     BodyNotHttplibCompatible,
@@ -466,7 +466,7 @@ class BaseHTTPResponse(io.IOBase):
     def __init__(
         self,
         *,
-        headers: typing.Mapping[str, str] | typing.Mapping[bytes, bytes] | None = None,
+        headers: _TYPE_HEADER_MAPPING | None = None,
         status: int,
         version: int,
         version_string: str,
@@ -478,7 +478,7 @@ class BaseHTTPResponse(io.IOBase):
         if isinstance(headers, HTTPHeaderDict):
             self.headers = headers
         else:
-            self.headers = HTTPHeaderDict(headers)  # type: ignore[arg-type]
+            self.headers = HTTPHeaderDict(headers)
         self.status = status
         self.version = version
         self.version_string = version_string
@@ -722,7 +722,7 @@ class HTTPResponse(BaseHTTPResponse):
     def __init__(
         self,
         body: _TYPE_BODY = "",
-        headers: typing.Mapping[str, str] | typing.Mapping[bytes, bytes] | None = None,
+        headers: _TYPE_HEADER_MAPPING | None = None,
         status: int = 0,
         version: int = 0,
         version_string: str = "HTTP/?",

--- a/test/test_collections.py
+++ b/test/test_collections.py
@@ -212,9 +212,7 @@ class TestHTTPHeaderDict:
 
     def test_setitem(self, d: HTTPHeaderDict) -> None:
         d["Cookie"] = "foo"
-        # The bytes value gets converted to str. The API is typed for str only,
-        # but the implementation continues supports bytes.
-        d[b"Cookie"] = "bar"  # type: ignore[index]
+        d[b"Cookie"] = b"bar"
         assert d["cookie"] == "bar"
         d["cookie"] = "with, comma"
         assert d.getlist("cookie") == ["with, comma"]
@@ -231,7 +229,7 @@ class TestHTTPHeaderDict:
         assert "COOKIE" not in d
 
     def test_delitem_with_bytes_key(self, d: HTTPHeaderDict) -> None:
-        del d[b"cookie"]  # type: ignore[arg-type]
+        del d[b"cookie"]
         assert "cookie" not in d
 
     def test_add_well_known_multiheader(self, d: HTTPHeaderDict) -> None:
@@ -241,9 +239,7 @@ class TestHTTPHeaderDict:
 
     def test_add_comma_separated_multiheader(self, d: HTTPHeaderDict) -> None:
         d.add("bar", "foo")
-        # The bytes value gets converted to str. The API is typed for str only,
-        # but the implementation continues supports bytes.
-        d.add(b"BAR", "bar")  # type: ignore[arg-type]
+        d.add(b"BAR", b"bar")
         d.add("Bar", "asdf")
         assert d.getlist("bar") == ["foo", "bar", "asdf"]
         assert d["bar"] == "foo, bar, asdf"
@@ -256,6 +252,8 @@ class TestHTTPHeaderDict:
         d.extend(dict(cookie="asdf"), b="100")
         assert d["cookie"] == "foo, bar, asdf"
         assert d["b"] == "100"
+        d.extend({b"c": b"200"})
+        assert d["c"] == "200"
         d.add("cookie", "with, comma")
         assert d.getlist("cookie") == ["foo", "bar", "asdf", "with, comma"]
 
@@ -323,12 +321,12 @@ class TestHTTPHeaderDict:
         assert d.getlist("b") == ["asdf"]
 
     def test_getlist_with_bytes_key(self, d: HTTPHeaderDict) -> None:
-        assert d.getlist(b"cookie") == ["foo", "bar"]  # type: ignore[call-overload]
+        assert d.getlist(b"cookie") == ["foo", "bar"]
 
     def test_getitem_with_bytes(self, d: HTTPHeaderDict) -> None:
         d["Content-Type"] = "application/json"
         d.add("Content-Type", "charset=utf-8")
-        result = d[b"Content-Type"]  # type: ignore[index]
+        result = d[b"Content-Type"]
         assert result == "application/json, charset=utf-8"
 
     def test_contains_with_bytes(self, d: HTTPHeaderDict) -> None:

--- a/test/test_typing.py
+++ b/test/test_typing.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import typing
+
+import urllib3
+
+if typing.TYPE_CHECKING:
+
+    def check_request_header_types() -> None:
+        str_headers: dict[str, str] = {"Accept": "application/json"}
+        str_bytes_headers: dict[str, bytes] = {"X-Token": b"abc"}
+        bytes_str_headers: dict[bytes, str] = {b"X-Token": "abc"}
+        bytes_headers: dict[bytes, bytes] = {b"X-Token": b"abc"}
+        mixed_headers: dict[str | bytes, str | bytes] = {
+            "Accept": "application/json",
+            b"X-Token": b"abc",
+        }
+        header_dict = urllib3.HTTPHeaderDict({"Accept": "application/json"})
+
+        urllib3.request("GET", "https://example.com", headers=str_headers)
+        urllib3.request("GET", "https://example.com", headers=str_bytes_headers)
+        urllib3.request("GET", "https://example.com", headers=bytes_str_headers)
+        urllib3.request("GET", "https://example.com", headers=bytes_headers)
+        urllib3.request("GET", "https://example.com", headers=mixed_headers)
+        urllib3.request("GET", "https://example.com", headers=header_dict)
+
+        pool = urllib3.PoolManager(headers=str_headers)
+        pool.request("GET", "https://example.com", headers=str_bytes_headers)
+        pool.request_encode_url("GET", "https://example.com", headers=bytes_str_headers)
+        pool.request_encode_body("POST", "https://example.com", headers=bytes_headers)
+
+        connection_pool = urllib3.HTTPConnectionPool(
+            "example.com", headers=mixed_headers
+        )
+        connection_pool.request("GET", "/", headers=header_dict)
+
+        proxy = urllib3.ProxyManager(
+            "http://example.com",
+            headers=bytes_str_headers,
+            proxy_headers=str_bytes_headers,
+        )
+        proxy.request("GET", "https://example.com", headers=mixed_headers)

--- a/test/with_dummyserver/test_connectionpool.py
+++ b/test/with_dummyserver/test_connectionpool.py
@@ -1112,7 +1112,7 @@ class TestConnectionPool(HypercornDummyServerTestCase):
 
     def test_bytes_header(self) -> None:
         with HTTPConnectionPool(self.host, self.port) as pool:
-            headers = {"User-Agent": "test header"}
+            headers = {b"User-Agent": b"test header"}
             r = pool.request("GET", "/headers", headers=headers)
             request_headers = r.json()
             assert "User-Agent" in request_headers
@@ -1121,7 +1121,7 @@ class TestConnectionPool(HypercornDummyServerTestCase):
     @pytest.mark.parametrize(
         "user_agent", ["Schönefeld/1.18.0", "Schönefeld/1.18.0".encode("iso-8859-1")]
     )
-    def test_user_agent_non_ascii_user_agent(self, user_agent: str) -> None:
+    def test_user_agent_non_ascii_user_agent(self, user_agent: str | bytes) -> None:
         with HTTPConnectionPool(self.host, self.port, retries=False) as pool:
             r = pool.urlopen(
                 "GET",


### PR DESCRIPTION
Closes #3047

This is an alternative implementation that covers both runtime behavior and typing regressions for request headers with `str`/`bytes` names and values.

## Summary
- Added shared header key/value typing for `str` and `bytes`.
- Normalized bytes header names and values through `HTTPHeaderDict`.
- Updated request, pool, proxy, connection, SOCKS, Emscripten, HTTP/2, response, and field header annotations.
- Added runtime coverage for bytes header values and real request sending.
- Added typing regression coverage for `dict[str, str]`, `dict[str, bytes]`, `dict[bytes, str]`, `dict[bytes, bytes]`, mixed mappings, and `HTTPHeaderDict`.

## Verification
- `python -m pytest test\test_collections.py test\with_dummyserver\test_connectionpool.py::TestConnectionPool::test_bytes_header test\with_dummyserver\test_connectionpool.py::TestConnectionPool::test_user_agent_non_ascii_user_agent test\test_typing.py -q`
- `python -m mypy --platform linux -p urllib3`
- `python -m mypy --follow-imports=silent test\test_collections.py test\with_dummyserver\test_connectionpool.py test\test_typing.py`
- `python -m black --check --target-version py310 <changed Python files>`
- `python -m isort --check-only <changed Python files>`
- `git diff --check`