### PR TITLE
Add cleartext HTTP/2 h2c support

### DIFF
--- a/changelog/3303.feature.rst
+++ b/changelog/3303.feature.rst
@@ -1,0 +1,1 @@
+Added opt-in support for cleartext HTTP/2 h2c using prior knowledge and HTTP/1.1 Upgrade.

--- a/src/urllib3/http2/__init__.py
+++ b/src/urllib3/http2/__init__.py
@@ -10,9 +10,12 @@ __all__ = [
 import typing
 
 orig_HTTPSConnection: typing.Any = None
+orig_HTTPConnection: typing.Any = None
 
 
-def inject_into_urllib3() -> None:
+def inject_into_urllib3(
+    *, h2c: bool | typing.Literal["prior_knowledge", "upgrade"] = False
+) -> None:
     # First check if h2 version is valid
     h2_version = version("h2")
     if not h2_version.startswith("4."):
@@ -25,15 +28,33 @@ def inject_into_urllib3() -> None:
     # Import here to avoid circular dependencies.
     from .. import connection as urllib3_connection
     from .. import util as urllib3_util
-    from ..connectionpool import HTTPSConnectionPool
+    from ..connectionpool import HTTPConnectionPool, HTTPSConnectionPool
     from ..util import ssl_ as urllib3_util_ssl
-    from .connection import HTTP2Connection
+    from .connection import (
+        HTTP2CleartextConnection,
+        HTTP2Connection,
+        HTTP2UpgradeConnection,
+    )
 
-    global orig_HTTPSConnection
-    orig_HTTPSConnection = urllib3_connection.HTTPSConnection
+    global orig_HTTPConnection, orig_HTTPSConnection
+    if orig_HTTPSConnection is None:
+        orig_HTTPSConnection = urllib3_connection.HTTPSConnection
+    if orig_HTTPConnection is None:
+        orig_HTTPConnection = urllib3_connection.HTTPConnection
+
+    if h2c is True or h2c == "prior_knowledge":
+        http_connection_cls = HTTP2CleartextConnection
+    elif h2c == "upgrade":
+        http_connection_cls = HTTP2UpgradeConnection
+    elif h2c is False:
+        http_connection_cls = orig_HTTPConnection
+    else:
+        raise ValueError("h2c must be True, 'prior_knowledge', 'upgrade', or False")
 
     HTTPSConnectionPool.ConnectionCls = HTTP2Connection
     urllib3_connection.HTTPSConnection = HTTP2Connection  # type: ignore[misc]
+    HTTPConnectionPool.ConnectionCls = http_connection_cls
+    urllib3_connection.HTTPConnection = http_connection_cls  # type: ignore[misc]
 
     # TODO: Offer 'http/1.1' as well, but for testing purposes this is handy.
     urllib3_util.ALPN_PROTOCOLS = ["h2"]
@@ -43,11 +64,18 @@ def inject_into_urllib3() -> None:
 def extract_from_urllib3() -> None:
     from .. import connection as urllib3_connection
     from .. import util as urllib3_util
-    from ..connectionpool import HTTPSConnectionPool
+    from ..connectionpool import HTTPConnectionPool, HTTPSConnectionPool
     from ..util import ssl_ as urllib3_util_ssl
 
-    HTTPSConnectionPool.ConnectionCls = orig_HTTPSConnection
-    urllib3_connection.HTTPSConnection = orig_HTTPSConnection  # type: ignore[misc]
+    global orig_HTTPConnection, orig_HTTPSConnection
+    if orig_HTTPSConnection is not None:
+        HTTPSConnectionPool.ConnectionCls = orig_HTTPSConnection
+        urllib3_connection.HTTPSConnection = orig_HTTPSConnection  # type: ignore[misc]
+        orig_HTTPSConnection = None
+    if orig_HTTPConnection is not None:
+        HTTPConnectionPool.ConnectionCls = orig_HTTPConnection
+        urllib3_connection.HTTPConnection = orig_HTTPConnection  # type: ignore[misc]
+        orig_HTTPConnection = None
 
     urllib3_util.ALPN_PROTOCOLS = ["http/1.1"]
     urllib3_util_ssl.ALPN_PROTOCOLS = ["http/1.1"]

--- a/src/urllib3/http2/connection.py
+++ b/src/urllib3/http2/connection.py
@@ -110,6 +110,12 @@ class HTTP2Connection(HTTPSConnection):
         super().connect()
         self._start_http2_connection()
 
+    @property
+    def is_connected(self) -> bool:
+        # Readable HTTP/2 sockets may only have control frames waiting, so the
+        # HTTP/1.1 dropped-connection probe is not reliable for HTTP/2.
+        return self.sock is not None
+
     def _start_http2_connection(self) -> None:
         with self._h2_conn as conn:
             conn.initiate_connection()
@@ -290,7 +296,9 @@ class HTTP2Connection(HTTPSConnection):
             # raise NotImplementedError("`chunked` isn't supported with HTTP/2")
             pass
 
-        if self.sock is not None:
+        if self.sock is None:
+            self.connect()
+        else:
             self.sock.settimeout(self.timeout)
 
         self.putrequest(method, url)

--- a/src/urllib3/http2/connection.py
+++ b/src/urllib3/http2/connection.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import http.client
 import logging
 import re
 import threading
@@ -10,9 +11,9 @@ import h2.config
 import h2.connection
 import h2.events
 
-from .._base_connection import _TYPE_BODY
+from .._base_connection import _TYPE_BODY, _ResponseOptions
 from .._collections import HTTPHeaderDict
-from ..connection import HTTPSConnection, _get_default_user_agent
+from ..connection import HTTPConnection, HTTPSConnection, _get_default_user_agent
 from ..exceptions import ConnectionError
 from ..response import BaseHTTPResponse
 
@@ -83,6 +84,9 @@ class _LockedObject(typing.Generic[T]):
 
 
 class HTTP2Connection(HTTPSConnection):
+    _http2_scheme: typing.ClassVar[bytes] = b"https"
+    _http2_default_port: typing.ClassVar[int] = 443
+
     def __init__(
         self, host: str, port: int | None = None, **kwargs: typing.Any
     ) -> None:
@@ -104,6 +108,9 @@ class HTTP2Connection(HTTPSConnection):
 
     def connect(self) -> None:
         super().connect()
+        self._start_http2_connection()
+
+    def _start_http2_connection(self) -> None:
         with self._h2_conn as conn:
             conn.initiate_connection()
             if data_to_send := conn.data_to_send():
@@ -128,11 +135,11 @@ class HTTP2Connection(HTTPSConnection):
         self._validate_path(url)  # type: ignore[attr-defined]
 
         if ":" in self.host:
-            authority = f"[{self.host}]:{self.port or 443}"
+            authority = f"[{self.host}]:{self.port or self._http2_default_port}"
         else:
-            authority = f"{self.host}:{self.port or 443}"
+            authority = f"{self.host}:{self.port or self._http2_default_port}"
 
-        self._headers.append((b":scheme", b"https"))
+        self._headers.append((b":scheme", self._http2_scheme))
         self._headers.append((b":method", method.encode()))
         self._headers.append((b":authority", authority.encode()))
         self._headers.append((b":path", url.encode()))
@@ -314,10 +321,149 @@ class HTTP2Connection(HTTPSConnection):
                 pass
 
         # Reset all our HTTP/2 connection state.
+        self._reset_http2_state()
+        super().close()
+
+    def _reset_http2_state(self) -> None:
         self._h2_conn = self._new_h2_conn()
         self._h2_stream = None
         self._headers = []
 
+
+class HTTP2CleartextConnection(HTTP2Connection):
+    _http2_scheme = b"http"
+    _http2_default_port = 80
+
+    def __init__(
+        self, host: str, port: int | None = None, **kwargs: typing.Any
+    ) -> None:
+        super().__init__(
+            host,
+            port=self._http2_default_port if port is None else port,
+            **kwargs,
+        )
+
+    def connect(self) -> None:
+        HTTPConnection.connect(self)
+        self._start_http2_connection()
+
+
+class HTTP2UpgradeConnection(HTTP2CleartextConnection):
+    def __init__(
+        self, host: str, port: int | None = None, **kwargs: typing.Any
+    ) -> None:
+        self._h2_upgrade_complete = False
+        super().__init__(host, port=port, **kwargs)
+
+    def connect(self) -> None:
+        HTTPConnection.connect(self)
+
+    def request(  # type: ignore[override]
+        self,
+        method: str,
+        url: str,
+        body: _TYPE_BODY | None = None,
+        headers: typing.Mapping[str, str] | None = None,
+        *,
+        preload_content: bool = True,
+        decode_content: bool = True,
+        enforce_content_length: bool = True,
+        **kwargs: typing.Any,
+    ) -> None:
+        if self._h2_upgrade_complete:
+            return super().request(
+                method,
+                url,
+                body=body,
+                headers=headers,
+                preload_content=preload_content,
+                decode_content=decode_content,
+                enforce_content_length=enforce_content_length,
+                **kwargs,
+            )
+
+        if body is not None:
+            raise NotImplementedError(
+                "HTTP/2 upgrade requests with a body aren't supported"
+            )
+        if kwargs.get("chunked"):
+            raise NotImplementedError(
+                "Chunked HTTP/2 upgrade requests aren't supported"
+            )
+
+        if self.sock is not None:
+            self.sock.settimeout(self.timeout)
+
+        with self._h2_conn as conn:
+            settings_header = conn.initiate_upgrade_connection()
+        assert settings_header is not None
+
+        upgrade_headers = dict(headers or {})
+        upgrade_headers["Connection"] = "Upgrade, HTTP2-Settings"
+        upgrade_headers["Upgrade"] = "h2c"
+        upgrade_headers["HTTP2-Settings"] = settings_header.decode("ascii")
+
+        self._h2_stream = 1
+        self._request_url = url or "/"
+
+        self._response_options = _ResponseOptions(
+            request_method=method,
+            request_url=url,
+            preload_content=preload_content,
+            decode_content=decode_content,
+            enforce_content_length=enforce_content_length,
+        )
+
+        header_keys = frozenset(k.lower() for k in upgrade_headers)
+        HTTPConnection.putrequest(
+            self,
+            method,
+            url,
+            skip_accept_encoding=True,
+            skip_host=True,
+        )
+        if "host" not in header_keys:
+            HTTPConnection.putheader(self, "Host", self._http2_authority())
+        if "accept-encoding" not in header_keys:
+            HTTPConnection.putheader(self, "Accept-Encoding", "identity")
+        if "user-agent" not in header_keys:
+            HTTPConnection.putheader(self, "User-Agent", _get_default_user_agent())
+        for header, value in upgrade_headers.items():
+            HTTPConnection.putheader(self, header, value)
+        self._send_http1_headers()
+
+    def _http2_authority(self) -> str:
+        if ":" in self.host:
+            return f"[{self.host}]:{self.port or self._http2_default_port}"
+        return f"{self.host}:{self.port or self._http2_default_port}"
+
+    def _send_http1_headers(self) -> None:
+        self._buffer.extend((b"", b""))  # type: ignore[attr-defined]
+        message = b"\r\n".join(self._buffer)  # type: ignore[attr-defined]
+        del self._buffer[:]  # type: ignore[attr-defined]
+        HTTPConnection.send(self, message)
+        self._HTTPConnection__state = http.client._CS_REQ_SENT  # type: ignore[attr-defined]
+
+    def getresponse(  # type: ignore[override]
+        self,
+    ) -> BaseHTTPResponse:
+        if self._h2_upgrade_complete:
+            return super().getresponse()
+
+        response = HTTPConnection.getresponse(self)
+        if response.status != 101:
+            self._reset_http2_state()
+            return response
+
+        with self._h2_conn as conn:
+            if data_to_send := conn.data_to_send():
+                self.sock.sendall(data_to_send)
+
+        self._h2_upgrade_complete = True
+        return super().getresponse()
+
+    def close(self) -> None:
+        self._h2_upgrade_complete = False
         super().close()
 
 

--- a/src/urllib3/http2/connection.py
+++ b/src/urllib3/http2/connection.py
@@ -406,7 +406,7 @@ class HTTP2UpgradeConnection(HTTP2CleartextConnection):
             settings_header = conn.initiate_upgrade_connection()
         assert settings_header is not None
 
-        upgrade_headers = dict(headers or {})
+        upgrade_headers = HTTPHeaderDict(headers or {})
         upgrade_headers["Connection"] = "Upgrade, HTTP2-Settings"
         upgrade_headers["Upgrade"] = "h2c"
         upgrade_headers["HTTP2-Settings"] = settings_header.decode("ascii")

--- a/test/test_compatibility.py
+++ b/test/test_compatibility.py
@@ -7,6 +7,13 @@ from unittest import mock
 import pytest
 
 import urllib3.http2
+from urllib3.connection import HTTPConnection, HTTPSConnection
+from urllib3.connectionpool import HTTPConnectionPool, HTTPSConnectionPool
+from urllib3.http2.connection import (
+    HTTP2CleartextConnection,
+    HTTP2Connection,
+    HTTP2UpgradeConnection,
+)
 from urllib3.response import HTTPResponse
 
 
@@ -46,3 +53,75 @@ class TestInitialization:
                 urllib3.http2.inject_into_urllib3()
         finally:
             urllib3.http2.extract_from_urllib3()
+
+    def test_h2c_injection_is_opt_in(self) -> None:
+        try:
+            urllib3.http2.inject_into_urllib3()
+
+            assert HTTPSConnectionPool.ConnectionCls is HTTP2Connection
+            assert HTTPConnectionPool.ConnectionCls is HTTPConnection
+        finally:
+            urllib3.http2.extract_from_urllib3()
+
+    def test_h2c_injection(self) -> None:
+        try:
+            urllib3.http2.inject_into_urllib3(h2c=True)
+
+            assert HTTPSConnectionPool.ConnectionCls is HTTP2Connection
+            assert HTTPConnectionPool.ConnectionCls is HTTP2CleartextConnection
+        finally:
+            urllib3.http2.extract_from_urllib3()
+
+        assert HTTPSConnectionPool.ConnectionCls is HTTPSConnection
+        assert HTTPConnectionPool.ConnectionCls is HTTPConnection
+
+    def test_h2c_prior_knowledge_injection(self) -> None:
+        try:
+            urllib3.http2.inject_into_urllib3(h2c="prior_knowledge")
+
+            assert HTTPSConnectionPool.ConnectionCls is HTTP2Connection
+            assert HTTPConnectionPool.ConnectionCls is HTTP2CleartextConnection
+        finally:
+            urllib3.http2.extract_from_urllib3()
+
+    def test_h2c_upgrade_injection(self) -> None:
+        try:
+            urllib3.http2.inject_into_urllib3(h2c="upgrade")
+
+            assert HTTPSConnectionPool.ConnectionCls is HTTP2Connection
+            assert HTTPConnectionPool.ConnectionCls is HTTP2UpgradeConnection
+        finally:
+            urllib3.http2.extract_from_urllib3()
+
+    def test_h2c_injection_rejects_unknown_mode(self) -> None:
+        try:
+            with pytest.raises(ValueError):
+                urllib3.http2.inject_into_urllib3(h2c="unknown")  # type: ignore[arg-type]
+
+            assert HTTPSConnectionPool.ConnectionCls is HTTPSConnection
+            assert HTTPConnectionPool.ConnectionCls is HTTPConnection
+        finally:
+            urllib3.http2.extract_from_urllib3()
+
+    def test_repeated_h2c_injection_can_disable_h2c(self) -> None:
+        try:
+            urllib3.http2.inject_into_urllib3(h2c="upgrade")
+            urllib3.http2.inject_into_urllib3()
+
+            assert HTTPSConnectionPool.ConnectionCls is HTTP2Connection
+            assert HTTPConnectionPool.ConnectionCls is HTTPConnection
+        finally:
+            urllib3.http2.extract_from_urllib3()
+
+    def test_repeated_h2c_injection_restores_original_connections(self) -> None:
+        try:
+            urllib3.http2.inject_into_urllib3(h2c="upgrade")
+            urllib3.http2.inject_into_urllib3(h2c="prior_knowledge")
+
+            assert HTTPSConnectionPool.ConnectionCls is HTTP2Connection
+            assert HTTPConnectionPool.ConnectionCls is HTTP2CleartextConnection
+        finally:
+            urllib3.http2.extract_from_urllib3()
+
+        assert HTTPSConnectionPool.ConnectionCls is HTTPSConnection
+        assert HTTPConnectionPool.ConnectionCls is HTTPConnection

--- a/test/test_http2_connection.py
+++ b/test/test_http2_connection.py
@@ -494,6 +494,44 @@ class TestHTTP2Connection:
         with pytest.raises(NotImplementedError):
             conn.request("POST", "/", body=b"body")
 
+    def test_upgrade_request_rejects_chunked_body(self) -> None:
+        conn = HTTP2UpgradeConnection("example.com")
+        with pytest.raises(NotImplementedError):
+            conn.request("POST", "/", chunked=True)
+
+    def test_upgrade_request_overrides_upgrade_headers_case_insensitively(
+        self,
+    ) -> None:
+        conn = HTTP2UpgradeConnection("example.com")
+        conn.sock = mock.MagicMock(sendall=mock.Mock(return_value=None))
+        conn._h2_conn._obj.initiate_upgrade_connection = mock.Mock(  # type: ignore[method-assign]
+            return_value=b"settings"
+        )
+
+        conn.request(
+            "GET",
+            "/",
+            headers={
+                "connection": "keep-alive",
+                "upgrade": "websocket",
+                "http2-settings": "old-settings",
+                "Host": "custom.example",
+                "Accept-Encoding": "gzip",
+                "User-Agent": "agent",
+            },
+        )
+
+        sent = b"".join(call.args[0] for call in conn.sock.sendall.call_args_list)
+        assert b"Connection: Upgrade, HTTP2-Settings\r\n" in sent
+        assert b"Upgrade: h2c\r\n" in sent
+        assert b"HTTP2-Settings: settings\r\n" in sent
+        assert b"connection: keep-alive\r\n" not in sent
+        assert b"upgrade: websocket\r\n" not in sent
+        assert b"http2-settings: old-settings\r\n" not in sent
+        assert b"Host: custom.example\r\n" in sent
+        assert b"Accept-Encoding: gzip\r\n" in sent
+        assert b"User-Agent: agent\r\n" in sent
+
     def test_upgrade_getresponse_switches_to_http2(self) -> None:
         conn = HTTP2UpgradeConnection("example.com")
         conn.sock = mock.MagicMock()

--- a/test/test_http2_connection.py
+++ b/test/test_http2_connection.py
@@ -1,19 +1,90 @@
 from __future__ import annotations
 
 import socket
+import threading
 from unittest import mock
 
+import h2.config
+import h2.connection
 import pytest
 
+import urllib3
+import urllib3.http2
+from urllib3.connection import HTTPConnection as _HTTPConnection
 from urllib3.connection import _get_default_user_agent
 from urllib3.exceptions import ConnectionError
 from urllib3.http2.connection import (
+    HTTP2CleartextConnection,
     HTTP2Connection,
+    HTTP2UpgradeConnection,
     _is_illegal_header_value,
     _is_legal_header_name,
 )
 
 # [1] https://httpwg.org/specs/rfc9113.html#n-field-validity
+
+
+def start_h2c_upgrade_server() -> (
+    tuple[
+        socket.socket, threading.Thread, dict[str, bytes], list[BaseException], str, int
+    ]
+):
+    ready = threading.Event()
+    result: dict[str, bytes] = {}
+    errors: list[BaseException] = []
+
+    def server(listener: socket.socket) -> None:
+        try:
+            ready.set()
+            conn, _ = listener.accept()
+            with conn:
+                request = b""
+                while b"\r\n\r\n" not in request:
+                    request += conn.recv(4096)
+                result["request"] = request
+
+                settings = None
+                for line in request.split(b"\r\n"):
+                    if line.lower().startswith(b"http2-settings:"):
+                        settings = line.split(b":", 1)[1].strip()
+                        break
+                assert settings is not None
+
+                conn.sendall(
+                    b"HTTP/1.1 101 Switching Protocols\r\n"
+                    b"Connection: Upgrade\r\n"
+                    b"Upgrade: h2c\r\n"
+                    b"\r\n"
+                )
+
+                h2_conn = h2.connection.H2Connection(
+                    config=h2.config.H2Configuration(client_side=False)
+                )
+                h2_conn.initiate_upgrade_connection(settings)
+                h2_conn.send_headers(
+                    1,
+                    [(":status", "200"), ("content-length", "2")],
+                )
+                h2_conn.send_data(1, b"ok", end_stream=True)
+                conn.sendall(h2_conn.data_to_send())
+
+                conn.settimeout(0.5)
+                try:
+                    conn.recv(65535)
+                except OSError:
+                    pass
+        except BaseException as e:
+            errors.append(e)
+
+    listener = socket.socket()
+    listener.bind(("127.0.0.1", 0))
+    listener.listen(1)
+    thread = threading.Thread(target=server, args=(listener,), daemon=True)
+    thread.start()
+    assert ready.wait(2)
+
+    host, port = listener.getsockname()
+    return listener, thread, result, errors, host, port
 
 
 class TestHTTP2Connection:
@@ -79,6 +150,26 @@ class TestHTTP2Connection:
         conn = HTTP2Connection("example.com")
         assert conn.socket_options == [(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)]
         assert conn.port == 443
+
+    def test_cleartext_default_socket_options(self) -> None:
+        conn = HTTP2CleartextConnection("example.com")
+        assert conn.socket_options == [(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)]
+        assert conn.port == 80
+
+    def test_cleartext_connect_uses_plain_http_connection(self) -> None:
+        conn = HTTP2CleartextConnection("example.com")
+        with (
+            mock.patch.object(
+                _HTTPConnection, "connect", autospec=True
+            ) as connect_mock,
+            mock.patch.object(
+                HTTP2CleartextConnection, "_start_http2_connection", autospec=True
+            ) as start_mock,
+        ):
+            conn.connect()
+
+        connect_mock.assert_called_once_with(conn)
+        start_mock.assert_called_once_with(conn)
 
     def test_putheader(self) -> None:
         conn = HTTP2Connection("example.com")
@@ -270,6 +361,177 @@ class TestHTTP2Connection:
         )
 
         close_connection.assert_called_with()
+
+    def test_cleartext_request_GET(self) -> None:
+        conn = HTTP2CleartextConnection("example.com")
+        conn.sock = mock.MagicMock(
+            sendall=mock.Mock(return_value=None),
+        )
+        sendall = conn.sock.sendall
+        data_to_send = conn._h2_conn._obj.data_to_send = mock.Mock(return_value=b"foo")  # type: ignore[method-assign]
+        send_headers = conn._h2_conn._obj.send_headers = mock.Mock(return_value=None)  # type: ignore[method-assign]
+        conn._h2_conn._obj.send_data = mock.Mock(return_value=None)  # type: ignore[method-assign]
+        conn._h2_conn._obj.get_next_available_stream_id = mock.Mock(return_value=1)  # type: ignore[method-assign]
+        close_connection = conn._h2_conn._obj.close_connection = mock.Mock(  # type: ignore[method-assign]
+            return_value=None
+        )
+
+        conn.request("GET", "/")
+        conn.close()
+
+        data_to_send.assert_called_with()
+        sendall.assert_called_with(b"foo")
+        send_headers.assert_called_with(
+            stream_id=1,
+            headers=[
+                (b":scheme", b"http"),
+                (b":method", b"GET"),
+                (b":authority", b"example.com:80"),
+                (b":path", b"/"),
+                (b"user-agent", _get_default_user_agent().encode()),
+            ],
+            end_stream=True,
+        )
+
+        close_connection.assert_called_with()
+
+    def test_upgrade_request_GET(self) -> None:
+        conn = HTTP2UpgradeConnection("example.com")
+        conn.sock = mock.MagicMock(sendall=mock.Mock(return_value=None))
+        conn._h2_conn._obj.initiate_upgrade_connection = mock.Mock(  # type: ignore[method-assign]
+            return_value=b"settings"
+        )
+
+        conn.request("GET", "/", headers={"Foo": "bar"})
+
+        sent = b"".join(call.args[0] for call in conn.sock.sendall.call_args_list)
+        assert sent.startswith(b"GET / HTTP/1.1\r\n")
+        assert b"Host: example.com:80\r\n" in sent
+        assert b"Accept-Encoding: identity\r\n" in sent
+        assert b"User-Agent: python-urllib3/" in sent
+        assert b"Foo: bar\r\n" in sent
+        assert b"Connection: Upgrade, HTTP2-Settings\r\n" in sent
+        assert b"Upgrade: h2c\r\n" in sent
+        assert b"HTTP2-Settings: settings\r\n" in sent
+        assert conn._h2_stream == 1
+        assert conn._request_url == "/"
+
+    def test_upgrade_connect_uses_plain_http_connection(self) -> None:
+        conn = HTTP2UpgradeConnection("example.com")
+        with (
+            mock.patch.object(
+                _HTTPConnection, "connect", autospec=True
+            ) as connect_mock,
+            mock.patch.object(
+                HTTP2UpgradeConnection, "_start_http2_connection", autospec=True
+            ) as start_mock,
+        ):
+            conn.connect()
+
+        connect_mock.assert_called_once_with(conn)
+        start_mock.assert_not_called()
+
+    def test_upgrade_request_rejects_body(self) -> None:
+        conn = HTTP2UpgradeConnection("example.com")
+        with pytest.raises(NotImplementedError):
+            conn.request("POST", "/", body=b"body")
+
+    def test_upgrade_getresponse_switches_to_http2(self) -> None:
+        conn = HTTP2UpgradeConnection("example.com")
+        conn.sock = mock.MagicMock()
+        conn._h2_conn._obj.data_to_send = mock.Mock(return_value=b"preface")  # type: ignore[method-assign]
+        h1_response = mock.Mock(status=101)
+        h2_response = mock.Mock()
+
+        with (
+            mock.patch.object(
+                _HTTPConnection, "getresponse", autospec=True, return_value=h1_response
+            ) as h1_getresponse,
+            mock.patch.object(
+                HTTP2CleartextConnection,
+                "getresponse",
+                autospec=True,
+                return_value=h2_response,
+            ) as h2_getresponse,
+        ):
+            response = conn.getresponse()
+
+        assert response is h2_response
+        h1_getresponse.assert_called_once_with(conn)
+        h2_getresponse.assert_called_once_with(conn)
+        conn.sock.sendall.assert_called_once_with(b"preface")
+        assert conn._h2_upgrade_complete
+
+    def test_upgrade_getresponse_returns_http1_response_without_101(self) -> None:
+        conn = HTTP2UpgradeConnection("example.com")
+        conn.sock = mock.MagicMock()
+        h1_response = mock.Mock(status=200)
+        h2_conn = conn._h2_conn
+
+        with mock.patch.object(
+            _HTTPConnection, "getresponse", autospec=True, return_value=h1_response
+        ):
+            response = conn.getresponse()
+
+        assert response is h1_response
+        conn.sock.sendall.assert_not_called()
+        assert not conn._h2_upgrade_complete
+        assert conn._h2_stream is None
+        assert conn._headers == []
+        assert conn._h2_conn is not h2_conn
+
+    def test_upgrade_close_resets_upgrade_state(self) -> None:
+        conn = HTTP2UpgradeConnection("example.com")
+        conn._h2_upgrade_complete = True
+        conn.close()
+
+        assert not conn._h2_upgrade_complete
+
+    def test_upgrade_h2c_smoke(self) -> None:
+        listener, thread, result, errors, host, port = start_h2c_upgrade_server()
+        conn = HTTP2UpgradeConnection(host, port)
+        try:
+            conn.request("GET", "/")
+            response = conn.getresponse()
+        finally:
+            conn.close()
+            listener.close()
+            thread.join(2)
+
+        assert not thread.is_alive()
+        assert errors == []
+        assert response.status == 200
+        assert response.data == b"ok"
+        assert result["request"].startswith(b"GET / HTTP/1.1\r\n")
+        assert b"Upgrade: h2c\r\n" in result["request"]
+        assert b"HTTP2-Settings:" in result["request"]
+
+    def test_upgrade_h2c_pool_smoke(self) -> None:
+        listener, thread, result, errors, host, port = start_h2c_upgrade_server()
+        try:
+            urllib3.http2.inject_into_urllib3(h2c="upgrade")
+            pool = urllib3.HTTPConnectionPool(
+                host,
+                port,
+                timeout=urllib3.Timeout(connect=2, read=2),
+                retries=False,
+            )
+            try:
+                response = pool.request("GET", "/")
+            finally:
+                pool.close()
+        finally:
+            urllib3.http2.extract_from_urllib3()
+            listener.close()
+            thread.join(2)
+
+        assert not thread.is_alive()
+        assert errors == []
+        assert response.status == 200
+        assert response.data == b"ok"
+        assert result["request"].startswith(b"GET / HTTP/1.1\r\n")
+        assert b"Upgrade: h2c\r\n" in result["request"]
+        assert b"HTTP2-Settings:" in result["request"]
 
     def test_request_POST(self) -> None:
         conn = HTTP2Connection("example.com")

--- a/test/test_http2_connection.py
+++ b/test/test_http2_connection.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import socket
 import threading
+import typing
 from unittest import mock
 
 import h2.config
@@ -24,13 +25,20 @@ from urllib3.http2.connection import (
 # [1] https://httpwg.org/specs/rfc9113.html#n-field-validity
 
 
-def start_h2c_upgrade_server() -> (
-    tuple[
-        socket.socket, threading.Thread, dict[str, bytes], list[BaseException], str, int
-    ]
-):
+def start_h2c_server(
+    *,
+    upgrade: bool,
+    request_count: int = 1,
+) -> tuple[
+    socket.socket,
+    threading.Thread,
+    dict[str, typing.Any],
+    list[BaseException],
+    str,
+    int,
+]:
     ready = threading.Event()
-    result: dict[str, bytes] = {}
+    result: dict[str, typing.Any] = {"streams": []}
     errors: list[BaseException] = []
 
     def server(listener: socket.socket) -> None:
@@ -38,41 +46,61 @@ def start_h2c_upgrade_server() -> (
             ready.set()
             conn, _ = listener.accept()
             with conn:
-                request = b""
-                while b"\r\n\r\n" not in request:
-                    request += conn.recv(4096)
-                result["request"] = request
-
-                settings = None
-                for line in request.split(b"\r\n"):
-                    if line.lower().startswith(b"http2-settings:"):
-                        settings = line.split(b":", 1)[1].strip()
-                        break
-                assert settings is not None
-
-                conn.sendall(
-                    b"HTTP/1.1 101 Switching Protocols\r\n"
-                    b"Connection: Upgrade\r\n"
-                    b"Upgrade: h2c\r\n"
-                    b"\r\n"
-                )
-
                 h2_conn = h2.connection.H2Connection(
                     config=h2.config.H2Configuration(client_side=False)
                 )
-                h2_conn.initiate_upgrade_connection(settings)
-                h2_conn.send_headers(
-                    1,
-                    [(":status", "200"), ("content-length", "2")],
-                )
-                h2_conn.send_data(1, b"ok", end_stream=True)
-                conn.sendall(h2_conn.data_to_send())
 
-                conn.settimeout(0.5)
-                try:
-                    conn.recv(65535)
-                except OSError:
-                    pass
+                responses_sent = 0
+                pending_upgrade_response = False
+                if upgrade:
+                    request = b""
+                    while b"\r\n\r\n" not in request:
+                        request += conn.recv(4096)
+                    result["request"] = request
+
+                    settings = None
+                    for line in request.split(b"\r\n"):
+                        if line.lower().startswith(b"http2-settings:"):
+                            settings = line.split(b":", 1)[1].strip()
+                            break
+                    assert settings is not None
+
+                    conn.sendall(
+                        b"HTTP/1.1 101 Switching Protocols\r\n"
+                        b"Connection: Upgrade\r\n"
+                        b"Upgrade: h2c\r\n"
+                        b"\r\n"
+                    )
+
+                    h2_conn.initiate_upgrade_connection(settings)
+                    pending_upgrade_response = True
+                else:
+                    h2_conn.initiate_connection()
+                    conn.sendall(h2_conn.data_to_send())
+
+                while responses_sent < request_count:
+                    received_data = conn.recv(65535)
+                    if not received_data:
+                        break
+                    events = h2_conn.receive_data(received_data)
+                    if pending_upgrade_response:
+                        result["streams"].append(1)
+                        _send_h2_response(h2_conn, 1, responses_sent)
+                        responses_sent += 1
+                        pending_upgrade_response = False
+                    for event in events:
+                        if isinstance(event, h2.events.RequestReceived):
+                            result["streams"].append(event.stream_id)
+                            _send_h2_response(h2_conn, event.stream_id, responses_sent)
+                            responses_sent += 1
+                        elif isinstance(event, h2.events.DataReceived):
+                            h2_conn.acknowledge_received_data(
+                                event.flow_controlled_length, event.stream_id
+                            )
+                    if data_to_send := h2_conn.data_to_send():
+                        conn.sendall(data_to_send)
+
+                _drain_socket(conn)
         except BaseException as e:
             errors.append(e)
 
@@ -85,6 +113,36 @@ def start_h2c_upgrade_server() -> (
 
     host, port = listener.getsockname()
     return listener, thread, result, errors, host, port
+
+
+def start_h2c_upgrade_server() -> tuple[
+    socket.socket,
+    threading.Thread,
+    dict[str, typing.Any],
+    list[BaseException],
+    str,
+    int,
+]:
+    return start_h2c_server(upgrade=True)
+
+
+def _send_h2_response(
+    h2_conn: h2.connection.H2Connection, stream_id: int, index: int
+) -> None:
+    body = f"ok{index}".encode()
+    h2_conn.send_headers(
+        stream_id,
+        [(":status", "200"), ("content-length", str(len(body)))],
+    )
+    h2_conn.send_data(stream_id, body, end_stream=True)
+
+
+def _drain_socket(conn: socket.socket) -> None:
+    conn.settimeout(0.5)
+    try:
+        conn.recv(65535)
+    except OSError:
+        pass
 
 
 class TestHTTP2Connection:
@@ -501,7 +559,7 @@ class TestHTTP2Connection:
         assert not thread.is_alive()
         assert errors == []
         assert response.status == 200
-        assert response.data == b"ok"
+        assert response.data == b"ok0"
         assert result["request"].startswith(b"GET / HTTP/1.1\r\n")
         assert b"Upgrade: h2c\r\n" in result["request"]
         assert b"HTTP2-Settings:" in result["request"]
@@ -528,7 +586,74 @@ class TestHTTP2Connection:
         assert not thread.is_alive()
         assert errors == []
         assert response.status == 200
-        assert response.data == b"ok"
+        assert response.data == b"ok0"
+        assert result["request"].startswith(b"GET / HTTP/1.1\r\n")
+        assert b"Upgrade: h2c\r\n" in result["request"]
+        assert b"HTTP2-Settings:" in result["request"]
+
+    def test_cleartext_h2c_pool_reuses_connection(self) -> None:
+        listener, thread, result, errors, host, port = start_h2c_server(
+            upgrade=False, request_count=2
+        )
+        try:
+            urllib3.http2.inject_into_urllib3(h2c=True)
+            pool = urllib3.HTTPConnectionPool(
+                host,
+                port,
+                timeout=urllib3.Timeout(connect=2, read=2),
+                retries=False,
+            )
+            try:
+                first = pool.request("GET", "/")
+                second = pool.request("GET", "/again")
+                num_connections = pool.num_connections
+            finally:
+                pool.close()
+        finally:
+            urllib3.http2.extract_from_urllib3()
+            listener.close()
+            thread.join(2)
+
+        assert not thread.is_alive()
+        assert errors == []
+        assert first.status == 200
+        assert first.data == b"ok0"
+        assert second.status == 200
+        assert second.data == b"ok1"
+        assert num_connections == 1
+        assert result["streams"] == [1, 3]
+
+    def test_upgrade_h2c_pool_reuses_connection(self) -> None:
+        listener, thread, result, errors, host, port = start_h2c_server(
+            upgrade=True, request_count=2
+        )
+        try:
+            urllib3.http2.inject_into_urllib3(h2c="upgrade")
+            pool = urllib3.HTTPConnectionPool(
+                host,
+                port,
+                timeout=urllib3.Timeout(connect=2, read=2),
+                retries=False,
+            )
+            try:
+                first = pool.request("GET", "/")
+                second = pool.request("GET", "/again")
+                num_connections = pool.num_connections
+            finally:
+                pool.close()
+        finally:
+            urllib3.http2.extract_from_urllib3()
+            listener.close()
+            thread.join(2)
+
+        assert not thread.is_alive()
+        assert errors == []
+        assert first.status == 200
+        assert first.data == b"ok0"
+        assert second.status == 200
+        assert second.data == b"ok1"
+        assert num_connections == 1
+        assert result["streams"] == [1, 3]
         assert result["request"].startswith(b"GET / HTTP/1.1\r\n")
         assert b"Upgrade: h2c\r\n" in result["request"]
         assert b"HTTP2-Settings:" in result["request"]


### PR DESCRIPTION
Closes #3303.

## Summary

This adds explicit h2c support to the experimental HTTP/2 adapter.

Related: #5015 splits out the HTTP/2 socket reuse fix that this change depends
on. If that lands first, I can rebase this PR so the remaining diff stays
focused on h2c.

The existing `inject_into_urllib3()` behavior is unchanged: HTTPS pools still use
HTTP/2 and HTTP pools stay on HTTP/1.1 by default. Cleartext HTTP/2 has to be
enabled explicitly:

- `inject_into_urllib3(h2c=True)`
- `inject_into_urllib3(h2c="prior_knowledge")`
- `inject_into_urllib3(h2c="upgrade")`

The prior-knowledge path uses a cleartext `HTTPConnection` socket and starts the
HTTP/2 connection immediately. The upgrade path sends an HTTP/1.1
`Upgrade: h2c` request, waits for `101 Switching Protocols`, and then continues
the request as HTTP/2 on stream 1.

The cleartext connection also uses `:scheme` `http` and port `80` as the default
authority port.

Prior-knowledge h2c now opens the cleartext socket before sending HTTP/2 frames
through an `HTTPConnectionPool`. HTTP/2 connections also avoid the HTTP/1.1
dropped-connection probe, since a readable HTTP/2 socket can just have control
frames waiting and should still be reusable.

I also reset h2c upgrade state when an upgrade falls back to an HTTP/1.1
response or when the connection is closed, so a pooled connection does not carry
stale HTTP/2 state into a later request.

## Tests

Added coverage for:

- prior-knowledge cleartext requests;
- HTTP/1.1 upgrade request headers;
- switching to HTTP/2 after a `101` response;
- `HTTPConnectionPool` with `h2c=True` reusing one connection for two requests;
- `HTTPConnectionPool` with `h2c="upgrade"` reusing one connection for two requests;
- opt-in injection and restoration behavior;
- repeated injection and upgrade-state reset behavior.

I also added a changelog fragment.

## Local checks

- `uv run pytest test/test_http2_connection.py test/test_compatibility.py -q`
- `uv run pytest test/with_dummyserver/test_https.py -q -k "http2 or alpn or simple"`
- `uv run pytest test/with_dummyserver/test_connectionpool.py -q -k "http2"`
- `uv run --group mypy mypy src/urllib3/http2/__init__.py src/urllib3/http2/connection.py test/test_http2_connection.py test/test_compatibility.py`
- `uv run --with pre-commit pre-commit run --files changelog/3303.feature.rst src/urllib3/http2/__init__.py src/urllib3/http2/connection.py test/test_http2_connection.py test/test_compatibility.py`
- `uv run towncrier check --compare-with origin/main`
