### PR TITLE
Construct auth headers from URL userinfo

### DIFF
--- a/changelog/1999.feature.rst
+++ b/changelog/1999.feature.rst
@@ -1,0 +1,1 @@
+Added support for constructing ``Authorization`` and ``Proxy-Authorization`` headers from username and password sections of request and proxy URLs.

--- a/src/urllib3/poolmanager.py
+++ b/src/urllib3/poolmanager.py
@@ -20,6 +20,7 @@ from .exceptions import (
 from .response import BaseHTTPResponse
 from .util.connection import _TYPE_SOCKET_OPTIONS
 from .util.proxy import connection_requires_http_tunnel
+from .util.request import make_headers
 from .util.retry import Retry
 from .util.timeout import Timeout
 from .util.url import Url, parse_url
@@ -159,6 +160,27 @@ key_fn_by_scheme = {
 }
 
 pool_classes_by_scheme = {"http": HTTPConnectionPool, "https": HTTPSConnectionPool}
+
+
+def _headers_with_url_auth(
+    headers: typing.Mapping[str, str] | None,
+    auth: str | None,
+    *,
+    proxy: bool = False,
+) -> typing.Mapping[str, str]:
+    if not auth:
+        return headers or {}
+
+    header_name = "Proxy-Authorization" if proxy else "Authorization"
+    headers_ = HTTPHeaderDict(headers)
+    if header_name not in headers_:
+        auth_header = make_headers(
+            basic_auth=None if proxy else auth,
+            proxy_basic_auth=auth if proxy else None,
+        )
+        headers_[header_name] = auth_header[header_name.lower()]
+
+    return headers_
 
 
 class PoolManager(RequestMethods):
@@ -453,6 +475,10 @@ class PoolManager(RequestMethods):
         if "headers" not in kw:
             kw["headers"] = self.headers
 
+        if u.auth:
+            kw["headers"] = _headers_with_url_auth(kw["headers"], u.auth)
+            url = u._replace(auth=None).url
+
         if self._proxy_requires_url_absolute_form(u):
             response = conn.urlopen(method, u._replace(fragment=None).url, **kw)
         else:
@@ -606,7 +632,9 @@ class ProxyManager(PoolManager):
             proxy = proxy._replace(port=port)
 
         self.proxy = proxy
-        self.proxy_headers = proxy_headers or {}
+        self.proxy_headers = _headers_with_url_auth(
+            proxy_headers, proxy.auth, proxy=True
+        )
         self.proxy_config = ProxyConfig(
             proxy_ssl_context,
             use_forwarding_for_https,

--- a/test/with_dummyserver/test_poolmanager.py
+++ b/test/with_dummyserver/test_poolmanager.py
@@ -515,10 +515,7 @@ class TestPoolManager(HypercornDummyServerTestCase):
                 f"http://user:password@{self.host}:{self.port}/headers",
             )
             returned_headers = r.json()
-            assert (
-                returned_headers.get("Authorization")
-                == "Basic dXNlcjpwYXNzd29yZA=="
-            )
+            assert returned_headers.get("Authorization") == "Basic dXNlcjpwYXNzd29yZA=="
             assert returned_headers.get("Host") == f"{self.host}:{self.port}"
 
     def test_authorization_header_not_overridden_by_url_auth(self) -> None:

--- a/test/with_dummyserver/test_poolmanager.py
+++ b/test/with_dummyserver/test_poolmanager.py
@@ -508,6 +508,29 @@ class TestPoolManager(HypercornDummyServerTestCase):
             assert returned_headers.get("Foo") is None
             assert returned_headers.get("Baz") == "quux"
 
+    def test_authorization_header_from_url_auth(self) -> None:
+        with PoolManager() as http:
+            r = http.request(
+                "GET",
+                f"http://user:password@{self.host}:{self.port}/headers",
+            )
+            returned_headers = r.json()
+            assert (
+                returned_headers.get("Authorization")
+                == "Basic dXNlcjpwYXNzd29yZA=="
+            )
+            assert returned_headers.get("Host") == f"{self.host}:{self.port}"
+
+    def test_authorization_header_not_overridden_by_url_auth(self) -> None:
+        with PoolManager() as http:
+            r = http.request(
+                "GET",
+                f"http://user:password@{self.host}:{self.port}/headers",
+                headers={"Authorization": "Bearer explicit"},
+            )
+            returned_headers = r.json()
+            assert returned_headers.get("Authorization") == "Bearer explicit"
+
     def test_headers_http_header_dict(self) -> None:
         # Test uses a list of headers to assert the order
         # that headers are sent in the request too.

--- a/test/with_dummyserver/test_proxy_poolmanager.py
+++ b/test/with_dummyserver/test_proxy_poolmanager.py
@@ -525,6 +525,27 @@ class TestHTTPProxyManager(HypercornDummyProxyTestCase):
                 returned_headers.get("Host") == f"{self.https_host}:{self.https_port}"
             )
 
+    def test_proxy_authorization_header_from_proxy_url_auth(self) -> None:
+        proxy_url = f"http://user:password@{self.proxy_host}:{self.proxy_port}"
+        with proxy_from_url(proxy_url, ca_certs=DEFAULT_CA) as http:
+            r = http.request_encode_url("GET", f"{self.http_url}/headers")
+            returned_headers = r.json()
+            assert (
+                returned_headers.get("Proxy-Authorization")
+                == "Basic dXNlcjpwYXNzd29yZA=="
+            )
+
+    def test_proxy_authorization_header_not_overridden_by_proxy_url_auth(self) -> None:
+        proxy_url = f"http://user:password@{self.proxy_host}:{self.proxy_port}"
+        with proxy_from_url(
+            proxy_url,
+            proxy_headers={"Proxy-Authorization": "Bearer explicit"},
+            ca_certs=DEFAULT_CA,
+        ) as http:
+            r = http.request_encode_url("GET", f"{self.http_url}/headers")
+            returned_headers = r.json()
+            assert returned_headers.get("Proxy-Authorization") == "Bearer explicit"
+
     def test_https_headers(self) -> None:
         with proxy_from_url(
             self.https_proxy_url,


### PR DESCRIPTION
Closes #1999.

This adds support for constructing `Authorization` and `Proxy-Authorization` headers from username/password userinfo in request and proxy URLs.

Behavior:

- request URL userinfo sets `Authorization` when no explicit authorization header is provided
- proxy URL userinfo sets `Proxy-Authorization` when no explicit proxy authorization header is provided
- explicit headers continue to win
- request targets sent through proxies strip userinfo from the absolute-form URL

Tests added for direct requests and HTTP proxy requests.

Tested with:

`python -m pytest test/with_dummyserver/test_poolmanager.py test/with_dummyserver/test_proxy_poolmanager.py`