### PR TITLE
Raise unrewindable for missing seek

### DIFF
--- a/changelog/3779.bugfix.rst
+++ b/changelog/3779.bugfix.rst
@@ -1,0 +1,3 @@
+Fixed ``rewind_body()`` to raise ``UnrewindableBodyError`` instead of a misleading
+``ValueError`` when a retry or redirect attempts to rewind a body that reports a
+position but does not support seeking.

--- a/src/urllib3/util/request.py
+++ b/src/urllib3/util/request.py
@@ -171,22 +171,28 @@ def rewind_body(body: typing.IO[typing.AnyStr], body_pos: _TYPE_BODY_POSITION) -
         Position to seek to in file.
     """
     body_seek = getattr(body, "seek", None)
-    if body_seek is not None and isinstance(body_pos, int):
-        try:
-            body_seek(body_pos)
-        except OSError as e:
-            raise UnrewindableBodyError(
-                "An error occurred when rewinding request body for redirect/retry."
-            ) from e
-    elif body_pos is _FAILEDTELL:
+    if body_pos is _FAILEDTELL:
         raise UnrewindableBodyError(
             "Unable to record file position for rewinding "
             "request body during a redirect/retry."
         )
-    else:
+    if not isinstance(body_pos, int):
         raise ValueError(
             f"body_pos must be of type integer, instead it was {type(body_pos)}."
         )
+
+    if body_seek is None:
+        raise UnrewindableBodyError(
+            "Unable to rewind request body for redirect/retry because "
+            "the body does not support seeking."
+        )
+
+    try:
+        body_seek(body_pos)
+    except OSError as e:
+        raise UnrewindableBodyError(
+            "An error occurred when rewinding request body for redirect/retry."
+        ) from e
 
 
 class ChunksAndContentLength(typing.NamedTuple):

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -622,6 +622,14 @@ class TestUtil:
         with pytest.raises(UnrewindableBodyError):
             rewind_body(BadSeek(), body_pos=2)
 
+    def test_rewind_body_missing_seek(self) -> None:
+        class TellOnly:
+            def tell(self) -> int:
+                return 0
+
+        with pytest.raises(UnrewindableBodyError, match="does not support seeking"):
+            rewind_body(TellOnly(), body_pos=0)  # type: ignore[arg-type]
+
     def test_add_stderr_logger(self) -> None:
         handler = add_stderr_logger(level=logging.INFO)  # Don't actually print debug
         logger = logging.getLogger("urllib3")


### PR DESCRIPTION
Closes #3779.

### This PR
- makes `rewind_body()` raise `UnrewindableBodyError` when `body_pos` is valid but the request body has no `seek()` method
- keeps `ValueError` for invalid `body_pos` values
- adds a regression test for a tell-only body and a changelog fragment

### Validation
- `git diff --check`
- `git diff --cached --check`
- `git diff --check HEAD~1..HEAD`
- Not run locally