### PR TITLE
Reject response headers with whitespace before colon

### DIFF
--- a/changelog/1362.bugfix.rst
+++ b/changelog/1362.bugfix.rst
@@ -1,0 +1,1 @@
+Rejected malformed response headers that included whitespace before the colon in a field name.

--- a/src/urllib3/util/response.py
+++ b/src/urllib3/util/response.py
@@ -88,16 +88,16 @@ def assert_header_parsing(headers: httplib.HTTPMessage) -> None:
 
     if unparsed_data:
         if isinstance(unparsed_data, bytes):
-            for line in unparsed_data.splitlines():
-                byte_header_name, separator, _ = line.partition(b":")
+            for byte_line in unparsed_data.splitlines():
+                byte_header_name, separator, _ = byte_line.partition(b":")
                 if separator and byte_header_name.rstrip(b" \t") != byte_header_name:
                     raise InvalidHeader(
                         "Invalid leading whitespace, reserved character(s), or "
                         f"return character(s) in header name: {byte_header_name!r}"
                     )
         else:
-            for line in unparsed_data.splitlines():
-                text_header_name, separator, _ = line.partition(":")
+            for text_line in unparsed_data.splitlines():
+                text_header_name, separator, _ = text_line.partition(":")
                 if separator and text_header_name.rstrip(" \t") != text_header_name:
                     raise InvalidHeader(
                         "Invalid leading whitespace, reserved character(s), or "

--- a/src/urllib3/util/response.py
+++ b/src/urllib3/util/response.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import http.client as httplib
 from email.errors import MultipartInvariantViolationDefect, StartBoundaryNotFoundDefect
 
-from ..exceptions import HeaderParsingError
+from ..exceptions import HeaderParsingError, InvalidHeader
 
 
 def is_fp_closed(obj: object) -> bool:
@@ -48,6 +48,8 @@ def assert_header_parsing(headers: httplib.HTTPMessage) -> None:
 
     :raises urllib3.exceptions.HeaderParsingError:
         If parsing errors are found.
+    :raises urllib3.exceptions.InvalidHeader:
+        If a header field name contains whitespace before the colon.
     """
 
     # This will fail silently if we pass in the wrong kind of parameter.
@@ -83,6 +85,28 @@ def assert_header_parsing(headers: httplib.HTTPMessage) -> None:
             defect, (StartBoundaryNotFoundDefect, MultipartInvariantViolationDefect)
         )
     ]
+
+    if unparsed_data:
+        invalid_header_lines = (
+            unparsed_data.splitlines()
+            if isinstance(unparsed_data, bytes)
+            else unparsed_data.splitlines()
+        )
+        for line in invalid_header_lines:
+            if isinstance(line, bytes):
+                header_name, separator, _ = line.partition(b":")
+                if separator and header_name.rstrip(b" \t") != header_name:
+                    raise InvalidHeader(
+                        "Invalid leading whitespace, reserved character(s), or "
+                        f"return character(s) in header name: {header_name!r}"
+                    )
+            else:
+                header_name, separator, _ = line.partition(":")
+                if separator and header_name.rstrip(" \t") != header_name:
+                    raise InvalidHeader(
+                        "Invalid leading whitespace, reserved character(s), or "
+                        f"return character(s) in header name: {header_name!r}"
+                    )
 
     if defects or unparsed_data:
         raise HeaderParsingError(defects=defects, unparsed_data=unparsed_data)

--- a/src/urllib3/util/response.py
+++ b/src/urllib3/util/response.py
@@ -90,10 +90,7 @@ def assert_header_parsing(headers: httplib.HTTPMessage) -> None:
         if isinstance(unparsed_data, bytes):
             for line in unparsed_data.splitlines():
                 byte_header_name, separator, _ = line.partition(b":")
-                if (
-                    separator
-                    and byte_header_name.rstrip(b" \t") != byte_header_name
-                ):
+                if separator and byte_header_name.rstrip(b" \t") != byte_header_name:
                     raise InvalidHeader(
                         "Invalid leading whitespace, reserved character(s), or "
                         f"return character(s) in header name: {byte_header_name!r}"
@@ -101,10 +98,7 @@ def assert_header_parsing(headers: httplib.HTTPMessage) -> None:
         else:
             for line in unparsed_data.splitlines():
                 text_header_name, separator, _ = line.partition(":")
-                if (
-                    separator
-                    and text_header_name.rstrip(" \t") != text_header_name
-                ):
+                if separator and text_header_name.rstrip(" \t") != text_header_name:
                     raise InvalidHeader(
                         "Invalid leading whitespace, reserved character(s), or "
                         f"return character(s) in header name: {text_header_name!r}"

--- a/src/urllib3/util/response.py
+++ b/src/urllib3/util/response.py
@@ -89,19 +89,25 @@ def assert_header_parsing(headers: httplib.HTTPMessage) -> None:
     if unparsed_data:
         if isinstance(unparsed_data, bytes):
             for line in unparsed_data.splitlines():
-                header_name, separator, _ = line.partition(b":")
-                if separator and header_name.rstrip(b" \t") != header_name:
+                byte_header_name, separator, _ = line.partition(b":")
+                if (
+                    separator
+                    and byte_header_name.rstrip(b" \t") != byte_header_name
+                ):
                     raise InvalidHeader(
                         "Invalid leading whitespace, reserved character(s), or "
-                        f"return character(s) in header name: {header_name!r}"
+                        f"return character(s) in header name: {byte_header_name!r}"
                     )
         else:
             for line in unparsed_data.splitlines():
-                header_name, separator, _ = line.partition(":")
-                if separator and header_name.rstrip(" \t") != header_name:
+                text_header_name, separator, _ = line.partition(":")
+                if (
+                    separator
+                    and text_header_name.rstrip(" \t") != text_header_name
+                ):
                     raise InvalidHeader(
                         "Invalid leading whitespace, reserved character(s), or "
-                        f"return character(s) in header name: {header_name!r}"
+                        f"return character(s) in header name: {text_header_name!r}"
                     )
 
     if defects or unparsed_data:

--- a/src/urllib3/util/response.py
+++ b/src/urllib3/util/response.py
@@ -87,20 +87,16 @@ def assert_header_parsing(headers: httplib.HTTPMessage) -> None:
     ]
 
     if unparsed_data:
-        invalid_header_lines = (
-            unparsed_data.splitlines()
-            if isinstance(unparsed_data, bytes)
-            else unparsed_data.splitlines()
-        )
-        for line in invalid_header_lines:
-            if isinstance(line, bytes):
+        if isinstance(unparsed_data, bytes):
+            for line in unparsed_data.splitlines():
                 header_name, separator, _ = line.partition(b":")
                 if separator and header_name.rstrip(b" \t") != header_name:
                     raise InvalidHeader(
                         "Invalid leading whitespace, reserved character(s), or "
                         f"return character(s) in header name: {header_name!r}"
                     )
-            else:
+        else:
+            for line in unparsed_data.splitlines():
                 header_name, separator, _ = line.partition(":")
                 if separator and header_name.rstrip(" \t") != header_name:
                     raise InvalidHeader(

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -865,12 +865,17 @@ class TestUtil:
         self,
     ) -> None:
         from http import client
+        from unittest.mock import patch
 
         headers = client.parse_headers(io.BytesIO(b"\r\n"))
-        headers.get_payload = lambda: b"Example-Header : value\r\n\r\n"  # type: ignore[method-assign]
 
-        with pytest.raises(InvalidHeader):
-            assert_header_parsing(headers)
+        with patch.object(
+            headers,
+            "get_payload",
+            return_value=b"Example-Header : value\r\n\r\n",
+        ):
+            with pytest.raises(InvalidHeader):
+                assert_header_parsing(headers)
 
     @pytest.mark.parametrize("host", [".localhost", "...", "t" * 64])
     def test_create_connection_with_invalid_idna_labels(self, host: str) -> None:

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -861,6 +861,17 @@ class TestUtil:
         with pytest.raises(InvalidHeader):
             assert_header_parsing(client.parse_headers(header_msg))
 
+    def test_assert_header_parsing_rejects_bytes_payload_with_whitespace_before_colon(
+        self,
+    ) -> None:
+        from http import client
+
+        headers = client.parse_headers(io.BytesIO(b"\r\n"))
+        headers.get_payload = lambda: b"Example-Header : value\r\n\r\n"  # type: ignore[method-assign]
+
+        with pytest.raises(InvalidHeader):
+            assert_header_parsing(headers)
+
     @pytest.mark.parametrize("host", [".localhost", "...", "t" * 64])
     def test_create_connection_with_invalid_idna_labels(self, host: str) -> None:
         with pytest.raises(

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -19,6 +19,7 @@ from urllib3 import add_stderr_logger, disable_warnings
 from urllib3.connection import ProxyConfig
 from urllib3.exceptions import (
     InsecureRequestWarning,
+    InvalidHeader,
     LocationParseError,
     TimeoutStateError,
     UnrewindableBodyError,
@@ -851,6 +852,14 @@ class TestUtil:
         )
         header_msg.seek(0)
         assert_header_parsing(client.parse_headers(header_msg))
+
+    def test_assert_header_parsing_rejects_whitespace_before_colon(self) -> None:
+        from http import client
+
+        header_msg = io.BytesIO(b"Example-Header : value\r\n\r\n")
+
+        with pytest.raises(InvalidHeader):
+            assert_header_parsing(client.parse_headers(header_msg))
 
     @pytest.mark.parametrize("host", [".localhost", "...", "t" * 64])
     def test_create_connection_with_invalid_idna_labels(self, host: str) -> None:

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -46,6 +46,7 @@ from urllib3.connection import HTTPConnection, _get_default_user_agent
 from urllib3.connectionpool import _url_from_pool
 from urllib3.exceptions import (
     InsecureRequestWarning,
+    InvalidHeader,
     MaxRetryError,
     ProtocolError,
     ProxyError,
@@ -2209,6 +2210,18 @@ class TestBrokenHeaders(SocketDummyServerTestCase):
         self._test_broken_header_parsing(
             [b"Broken Header", b"Another: Header"], "Broken Header"
         )
+
+    def test_header_name_with_whitespace_before_colon(self) -> None:
+        self.start_response_handler(
+            b"HTTP/1.1 200 OK\r\n"
+            b"Content-Length: 0\r\n"
+            b"Example-Header : value\r\n"
+            b"\r\n"
+        )
+
+        with HTTPConnectionPool(self.host, self.port, retries=False) as pool:
+            with pytest.raises(InvalidHeader):
+                pool.request("GET", "/")
 
 
 class TestHeaderParsingContentType(SocketDummyServerTestCase):


### PR DESCRIPTION
## Summary
- reject response headers whose field name contains trailing whitespace before the colon
- preserve the existing warning-only behavior for other header parsing defects
- add unit and socket-level regression coverage

Fixes #1362

## Tests
- python -m pytest test\test_util.py test\with_dummyserver\test_socketlevel.py -k header_parsing_or_related_cases