### PR TITLE
Keep HTTP/2 sockets reusable with pending control frames

### DIFF
--- a/changelog/3301.bugfix.rst
+++ b/changelog/3301.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed HTTP/2 connection reuse when control frames are waiting on the socket.

--- a/src/urllib3/http2/connection.py
+++ b/src/urllib3/http2/connection.py
@@ -109,6 +109,12 @@ class HTTP2Connection(HTTPSConnection):
             if data_to_send := conn.data_to_send():
                 self.sock.sendall(data_to_send)
 
+    @property
+    def is_connected(self) -> bool:
+        # Readable HTTP/2 sockets may only have control frames waiting, so the
+        # HTTP/1.1 dropped-connection probe is not reliable for HTTP/2.
+        return self.sock is not None
+
     def putrequest(  # type: ignore[override]
         self,
         method: str,

--- a/test/test_http2_connection.py
+++ b/test/test_http2_connection.py
@@ -3,8 +3,12 @@ from __future__ import annotations
 import socket
 from unittest import mock
 
+import h2.config
+import h2.connection
+import h2.events
 import pytest
 
+from urllib3 import HTTPSConnectionPool
 from urllib3.connection import _get_default_user_agent
 from urllib3.exceptions import ConnectionError
 from urllib3.http2.connection import (
@@ -79,6 +83,74 @@ class TestHTTP2Connection:
         conn = HTTP2Connection("example.com")
         assert conn.socket_options == [(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)]
         assert conn.port == 443
+
+    def test_pool_reuses_connection_with_pending_control_frame(self) -> None:
+        client_sock, server_sock = socket.socketpair()
+        server_h2 = h2.connection.H2Connection(
+            config=h2.config.H2Configuration(client_side=False)
+        )
+        conn = HTTP2Connection("example.com")
+        pool = HTTPSConnectionPool("example.com", maxsize=1)
+
+        try:
+            conn.sock = client_sock
+            with conn._h2_conn as client_h2:
+                client_h2.initiate_connection()
+                client_sock.sendall(client_h2.data_to_send())
+
+            server_h2.initiate_connection()
+            server_h2.receive_data(server_sock.recv(65535))
+            server_sock.sendall(server_h2.data_to_send())
+
+            conn.request("GET", "/")
+            events = server_h2.receive_data(server_sock.recv(65535))
+            stream_id = next(
+                event.stream_id
+                for event in events
+                if isinstance(event, h2.events.RequestReceived)
+            )
+            server_h2.send_headers(
+                stream_id,
+                [(":status", "200"), ("content-length", "2")],
+            )
+            server_h2.send_data(stream_id, b"ok", end_stream=True)
+            server_sock.sendall(server_h2.data_to_send())
+
+            response = conn.getresponse()
+            assert response.data == b"ok"
+
+            server_h2.ping(b"12345678")
+            server_sock.sendall(server_h2.data_to_send())
+
+            assert pool.pool is not None
+            pool.pool.get(block=False)
+            pool._put_conn(conn)
+
+            reused = pool._get_conn()
+            assert reused is conn
+            assert conn.sock is client_sock
+
+            reused.request("GET", "/again")
+            events = server_h2.receive_data(server_sock.recv(65535))
+            second_stream_id = next(
+                event.stream_id
+                for event in events
+                if isinstance(event, h2.events.RequestReceived)
+            )
+            assert second_stream_id > stream_id
+            server_h2.send_headers(
+                second_stream_id,
+                [(":status", "200"), ("content-length", "5")],
+            )
+            server_h2.send_data(second_stream_id, b"again", end_stream=True)
+            server_sock.sendall(server_h2.data_to_send())
+
+            second_response = reused.getresponse()
+            assert second_response.data == b"again"
+        finally:
+            conn.close()
+            pool.close()
+            server_sock.close()
 
     def test_putheader(self) -> None:
         conn = HTTP2Connection("example.com")


### PR DESCRIPTION
Closes #3301.

## Summary

HTTP/2 sockets can be readable even when the connection is still healthy. For
example, the peer may have sent a control frame after the response stream ended.
The HTTP/1.1 dropped-connection probe treats any readable socket as disconnected,
which can cause a pooled `HTTP2Connection` to be closed instead of reused.

This is also split out from #5014 so the socket reuse behavior can be reviewed
independently from h2c support.

This overrides `HTTP2Connection.is_connected` so the pool keeps an open HTTP/2
socket available for future requests. The existing request model is unchanged:
urllib3 still has one active request per pooled connection here, and this does
not add HTTP/2 multiplexing.

## Tests

Added a socketpair regression test that:

- sends a complete HTTP/2 response;
- leaves a pending HTTP/2 control frame on the socket;
- returns the connection to an `HTTPSConnectionPool`;
- checks that the same connection is reused without closing the socket;
- sends a second request on the reused HTTP/2 connection and reads the response.

## Local checks

- `uv run pytest test/test_http2_connection.py test/test_compatibility.py -q`
- `uv run pytest test/with_dummyserver/test_https.py -q -k "http2"`
- `uv run pytest test/with_dummyserver/test_connectionpool.py -q -k "http2"`
- `uv run --group mypy mypy src/urllib3/http2/connection.py test/test_http2_connection.py test/test_compatibility.py`
- `uv run --with pre-commit pre-commit run --files changelog/3301.bugfix.rst src/urllib3/http2/connection.py test/test_http2_connection.py`
- `uv run towncrier check --compare-with origin/main`
