### PR TITLE
Treat empty retry allowed_methods as no methods

### DIFF
--- a/changelog/5044.bugfix.rst
+++ b/changelog/5044.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed ``Retry(allowed_methods=...)`` to distinguish ``None`` from an empty
+collection, so an explicitly empty collection retries no request methods.

--- a/src/urllib3/util/retry.py
+++ b/src/urllib3/util/retry.py
@@ -404,9 +404,9 @@ class Retry:
         """Checks if a given HTTP method should be retried upon, depending if
         it is included in the allowed_methods
         """
-        if self.allowed_methods and method.upper() not in self.allowed_methods:
-            return False
-        return True
+        if self.allowed_methods is None:
+            return True
+        return method.upper() in self.allowed_methods
 
     def is_retry(
         self, method: str, status_code: int, has_retry_after: bool = False

--- a/test/test_retry.py
+++ b/test/test_retry.py
@@ -263,10 +263,14 @@ class TestRetry:
         assert not retry.is_retry("GET", status_code=418)
 
     def test_allowed_methods_with_status_forcelist(self) -> None:
-        # Falsey allowed_methods means to retry on any method.
+        # None allowed_methods means to retry on any method.
         retry = Retry(status_forcelist=[500], allowed_methods=None)
         assert retry.is_retry("GET", status_code=500)
         assert retry.is_retry("POST", status_code=500)
+
+        retry = Retry(status_forcelist=[500], allowed_methods=set())
+        assert not retry.is_retry("GET", status_code=500)
+        assert not retry.is_retry("POST", status_code=500)
 
         # Criteria of allowed_methods and status_forcelist are ANDed.
         retry = Retry(status_forcelist=[500], allowed_methods=["POST"])


### PR DESCRIPTION
## Summary
- distinguish `allowed_methods=None` from an explicitly empty collection
- make an empty `allowed_methods` collection retry no methods
- add regression coverage for status retries with `allowed_methods=set()`

## Verification
- `python -m pytest test/test_retry.py::TestRetry::test_allowed_methods_with_status_forcelist -q` (failed before implementation)
- `python -m pytest test/test_retry.py -q`
- `python -m mypy src/urllib3/util/retry.py`
- `python -m compileall -q src test/test_retry.py`
- `git diff --check`
- `python -m pytest test -q` reached 1977 passed / 304 skipped / 4 xfailed, with one unrelated `TestHTTPSProxyVerification::test_https_proxy_ipv4_san` unclosed-socket ResourceWarning on Python 3.14.5; rerunning that test alone passed.

Fixes #5044.

AI-assisted: yes. I used AI assistance to prepare this patch and reviewed/tested the resulting code locally.