### PR TITLE
Make `is_ipaddress` detect non-standard forms of IPv4 addresses

### DIFF
--- a/changelog/5029.bugfix.rst
+++ b/changelog/5029.bugfix.rst
@@ -1,0 +1,4 @@
+Fixed ``is_ipaddress()`` to detect non-standard IPv4 forms accepted by
+``socket.connect``, such as hex (``0x7f000001``), octal (``0177.0.0.1``), and
+decimal integers (``2130706433``), ensuring SSL certificate verification uses
+the correct mode for these addresses.

--- a/src/urllib3/util/url.py
+++ b/src/urllib3/util/url.py
@@ -55,7 +55,9 @@ _IPV6_ADDRZ_PAT = r"\[" + _IPV6_PAT + r"(?:" + _ZONE_ID_PAT + r")?\]"
 _REG_NAME_PAT = r"(?:[^\[\]%:/?#]|%[a-fA-F0-9]{2})*"
 _TARGET_RE = re.compile(r"^(/[^?#]*)(?:\?([^#]*))?(?:#.*)?$")
 
-_IPV4_RE = re.compile("^" + _IPV4_PAT + "$")
+_IPV4_RE = re.compile(
+    r"^(?:0[xX][0-9a-fA-F]+|[0-9]+)(?:\.(?:0[xX][0-9a-fA-F]+|[0-9]+)){0,3}$"
+)
 _IPV6_RE = re.compile("^" + _IPV6_PAT + "$")
 _IPV6_ADDRZ_RE = re.compile("^" + _IPV6_ADDRZ_PAT + "$")
 _BRACELESS_IPV6_ADDRZ_RE = re.compile("^" + _IPV6_ADDRZ_PAT[2:-2] + "$")

--- a/test/test_ssl.py
+++ b/test/test_ssl.py
@@ -23,6 +23,13 @@ class TestSSL:
             "127.0.0.1",
             "8.8.8.8",
             b"127.0.0.1",
+            # Non-standard IPv4 forms accepted by socket.connect
+            "2130706433",  # decimal integer
+            "0x7f000001",  # hex integer
+            "0177.0.0.01",  # dotted octal
+            "0x7f.0x0.0x0.0x1",  # dotted hex
+            "127.1",  # 2-part
+            "127.0.1",  # 3-part
             # IPv6 w/ Zone IDs
             "FE80::8939:7684:D84b:a5A4%251",
             b"FE80::8939:7684:D84b:a5A4%251",


### PR DESCRIPTION
@christos-spearbit highlighted that urllib3 can connect to hosts represented as non-standard IPv4 addresses via `socket.connect` (e.g., `urllib3.request("GET", "http://2130706433:8000/")`), but our `is_ipaddress` function does not detect such forms so some logic of the library that relies on `is_ipaddress` may be missed.

I update the `_IPV4_RE` regex to match the forms too.

FYI, non-standard IPv4 forms are not allowed inside IPv4-mapped IPv6 addresses like `::ffff:192.168.1.1`, so urllib3's logic for them is aligned with RFCs.