### PR TITLE
Unfold obs-fold in response headers

### DIFF
--- a/changelog/1362.bugfix.rst
+++ b/changelog/1362.bugfix.rst
@@ -1,0 +1,1 @@
+Unfolded obsolete line folding in response header values before interpreting them.

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -22,7 +22,7 @@ if typing.TYPE_CHECKING:
 
 from ._collections import HTTPHeaderDict
 from .http2 import probe as http2_probe
-from .util.response import assert_header_parsing
+from .util.response import assert_header_parsing, sanitize_header_items
 from .util.timeout import _DEFAULT_TIMEOUT, _TYPE_TIMEOUT, Timeout
 from .util.util import to_str
 from .util.wait import wait_for_read
@@ -580,7 +580,7 @@ class HTTPConnection(_HTTPConnection):
                 exc_info=True,
             )
 
-        headers = HTTPHeaderDict(httplib_response.msg.items())
+        headers = HTTPHeaderDict(sanitize_header_items(httplib_response.msg.items()))
 
         response = HTTPResponse(
             body=httplib_response,

--- a/src/urllib3/util/response.py
+++ b/src/urllib3/util/response.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import http.client as httplib
+import re
 from email.errors import MultipartInvariantViolationDefect, StartBoundaryNotFoundDefect
 
+from ..exceptions import InvalidHeader
 from ..exceptions import HeaderParsingError
 
 
@@ -86,6 +88,50 @@ def assert_header_parsing(headers: httplib.HTTPMessage) -> None:
 
     if defects or unparsed_data:
         raise HeaderParsingError(defects=defects, unparsed_data=unparsed_data)
+
+
+_HEADER_VALUE_OBS_FOLD_RE = re.compile(r"(?:\r\n|\n)[ \t]+")
+
+
+def sanitize_header_items(
+    header_items: list[tuple[str, str]] | list[tuple[bytes, bytes]],
+) -> list[tuple[str, str]] | list[tuple[bytes, bytes]]:
+    """
+    Sanitize header items from ``http.client``.
+
+    Historically, ``http.client`` may return values containing obsolete line folding
+    (CRLF + leading whitespace). This is deprecated and can lead to header injection
+    when upstream libraries consume values verbatim.
+
+    This function unfolds obs-fold sequences into a single space and rejects any
+    remaining CR/LF characters in header names or values.
+    """
+
+    sanitized: list[tuple[object, object]] = []
+
+    for name, value in header_items:
+        if isinstance(name, str) and ("\r" in name or "\n" in name):
+            raise InvalidHeader(f"Invalid header name {name!r}")
+        if isinstance(name, (bytes, bytearray, memoryview)):
+            name_bytes = bytes(name)
+            if b"\r" in name_bytes or b"\n" in name_bytes:
+                raise InvalidHeader(f"Invalid header name {name_bytes!r}")
+
+        if isinstance(value, str):
+            unfolded = _HEADER_VALUE_OBS_FOLD_RE.sub(" ", value)
+            if "\r" in unfolded or "\n" in unfolded:
+                raise InvalidHeader(f"Invalid header value for {name!r}")
+            sanitized.append((name, unfolded))
+        elif isinstance(value, (bytes, bytearray, memoryview)):
+            value_bytes = bytes(value)
+            unfolded_bytes = re.sub(rb"(?:\r\n|\n)[ \t]+", b" ", value_bytes)
+            if b"\r" in unfolded_bytes or b"\n" in unfolded_bytes:
+                raise InvalidHeader(f"Invalid header value for {name!r}")
+            sanitized.append((name, unfolded_bytes))
+        else:
+            sanitized.append((name, value))
+
+    return sanitized  # type: ignore[return-value]
 
 
 def is_response_to_head(response: httplib.HTTPResponse) -> bool:

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -88,6 +88,30 @@ class TestCookies(SocketDummyServerTestCase):
             assert r.headers == {"set-cookie": "foo=1, bar=1"}
             assert r.headers.getlist("set-cookie") == ["foo=1", "bar=1"]
 
+    def test_setcookie_obs_fold_is_unfolded(self) -> None:
+        def response_handler(listener: socket.socket) -> None:
+            sock = listener.accept()[0]
+
+            buf = b""
+            while not buf.endswith(b"\r\n\r\n"):
+                buf += sock.recv(65536)
+
+            sock.send(
+                b"HTTP/1.1 200 OK\r\n"
+                b"Set-Cookie: a=b\r\n"
+                b"\tXbNOjalT: Lte; Path=/; Max-Age=900\r\n"
+                b"\r\n"
+            )
+            sock.close()
+
+        self._start_server(response_handler)
+        with HTTPConnectionPool(self.host, self.port) as pool:
+            r = pool.request("GET", "/", retries=0)
+            cookie_header = r.headers["set-cookie"]
+            assert "\r" not in cookie_header
+            assert "\n" not in cookie_header
+            assert cookie_header == "a=b XbNOjalT: Lte; Path=/; Max-Age=900"
+
 
 class TestSNI(SocketDummyServerTestCase):
     def test_hostname_in_first_request_packet(self) -> None:


### PR DESCRIPTION
Fixes #1362.

## Summary
- Unfold obsolete line folding (obs-fold) in response header values returned by `http.client` before storing them in `HTTPHeaderDict`.
- Reject remaining CR/LF characters in response header names or values after unfolding.
- Add a socket-level regression test for a folded `Set-Cookie` header.

## Verification
- `PYTHONPATH=src ./.venv/bin/python -m pytest -q test/with_dummyserver/test_socketlevel.py -k 'TestCookies'`

Bounty: $100 OpenCollective bounty on #1362.
