### PR TITLE
HTTPResponse: drain_conn in 64KiB chunks to avoid overloading memory

### DIFF
--- a/changelog/5019.bugfix.rst
+++ b/changelog/5019.bugfix.rst
@@ -1,1 +1,1 @@
-Fixed ``HTTPResponse.drain_conn()`` to discard unread response data in 128 KiB chunks, updated ``HTTPResponse.stream(...)`` default ``amt`` value to the same 128 KiB constant (increased from 64 KiB).
+Fixed ``HTTPResponse.drain_conn()`` to discard unread response data in 64 KiB chunks (same as the default ``amt`` when doing ``HTTPResponse.stream(...)``).

--- a/changelog/5019.bugfix.rst
+++ b/changelog/5019.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed ``HTTPResponse.drain_conn()`` to discard unread response data in 128 KiB chunks, updated ``HTTPResponse.stream(...)`` default ``amt`` value to the same 128 KiB constant (increased from 64 KiB).

--- a/src/urllib3/response.py
+++ b/src/urllib3/response.py
@@ -562,7 +562,7 @@ class BaseHTTPResponse(io.IOBase):
         self._retries = retries
 
     def stream(
-        self, amt: int | None = 2**16, decode_content: bool | None = None
+        self, amt: int | None = _READ_CHUNK_SIZE, decode_content: bool | None = None
     ) -> typing.Iterator[bytes]:
         raise NotImplementedError()
 
@@ -1240,7 +1240,7 @@ class HTTPResponse(BaseHTTPResponse):
         return self._decoded_buffer.get(amt)
 
     def stream(
-        self, amt: int | None = 2**16, decode_content: bool | None = None
+        self, amt: int | None = _READ_CHUNK_SIZE, decode_content: bool | None = None
     ) -> typing.Generator[bytes]:
         """
         A generator wrapper for the read() method. A call will block until

--- a/src/urllib3/response.py
+++ b/src/urllib3/response.py
@@ -50,8 +50,8 @@ if typing.TYPE_CHECKING:
 
 log = logging.getLogger(__name__)
 
-# Read in 128 KiB chunks, CPython http.client uses 1 MiB limit before chunking.
-_READ_CHUNK_SIZE = 1 << 17
+# Read in 64 KiB chunks
+_READ_CHUNK_SIZE = 1 << 16
 
 
 class ContentDecoder:

--- a/src/urllib3/response.py
+++ b/src/urllib3/response.py
@@ -50,6 +50,9 @@ if typing.TYPE_CHECKING:
 
 log = logging.getLogger(__name__)
 
+# Read in 128 KiB chunks, CPython http.client uses 1 MiB limit before chunking.
+_READ_CHUNK_SIZE = 1 << 17
+
 
 class ContentDecoder:
     def decompress(self, data: bytes, max_length: int = -1) -> bytes:
@@ -798,7 +801,8 @@ class HTTPResponse(BaseHTTPResponse):
         Unread data in the HTTPResponse connection blocks the connection from being released back to the pool.
         """
         try:
-            self._raw_read()
+            while self._raw_read(_READ_CHUNK_SIZE):
+                pass
         except (HTTPError, OSError, BaseSSLError, HTTPException):
             pass
         if self._has_decoded_content:

--- a/src/urllib3/response.py
+++ b/src/urllib3/response.py
@@ -51,7 +51,7 @@ if typing.TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 # Read in 64 KiB chunks
-_READ_CHUNK_SIZE = 1 << 16
+_READ_CHUNK_SIZE = 2 ** 16
 
 
 class ContentDecoder:

--- a/src/urllib3/response.py
+++ b/src/urllib3/response.py
@@ -51,7 +51,7 @@ if typing.TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 # Read in 64 KiB chunks
-_READ_CHUNK_SIZE = 2 ** 16
+_READ_CHUNK_SIZE = 2**16
 
 
 class ContentDecoder:


### PR DESCRIPTION
Should be a safe/conservative change. Let me know if 128KiB doesn't feel right or if we'd like any additional testing for it.

One question I had: I noticed in a few places we're doing chunked reads, and have another hardcoded value here in the read1 implementation from 3+ years ago:

https://github.com/urllib3/urllib3/blob/main/src/urllib3/response.py#L1224-L1232

And another default value to 64 KiB here:
https://github.com/urllib3/urllib3/blob/main/src/urllib3/response.py#L1238-L1240

Any chance we want to normalize them to one constant?