### PR TITLE
Normalize obs-fold response header values

### DIFF
--- a/changelog/1362.bugfix.rst
+++ b/changelog/1362.bugfix.rst
@@ -1,0 +1,1 @@
+Replaced obsolete line folding in response header values with spaces.

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -77,6 +77,11 @@ port_by_scheme = {"http": 80, "https": 443}
 RECENT_DATE = datetime.date(2025, 1, 1)
 
 _CONTAINS_CONTROL_CHAR_RE = re.compile(r"[^-!#$%&'*+.^_`|~0-9a-zA-Z]")
+_OBS_FOLD_RE = re.compile(r"\r\n[ \t]+")
+
+
+def _normalize_response_header_value(value: str) -> str:
+    return _OBS_FOLD_RE.sub(" ", value)
 
 
 class HTTPConnection(_HTTPConnection):
@@ -580,7 +585,10 @@ class HTTPConnection(_HTTPConnection):
                 exc_info=True,
             )
 
-        headers = HTTPHeaderDict(httplib_response.msg.items())
+        headers = HTTPHeaderDict(
+            (key, _normalize_response_header_value(value))
+            for key, value in httplib_response.msg.items()
+        )
 
         response = HTTPResponse(
             body=httplib_response,

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -88,6 +88,22 @@ class TestCookies(SocketDummyServerTestCase):
             assert r.headers == {"set-cookie": "foo=1, bar=1"}
             assert r.headers.getlist("set-cookie") == ["foo=1", "bar=1"]
 
+    def test_setcookie_obs_fold_is_replaced_by_space(self) -> None:
+        self.start_response_handler(
+            b"HTTP/1.1 200 OK\r\n"
+            b"Content-Length: 0\r\n"
+            b"Set-Cookie: ___utmvbtouVBFmB=gZg\r\n"
+            b"    XbNOjalT: Lte; path=/; Max-Age=900\r\n"
+            b"\r\n"
+        )
+
+        with HTTPConnectionPool(self.host, self.port) as pool:
+            r = pool.request("GET", "/", retries=0)
+
+        assert r.headers.getlist("set-cookie") == [
+            "___utmvbtouVBFmB=gZg XbNOjalT: Lte; path=/; Max-Age=900"
+        ]
+
 
 class TestSNI(SocketDummyServerTestCase):
     def test_hostname_in_first_request_packet(self) -> None:


### PR DESCRIPTION
## Summary
- normalize obs-folded response header values to a single space before building `HTTPHeaderDict`
- add a socket-level regression test for folded `Set-Cookie` headers
- add a changelog fragment for issue #1362

Fixes #1362.

## Testing
- `.venv\\Scripts\\python.exe -m pytest test/with_dummyserver/test_socketlevel.py::TestCookies test/with_dummyserver/test_socketlevel.py::TestBrokenHeaders test/with_dummyserver/test_socketlevel.py::TestHeaderParsingContentType test/test_compatibility.py -q`