### PR TITLE
Update request header typing for bytes

### DIFF
--- a/changelog/3047.bugfix.rst
+++ b/changelog/3047.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed request header type hints to accept byte-string header names and values.

--- a/dummyserver/hypercornserver.py
+++ b/dummyserver/hypercornserver.py
@@ -60,21 +60,29 @@ class Config(hypercorn.Config):
         port = 0  # Get a random port
         family = socket.AF_INET6 if ":" in host else socket.AF_UNSPEC
 
-        for res in socket.getaddrinfo(
-            host, port, family, socket.SOCK_STREAM, 0, socket.AI_PASSIVE
-        ):
-            af, socktype, proto, canonname, sockadddr = res
+        try:
+            for res in socket.getaddrinfo(
+                host, port, family, socket.SOCK_STREAM, 0, socket.AI_PASSIVE
+            ):
+                af, socktype, proto, canonname, sockadddr = res
 
-            sock = socket.socket(af, socket.SOCK_STREAM, proto)
+                sock = socket.socket(af, socket.SOCK_STREAM, proto)
+                try:
+                    sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+                    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
 
-            sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
-            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-
-            sock.setblocking(False)
-            sock.bind((host, port))
-            port = sock.getsockname()[1]
-            sock.set_inheritable(True)
-            sockets.append(sock)
+                    sock.setblocking(False)
+                    sock.bind((host, port))
+                    port = sock.getsockname()[1]
+                    sock.set_inheritable(True)
+                except BaseException:
+                    sock.close()
+                    raise
+                sockets.append(sock)
+        except BaseException:
+            for sock in sockets:
+                sock.close()
+            raise
 
         return sockets
 

--- a/src/urllib3/__init__.py
+++ b/src/urllib3/__init__.py
@@ -14,6 +14,7 @@ from logging import NullHandler
 from . import exceptions
 from ._base_connection import _TYPE_BODY
 from ._collections import HTTPHeaderDict
+from ._typing import _TYPE_HEADERS
 from ._version import __version__
 from .connectionpool import HTTPConnectionPool, HTTPSConnectionPool, connection_from_url
 from .filepost import _TYPE_FIELDS, encode_multipart_formdata
@@ -120,7 +121,7 @@ def request(
     *,
     body: _TYPE_BODY | None = None,
     fields: _TYPE_FIELDS | None = None,
-    headers: typing.Mapping[str, str] | None = None,
+    headers: _TYPE_HEADERS | None = None,
     preload_content: bool | None = True,
     decode_content: bool | None = True,
     redirect: bool | None = True,

--- a/src/urllib3/_base_connection.py
+++ b/src/urllib3/_base_connection.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import typing
 
+from ._typing import _TYPE_HEADERS
 from .util.connection import _TYPE_SOCKET_OPTIONS
 from .util.timeout import _DEFAULT_TIMEOUT, _TYPE_TIMEOUT
 from .util.url import Url
@@ -70,7 +71,7 @@ if typing.TYPE_CHECKING:
             self,
             host: str,
             port: int | None = None,
-            headers: typing.Mapping[str, str] | None = None,
+            headers: _TYPE_HEADERS | None = None,
             scheme: str = "http",
         ) -> None: ...
 
@@ -81,7 +82,7 @@ if typing.TYPE_CHECKING:
             method: str,
             url: str,
             body: _TYPE_BODY | None = None,
-            headers: typing.Mapping[str, str] | None = None,
+            headers: _TYPE_HEADERS | None = None,
             # We know *at least* botocore is depending on the order of the
             # first 3 parameters so to be safe we only mark the later ones
             # as keyword-only to ensure we have space to extend.

--- a/src/urllib3/_collections.py
+++ b/src/urllib3/_collections.py
@@ -356,6 +356,9 @@ class HTTPHeaderDict(typing.MutableMapping[str, str]):
             for key, val in other.items():
                 self.add(key, val)
         elif isinstance(other, typing.Iterable):
+            other = typing.cast(  # type: ignore[redundant-cast, unused-ignore]
+                typing.Iterable[tuple[str, str]], other
+            )
             for key, value in other:
                 self.add(key, value)
         elif hasattr(other, "keys") and hasattr(other, "__getitem__"):

--- a/src/urllib3/_request_methods.py
+++ b/src/urllib3/_request_methods.py
@@ -6,8 +6,10 @@ from urllib.parse import urlencode
 
 from ._base_connection import _TYPE_BODY
 from ._collections import HTTPHeaderDict
+from ._typing import _TYPE_HEADERS
 from .filepost import _TYPE_FIELDS, encode_multipart_formdata
 from .response import BaseHTTPResponse
+from .util.util import to_str
 
 __all__ = ["RequestMethods"]
 
@@ -48,7 +50,7 @@ class RequestMethods:
 
     _encode_url_methods = {"DELETE", "GET", "HEAD", "OPTIONS"}
 
-    def __init__(self, headers: typing.Mapping[str, str] | None = None) -> None:
+    def __init__(self, headers: _TYPE_HEADERS | None = None) -> None:
         self.headers = headers or {}
 
     def urlopen(
@@ -56,7 +58,7 @@ class RequestMethods:
         method: str,
         url: str,
         body: _TYPE_BODY | None = None,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADERS | None = None,
         encode_multipart: bool = True,
         multipart_boundary: str | None = None,
         **kw: typing.Any,
@@ -72,7 +74,7 @@ class RequestMethods:
         url: str,
         body: _TYPE_BODY | None = None,
         fields: _TYPE_FIELDS | None = None,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADERS | None = None,
         json: typing.Any | None = None,
         **urlopen_kw: typing.Any,
     ) -> BaseHTTPResponse:
@@ -120,8 +122,8 @@ class RequestMethods:
             if headers is None:
                 headers = self.headers
 
-            if not ("content-type" in map(str.lower, headers.keys())):
-                headers = HTTPHeaderDict(headers)
+            if not ("content-type" in (to_str(key).lower() for key in headers.keys())):
+                headers = HTTPHeaderDict(typing.cast(typing.Mapping[str, str], headers))
                 headers["Content-Type"] = "application/json"
 
             body = _json.dumps(json, separators=(",", ":"), ensure_ascii=False).encode(
@@ -149,7 +151,7 @@ class RequestMethods:
         method: str,
         url: str,
         fields: _TYPE_ENCODE_URL_FIELDS | None = None,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADERS | None = None,
         **urlopen_kw: str,
     ) -> BaseHTTPResponse:
         """
@@ -186,7 +188,7 @@ class RequestMethods:
         method: str,
         url: str,
         fields: _TYPE_FIELDS | None = None,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADERS | None = None,
         encode_multipart: bool = True,
         multipart_boundary: str | None = None,
         **urlopen_kw: str,
@@ -251,7 +253,9 @@ class RequestMethods:
         if headers is None:
             headers = self.headers
 
-        extra_kw: dict[str, typing.Any] = {"headers": HTTPHeaderDict(headers)}
+        extra_kw: dict[str, typing.Any] = {
+            "headers": HTTPHeaderDict(typing.cast(typing.Mapping[str, str], headers))
+        }
         body: bytes | str
 
         if fields:

--- a/src/urllib3/_typing.py
+++ b/src/urllib3/_typing.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+import typing
+
+_TYPE_HEADER_KEY = typing.Union[str, bytes]
+_TYPE_HEADER_VALUE = typing.Union[str, bytes]
+_TYPE_HEADERS = typing.Union[
+    typing.Mapping[str, _TYPE_HEADER_VALUE],
+    typing.Mapping[bytes, _TYPE_HEADER_VALUE],
+    typing.Mapping[_TYPE_HEADER_KEY, _TYPE_HEADER_VALUE],
+]

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -16,11 +16,14 @@ from http.client import ResponseNotReady
 from socket import timeout as SocketTimeout
 
 if typing.TYPE_CHECKING:
+    from collections.abc import Buffer
+
     from .response import HTTPResponse
     from .util.ssl_ import _TYPE_PEER_CERT_RET_DICT
     from .util.ssltransport import SSLTransport
 
 from ._collections import HTTPHeaderDict
+from ._typing import _TYPE_HEADER_KEY, _TYPE_HEADERS
 from .http2 import probe as http2_probe
 from .util.response import assert_header_parsing
 from .util.timeout import _DEFAULT_TIMEOUT, _TYPE_TIMEOUT, Timeout
@@ -228,14 +231,18 @@ class HTTPConnection(_HTTPConnection):
         self,
         host: str,
         port: int | None = None,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADERS | None = None,
         scheme: str = "http",
     ) -> None:
         if scheme not in ("http", "https"):
             raise ValueError(
                 f"Invalid proxy scheme for tunneling: {scheme!r}, must be either 'http' or 'https'"
             )
-        super().set_tunnel(host, port=port, headers=headers)
+        super().set_tunnel(
+            host,
+            port=port,
+            headers=typing.cast(typing.Mapping[str, str] | None, headers),
+        )
         self._tunnel_scheme = scheme
 
     if sys.version_info < (3, 11, 9) or ((3, 12) <= sys.version_info < (3, 12, 3)):
@@ -407,7 +414,7 @@ class HTTPConnection(_HTTPConnection):
             method, url, skip_host=skip_host, skip_accept_encoding=skip_accept_encoding
         )
 
-    def putheader(self, header: str, *values: str) -> None:  # type: ignore[override]
+    def putheader(self, header: _TYPE_HEADER_KEY, *values: Buffer | str | int) -> None:
         """"""
         if not any(isinstance(v, str) and v == SKIP_HEADER for v in values):
             super().putheader(header, *values)
@@ -426,7 +433,7 @@ class HTTPConnection(_HTTPConnection):
         method: str,
         url: str,
         body: _TYPE_BODY | None = None,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADERS | None = None,
         *,
         chunked: bool = False,
         preload_content: bool = True,
@@ -523,7 +530,7 @@ class HTTPConnection(_HTTPConnection):
         method: str,
         url: str,
         body: _TYPE_BODY | None = None,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADERS | None = None,
     ) -> None:
         """
         Alternative to the common request method, which sends the

--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -13,6 +13,7 @@ from types import TracebackType
 from ._base_connection import _TYPE_BODY
 from ._collections import HTTPHeaderDict
 from ._request_methods import RequestMethods
+from ._typing import _TYPE_HEADERS
 from .connection import (
     BaseSSLError,
     BrokenPipeError,
@@ -179,10 +180,10 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         timeout: _TYPE_TIMEOUT | None = _DEFAULT_TIMEOUT,
         maxsize: int = 1,
         block: bool = False,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADERS | None = None,
         retries: Retry | bool | int | None = None,
         _proxy: Url | None = None,
-        _proxy_headers: typing.Mapping[str, str] | None = None,
+        _proxy_headers: _TYPE_HEADERS | None = None,
         _proxy_config: ProxyConfig | None = None,
         **conn_kw: typing.Any,
     ):
@@ -380,7 +381,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         method: str,
         url: str,
         body: _TYPE_BODY | None = None,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADERS | None = None,
         retries: Retry | None = None,
         timeout: _TYPE_TIMEOUT = _DEFAULT_TIMEOUT,
         chunked: bool = False,
@@ -594,7 +595,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         method: str,
         url: str,
         body: _TYPE_BODY | None = None,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADERS | None = None,
         retries: Retry | bool | int | None = None,
         redirect: bool = True,
         assert_same_host: bool = True,
@@ -746,8 +747,8 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         # have to copy the headers dict so we can safely change it without those
         # changes being reflected in anyone else's copy.
         if not http_tunnel_required:
-            headers = headers.copy()  # type: ignore[attr-defined]
-            headers.update(self.proxy_headers)  # type: ignore[union-attr]
+            headers = HTTPHeaderDict(typing.cast(typing.Mapping[str, str], headers))
+            headers.update(typing.cast(typing.Mapping[str, str], self.proxy_headers))
 
         # Must keep the exception bound to a separate variable or else Python 3
         # complains about UnboundLocalError.
@@ -895,7 +896,9 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
                 method = "GET"
                 # And lose the body not to transfer anything sensitive.
                 body = None
-                headers = HTTPHeaderDict(headers)._prepare_for_method_change()
+                headers = HTTPHeaderDict(
+                    typing.cast(typing.Mapping[str, str], headers)
+                )._prepare_for_method_change()
 
             # Strip headers marked as unsafe to forward to the redirected location.
             # Check remove_headers_on_redirect to avoid a potential network call within
@@ -997,10 +1000,10 @@ class HTTPSConnectionPool(HTTPConnectionPool):
         timeout: _TYPE_TIMEOUT | None = _DEFAULT_TIMEOUT,
         maxsize: int = 1,
         block: bool = False,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADERS | None = None,
         retries: Retry | bool | int | None = None,
         _proxy: Url | None = None,
-        _proxy_headers: typing.Mapping[str, str] | None = None,
+        _proxy_headers: _TYPE_HEADERS | None = None,
         key_file: str | None = None,
         cert_file: str | None = None,
         cert_reqs: int | str | None = None,

--- a/src/urllib3/contrib/emscripten/connection.py
+++ b/src/urllib3/contrib/emscripten/connection.py
@@ -8,12 +8,14 @@ from http.client import HTTPException as HTTPException  # noqa: F401
 from http.client import ResponseNotReady
 
 from ..._base_connection import _TYPE_BODY
+from ..._typing import _TYPE_HEADERS
 from ...connection import HTTPConnection, ProxyConfig, port_by_scheme
 from ...exceptions import TimeoutError
 from ...response import BaseHTTPResponse
 from ...util.connection import _TYPE_SOCKET_OPTIONS
 from ...util.timeout import _DEFAULT_TIMEOUT, _TYPE_TIMEOUT
 from ...util.url import Url
+from ...util.util import to_str
 from .fetch import _RequestError, _TimeoutError, send_request, send_streaming_request
 from .request import EmscriptenRequest
 from .response import EmscriptenHttpResponseWrapper, EmscriptenResponse
@@ -74,7 +76,7 @@ class EmscriptenHTTPConnection:
         self,
         host: str,
         port: int | None = 0,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADERS | None = None,
         scheme: str = "http",
     ) -> None:
         pass
@@ -87,7 +89,7 @@ class EmscriptenHTTPConnection:
         method: str,
         url: str,
         body: _TYPE_BODY | None = None,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADERS | None = None,
         # We know *at least* botocore is depending on the order of the
         # first 3 parameters so to be safe we only mark the later ones
         # as keyword-only to ensure we have space to extend.
@@ -114,7 +116,7 @@ class EmscriptenHTTPConnection:
         request.set_body(body)
         if headers:
             for k, v in headers.items():
-                request.set_header(k, v)
+                request.set_header(to_str(k), to_str(v))
         self._response = None
         try:
             if not preload_content:

--- a/src/urllib3/contrib/socks.py
+++ b/src/urllib3/contrib/socks.py
@@ -60,6 +60,7 @@ except ImportError:
 import typing
 from socket import timeout as SocketTimeout
 
+from .._typing import _TYPE_HEADERS
 from ..connection import HTTPConnection, HTTPSConnection
 from ..connectionpool import HTTPConnectionPool, HTTPSConnectionPool
 from ..exceptions import ConnectTimeoutError, NewConnectionError
@@ -187,7 +188,7 @@ class SOCKSProxyManager(PoolManager):
         username: str | None = None,
         password: str | None = None,
         num_pools: int = 10,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADERS | None = None,
         **connection_pool_kw: typing.Any,
     ):
         parsed = parse_url(proxy_url)

--- a/src/urllib3/http2/connection.py
+++ b/src/urllib3/http2/connection.py
@@ -12,6 +12,7 @@ import h2.events
 
 from .._base_connection import _TYPE_BODY
 from .._collections import HTTPHeaderDict
+from .._typing import _TYPE_HEADERS
 from ..connection import HTTPSConnection, _get_default_user_agent
 from ..exceptions import ConnectionError
 from ..response import BaseHTTPResponse
@@ -216,7 +217,7 @@ class HTTP2Connection(HTTPSConnection):
         self,
         host: str,
         port: int | None = None,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADERS | None = None,
         scheme: str = "http",
     ) -> None:
         raise NotImplementedError(
@@ -270,7 +271,7 @@ class HTTP2Connection(HTTPSConnection):
         method: str,
         url: str,
         body: _TYPE_BODY | None = None,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADERS | None = None,
         *,
         preload_content: bool = True,
         decode_content: bool = True,

--- a/src/urllib3/poolmanager.py
+++ b/src/urllib3/poolmanager.py
@@ -9,6 +9,7 @@ from urllib.parse import urljoin
 
 from ._collections import HTTPHeaderDict, RecentlyUsedContainer
 from ._request_methods import RequestMethods
+from ._typing import _TYPE_HEADERS
 from .connection import ProxyConfig
 from .connectionpool import HTTPConnectionPool, HTTPSConnectionPool, port_by_scheme
 from .exceptions import (
@@ -23,6 +24,7 @@ from .util.proxy import connection_requires_http_tunnel
 from .util.retry import Retry
 from .util.timeout import Timeout
 from .util.url import Url, parse_url
+from .util.util import to_str
 
 if typing.TYPE_CHECKING:
     import ssl
@@ -199,7 +201,7 @@ class PoolManager(RequestMethods):
     def __init__(
         self,
         num_pools: int = 10,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADERS | None = None,
         **connection_pool_kw: typing.Any,
     ) -> None:
         super().__init__(headers)
@@ -564,8 +566,8 @@ class ProxyManager(PoolManager):
         self,
         proxy_url: str,
         num_pools: int = 10,
-        headers: typing.Mapping[str, str] | None = None,
-        proxy_headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADERS | None = None,
+        proxy_headers: _TYPE_HEADERS | None = None,
         proxy_ssl_context: ssl.SSLContext | None = None,
         use_forwarding_for_https: bool = False,
         proxy_assert_hostname: None | str | typing.Literal[False] = None,
@@ -618,7 +620,7 @@ class ProxyManager(PoolManager):
         )
 
     def _set_proxy_headers(
-        self, url: str, headers: typing.Mapping[str, str] | None = None
+        self, url: str, headers: _TYPE_HEADERS | None = None
     ) -> typing.Mapping[str, str]:
         """
         Sets headers needed by proxies: specifically, the Accept and Host
@@ -631,7 +633,9 @@ class ProxyManager(PoolManager):
             headers_["Host"] = netloc
 
         if headers:
-            headers_.update(headers)
+            headers_.update(
+                (to_str(key), to_str(value)) for key, value in headers.items()
+            )
         return headers_
 
     def urlopen(  # type: ignore[override]

--- a/test/test_request_header_typing.py
+++ b/test/test_request_header_typing.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import typing
+
+if typing.TYPE_CHECKING:
+    import urllib3
+    from urllib3.connection import HTTPConnection
+
+    def _request_headers_accept_str_and_bytes(
+        str_headers: typing.Mapping[str, str],
+        bytes_headers: typing.Mapping[bytes, bytes],
+        mixed_headers: typing.Mapping[str | bytes, str | bytes],
+    ) -> None:
+        urllib3.request("GET", "https://example.com", headers=str_headers)
+        urllib3.request("GET", "https://example.com", headers=bytes_headers)
+        urllib3.request("GET", "https://example.com", headers=mixed_headers)
+
+        pool = urllib3.HTTPConnectionPool("example.com", headers=bytes_headers)
+        pool.request("GET", "/", headers=mixed_headers)
+
+        manager = urllib3.PoolManager(headers=mixed_headers)
+        manager.request("GET", "https://example.com", headers=bytes_headers)
+
+        proxy = urllib3.ProxyManager(
+            "http://proxy.example.com",
+            headers=str_headers,
+            proxy_headers=bytes_headers,
+        )
+        proxy.request("GET", "https://example.com", headers=mixed_headers)
+
+        connection = HTTPConnection("example.com")
+        connection.set_tunnel("example.com", headers=bytes_headers)
+        connection.request("GET", "/", headers=mixed_headers)


### PR DESCRIPTION
## Summary
- add a shared request-header typing alias that accepts string, byte, and mixed string/byte header mappings
- apply the alias to request-facing APIs across pools, managers, connections, SOCKS, and emscripten
- add a type-only regression covering public request APIs with `Mapping[str, str]`, `Mapping[bytes, bytes]`, and `Mapping[str | bytes, str | bytes]`

Closes #3047

## Testing
- `.venv/bin/mypy -p urllib3`
- `.venv/bin/mypy test/test_request_header_typing.py`
- `PYTHONPATH=src .venv/bin/pytest -q test/test_collections.py test/test_request_header_typing.py`
- `PYTHONPATH=src .venv/bin/pytest -q test/with_dummyserver/test_socketlevel.py -k "headers_are_sent_with_the_original_case or ua_header_can_be_overridden"`
- `git diff --check`