### PR TITLE
Resolve connection pool queue class lazily

### DIFF
--- a/changelog/3289.bugfix.rst
+++ b/changelog/3289.bugfix.rst
@@ -1,0 +1,1 @@
+Resolved the default connection pool queue class at pool construction time so queue monkey patches applied after importing urllib3 can be honored while preserving custom ``QueueCls`` subclasses.

--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -76,7 +76,13 @@ class ConnectionPool:
     """
 
     scheme: str | None = None
-    QueueCls = queue.LifoQueue
+    QueueCls: type[queue.LifoQueue[typing.Any]] = queue.LifoQueue
+
+    def _get_queue_cls(self) -> type[queue.LifoQueue[typing.Any]]:
+        if self.QueueCls is ConnectionPool.QueueCls:
+            return queue.LifoQueue
+
+        return self.QueueCls
 
     def __init__(self, host: str, port: int | None = None) -> None:
         if not host:
@@ -198,7 +204,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         self.timeout = timeout
         self.retries = retries
 
-        self.pool: queue.LifoQueue[typing.Any] | None = self.QueueCls(maxsize)
+        self.pool: queue.LifoQueue[typing.Any] | None = self._get_queue_cls()(maxsize)
         self.block = block
 
         self.proxy = _proxy

--- a/test/test_queue_monkeypatch.py
+++ b/test/test_queue_monkeypatch.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import queue
+import typing
 from unittest import mock
 
 import pytest
@@ -15,6 +16,14 @@ class BadError(Exception):
     """
 
 
+class PatchedQueue(queue.LifoQueue[typing.Any]):
+    pass
+
+
+class CustomQueue(queue.LifoQueue[typing.Any]):
+    pass
+
+
 class TestMonkeypatchResistance:
     """
     Test that connection pool works even with a monkey patched Queue module,
@@ -27,3 +36,16 @@ class TestMonkeypatchResistance:
                 http._get_conn()
                 with pytest.raises(EmptyPoolError):
                     http._get_conn(timeout=0)
+
+    def test_default_queue_class_is_resolved_when_pool_is_created(self) -> None:
+        with mock.patch.object(queue, "LifoQueue", PatchedQueue):
+            with HTTPConnectionPool(host="localhost") as http:
+                assert isinstance(http.pool, PatchedQueue)
+
+    def test_custom_queue_class_is_not_replaced_by_monkeypatch(self) -> None:
+        class CustomConnectionPool(HTTPConnectionPool):
+            QueueCls = CustomQueue
+
+        with mock.patch.object(queue, "LifoQueue", PatchedQueue):
+            with CustomConnectionPool(host="localhost") as http:
+                assert isinstance(http.pool, CustomQueue)


### PR DESCRIPTION
This PR resolves #3289 by deferring resolution of the default connection-pool queue class until a pool is constructed.

Previously `ConnectionPool.QueueCls` captured `queue.LifoQueue` at import time. If a runtime such as gevent patched the `queue` module after urllib3 was imported, the default pool still used the original class reference. The change keeps custom `QueueCls` subclasses working as before, but when the class is still the default it uses the current `queue.LifoQueue` at pool creation time.

Validation:
- `.venv\Scripts\python.exe -m pytest test/test_queue_monkeypatch.py`
- `.venv\Scripts\python.exe -m pytest test/test_connectionpool.py test/test_queue_monkeypatch.py`
- `.venv\Scripts\python.exe -m mypy src\urllib3\connectionpool.py`
- `git diff --check`

Fixes #3289