### PR TITLE
Clarify Retry-After status code docs

### DIFF
--- a/changelog/3546.bugfix.rst
+++ b/changelog/3546.bugfix.rst
@@ -1,0 +1,2 @@
+Clarified the documentation for ``Retry.RETRY_AFTER_STATUS_CODES`` to describe
+its ``Retry-After`` behavior accurately.

--- a/src/urllib3/util/retry.py
+++ b/src/urllib3/util/retry.py
@@ -198,7 +198,7 @@ class Retry:
         ["HEAD", "GET", "PUT", "DELETE", "OPTIONS", "TRACE"]
     )
 
-    #: Default status codes to be used for ``status_forcelist``
+    #: Default status codes for which to honor ``Retry-After`` headers.
     RETRY_AFTER_STATUS_CODES = frozenset([413, 429, 503])
 
     #: Default headers to be used for ``remove_headers_on_redirect``


### PR DESCRIPTION
Fixes #3546.

## Summary
- clarify that `Retry.RETRY_AFTER_STATUS_CODES` identifies statuses for which `Retry-After` headers are honored
- avoid implying that the constant is the default value of `status_forcelist`

## Validation
- Not run locally
- Awaiting remote CI signal on this PR.