### PR TITLE
Decode SOCKS proxy credentials from URLs

### DIFF
--- a/changelog/3785.bugfix.rst
+++ b/changelog/3785.bugfix.rst
@@ -1,0 +1,1 @@
+Decoded percent-encoded SOCKS proxy credentials before authenticating with the proxy server.

--- a/src/urllib3/contrib/socks.py
+++ b/src/urllib3/contrib/socks.py
@@ -59,6 +59,7 @@ except ImportError:
 
 import typing
 from socket import timeout as SocketTimeout
+from urllib.parse import unquote
 
 from ..connection import HTTPConnection, HTTPSConnection
 from ..connectionpool import HTTPConnectionPool, HTTPSConnectionPool
@@ -193,9 +194,9 @@ class SOCKSProxyManager(PoolManager):
         parsed = parse_url(proxy_url)
 
         if username is None and password is None and parsed.auth is not None:
-            split = parsed.auth.split(":")
-            if len(split) == 2:
-                username, password = split
+            username, separator, password = parsed.auth.partition(":")
+            username = unquote(username)
+            password = unquote(password) if separator else None
         if parsed.scheme == "socks5":
             socks_version = socks.PROXY_TYPE_SOCKS5
             rdns = False

--- a/test/contrib/test_socks.py
+++ b/test/contrib/test_socks.py
@@ -482,6 +482,42 @@ class TestSocks5Proxy(IPV4SocketDummyServerTestCase):
             assert response.data == b""
             assert response.headers["Server"] == "SocksTestServer"
 
+    def test_socks_with_percent_encoded_auth_in_url(self) -> None:
+        def request_handler(listener: socket.socket) -> None:
+            sock = listener.accept()[0]
+
+            handler = handle_socks5_negotiation(
+                sock, negotiate=True, username=b"user:name", password=b"pa@ss"
+            )
+            addr, port = next(handler)
+
+            assert addr == "16.17.18.19"
+            assert port == 80
+            with pytest.raises(StopIteration):
+                handler.send(True)
+
+            while True:
+                buf = sock.recv(65535)
+                if buf.endswith(b"\r\n\r\n"):
+                    break
+
+            sock.sendall(
+                b"HTTP/1.1 200 OK\r\n"
+                b"Server: SocksTestServer\r\n"
+                b"Content-Length: 0\r\n"
+                b"\r\n"
+            )
+            sock.close()
+
+        self._start_server(request_handler)
+        proxy_url = f"socks5://user%3Aname:pa%40ss@{self.host}:{self.port}"
+        with socks.SOCKSProxyManager(proxy_url) as pm:
+            response = pm.request("GET", "http://16.17.18.19")
+
+            assert response.status == 200
+            assert response.data == b""
+            assert response.headers["Server"] == "SocksTestServer"
+
     def test_socks_with_invalid_password(self, monkeypatch: pytest.MonkeyPatch) -> None:
         _set_up_fake_getaddrinfo(monkeypatch)
 
@@ -703,6 +739,40 @@ class TestSOCKS4Proxy(IPV4SocketDummyServerTestCase):
         self._start_server(request_handler)
         proxy_url = f"socks4://{self.host}:{self.port}"
         with socks.SOCKSProxyManager(proxy_url, username="user") as pm:
+            response = pm.request("GET", "http://16.17.18.19")
+
+            assert response.status == 200
+            assert response.data == b""
+            assert response.headers["Server"] == "SocksTestServer"
+
+    def test_socks4_with_percent_encoded_username_in_url(self) -> None:
+        def request_handler(listener: socket.socket) -> None:
+            sock = listener.accept()[0]
+
+            handler = handle_socks4_negotiation(sock, username=b"user:name")
+            addr, port = next(handler)
+
+            assert addr == "16.17.18.19"
+            assert port == 80
+            with pytest.raises(StopIteration):
+                handler.send(True)
+
+            while True:
+                buf = sock.recv(65535)
+                if buf.endswith(b"\r\n\r\n"):
+                    break
+
+            sock.sendall(
+                b"HTTP/1.1 200 OK\r\n"
+                b"Server: SocksTestServer\r\n"
+                b"Content-Length: 0\r\n"
+                b"\r\n"
+            )
+            sock.close()
+
+        self._start_server(request_handler)
+        proxy_url = f"socks4://user%3Aname@{self.host}:{self.port}"
+        with socks.SOCKSProxyManager(proxy_url) as pm:
             response = pm.request("GET", "http://16.17.18.19")
 
             assert response.status == 200


### PR DESCRIPTION
﻿## Summary

- decode SOCKS proxy credentials parsed from `proxy_url` before passing them to PySocks
- use `partition(:)` so URL credentials with an optional password are handled consistently
- add regression coverage for percent-encoded SOCKS5 credentials and SOCKS4 usernames, plus a changelog entry

## Rationale

`parse_url()` keeps RFC 3986 userinfo percent-encoded. `SOCKSProxyManager` currently forwards those encoded bytes directly to the proxy server, so credentials such as `user%3Aname` or `pa%40ss` fail authentication even though the URL itself is valid. Decoding after the username/password split preserves the separator semantics while giving the proxy the intended credentials.

Fixes #3785.

## Validation

- Not run locally
- relying on the repository's GitHub Actions checks for remote validation