### PR TITLE
Add HTTP/2 response streaming

### DIFF
--- a/changelog/3300.feature.rst
+++ b/changelog/3300.feature.rst
@@ -1,0 +1,1 @@
+Added streaming ``read()`` and ``stream()`` support for HTTP/2 responses.

--- a/src/urllib3/http2/connection.py
+++ b/src/urllib3/http2/connection.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import io
 import logging
 import re
 import threading
@@ -14,7 +15,11 @@ from .._base_connection import _TYPE_BODY
 from .._collections import HTTPHeaderDict
 from ..connection import HTTPSConnection, _get_default_user_agent
 from ..exceptions import ConnectionError
-from ..response import BaseHTTPResponse
+from ..response import _READ_CHUNK_SIZE, BaseHTTPResponse, BytesQueueBuffer
+
+if typing.TYPE_CHECKING:
+    from .._base_connection import BaseHTTPConnection
+    from ..connectionpool import HTTPConnectionPool
 
 orig_HTTPSConnection = HTTPSConnection
 
@@ -89,6 +94,8 @@ class HTTP2Connection(HTTPSConnection):
         self._h2_conn = self._new_h2_conn()
         self._h2_stream: int | None = None
         self._headers: list[tuple[bytes, bytes]] = []
+        self._preload_content = True
+        self._decode_content = True
 
         if "proxy" in kwargs or "proxy_config" in kwargs:  # Defensive:
             raise NotImplementedError("Proxies aren't supported with HTTP/2")
@@ -226,11 +233,15 @@ class HTTP2Connection(HTTPSConnection):
     def getresponse(  # type: ignore[override]
         self,
     ) -> HTTP2Response:
-        status = None
-        data = bytearray()
+        status: int | None = None
+        headers: HTTPHeaderDict | None = None
+        data_buffer = BytesQueueBuffer()
+        stream_ended = False
+        if self._h2_stream is None:
+            raise ConnectionError("Must call `putrequest` first.")
+
         with self._h2_conn as conn:
-            end_stream = False
-            while not end_stream:
+            while headers is None:
                 # TODO: Arbitrary read value.
                 if received_data := self.sock.recv(65535):
                     events = conn.receive_data(received_data)
@@ -246,23 +257,34 @@ class HTTP2Connection(HTTPSConnection):
                                     )
 
                         elif isinstance(event, h2.events.DataReceived):
-                            data += event.data
+                            if event.stream_id == self._h2_stream:
+                                data_buffer.put(event.data)
                             conn.acknowledge_received_data(
                                 event.flow_controlled_length, event.stream_id
                             )
 
                         elif isinstance(event, h2.events.StreamEnded):
-                            end_stream = True
+                            if event.stream_id == self._h2_stream:
+                                stream_ended = True
+                else:
+                    break
 
                 if data_to_send := conn.data_to_send():
                     self.sock.sendall(data_to_send)
 
         assert status is not None
+        assert headers is not None
         return HTTP2Response(
             status=status,
             headers=headers,
             request_url=self._request_url,
-            data=bytes(data),
+            sock=self.sock,
+            h2_conn=self._h2_conn,
+            stream_id=self._h2_stream,
+            data_buffer=data_buffer,
+            stream_ended=stream_ended,
+            preload_content=self._preload_content,
+            decode_content=self._decode_content,
         )
 
     def request(  # type: ignore[override]
@@ -278,6 +300,9 @@ class HTTP2Connection(HTTPSConnection):
         **kwargs: typing.Any,
     ) -> None:
         """Send an HTTP/2 request"""
+        self._preload_content = preload_content
+        self._decode_content = decode_content
+
         if "chunked" in kwargs:
             # TODO this is often present from upstream.
             # raise NotImplementedError("`chunked` isn't supported with HTTP/2")
@@ -322,14 +347,18 @@ class HTTP2Connection(HTTPSConnection):
 
 
 class HTTP2Response(BaseHTTPResponse):
-    # TODO: This is a woefully incomplete response object, but works for non-streaming.
     def __init__(
         self,
         status: int,
         headers: HTTPHeaderDict,
         request_url: str,
-        data: bytes,
-        decode_content: bool = False,  # TODO: support decoding
+        sock: typing.Any,
+        h2_conn: _LockedObject[h2.connection.H2Connection],
+        stream_id: int,
+        data_buffer: BytesQueueBuffer,
+        stream_ended: bool,
+        preload_content: bool = True,
+        decode_content: bool = True,
     ) -> None:
         super().__init__(
             status=status,
@@ -342,15 +371,215 @@ class HTTP2Response(BaseHTTPResponse):
             decode_content=decode_content,
             request_url=request_url,
         )
-        self._data = data
-        self.length_remaining = 0
+        self._sock = sock
+        self._h2_conn = h2_conn
+        self._stream_id = stream_id
+        self._data_buffer = data_buffer
+        self._stream_ended = stream_ended
+        self._body: bytes | None = None
+        self._decoded_buffer = BytesQueueBuffer()
+        self._uncached_read_occurred = False
+        self._fp_bytes_read = len(data_buffer)
+        self._pool: HTTPConnectionPool | None = None
+        self._connection: BaseHTTPConnection | None = None
+
+        content_length = self.headers.get("content-length")
+        self.length_remaining = None
+        if content_length is not None:
+            try:
+                self.length_remaining = int(content_length)
+            except ValueError:
+                pass
+            else:
+                self.length_remaining -= len(data_buffer)
+
+        if preload_content:
+            self._body = self.read(cache_content=True)
 
     @property
     def data(self) -> bytes:
-        return self._data
+        if self._body is not None:
+            return self._body
+        return self.read(cache_content=True)
+
+    @property
+    def url(self) -> str | None:
+        return self._request_url
+
+    @url.setter
+    def url(self, url: str | None) -> None:
+        self._request_url = url
+
+    @property
+    def connection(self) -> BaseHTTPConnection | None:
+        return self._connection
 
     def get_redirect_location(self) -> None:
         return None
 
+    def _read_next_event(self) -> None:
+        if self._stream_ended:
+            return
+
+        with self._h2_conn as conn:
+            while not self._stream_ended and not self._data_buffer:
+                if not (received_data := self._sock.recv(65535)):
+                    self._stream_ended = True
+                    break
+
+                events = conn.receive_data(received_data)
+                for event in events:
+                    if isinstance(event, h2.events.DataReceived):
+                        if event.stream_id == self._stream_id:
+                            self._data_buffer.put(event.data)
+                            self._fp_bytes_read += len(event.data)
+                            if self.length_remaining is not None:
+                                self.length_remaining -= len(event.data)
+                        conn.acknowledge_received_data(
+                            event.flow_controlled_length, event.stream_id
+                        )
+                    elif isinstance(event, h2.events.StreamEnded):
+                        if event.stream_id == self._stream_id:
+                            self._stream_ended = True
+
+                if data_to_send := conn.data_to_send():
+                    self._sock.sendall(data_to_send)
+
+    def _raw_read(self, amt: int | None = None) -> bytes:
+        if amt == 0:
+            return b""
+
+        if amt is None:
+            chunks = []
+            while self._data_buffer or not self._stream_ended:
+                if self._data_buffer:
+                    chunks.append(self._data_buffer.get_all())
+                else:
+                    self._read_next_event()
+            return b"".join(chunks)
+
+        while len(self._data_buffer) < amt and not self._stream_ended:
+            self._read_next_event()
+
+        if not self._data_buffer:
+            return b""
+        return self._data_buffer.get(min(amt, len(self._data_buffer)))
+
+    def _release_when_stream_consumed(self) -> None:
+        if self._stream_ended and not self._data_buffer:
+            self.release_conn()
+
+    def read(
+        self,
+        amt: int | None = None,
+        decode_content: bool | None = None,
+        cache_content: bool = False,
+    ) -> bytes:
+        self._init_decoder()
+        if decode_content is None:
+            decode_content = self.decode_content
+
+        if amt and amt < 0:
+            amt = None
+        elif amt == 0:
+            return b""
+
+        if amt is None:
+            data = self._raw_read()
+            if not cache_content:
+                self._uncached_read_occurred = True
+            data = self._decode(data, decode_content, flush_decoder=True)
+            if decode_content and len(self._decoded_buffer) > 0:
+                self._decoded_buffer.put(data)
+                data = self._decoded_buffer.get_all()
+            if cache_content and not self._uncached_read_occurred:
+                self._body = data
+            self._release_when_stream_consumed()
+            return data
+
+        self._uncached_read_occurred = True
+        while len(self._decoded_buffer) < amt:
+            raw_data = self._raw_read(amt)
+            if not raw_data:
+                self._decoded_buffer.put(
+                    self._decode(raw_data, decode_content, flush_decoder=True)
+                )
+                break
+
+            if not decode_content:
+                if self._has_decoded_content:
+                    raise RuntimeError(
+                        "Calling read(decode_content=False) is not supported after "
+                        "read(decode_content=True) was called."
+                    )
+                self._release_when_stream_consumed()
+                return raw_data
+
+            decoded_data = self._decode(
+                raw_data,
+                decode_content,
+                flush_decoder=False,
+                max_length=amt - len(self._decoded_buffer),
+            )
+            self._decoded_buffer.put(decoded_data)
+
+        if not self._decoded_buffer:
+            self._release_when_stream_consumed()
+            return b""
+        data = self._decoded_buffer.get(min(amt, len(self._decoded_buffer)))
+        self._release_when_stream_consumed()
+        return data
+
+    def read1(
+        self,
+        amt: int | None = None,
+        decode_content: bool | None = None,
+    ) -> bytes:
+        return self.read(amt=amt, decode_content=decode_content)
+
+    def stream(
+        self, amt: int | None = _READ_CHUNK_SIZE, decode_content: bool | None = None
+    ) -> typing.Generator[bytes]:
+        if amt == 0:
+            return
+
+        while True:
+            data = self.read(amt=amt, decode_content=decode_content)
+            if not data:
+                break
+            yield data
+
+    def read_chunked(
+        self,
+        amt: int | None = None,
+        decode_content: bool | None = None,
+    ) -> typing.Iterator[bytes]:
+        return self.stream(amt=amt, decode_content=decode_content)
+
+    def release_conn(self) -> None:
+        if not self._pool or not self._connection:
+            return None
+
+        self._pool._put_conn(self._connection)
+        self._connection = None
+        return None
+
+    def drain_conn(self) -> None:
+        self.read()
+
+    def shutdown(self) -> None:
+        self.close()
+
     def close(self) -> None:
-        pass
+        self._stream_ended = True
+        if self._connection:
+            self._connection.close()
+            self._connection = None
+        if not self.closed:
+            io.IOBase.close(self)
+
+    def readable(self) -> bool:
+        return True
+
+    def tell(self) -> int:
+        return self._fp_bytes_read

--- a/test/test_http2_connection.py
+++ b/test/test_http2_connection.py
@@ -105,10 +105,30 @@ class TestHTTP2Connection:
         assert conn.socket_options == [(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)]
         assert conn.port == 443
 
+    def test_connect_sends_connection_preface(self) -> None:
+        conn = HTTP2Connection("example.com")
+        conn.sock = mock.MagicMock(sendall=mock.Mock(return_value=None))
+        conn._h2_conn._obj.initiate_connection = mock.Mock(return_value=None)  # type: ignore[method-assign]
+        conn._h2_conn._obj.data_to_send = mock.Mock(return_value=b"preface")  # type: ignore[method-assign]
+
+        with mock.patch("urllib3.http2.connection.HTTPSConnection.connect"):
+            conn.connect()
+
+        conn._h2_conn._obj.initiate_connection.assert_called_once_with()
+        typing.cast(mock.Mock, conn.sock.sendall).assert_called_once_with(b"preface")
+
     def test_putheader(self) -> None:
         conn = HTTP2Connection("example.com")
         conn.putheader("foo", "bar")
         assert conn._headers == [(b"foo", b"bar")]
+
+    def test_putrequest_ipv6_authority(self) -> None:
+        conn = HTTP2Connection("[::1]")
+        conn._h2_conn._obj.get_next_available_stream_id = mock.Mock(return_value=1)  # type: ignore[method-assign]
+
+        conn.putrequest("GET", "/")
+
+        assert (b":authority", b"[::1]:443") in conn._headers
 
     def test_request_putheader(self) -> None:
         conn = HTTP2Connection("example.com")
@@ -426,6 +446,117 @@ class TestHTTP2Connection:
         assert response.read() == b""
         assert response.length_remaining == 0
 
+    def test_getresponse_without_request_errors(self) -> None:
+        conn = HTTP2Connection("example.com")
+
+        with pytest.raises(ConnectionError, match="Must call `putrequest` first"):
+            conn.getresponse()
+
+    def test_getresponse_empty_socket_before_headers_errors(self) -> None:
+        conn = HTTP2Connection("example.com")
+        conn.sock = mock.MagicMock(
+            recv=mock.Mock(return_value=b""),
+            sendall=mock.Mock(return_value=None),
+        )
+        conn._h2_stream = 1
+
+        with pytest.raises(AssertionError):
+            conn.getresponse()
+
+    def test_getresponse_streaming_response_ends_with_initial_headers(self) -> None:
+        conn = self._streaming_response_conn(
+            [
+                [
+                    h2.events.ResponseReceived(
+                        stream_id=1,
+                        headers=[(b":status", b"200"), (b"content-length", b"invalid")],
+                    ),
+                    h2.events.DataReceived(
+                        stream_id=1,
+                        data=b"foo",
+                        flow_controlled_length=3,
+                    ),
+                    h2.events.StreamEnded(stream_id=1),
+                ],
+            ]
+        )
+        conn._h2_conn._obj.data_to_send = mock.Mock(return_value=b"window")  # type: ignore[method-assign]
+
+        response = conn.getresponse()
+
+        assert response.length_remaining is None
+        assert response.read() == b"foo"
+        assert typing.cast(mock.Mock, conn.sock.recv).call_count == 1
+        typing.cast(mock.Mock, conn.sock.sendall).assert_called_with(b"window")
+
+    def test_getresponse_streaming_empty_socket_ends_body(self) -> None:
+        conn = self._streaming_response_conn(
+            [
+                [
+                    h2.events.ResponseReceived(
+                        stream_id=1,
+                        headers=[(b":status", b"200")],
+                    )
+                ],
+            ]
+        )
+
+        response = conn.getresponse()
+        recv = typing.cast(mock.Mock, conn.sock.recv)
+        recv.side_effect = None
+        recv.return_value = b""
+
+        assert response.read() == b""
+
+    def test_getresponse_streaming_sends_flow_control_updates(self) -> None:
+        conn = self._streaming_response_conn(
+            [
+                [
+                    h2.events.ResponseReceived(
+                        stream_id=1,
+                        headers=[(b":status", b"200")],
+                    )
+                ],
+                [
+                    h2.events.DataReceived(
+                        stream_id=1,
+                        data=b"foo",
+                        flow_controlled_length=3,
+                    ),
+                    h2.events.StreamEnded(stream_id=1),
+                ],
+            ]
+        )
+
+        response = conn.getresponse()
+        conn._h2_conn._obj.data_to_send = mock.Mock(return_value=b"window")  # type: ignore[method-assign]
+
+        assert response.read(3) == b"foo"
+        typing.cast(mock.Mock, conn.sock.sendall).assert_called_with(b"window")
+
+    def test_getresponse_streaming_response_accessors(self) -> None:
+        conn = self._streaming_response_conn(
+            [
+                [
+                    h2.events.ResponseReceived(
+                        stream_id=1,
+                        headers=[(b":status", b"200")],
+                    ),
+                    h2.events.StreamEnded(stream_id=1),
+                ],
+            ]
+        )
+
+        response = conn.getresponse()
+
+        assert response.url == "/"
+        response.url = "/changed"
+        assert response.url == "/changed"
+        response.get_redirect_location()
+        assert response.readable()
+        assert response.tell() == 0
+        response._read_next_event()
+
     def test_getresponse_streaming_data_property_caches_body(self) -> None:
         conn = self._streaming_response_conn(
             [
@@ -518,6 +649,171 @@ class TestHTTP2Connection:
 
         assert response.data == b"foobar"
         assert typing.cast(mock.Mock, conn.sock.recv).call_count == 2
+
+    def test_getresponse_streaming_read_variants(self) -> None:
+        conn = self._streaming_response_conn(
+            [
+                [
+                    h2.events.ResponseReceived(
+                        stream_id=1,
+                        headers=[(b":status", b"200")],
+                    ),
+                    h2.events.DataReceived(
+                        stream_id=1,
+                        data=b"foo",
+                        flow_controlled_length=3,
+                    ),
+                    h2.events.StreamEnded(stream_id=1),
+                ],
+            ]
+        )
+
+        response = conn.getresponse()
+
+        assert response.read(0) == b""
+        assert response._raw_read(0) == b""
+        assert response.read1(1) == b"f"
+        assert response.read(-1) == b"oo"
+        assert list(response.stream(0)) == []
+
+    def test_getresponse_streaming_read_decode_content_false(self) -> None:
+        conn = self._streaming_response_conn(
+            [
+                [
+                    h2.events.ResponseReceived(
+                        stream_id=1,
+                        headers=[(b":status", b"200")],
+                    ),
+                    h2.events.DataReceived(
+                        stream_id=1,
+                        data=b"foo",
+                        flow_controlled_length=3,
+                    ),
+                    h2.events.StreamEnded(stream_id=1),
+                ],
+            ]
+        )
+
+        response = conn.getresponse()
+
+        assert response.read(1, decode_content=False) == b"f"
+
+    def test_getresponse_streaming_read_chunked(self) -> None:
+        conn = self._streaming_response_conn(
+            [
+                [
+                    h2.events.ResponseReceived(
+                        stream_id=1,
+                        headers=[(b":status", b"200")],
+                    ),
+                    h2.events.DataReceived(
+                        stream_id=1,
+                        data=b"foo",
+                        flow_controlled_length=3,
+                    ),
+                    h2.events.StreamEnded(stream_id=1),
+                ],
+            ]
+        )
+
+        response = conn.getresponse()
+
+        assert list(response.read_chunked(2)) == [b"fo", b"o"]
+
+    def test_getresponse_streaming_drain_conn(self) -> None:
+        conn = self._streaming_response_conn(
+            [
+                [
+                    h2.events.ResponseReceived(
+                        stream_id=1,
+                        headers=[(b":status", b"200")],
+                    )
+                ],
+                [
+                    h2.events.DataReceived(
+                        stream_id=1,
+                        data=b"foo",
+                        flow_controlled_length=3,
+                    ),
+                    h2.events.StreamEnded(stream_id=1),
+                ],
+            ]
+        )
+
+        response = conn.getresponse()
+
+        response.drain_conn()
+        assert response.tell() == 3
+
+    def test_getresponse_streaming_close_connection_on_shutdown(self) -> None:
+        conn = self._streaming_response_conn(
+            [
+                [
+                    h2.events.ResponseReceived(
+                        stream_id=1,
+                        headers=[(b":status", b"200")],
+                    ),
+                    h2.events.StreamEnded(stream_id=1),
+                ],
+            ]
+        )
+        connection = mock.MagicMock()
+
+        response = conn.getresponse()
+        response._connection = connection
+        response.shutdown()
+
+        connection.close.assert_called_once_with()
+        assert response.connection is None
+
+    def test_getresponse_streaming_full_read_flushes_decoded_buffer(self) -> None:
+        conn = self._streaming_response_conn(
+            [
+                [
+                    h2.events.ResponseReceived(
+                        stream_id=1,
+                        headers=[(b":status", b"200")],
+                    ),
+                    h2.events.DataReceived(
+                        stream_id=1,
+                        data=b"foo",
+                        flow_controlled_length=3,
+                    ),
+                    h2.events.StreamEnded(stream_id=1),
+                ],
+            ]
+        )
+
+        response = conn.getresponse()
+        response._decoded_buffer.put(b"bar")
+
+        assert response.read() == b"barfoo"
+
+    def test_getresponse_streaming_decode_content_false_after_decoding_errors(
+        self,
+    ) -> None:
+        conn = self._streaming_response_conn(
+            [
+                [
+                    h2.events.ResponseReceived(
+                        stream_id=1,
+                        headers=[(b":status", b"200")],
+                    ),
+                    h2.events.DataReceived(
+                        stream_id=1,
+                        data=b"foo",
+                        flow_controlled_length=3,
+                    ),
+                    h2.events.StreamEnded(stream_id=1),
+                ],
+            ]
+        )
+
+        response = conn.getresponse()
+        response._has_decoded_content = True
+
+        with pytest.raises(RuntimeError, match="decode_content=False"):
+            response.read(1, decode_content=False)
 
     def test_getresponse_releases_connection_after_body_read(self) -> None:
         conn = self._streaming_response_conn(

--- a/test/test_http2_connection.py
+++ b/test/test_http2_connection.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import socket
+import typing
 from unittest import mock
 
+import h2.events
 import pytest
 
 from urllib3.connection import _get_default_user_agent
@@ -17,6 +19,29 @@ from urllib3.http2.connection import (
 
 
 class TestHTTP2Connection:
+    def _streaming_response_conn(
+        self,
+        event_batches: list[list[h2.events.Event]],
+        *,
+        preload_content: bool = False,
+    ) -> HTTP2Connection:
+        conn = HTTP2Connection("example.com")
+        conn.sock = mock.MagicMock(
+            recv=mock.Mock(side_effect=[b"frame"] * len(event_batches)),
+            sendall=mock.Mock(return_value=None),
+        )
+        conn._request_url = "/"
+        conn._h2_stream = 1
+        conn._preload_content = preload_content
+        conn._h2_conn._obj.receive_data = mock.Mock(  # type: ignore[method-assign]
+            side_effect=event_batches
+        )
+        conn._h2_conn._obj.data_to_send = mock.Mock(return_value=b"")  # type: ignore[method-assign]
+        conn._h2_conn._obj.acknowledge_received_data = mock.Mock(  # type: ignore[method-assign]
+            return_value=None
+        )
+        return conn
+
     def test__is_legal_header_name(self) -> None:
         assert _is_legal_header_name(b"foo"), "foo"
         assert _is_legal_header_name(b"foo-bar"), "foo-bar"
@@ -358,3 +383,167 @@ class TestHTTP2Connection:
         )
 
         close_connection.assert_called_with()
+
+    def test_getresponse_streaming_read(self) -> None:
+        conn = self._streaming_response_conn(
+            [
+                [
+                    h2.events.ResponseReceived(
+                        stream_id=1,
+                        headers=[(b":status", b"200"), (b"content-length", b"9")],
+                    ),
+                    h2.events.DataReceived(
+                        stream_id=1,
+                        data=b"foo",
+                        flow_controlled_length=3,
+                    ),
+                ],
+                [
+                    h2.events.DataReceived(
+                        stream_id=1,
+                        data=b"bar",
+                        flow_controlled_length=3,
+                    )
+                ],
+                [
+                    h2.events.DataReceived(
+                        stream_id=1,
+                        data=b"baz",
+                        flow_controlled_length=3,
+                    ),
+                    h2.events.StreamEnded(stream_id=1),
+                ],
+            ]
+        )
+
+        response = conn.getresponse()
+
+        assert response.status == 200
+        assert response.read(3) == b"foo"
+        assert typing.cast(mock.Mock, conn.sock.recv).call_count == 1
+        assert response.read(3) == b"bar"
+        assert response.read() == b"baz"
+        assert response.read() == b""
+        assert response.length_remaining == 0
+
+    def test_getresponse_streaming_data_property_caches_body(self) -> None:
+        conn = self._streaming_response_conn(
+            [
+                [
+                    h2.events.ResponseReceived(
+                        stream_id=1,
+                        headers=[(b":status", b"200")],
+                    )
+                ],
+                [
+                    h2.events.DataReceived(
+                        stream_id=1,
+                        data=b"foo",
+                        flow_controlled_length=3,
+                    )
+                ],
+                [
+                    h2.events.DataReceived(
+                        stream_id=1,
+                        data=b"bar",
+                        flow_controlled_length=3,
+                    ),
+                    h2.events.StreamEnded(stream_id=1),
+                ],
+            ]
+        )
+
+        response = conn.getresponse()
+
+        assert response.data == b"foobar"
+        assert response.data == b"foobar"
+        assert typing.cast(mock.Mock, conn.sock.recv).call_count == 3
+
+    def test_getresponse_streaming_stream(self) -> None:
+        conn = self._streaming_response_conn(
+            [
+                [
+                    h2.events.ResponseReceived(
+                        stream_id=1,
+                        headers=[(b":status", b"200")],
+                    ),
+                    h2.events.DataReceived(
+                        stream_id=1,
+                        data=b"foo",
+                        flow_controlled_length=3,
+                    ),
+                ],
+                [
+                    h2.events.DataReceived(
+                        stream_id=1,
+                        data=b"bar",
+                        flow_controlled_length=3,
+                    ),
+                    h2.events.StreamEnded(stream_id=1),
+                ],
+            ]
+        )
+
+        response = conn.getresponse()
+
+        assert list(response.stream(3)) == [b"foo", b"bar"]
+
+    def test_getresponse_preloads_body_by_default(self) -> None:
+        conn = self._streaming_response_conn(
+            [
+                [
+                    h2.events.ResponseReceived(
+                        stream_id=1,
+                        headers=[(b":status", b"200")],
+                    ),
+                    h2.events.DataReceived(
+                        stream_id=1,
+                        data=b"foo",
+                        flow_controlled_length=3,
+                    ),
+                ],
+                [
+                    h2.events.DataReceived(
+                        stream_id=1,
+                        data=b"bar",
+                        flow_controlled_length=3,
+                    ),
+                    h2.events.StreamEnded(stream_id=1),
+                ],
+            ],
+            preload_content=True,
+        )
+
+        response = conn.getresponse()
+
+        assert response.data == b"foobar"
+        assert typing.cast(mock.Mock, conn.sock.recv).call_count == 2
+
+    def test_getresponse_releases_connection_after_body_read(self) -> None:
+        conn = self._streaming_response_conn(
+            [
+                [
+                    h2.events.ResponseReceived(
+                        stream_id=1,
+                        headers=[(b":status", b"200")],
+                    )
+                ],
+                [
+                    h2.events.DataReceived(
+                        stream_id=1,
+                        data=b"foo",
+                        flow_controlled_length=3,
+                    ),
+                    h2.events.StreamEnded(stream_id=1),
+                ],
+            ]
+        )
+        pool = mock.MagicMock()
+
+        response = conn.getresponse()
+        response._pool = pool
+        response._connection = conn
+
+        assert response.read() == b"foo"
+        pool._put_conn.assert_called_once_with(conn)
+        assert response.connection is None

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -65,6 +65,55 @@ else:
     StrOrBytesPath = object
 
 
+def _client_hello_alpn_protocols(data: bytes) -> list[bytes]:
+    if len(data) < 43 or data[0] != 0x16 or data[5] != 0x01:
+        return []
+
+    pos = 5 + 4 + 2 + 32
+    session_id_len = data[pos]
+    pos += 1 + session_id_len
+    if pos + 2 > len(data):
+        return []
+
+    cipher_suites_len = int.from_bytes(data[pos : pos + 2], "big")
+    pos += 2 + cipher_suites_len
+    if pos + 1 > len(data):
+        return []
+
+    compression_methods_len = data[pos]
+    pos += 1 + compression_methods_len
+    if pos + 2 > len(data):
+        return []
+
+    extensions_len = int.from_bytes(data[pos : pos + 2], "big")
+    pos += 2
+    extensions_end = min(pos + extensions_len, len(data))
+
+    while pos + 4 <= extensions_end:
+        extension_type = int.from_bytes(data[pos : pos + 2], "big")
+        extension_len = int.from_bytes(data[pos + 2 : pos + 4], "big")
+        pos += 4
+        extension_end = pos + extension_len
+        if extension_end > extensions_end:
+            return []
+
+        if extension_type == 0x0010:
+            protocols: list[bytes] = []
+            names_len = int.from_bytes(data[pos : pos + 2], "big")
+            name_pos = pos + 2
+            names_end = min(name_pos + names_len, extension_end)
+            while name_pos < names_end:
+                name_len = data[name_pos]
+                name_pos += 1
+                protocols.append(data[name_pos : name_pos + name_len])
+                name_pos += name_len
+            return protocols
+
+        pos = extension_end
+
+    return []
+
+
 class TestCookies(SocketDummyServerTestCase):
     def test_multi_setcookie(self) -> None:
         def multicookie_response_handler(listener: socket.socket) -> None:
@@ -1231,8 +1280,9 @@ class TestProxyManager(SocketDummyServerTestCase):
                 proxy.request("GET", "https://localhost/")
 
         done_receiving.wait()
-        assert b"http/1.1" in self.buf
-        assert b"h2" not in self.buf
+        alpn_protocols = _client_hello_alpn_protocols(self.buf)
+        assert b"http/1.1" in alpn_protocols
+        assert b"h2" not in alpn_protocols
 
     def test_connect_reconn(self) -> None:
         def proxy_ssl_one(listener: socket.socket) -> None:


### PR DESCRIPTION
## Summary
- return HTTP/2 responses after headers and let `HTTP2Response` read the response body on demand
- add `read()`, `read1()`, `stream()`, `read_chunked()`, `drain_conn()`, and connection release behavior for HTTP/2 responses
- preserve default preloading behavior while supporting `preload_content=False` streaming

Fixes #3300.

## Notes
This keeps the existing request/getresponse API shape and focuses on one response stream at a time.

## Testing
- `uv run pytest test/test_http2_connection.py -q`
- `uv run pytest test/with_dummyserver/test_https.py -k 'http2 or alpn_default' -q`
- `uv run --group mypy mypy src/urllib3/http2/connection.py test/test_http2_connection.py`
- `uvx black --check src/urllib3/http2/connection.py test/test_http2_connection.py`
- `uvx isort --check-only src/urllib3/http2/connection.py test/test_http2_connection.py`
- `uvx flake8 src/urllib3/http2/connection.py test/test_http2_connection.py`
- `uv run python -m py_compile src/urllib3/http2/connection.py test/test_http2_connection.py`
- `git diff --check`
