### PR TITLE
Document retry backoff guidance

### DIFF
--- a/changelog/3677.feature.rst
+++ b/changelog/3677.feature.rst
@@ -1,0 +1,1 @@
+Documented how to configure retry backoff when enabling retries.

--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -596,6 +596,23 @@ For example, to do a total of 3 retries, but limit to only 2 redirects:
     )
     # MaxRetryError
 
+When enabling retries after failures, set a non-zero ``backoff_factor`` so
+urllib3 waits between attempts instead of retrying immediately. If many clients
+may retry at the same time, ``backoff_jitter`` can help spread those attempts
+out:
+
+.. code-block:: python
+
+    urllib3.request(
+        "GET",
+        "https://httpbin.org/status/503",
+        retries=urllib3.Retry(
+            total=5,
+            backoff_factor=0.2,
+            backoff_jitter=0.1,
+        ),
+    )
+
 You can also disable exceptions for too many redirects and just return the
 ``302`` response:
 


### PR DESCRIPTION
## Summary
- document that failure retries should use a non-zero `backoff_factor`
- mention `backoff_jitter` as a way to spread simultaneous retries
- add a changelog fragment for the new guidance

## Why
The user guide already shows how to configure `Retry`, but it does not currently explain that the default `backoff_factor=0` retries immediately. Issue #3677 asks for clearer best-practice guidance when enabling retries, without changing the default itself.

Closes #3677.

## Validation
- Not run locally
- Awaiting remote CI from GitHub / Read the Docs.