### PR TITLE
Normalize folded response header values

### DIFF
--- a/changelog/1362.bugfix.rst
+++ b/changelog/1362.bugfix.rst
@@ -1,0 +1,1 @@
+Replaced obsolete folded response header continuations with spaces before exposing parsed header values.

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -22,7 +22,7 @@ if typing.TYPE_CHECKING:
 
 from ._collections import HTTPHeaderDict
 from .http2 import probe as http2_probe
-from .util.response import assert_header_parsing
+from .util.response import assert_header_parsing, normalize_header_value
 from .util.timeout import _DEFAULT_TIMEOUT, _TYPE_TIMEOUT, Timeout
 from .util.util import to_str
 from .util.wait import wait_for_read
@@ -580,7 +580,10 @@ class HTTPConnection(_HTTPConnection):
                 exc_info=True,
             )
 
-        headers = HTTPHeaderDict(httplib_response.msg.items())
+        headers = HTTPHeaderDict(
+            (key, normalize_header_value(value))
+            for key, value in httplib_response.msg.items()
+        )
 
         response = HTTPResponse(
             body=httplib_response,

--- a/src/urllib3/util/response.py
+++ b/src/urllib3/util/response.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 import http.client as httplib
+import re
 from email.errors import MultipartInvariantViolationDefect, StartBoundaryNotFoundDefect
 
 from ..exceptions import HeaderParsingError
+
+_OBS_FOLD_RE = re.compile(r"\r\n[ \t]+|\r[ \t]+|\n[ \t]+")
 
 
 def is_fp_closed(obj: object) -> bool:
@@ -86,6 +89,18 @@ def assert_header_parsing(headers: httplib.HTTPMessage) -> None:
 
     if defects or unparsed_data:
         raise HeaderParsingError(defects=defects, unparsed_data=unparsed_data)
+
+
+def normalize_header_value(value: str) -> str:
+    """
+    Replace obsolete folded header continuations with a single space.
+
+    ``http.client`` preserves obs-fold sequences in parsed header values,
+    but RFC 7230 requires recipients to replace them before interpreting
+    the field value.
+    """
+
+    return _OBS_FOLD_RE.sub(" ", value)
 
 
 def is_response_to_head(response: httplib.HTTPResponse) -> bool:

--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import datetime
+import io
 import socket
 import typing
 from http.client import ResponseNotReady
@@ -240,6 +241,40 @@ class TestConnection:
         # Should error if a request has not been sent
         with pytest.raises(ResponseNotReady):
             conn.getresponse()
+
+    def test_getresponse_normalizes_folded_header_values(self) -> None:
+        class MockSocket:
+            def makefile(self, *args: typing.Any, **kwargs: typing.Any) -> io.BytesIO:
+                return io.BytesIO(
+                    b"HTTP/1.1 200 OK\r\n"
+                    b"Set-Cookie: ___utmvbtouVBFmB=gZg\r\n"
+                    b"    XbNOjalT: Lte; path=/; Max-Age=900\r\n"
+                    b"Content-Length: 0\r\n"
+                    b"\r\n"
+                )
+
+            def settimeout(self, timeout: object) -> None:
+                pass
+
+            def sendall(self, data: bytes) -> None:
+                pass
+
+            def shutdown(self, how: int) -> None:
+                pass
+
+            def close(self) -> None:
+                pass
+
+        conn = HTTPConnection("example.com", port=80)
+        conn.sock = typing.cast(typing.Any, MockSocket())
+        conn.request("GET", "/", preload_content=False, decode_content=False)
+
+        response = conn.getresponse()
+
+        assert (
+            response.headers["Set-Cookie"]
+            == "___utmvbtouVBFmB=gZg XbNOjalT: Lte; path=/; Max-Age=900"
+        )
 
     def test_assert_fingerprint_closes_socket(self) -> None:
         context = mock.create_autospec(ssl_.SSLContext)

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -27,7 +27,7 @@ from urllib3.util import is_fp_closed
 from urllib3.util.connection import _has_ipv6, allowed_gai_family, create_connection
 from urllib3.util.proxy import connection_requires_http_tunnel
 from urllib3.util.request import _FAILEDTELL, make_headers, rewind_body
-from urllib3.util.response import assert_header_parsing
+from urllib3.util.response import assert_header_parsing, normalize_header_value
 from urllib3.util.ssl_ import (
     _is_has_never_check_common_name_reliable,
     resolve_cert_reqs,
@@ -851,6 +851,11 @@ class TestUtil:
         )
         header_msg.seek(0)
         assert_header_parsing(client.parse_headers(header_msg))
+
+    def test_normalize_header_value_replaces_obs_fold(self) -> None:
+        value = "foo=bar\r\n\tcontinued\r\n    another"
+
+        assert normalize_header_value(value) == "foo=bar continued another"
 
     @pytest.mark.parametrize("host", [".localhost", "...", "t" * 64])
     def test_create_connection_with_invalid_idna_labels(self, host: str) -> None:


### PR DESCRIPTION
## Summary

Fixes #1362 by normalizing obsolete folded response header continuations before urllib3 exposes parsed header values.

`http.client` preserves obs-fold sequences like `\r\n    ` in parsed header values. RFC 7230 requires recipients to replace obs-fold with spaces before interpreting the field value, so urllib3 now normalizes these sequences when converting `HTTPMessage` entries into `HTTPHeaderDict`.

## Verification

- `python -m pytest test/test_util.py test/test_connection.py`