### PR TITLE
Use seek and tell for file body length

### DIFF
--- a/changelog/3689.feature.rst
+++ b/changelog/3689.feature.rst
@@ -1,0 +1,1 @@
+Added ``Content-Length`` detection for seekable binary file-like request bodies.

--- a/src/urllib3/util/request.py
+++ b/src/urllib3/util/request.py
@@ -194,6 +194,44 @@ class ChunksAndContentLength(typing.NamedTuple):
     content_length: int | None
 
 
+def _get_body_file_position_length(body: typing.Any) -> int | None:
+    body_tell = getattr(body, "tell", None)
+    body_seek = getattr(body, "seek", None)
+
+    if body_tell is None or body_seek is None or isinstance(body, io.TextIOBase):
+        return None
+
+    try:
+        current_position = body_tell()
+    except (OSError, ValueError):
+        return None
+
+    if not isinstance(current_position, int):
+        return None
+
+    restored_position = False
+    try:
+        body_seek(0, io.SEEK_END)
+        end_position = body_tell()
+    except (OSError, ValueError):
+        return None
+    finally:
+        try:
+            body_seek(current_position)
+        except (OSError, ValueError):
+            pass
+        else:
+            restored_position = True
+
+    if not restored_position:
+        return None
+
+    if not isinstance(end_position, int):
+        return None
+
+    return max(0, end_position - current_position)
+
+
 def body_to_chunks(
     body: typing.Any | None, method: str, blocksize: int
 ) -> ChunksAndContentLength:
@@ -224,7 +262,7 @@ def body_to_chunks(
         chunks = (to_bytes(body),)
         content_length = len(chunks[0])
 
-    # File-like object, TODO: use seek() and tell() for length?
+    # File-like object.
     elif hasattr(body, "read"):
 
         def chunk_readable() -> typing.Iterable[bytes]:
@@ -238,7 +276,7 @@ def body_to_chunks(
                 yield datablock
 
         chunks = chunk_readable()
-        content_length = None
+        content_length = _get_body_file_position_length(body)
 
     # Otherwise we need to start checking via duck-typing.
     else:

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -26,7 +26,7 @@ from urllib3.exceptions import (
 from urllib3.util import is_fp_closed
 from urllib3.util.connection import _has_ipv6, allowed_gai_family, create_connection
 from urllib3.util.proxy import connection_requires_http_tunnel
-from urllib3.util.request import _FAILEDTELL, make_headers, rewind_body
+from urllib3.util.request import _FAILEDTELL, body_to_chunks, make_headers, rewind_body
 from urllib3.util.response import assert_header_parsing
 from urllib3.util.ssl_ import (
     _is_has_never_check_common_name_reliable,
@@ -621,6 +621,115 @@ class TestUtil:
 
         with pytest.raises(UnrewindableBodyError):
             rewind_body(BadSeek(), body_pos=2)
+
+    def test_body_to_chunks_uses_seek_tell_for_binary_file_length(self) -> None:
+        body = io.BytesIO(b"test data")
+        assert body.read(5) == b"test "
+
+        chunks, content_length = body_to_chunks(body, method="POST", blocksize=2)
+
+        assert content_length == 4
+        assert body.tell() == 5
+        assert chunks is not None
+        assert b"".join(chunks) == b"data"
+
+    def test_body_to_chunks_keeps_unknown_length_for_text_file(self) -> None:
+        body = io.StringIO("é test")
+
+        chunks, content_length = body_to_chunks(body, method="POST", blocksize=4)
+
+        assert content_length is None
+        assert chunks is not None
+        assert b"".join(chunks) == "é test".encode()
+
+    def test_body_to_chunks_keeps_unknown_length_without_seek_tell(self) -> None:
+        class ReadOnlyBody:
+            def __init__(self) -> None:
+                self._body = io.BytesIO(b"test data")
+
+            def read(self, blocksize: int) -> bytes:
+                return self._body.read(blocksize)
+
+        chunks, content_length = body_to_chunks(
+            ReadOnlyBody(), method="POST", blocksize=4
+        )
+
+        assert content_length is None
+        assert chunks is not None
+        assert b"".join(chunks) == b"test data"
+
+    def test_body_to_chunks_keeps_unknown_length_when_end_seek_fails(self) -> None:
+        class NoEndSeek(io.BytesIO):
+            def seek(self, offset: int, whence: int = 0) -> int:
+                if whence == io.SEEK_END:
+                    raise OSError
+                return super().seek(offset, whence)
+
+        body = NoEndSeek(b"test data")
+        assert body.read(5) == b"test "
+
+        chunks, content_length = body_to_chunks(body, method="POST", blocksize=2)
+
+        assert content_length is None
+        assert body.tell() == 5
+        assert chunks is not None
+        assert b"".join(chunks) == b"data"
+
+    def test_body_to_chunks_keeps_unknown_length_for_non_integer_position(
+        self,
+    ) -> None:
+        class NonIntegerPosition(io.BytesIO):
+            def tell(self) -> str:  # type: ignore[override]
+                return "0"
+
+        chunks, content_length = body_to_chunks(
+            NonIntegerPosition(b"test data"), method="POST", blocksize=4
+        )
+
+        assert content_length is None
+        assert chunks is not None
+        assert b"".join(chunks) == b"test data"
+
+    def test_body_to_chunks_keeps_unknown_length_when_restore_seek_fails(
+        self,
+    ) -> None:
+        class NoRestoreSeek(io.BytesIO):
+            fail_restore = False
+
+            def seek(self, offset: int, whence: int = 0) -> int:
+                if self.fail_restore and whence == io.SEEK_SET:
+                    raise OSError
+                position = super().seek(offset, whence)
+                if whence == io.SEEK_END:
+                    self.fail_restore = True
+                return position
+
+        chunks, content_length = body_to_chunks(
+            NoRestoreSeek(b"test data"), method="POST", blocksize=4
+        )
+
+        assert content_length is None
+        assert chunks is not None
+
+    def test_body_to_chunks_keeps_unknown_length_for_non_integer_end_position(
+        self,
+    ) -> None:
+        class NonIntegerEndPosition(io.BytesIO):
+            tell_calls = 0
+
+            def tell(self) -> int | str:  # type: ignore[override]
+                self.tell_calls += 1
+                if self.tell_calls == 1:
+                    return super().tell()
+                return "end"
+
+        chunks, content_length = body_to_chunks(
+            NonIntegerEndPosition(b"test data"), method="POST", blocksize=4
+        )
+
+        assert content_length is None
+        assert chunks is not None
+        assert b"".join(chunks) == b"test data"
 
     def test_add_stderr_logger(self) -> None:
         handler = add_stderr_logger(level=logging.INFO)  # Don't actually print debug

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -2124,7 +2124,7 @@ class TestHeaders(SocketDummyServerTestCase):
         elif body_type == "bytes-io":
             body = io.BytesIO(b"bytes-io-body")
             body.seek(0, 0)
-            expected = b"bytes-io-body\r\n0\r\n\r\n"
+            expected = b"\r\n\r\nbytes-io-body"
         else:
             raise ValueError("Unknown body type")
 
@@ -2606,6 +2606,8 @@ class TestContentFraming(SocketDummyServerTestCase):
 
             body = body_generator()
         elif body_type == "file":
+            if chunked is False:
+                pytest.skip("urllib3 uses Content-Length in this case")
             body = io.BytesIO(b"x" * 10)
             body.seek(0, 0)
         else:
@@ -2647,7 +2649,7 @@ class TestContentFraming(SocketDummyServerTestCase):
         elif body_type == "file":
             body = io.BytesIO(b"x" * 10)
             body.seek(0, 0)
-            should_be_chunked = True
+            should_be_chunked = False
         elif body_type == "file_text":
             body = io.StringIO("x" * 10)
             body.seek(0, 0)


### PR DESCRIPTION
Fixes #3689.

This uses `tell()` and `seek()` to detect the remaining length for binary file-like request bodies when the current position can be restored safely. Text streams and non-seekable bodies still keep an unknown length, so they continue using chunked framing.

Validation:
- `python -m pytest test/test_util.py::TestUtil::test_body_to_chunks_uses_seek_tell_for_binary_file_length test/test_util.py::TestUtil::test_body_to_chunks_keeps_unknown_length_for_text_file test/test_util.py::TestUtil::test_body_to_chunks_keeps_unknown_length_without_seek_tell test/test_util.py::TestUtil::test_body_to_chunks_keeps_unknown_length_when_end_seek_fails test/with_dummyserver/test_socketlevel.py::TestContentFraming::test_chunked_not_specified test/with_dummyserver/test_socketlevel.py::TestContentFraming::test_chunked_specified`
- `python -m towncrier check --compare-with origin/main`
- `python -m compileall src/urllib3/util/request.py test/test_util.py test/with_dummyserver/test_socketlevel.py`
- `git diff --check origin/main...HEAD`