### PR TITLE
Fix ProxyManager honoring default socket options

### DIFF
--- a/changelog/2936.bugfix.rst
+++ b/changelog/2936.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed ``ProxyManager`` ignoring customized ``HTTPConnection.default_socket_options`` values when creating proxy connections.

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -76,6 +76,15 @@ port_by_scheme = {"http": 80, "https": 443}
 # (ie test_recent_date is failing) update it to ~6 months before the current date.
 RECENT_DATE = datetime.date(2025, 1, 1)
 
+_DEFAULT_SOCKET_OPTIONS = ((socket.IPPROTO_TCP, socket.TCP_NODELAY, 1),)
+
+
+class _DefaultSocketOptionsType:
+    pass
+
+
+_DEFAULT_SOCKET_OPTIONS_SENTINEL = _DefaultSocketOptionsType()
+
 _CONTAINS_CONTROL_CHAR_RE = re.compile(r"[^-!#$%&'*+.^_`|~0-9a-zA-Z]")
 
 
@@ -109,7 +118,7 @@ class HTTPConnection(_HTTPConnection):
     #: Disable Nagle's algorithm by default.
     #: ``[(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)]``
     default_socket_options: typing.ClassVar[connection._TYPE_SOCKET_OPTIONS] = [
-        (socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+        *_DEFAULT_SOCKET_OPTIONS
     ]
 
     #: Whether this connection verifies the host's certificate.
@@ -137,9 +146,9 @@ class HTTPConnection(_HTTPConnection):
         timeout: _TYPE_TIMEOUT = _DEFAULT_TIMEOUT,
         source_address: tuple[str, int] | None = None,
         blocksize: int = 16384,
-        socket_options: None | (
-            connection._TYPE_SOCKET_OPTIONS
-        ) = default_socket_options,
+        socket_options: (
+            None | (connection._TYPE_SOCKET_OPTIONS) | _DefaultSocketOptionsType
+        ) = _DEFAULT_SOCKET_OPTIONS_SENTINEL,
         proxy: Url | None = None,
         proxy_config: ProxyConfig | None = None,
     ) -> None:
@@ -150,6 +159,8 @@ class HTTPConnection(_HTTPConnection):
             source_address=source_address,
             blocksize=blocksize,
         )
+        if isinstance(socket_options, _DefaultSocketOptionsType):
+            socket_options = self.default_socket_options
         self.socket_options = socket_options
         self.proxy = proxy
         self.proxy_config = proxy_config
@@ -268,7 +279,7 @@ class HTTPConnection(_HTTPConnection):
 
                 response = self.response_class(self.sock, method=self._method)  # type: ignore[attr-defined]
                 try:
-                    (version, code, message) = response._read_status()  # type: ignore[attr-defined]
+                    version, code, message = response._read_status()  # type: ignore[attr-defined]
 
                     if code != http.HTTPStatus.OK:
                         self.close()
@@ -310,7 +321,7 @@ class HTTPConnection(_HTTPConnection):
 
                 response = self.response_class(self.sock, method=self._method)  # type: ignore[attr-defined]
                 try:
-                    (version, code, message) = response._read_status()  # type: ignore[attr-defined]
+                    version, code, message = response._read_status()  # type: ignore[attr-defined]
 
                     self._raw_proxy_headers = http.client._read_headers(response.fp)  # type: ignore[attr-defined]
 
@@ -626,9 +637,9 @@ class HTTPSConnection(HTTPConnection):
         timeout: _TYPE_TIMEOUT = _DEFAULT_TIMEOUT,
         source_address: tuple[str, int] | None = None,
         blocksize: int = 16384,
-        socket_options: None | (
-            connection._TYPE_SOCKET_OPTIONS
-        ) = HTTPConnection.default_socket_options,
+        socket_options: (
+            None | (connection._TYPE_SOCKET_OPTIONS) | _DefaultSocketOptionsType
+        ) = _DEFAULT_SOCKET_OPTIONS_SENTINEL,
         proxy: Url | None = None,
         proxy_config: ProxyConfig | None = None,
         cert_reqs: int | str | None = None,

--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -14,6 +14,7 @@ from ._base_connection import _TYPE_BODY
 from ._collections import HTTPHeaderDict
 from ._request_methods import RequestMethods
 from .connection import (
+    _DEFAULT_SOCKET_OPTIONS,
     BaseSSLError,
     BrokenPipeError,
     DummyConnection,
@@ -216,9 +217,15 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
 
         if self.proxy:
             # Enable Nagle's algorithm for proxies, to avoid packet fragmentation.
-            # Defaulting `socket_options` to an empty list avoids it defaulting to
-            # ``HTTPConnection.default_socket_options``.
-            self.conn_kw.setdefault("socket_options", [])
+            # Defaulting `socket_options` to an empty list avoids using the
+            # built-in ``HTTPConnection.default_socket_options``. If the
+            # default options have been customized then respect that value.
+            if (
+                "socket_options" not in self.conn_kw
+                and tuple(self.ConnectionCls.default_socket_options)
+                == _DEFAULT_SOCKET_OPTIONS
+            ):
+                self.conn_kw["socket_options"] = []
 
             self.conn_kw["proxy"] = self.proxy
             self.conn_kw["proxy_config"] = self.proxy_config

--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -213,6 +213,20 @@ class TestConnection:
         conn = HTTPSConnection("not.a.real.host", port=443)
         assert conn.socket_options == [(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)]
 
+    def test_connection_default_socket_options_are_dynamic(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        socket_options = HTTPConnection.default_socket_options + [
+            (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
+        ]
+        monkeypatch.setattr(HTTPConnection, "default_socket_options", socket_options)
+
+        http_conn = HTTPConnection("not.a.real.host", port=80)
+        https_conn = HTTPSConnection("not.a.real.host", port=443)
+
+        assert http_conn.socket_options == socket_options
+        assert https_conn.socket_options == socket_options
+
     @pytest.mark.parametrize(
         "proxy_scheme, err_part",
         [

--- a/test/test_proxymanager.py
+++ b/test/test_proxymanager.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import socket
+
 import pytest
 
+from urllib3.connection import HTTPConnection
 from urllib3.exceptions import MaxRetryError, NewConnectionError, ProxyError
 from urllib3.poolmanager import ProxyManager
 from urllib3.util.retry import Retry
@@ -48,6 +51,26 @@ class TestProxyManager:
         with ProxyManager("https://something") as p:
             assert p.proxy is not None
             assert p.proxy.port == 443
+
+    def test_default_proxy_socket_options_are_empty(self) -> None:
+        with ProxyManager("http://proxy:8080") as p:
+            pool = p.connection_from_host("example.com", scheme="http")
+            assert pool.conn_kw["socket_options"] == []
+
+    def test_custom_default_socket_options_are_honored(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        socket_options = HTTPConnection.default_socket_options + [
+            (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
+        ]
+        monkeypatch.setattr(HTTPConnection, "default_socket_options", socket_options)
+
+        with ProxyManager("http://proxy:8080") as p:
+            pool = p.connection_from_host("example.com", scheme="http")
+            conn = pool._new_conn()
+
+        assert "socket_options" not in pool.conn_kw
+        assert conn.socket_options == socket_options
 
     def test_invalid_scheme(self) -> None:
         with pytest.raises(AssertionError):


### PR DESCRIPTION
Closes #2936.

## Summary
- Resolve `HTTPConnection.default_socket_options` dynamically when connections are instantiated.
- Keep the existing proxy default of empty `socket_options` when defaults are unmodified, while honoring customized defaults for proxy connections.
- Add regression coverage for direct connections and `ProxyManager`, plus a changelog entry.

## Testing
- `python -m pytest test/test_connection.py`
- `python -m pytest test/test_poolmanager.py test/test_proxymanager.py`
- `python -m mypy -m urllib3.connection -m urllib3.connectionpool`
- `python -m black --check --target-version py310 src/urllib3/connection.py src/urllib3/connectionpool.py test/test_connection.py test/test_proxymanager.py`
- `python -m isort --check-only src/urllib3/connection.py src/urllib3/connectionpool.py test/test_connection.py test/test_proxymanager.py`
- `python -m flake8 src/urllib3/connection.py src/urllib3/connectionpool.py test/test_connection.py test/test_proxymanager.py`
- `python -m compileall -q src/urllib3`