### PR TITLE
Reject folded response headers

### DIFF
--- a/changelog/5034.bugfix.rst
+++ b/changelog/5034.bugfix.rst
@@ -1,0 +1,1 @@
+Rejected HTTP responses containing folded header values.

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -22,7 +22,7 @@ if typing.TYPE_CHECKING:
 
 from ._collections import HTTPHeaderDict
 from .http2 import probe as http2_probe
-from .util.response import assert_header_parsing
+from .util.response import assert_header_parsing, assert_no_response_header_folding
 from .util.timeout import _DEFAULT_TIMEOUT, _TYPE_TIMEOUT, Timeout
 from .util.util import to_str
 from .util.wait import wait_for_read
@@ -579,6 +579,8 @@ class HTTPConnection(_HTTPConnection):
                 hpe,
                 exc_info=True,
             )
+
+        assert_no_response_header_folding(httplib_response.msg)
 
         headers = HTTPHeaderDict(httplib_response.msg.items())
 

--- a/src/urllib3/util/response.py
+++ b/src/urllib3/util/response.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import http.client as httplib
 from email.errors import MultipartInvariantViolationDefect, StartBoundaryNotFoundDefect
 
-from ..exceptions import HeaderParsingError
+from ..exceptions import HeaderParsingError, InvalidHeader
 
 
 def is_fp_closed(obj: object) -> bool:
@@ -86,6 +86,12 @@ def assert_header_parsing(headers: httplib.HTTPMessage) -> None:
 
     if defects or unparsed_data:
         raise HeaderParsingError(defects=defects, unparsed_data=unparsed_data)
+
+
+def assert_no_response_header_folding(headers: httplib.HTTPMessage) -> None:
+    for name, value in headers.items():
+        if "\r" in value or "\n" in value:
+            raise InvalidHeader(f"Invalid folded response header {name!r}: {value!r}")
 
 
 def is_response_to_head(response: httplib.HTTPResponse) -> bool:

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -19,6 +19,7 @@ from urllib3 import add_stderr_logger, disable_warnings
 from urllib3.connection import ProxyConfig
 from urllib3.exceptions import (
     InsecureRequestWarning,
+    InvalidHeader,
     LocationParseError,
     TimeoutStateError,
     UnrewindableBodyError,
@@ -27,7 +28,10 @@ from urllib3.util import is_fp_closed
 from urllib3.util.connection import _has_ipv6, allowed_gai_family, create_connection
 from urllib3.util.proxy import connection_requires_http_tunnel
 from urllib3.util.request import _FAILEDTELL, make_headers, rewind_body
-from urllib3.util.response import assert_header_parsing
+from urllib3.util.response import (
+    assert_header_parsing,
+    assert_no_response_header_folding,
+)
 from urllib3.util.ssl_ import (
     _is_has_never_check_common_name_reliable,
     resolve_cert_reqs,
@@ -851,6 +855,21 @@ class TestUtil:
         )
         header_msg.seek(0)
         assert_header_parsing(client.parse_headers(header_msg))
+
+    def test_assert_no_response_header_folding_raises_on_folded_value(self) -> None:
+        from http import client
+
+        header_msg = io.BytesIO(b"Set-Cookie: a=b\r\n\tX-Foo: bar\r\n\r\n")
+
+        with pytest.raises(InvalidHeader, match="Invalid folded response header"):
+            assert_no_response_header_folding(client.parse_headers(header_msg))
+
+    def test_assert_no_response_header_folding_accepts_plain_values(self) -> None:
+        from http import client
+
+        header_msg = io.BytesIO(b"Set-Cookie: a=b\r\nX-Foo: bar\r\n\r\n")
+
+        assert_no_response_header_folding(client.parse_headers(header_msg))
 
     @pytest.mark.parametrize("host", [".localhost", "...", "t" * 64])
     def test_create_connection_with_invalid_idna_labels(self, host: str) -> None:

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -46,6 +46,7 @@ from urllib3.connection import HTTPConnection, _get_default_user_agent
 from urllib3.connectionpool import _url_from_pool
 from urllib3.exceptions import (
     InsecureRequestWarning,
+    InvalidHeader,
     MaxRetryError,
     ProtocolError,
     ProxyError,
@@ -2209,6 +2210,20 @@ class TestBrokenHeaders(SocketDummyServerTestCase):
         self._test_broken_header_parsing(
             [b"Broken Header", b"Another: Header"], "Broken Header"
         )
+
+    def test_folded_response_header_is_rejected(self) -> None:
+        self.start_response_handler(
+            b"HTTP/1.1 200 OK\r\n"
+            b"Content-Length: 0\r\n"
+            b"Content-type: text/plain\r\n"
+            b"Set-Cookie: a=b\r\n"
+            b"\tX-Foo: bar\r\n"
+            b"\r\n"
+        )
+
+        with HTTPConnectionPool(self.host, self.port, retries=False) as pool:
+            with pytest.raises(InvalidHeader, match="Invalid folded response header"):
+                pool.request("GET", "/")
 
 
 class TestHeaderParsingContentType(SocketDummyServerTestCase):


### PR DESCRIPTION
### Summary
- reject HTTP responses whose parsed header values still contain folded CR/LF continuations
- add a response-header helper plus unit coverage
- add socket-level coverage for a folded `Set-Cookie` response header
- keep the fix narrow: invalid folded response headers are rejected instead of silently sanitizing or accepting them

### Testing
- `uv run --group test pytest test/test_util.py -k 'assert_header_parsing or assert_no_response_header_folding'`
- `uv run --group test pytest test/with_dummyserver/test_socketlevel.py -k 'folded_response_header_is_rejected or BrokenHeaders'`
- `uv run --group test pytest test/test_util.py test/with_dummyserver/test_socketlevel.py`
- `uv run --group mypy mypy src/urllib3/util/response.py src/urllib3/connection.py`
- GitHub CI is now fully green on the PR: package, changelog, CodeQL, lint, downstream requests/botocore, docs, coverage, and the full Python/platform matrix all report success.

/claim #5034
