### PR TITLE
Normalize obsolete folded response headers

### DIFF
--- a/changelog/1362.bugfix.rst
+++ b/changelog/1362.bugfix.rst
@@ -1,0 +1,1 @@
+Normalized obsolete folded response header values before exposing them to callers.

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -22,7 +22,7 @@ if typing.TYPE_CHECKING:
 
 from ._collections import HTTPHeaderDict
 from .http2 import probe as http2_probe
-from .util.response import assert_header_parsing
+from .util.response import _normalize_header_value, assert_header_parsing
 from .util.timeout import _DEFAULT_TIMEOUT, _TYPE_TIMEOUT, Timeout
 from .util.util import to_str
 from .util.wait import wait_for_read
@@ -580,7 +580,10 @@ class HTTPConnection(_HTTPConnection):
                 exc_info=True,
             )
 
-        headers = HTTPHeaderDict(httplib_response.msg.items())
+        headers = HTTPHeaderDict(
+            (key, _normalize_header_value(value))
+            for key, value in httplib_response.msg.items()
+        )
 
         response = HTTPResponse(
             body=httplib_response,

--- a/src/urllib3/util/response.py
+++ b/src/urllib3/util/response.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 import http.client as httplib
+import re
 from email.errors import MultipartInvariantViolationDefect, StartBoundaryNotFoundDefect
 
 from ..exceptions import HeaderParsingError
+
+_OBSOLETE_FOLD_RE = re.compile(r"\r\n[ \t]+")
 
 
 def is_fp_closed(obj: object) -> bool:
@@ -86,6 +89,19 @@ def assert_header_parsing(headers: httplib.HTTPMessage) -> None:
 
     if defects or unparsed_data:
         raise HeaderParsingError(defects=defects, unparsed_data=unparsed_data)
+
+
+def _normalize_header_value(value: str) -> str:
+    """
+    Replaces obsolete line folding with a single space.
+
+    RFC 9112 section 5.2 permits recipients to replace obs-fold with SP before
+    interpreting a header field value. Python's ``http.client`` parser preserves
+    the original CRLF bytes in parsed values, so urllib3 normalizes them before
+    exposing response headers to callers.
+    """
+
+    return _OBSOLETE_FOLD_RE.sub(" ", value)
 
 
 def is_response_to_head(response: httplib.HTTPResponse) -> bool:

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -88,6 +88,31 @@ class TestCookies(SocketDummyServerTestCase):
             assert r.headers == {"set-cookie": "foo=1, bar=1"}
             assert r.headers.getlist("set-cookie") == ["foo=1", "bar=1"]
 
+    def test_obsolete_folded_set_cookie_is_normalized(self) -> None:
+        def folded_setcookie_response_handler(listener: socket.socket) -> None:
+            sock = listener.accept()[0]
+
+            buf = b""
+            while not buf.endswith(b"\r\n\r\n"):
+                buf += sock.recv(65536)
+
+            sock.send(
+                b"HTTP/1.1 200 OK\r\n"
+                b"Set-Cookie: ___utmvbtouVBFmB=gZg\r\n"
+                b"    XbNOjalT: Lte; path=/; Max-Age=900\r\n"
+                b"\r\n"
+            )
+            sock.close()
+
+        self._start_server(folded_setcookie_response_handler)
+        with HTTPConnectionPool(self.host, self.port) as pool:
+            r = pool.request("GET", "/", retries=0)
+
+            assert "\r\n" not in r.headers["set-cookie"]
+            assert r.headers["set-cookie"] == (
+                "___utmvbtouVBFmB=gZg XbNOjalT: Lte; path=/; Max-Age=900"
+            )
+
 
 class TestSNI(SocketDummyServerTestCase):
     def test_hostname_in_first_request_packet(self) -> None:


### PR DESCRIPTION
Closes #1362.

This normalizes obsolete folded response header values before urllib3 exposes them through `HTTPHeaderDict`. Python's `http.client` parser preserves CRLF + leading whitespace inside parsed values; RFC 9112 allows recipients to replace obs-fold with a single space before interpreting the field value.

The regression test covers the reported folded `Set-Cookie` shape and asserts no raw CRLF is exposed in the response header value.

Tested locally:

```
.venv/bin/python -m pytest test/with_dummyserver/test_socketlevel.py::TestCookies test/test_util.py -q
326 passed, 6 skipped in 0.16s
```