### PR TITLE
Fix empty allowed_methods retry handling

### DIFF
--- a/changelog/5044.bugfix.rst
+++ b/changelog/5044.bugfix.rst
@@ -1,0 +1,1 @@
+Treated an empty ``Retry.allowed_methods`` container as retrying no methods instead of all methods.

--- a/src/urllib3/util/retry.py
+++ b/src/urllib3/util/retry.py
@@ -404,7 +404,10 @@ class Retry:
         """Checks if a given HTTP method should be retried upon, depending if
         it is included in the allowed_methods
         """
-        if self.allowed_methods and method.upper() not in self.allowed_methods:
+        if (
+            self.allowed_methods is not None
+            and method.upper() not in self.allowed_methods
+        ):
             return False
         return True
 

--- a/test/test_retry.py
+++ b/test/test_retry.py
@@ -263,10 +263,15 @@ class TestRetry:
         assert not retry.is_retry("GET", status_code=418)
 
     def test_allowed_methods_with_status_forcelist(self) -> None:
-        # Falsey allowed_methods means to retry on any method.
+        # None means to retry on any method.
         retry = Retry(status_forcelist=[500], allowed_methods=None)
         assert retry.is_retry("GET", status_code=500)
         assert retry.is_retry("POST", status_code=500)
+
+        # Empty allowed_methods means to retry on no methods.
+        retry = Retry(status_forcelist=[500], allowed_methods=set())
+        assert not retry.is_retry("GET", status_code=500)
+        assert not retry.is_retry("POST", status_code=500)
 
         # Criteria of allowed_methods and status_forcelist are ANDed.
         retry = Retry(status_forcelist=[500], allowed_methods=["POST"])


### PR DESCRIPTION
## Summary
- distinguish `allowed_methods=None` from an explicitly empty container
- make empty `allowed_methods` retry no methods instead of all methods
- add regression coverage and a changelog entry

Fixes #5044

## Tests
- `python -m pytest test/test_retry.py::TestRetry::test_allowed_methods_with_status_forcelist`
- `python -m pytest test/test_retry.py`
- `python -m ruff format --check src/urllib3/util/retry.py test/test_retry.py`
- `python -m ruff check src/urllib3/util/retry.py test/test_retry.py`
- `git diff --check`
