### PR TITLE
Unfold obsolete folded response header values

### DIFF
--- a/changelog/1362.bugfix.rst
+++ b/changelog/1362.bugfix.rst
@@ -1,0 +1,1 @@
+Unfolded obsolete folded response header values before exposing them through response headers.

--- a/changelog/1362.bugfix.rst
+++ b/changelog/1362.bugfix.rst
@@ -1,1 +1,3 @@
-Unfolded obsolete folded response header values before exposing them through response headers.
+Fixed response header handling to replace obsolete folded header lines
+(`obs-fold`) with spaces in accordance with RFC 9112, preventing raw
+CRLF sequences from appearing in header values such as ``Set-Cookie``.

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -77,6 +77,11 @@ port_by_scheme = {"http": 80, "https": 443}
 RECENT_DATE = datetime.date(2025, 1, 1)
 
 _CONTAINS_CONTROL_CHAR_RE = re.compile(r"[^-!#$%&'*+.^_`|~0-9a-zA-Z]")
+_OBSOLETE_FOLD_RE = re.compile(r"\r\n[ \t]+")
+
+
+def _normalize_header_value(value: str) -> str:
+    return _OBSOLETE_FOLD_RE.sub(" ", value)
 
 
 class HTTPConnection(_HTTPConnection):
@@ -616,7 +621,10 @@ class HTTPConnection(_HTTPConnection):
                 exc_info=True,
             )
 
-        headers = HTTPHeaderDict(httplib_response.msg.items())
+        headers = HTTPHeaderDict(
+            (name, _normalize_header_value(value))
+            for name, value in httplib_response.msg.items()
+        )
 
         response = HTTPResponse(
             body=httplib_response,

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -77,11 +77,37 @@ port_by_scheme = {"http": 80, "https": 443}
 RECENT_DATE = datetime.date(2025, 1, 1)
 
 _CONTAINS_CONTROL_CHAR_RE = re.compile(r"[^-!#$%&'*+.^_`|~0-9a-zA-Z]")
-_OBSOLETE_FOLD_RE = re.compile(r"\r\n[ \t]+")
+# Starting the optional OWS match at the beginning of a whitespace run avoids
+# quadratic backtracking for long header values.
+_OBSOLETE_FOLD_RE = re.compile(r"(?:(?<![ \t])[ \t]+)?\r\n[ \t]+")
 
 
 def _normalize_header_value(value: str) -> str:
+    if "\r\n" not in value:
+        return value
     return _OBSOLETE_FOLD_RE.sub(" ", value)
+
+
+def _normalize_header_values(
+    message: http.client.HTTPMessage,
+) -> list[tuple[str, str]]:
+    header_items = message.items()
+    headers_changed = False
+    for index, (name, value) in enumerate(header_items):
+        normalized_value = _normalize_header_value(value)
+        if normalized_value != value:
+            header_items[index] = (name, normalized_value)
+            headers_changed = True
+
+    if headers_changed:
+        # Keep the original message in sync for downstream consumers such as
+        # cookie jars while preserving its identity and header ordering.
+        for name, _ in header_items:
+            del message[name]
+        for name, value in header_items:
+            message[name] = value
+
+    return header_items
 
 
 class HTTPConnection(_HTTPConnection):
@@ -621,10 +647,8 @@ class HTTPConnection(_HTTPConnection):
                 exc_info=True,
             )
 
-        headers = HTTPHeaderDict(
-            (name, _normalize_header_value(value))
-            for name, value in httplib_response.msg.items()
-        )
+        header_items = _normalize_header_values(httplib_response.msg)
+        headers = HTTPHeaderDict(header_items)
 
         response = HTTPResponse(
             body=httplib_response,

--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import datetime
 import socket
 import typing
-from http.client import ResponseNotReady
+from http.client import HTTPMessage, ResponseNotReady
 from unittest import mock
 
 import pytest
@@ -14,6 +14,8 @@ from urllib3.connection import (  # type: ignore[attr-defined]
     HTTPConnection,
     HTTPSConnection,
     _match_hostname,
+    _normalize_header_value,
+    _normalize_header_values,
     _url_from_connection,
     _wrap_proxy_error,
 )
@@ -208,6 +210,43 @@ class TestConnection:
         # according to the rules defined in that file.
         two_years = datetime.timedelta(days=365 * 2)
         assert RECENT_DATE > (datetime.datetime.today() - two_years).date()
+
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            ("ordinary\tvalue", "ordinary\tvalue"),
+            ("before \t\r\n\t  after", "before after"),
+            ("one\r\n two\t\r\n\tthree", "one two three"),
+            ("one\r\n \r\n\tthree", "one  three"),
+        ],
+    )
+    def test_normalize_header_value(self, value: str, expected: str) -> None:
+        assert _normalize_header_value(value) == expected
+
+    def test_normalize_header_values_preserves_message(self) -> None:
+        message = HTTPMessage()
+        message["X-First"] = "one"
+        message["Set-Cookie"] = "a=1 \r\n two"
+        message["X-Second"] = "three"
+        message["Set-Cookie"] = "b=2"
+        message.set_payload("payload")
+        defects = message.defects
+        policy = message.policy
+
+        header_items = _normalize_header_values(message)
+
+        expected = [
+            ("X-First", "one"),
+            ("Set-Cookie", "a=1 two"),
+            ("X-Second", "three"),
+            ("Set-Cookie", "b=2"),
+        ]
+        assert header_items == expected
+        assert message.items() == expected
+        assert message.get_all("Set-Cookie") == ["a=1 two", "b=2"]
+        assert message.get_payload() == "payload"
+        assert message.defects is defects
+        assert message.policy is policy
 
     def test_HTTPSConnection_default_socket_options(self) -> None:
         conn = HTTPSConnection("not.a.real.host", port=443)

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -88,6 +88,32 @@ class TestCookies(SocketDummyServerTestCase):
             assert r.headers == {"set-cookie": "foo=1, bar=1"}
             assert r.headers.getlist("set-cookie") == ["foo=1", "bar=1"]
 
+    def test_setcookie_obsolete_line_folding_is_unfolded(self) -> None:
+        def folded_cookie_response_handler(listener: socket.socket) -> None:
+            sock = listener.accept()[0]
+
+            buf = b""
+            while not buf.endswith(b"\r\n\r\n"):
+                buf += sock.recv(65536)
+
+            sock.send(
+                b"HTTP/1.1 200 OK\r\n"
+                b"Set-Cookie: ___utmvbtouVBFmB=gZg\r\n"
+                b"    XbNOjalT: Lte; path=/; Max-Age=900\r\n"
+                b"Content-Length: 0\r\n"
+                b"\r\n"
+            )
+            sock.close()
+
+        self._start_server(folded_cookie_response_handler)
+        with HTTPConnectionPool(self.host, self.port) as pool:
+            r = pool.request("GET", "/", retries=0)
+
+            assert r.headers.getlist("set-cookie") == [
+                "___utmvbtouVBFmB=gZg XbNOjalT: Lte; path=/; Max-Age=900"
+            ]
+            assert "\r\n" not in r.headers["set-cookie"]
+
 
 class TestSNI(SocketDummyServerTestCase):
     def test_hostname_in_first_request_packet(self) -> None:

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -37,6 +37,7 @@ from dummyserver.testcase import SocketDummyServerTestCase, consume_socket
 from urllib3 import (
     BaseHTTPResponse,
     HTTPConnectionPool,
+    HTTPResponse,
     HTTPSConnectionPool,
     ProxyManager,
     util,
@@ -88,31 +89,61 @@ class TestCookies(SocketDummyServerTestCase):
             assert r.headers == {"set-cookie": "foo=1, bar=1"}
             assert r.headers.getlist("set-cookie") == ["foo=1", "bar=1"]
 
-    def test_setcookie_obsolete_line_folding_is_unfolded(self) -> None:
+    def test_obsolete_line_folding_is_unfolded(self) -> None:
         def folded_cookie_response_handler(listener: socket.socket) -> None:
-            sock = listener.accept()[0]
+            with listener.accept()[0] as sock:
+                buf = b""
+                while not buf.endswith(b"\r\n\r\n"):
+                    buf += sock.recv(65536)
 
-            buf = b""
-            while not buf.endswith(b"\r\n\r\n"):
-                buf += sock.recv(65536)
-
-            sock.send(
-                b"HTTP/1.1 200 OK\r\n"
-                b"Set-Cookie: ___utmvbtouVBFmB=gZg\r\n"
-                b"    XbNOjalT: Lte; path=/; Max-Age=900\r\n"
-                b"Content-Length: 0\r\n"
-                b"\r\n"
-            )
-            sock.close()
+                sock.sendall(
+                    b"HTTP/1.1 200 OK\r\n"
+                    b"Set-Cookie: ___utmvbtouVBFmB=gZg\r\n"
+                    b"    XbNOjalT: Lte; path=/; Max-Age=900\r\n"
+                    b"Set-Cookie: ordinary=1; Path=/\r\n"
+                    b"Fold-Space-Space: before \r\n"
+                    b" after\r\n"
+                    b"Fold-Space-Tab: before \r\n"
+                    b"\tafter\r\n"
+                    b"Fold-Tab-Space: before\t\r\n"
+                    b" after\r\n"
+                    b"Fold-Tab-Tab: before\t\r\n"
+                    b"\tafter\r\n"
+                    b"Fold-Mixed-Repeated: one \t\r\n"
+                    b"\t  two\t \r\n"
+                    b" \tthree\r\n"
+                    b"Ordinary: one\t two\r\n"
+                    b"Content-Length: 0\r\n"
+                    b"\r\n"
+                )
 
         self._start_server(folded_cookie_response_handler)
         with HTTPConnectionPool(self.host, self.port) as pool:
             r = pool.request("GET", "/", retries=0)
 
             assert r.headers.getlist("set-cookie") == [
-                "___utmvbtouVBFmB=gZg XbNOjalT: Lte; path=/; Max-Age=900"
+                "___utmvbtouVBFmB=gZg XbNOjalT: Lte; path=/; Max-Age=900",
+                "ordinary=1; Path=/",
             ]
-            assert "\r\n" not in r.headers["set-cookie"]
+            assert r.headers["fold-space-space"] == "before after"
+            assert r.headers["fold-space-tab"] == "before after"
+            assert r.headers["fold-tab-space"] == "before after"
+            assert r.headers["fold-tab-tab"] == "before after"
+            assert r.headers["fold-mixed-repeated"] == "one two three"
+            assert r.headers["ordinary"] == "one\t two"
+            assert r.headers["content-length"] == "0"
+            assert all(
+                "\r" not in value and "\n" not in value for value in r.headers.values()
+            )
+
+            assert isinstance(r, HTTPResponse)
+            assert r._original_response is not None
+            assert r._original_response.headers is r._original_response.msg
+            assert r._original_response.msg.get_all("set-cookie") == [
+                "___utmvbtouVBFmB=gZg XbNOjalT: Lte; path=/; Max-Age=900",
+                "ordinary=1; Path=/",
+            ]
+            assert r._original_response.msg["fold-mixed-repeated"] == "one two three"
 
 
 class TestSNI(SocketDummyServerTestCase):


### PR DESCRIPTION
Addresses the original obs-fold response-header case discussed in #1362.

Python's `http.client` preserves obsolete folded response header lines in
`HTTPMessage` values. This change replaces each RFC 9112
`OWS CRLF RWS` sequence with a single space before urllib3 or downstream
consumers interpret the value.

The normalization:

- keeps urllib3's `HTTPHeaderDict` and the original `HTTPMessage` synchronized,
  preventing cookie consumers such as Requests from re-emitting raw CRLF;
- preserves header names, ordering, duplicate fields, and parser state;
- uses a common-case fast path and a linear-time pattern for long field values.

The socket regression covers the original folded `Set-Cookie`, duplicate
cookies, every SP/HTAB combination around CRLF, mixed and repeated whitespace,
multiple folds, and ordinary headers. Focused unit coverage also verifies
adjacent folds and preservation of the original message's order, duplicates,
payload, policy, and defects.

This intentionally does not address the separate whitespace-before-colon/header
name validation scope discussed on #1362.

Validation performed:

- full local suite: 2,279 passed, 333 skipped, 4 xfailed;
- focused strict nox sessions on Python 3.12, 3.13, and 3.14;
- pyupgrade, Black, isort, and flake8;
- towncrier changelog validation;
- source distribution and wheel builds;
- end-to-end Requests cookie extraction and subsequent request serialization.
