### PR TITLE
Sanitize folded response header values

### DIFF
--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -77,6 +77,7 @@ port_by_scheme = {"http": 80, "https": 443}
 RECENT_DATE = datetime.date(2025, 1, 1)
 
 _CONTAINS_CONTROL_CHAR_RE = re.compile(r"[^-!#$%&'*+.^_`|~0-9a-zA-Z]")
+_HEADER_FOLDING_RE = re.compile(r"\r?\n[ \t]+")
 
 
 class HTTPConnection(_HTTPConnection):
@@ -580,7 +581,13 @@ class HTTPConnection(_HTTPConnection):
                 exc_info=True,
             )
 
-        headers = HTTPHeaderDict(httplib_response.msg.items())
+        headers = HTTPHeaderDict()
+        for header, value in httplib_response.msg.items():
+            # Unfold obsolete folded headers and strip CR/LF to avoid header injection.
+            sanitized_value = _HEADER_FOLDING_RE.sub(" ", value).replace(
+                "\r", " "
+            ).replace("\n", " ")
+            headers.add(header, sanitized_value)
 
         response = HTTPResponse(
             body=httplib_response,

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -88,6 +88,31 @@ class TestCookies(SocketDummyServerTestCase):
             assert r.headers == {"set-cookie": "foo=1, bar=1"}
             assert r.headers.getlist("set-cookie") == ["foo=1", "bar=1"]
 
+    def test_folded_set_cookie_header_is_unfolded(self) -> None:
+        def folded_cookie_response_handler(listener: socket.socket) -> None:
+            sock = listener.accept()[0]
+
+            buf = b""
+            while not buf.endswith(b"\r\n\r\n"):
+                buf += sock.recv(65536)
+
+            sock.send(
+                b"HTTP/1.1 200 OK\r\n"
+                b"Set-Cookie: foo=bar\r\n"
+                b"\tbaz=qux; Path=/\r\n"
+                b"Content-Length: 0\r\n"
+                b"\r\n"
+            )
+            sock.close()
+
+        self._start_server(folded_cookie_response_handler)
+        with HTTPConnectionPool(self.host, self.port) as pool:
+            response = pool.request("GET", "/", retries=0)
+            cookie = response.headers["set-cookie"]
+            assert "\r" not in cookie
+            assert "\n" not in cookie
+            assert cookie == "foo=bar baz=qux; Path=/"
+
 
 class TestSNI(SocketDummyServerTestCase):
     def test_hostname_in_first_request_packet(self) -> None:


### PR DESCRIPTION
## Summary
- unfold obsolete folded response header values (obs-fold) into spaces before storing headers
- strip remaining CR/LF characters from header values to prevent newline propagation
- add a socket-level regression test for folded `Set-Cookie` values

## Testing
- `pytest -q test/with_dummyserver/test_socketlevel.py -k "folded_set_cookie_header_is_unfolded or multi_setcookie"`

Closes #1362
