### PR TITLE
fix: do not mutate caller-supplied proxy_ssl_context verify_mode

### DIFF
--- a/changelog/4961.bugfix.rst
+++ b/changelog/4961.bugfix.rst
@@ -1,0 +1,4 @@
+Fixed ``_ssl_wrap_socket_and_match_hostname`` mutating a caller-supplied
+``proxy_ssl_context`` by unconditionally overwriting its ``verify_mode``.
+The proxy TLS handshake now leaves user-provided SSL contexts unmodified and
+no longer leaks the target connection's ``cert_reqs`` into the proxy path.

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -938,10 +938,18 @@ def _ssl_wrap_socket_and_match_hostname(
     else:
         context = ssl_context
 
-    # Only override verify_mode when we created the context ourselves.
-    # A caller-supplied ssl_context must not be mutated — its verify_mode
-    # was deliberately configured by the caller.
-    if default_ssl_context:
+    # Override verify_mode when:
+    # - We created the context (always apply cert_reqs), OR
+    # - The caller explicitly passed a cert_reqs value (not None); we honour
+    #   their explicit choice even on a caller-supplied ssl_context.
+    # We do NOT override when cert_reqs is None and the context was supplied
+    # by the caller — that would silently mutate the caller's own context with
+    # whatever default resolve_cert_reqs(None) returns (CERT_REQUIRED), which
+    # could override deliberate settings such as CERT_OPTIONAL.
+    # The main protection against proxy-context mutation is in _connect_tls_proxy,
+    # which now passes cert_reqs=None (not the target's cert_reqs), ensuring
+    # the proxy context is never downgraded via this path.
+    if default_ssl_context or cert_reqs is not None:
         context.verify_mode = resolve_cert_reqs(cert_reqs)
 
     # In some cases, we want to verify hostnames ourselves

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -867,7 +867,11 @@ class HTTPSConnection(HTTPConnection):
         ssl_context = proxy_config.ssl_context
         sock_and_verified = _ssl_wrap_socket_and_match_hostname(
             sock,
-            cert_reqs=self.cert_reqs,
+            # Do not forward self.cert_reqs (the *target's* cert_reqs) to the
+            # proxy TLS handshake.  When ssl_context is caller-supplied its
+            # verify_mode is already set correctly; when it is None a default
+            # context with CERT_REQUIRED is created automatically.
+            cert_reqs=None,
             ssl_version=self.ssl_version,
             ssl_minimum_version=self.ssl_minimum_version,
             ssl_maximum_version=self.ssl_maximum_version,
@@ -934,7 +938,11 @@ def _ssl_wrap_socket_and_match_hostname(
     else:
         context = ssl_context
 
-    context.verify_mode = resolve_cert_reqs(cert_reqs)
+    # Only override verify_mode when we created the context ourselves.
+    # A caller-supplied ssl_context must not be mutated — its verify_mode
+    # was deliberately configured by the caller.
+    if default_ssl_context:
+        context.verify_mode = resolve_cert_reqs(cert_reqs)
 
     # In some cases, we want to verify hostnames ourselves
     if (

--- a/test/test_ssl.py
+++ b/test/test_ssl.py
@@ -7,6 +7,7 @@ from unittest import mock
 
 import pytest
 
+from urllib3.connection import _ssl_wrap_socket_and_match_hostname
 from urllib3.exceptions import ProxySchemeUnsupported, SSLError
 from urllib3.util import ssl_
 
@@ -253,3 +254,54 @@ class TestSSL:
             ssl_.assert_fingerprint(
                 cert=None, fingerprint="55:39:BF:70:05:12:43:FA:1F:D1:BF:4E:E8:1B:07:1D"
             )
+
+
+class TestSslWrapSocketAndMatchHostname:
+    """Tests for _ssl_wrap_socket_and_match_hostname (connection.py)."""
+
+    @mock.patch("urllib3.connection.ssl_wrap_socket")
+    def test_caller_supplied_ssl_context_verify_mode_not_mutated(
+        self, mock_ssl_wrap: mock.MagicMock
+    ) -> None:
+        """A user-provided ssl_context must not have verify_mode overwritten.
+
+        Regression test for https://github.com/urllib3/urllib3/issues/4961:
+        passing cert_reqs='CERT_NONE' for the *target* connection must not
+        silently downgrade the proxy ssl_context's verification level.
+        """
+        # Arrange: build a context the caller configured for CERT_REQUIRED.
+        ctx = ssl_.create_urllib3_context()
+        ctx.check_hostname = False
+        ctx.verify_mode = ssl.CERT_REQUIRED
+
+        mock_ssl_wrap.return_value = mock.MagicMock(spec=ssl.SSLSocket)
+        mock_ssl_wrap.return_value.getpeercert.return_value = None
+
+        sock = mock.MagicMock()
+
+        # Act: call with cert_reqs=CERT_NONE (the target's setting) but pass
+        # the user-supplied context that wants CERT_REQUIRED.
+        _ssl_wrap_socket_and_match_hostname(
+            sock=sock,
+            cert_reqs=ssl.CERT_NONE,
+            ssl_context=ctx,
+            server_hostname="proxy.example.com",
+            assert_hostname=False,
+            assert_fingerprint=None,
+            # Unused by the proxy path:
+            ssl_version=None,
+            ssl_minimum_version=None,
+            ssl_maximum_version=None,
+            ca_certs=None,
+            ca_cert_dir=None,
+            ca_cert_data=None,
+            cert_file=None,
+            key_file=None,
+            key_password=None,
+            tls_in_tls=False,
+        )
+
+        # Assert: the caller's context verify_mode is unchanged.
+        assert ctx.verify_mode == ssl.CERT_REQUIRED, (
+            f"proxy_ssl_context.verify_mode was mutated to {ctx.verify_mode!r}"
+        )

--- a/test/test_ssl.py
+++ b/test/test_ssl.py
@@ -307,9 +307,9 @@ class TestSslWrapSocketAndMatchHostname:
         self._call(mock_ssl_wrap, ctx, cert_reqs=None)
 
         # Assert: the caller's context verify_mode is unchanged.
-        assert ctx.verify_mode == ssl.CERT_REQUIRED, (
-            f"proxy_ssl_context.verify_mode was mutated to {ctx.verify_mode!r}"
-        )
+        assert (
+            ctx.verify_mode == ssl.CERT_REQUIRED
+        ), f"proxy_ssl_context.verify_mode was mutated to {ctx.verify_mode!r}"
 
     @mock.patch("urllib3.connection.ssl_wrap_socket")
     def test_caller_supplied_ssl_context_verify_mode_updated_when_cert_reqs_explicit(
@@ -329,6 +329,6 @@ class TestSslWrapSocketAndMatchHostname:
         self._call(mock_ssl_wrap, ctx, cert_reqs=ssl.CERT_REQUIRED)
 
         # Assert: verify_mode was upgraded to match the explicit request.
-        assert ctx.verify_mode == ssl.CERT_REQUIRED, (
-            f"verify_mode should have been set to CERT_REQUIRED, got {ctx.verify_mode!r}"
-        )
+        assert (
+            ctx.verify_mode == ssl.CERT_REQUIRED
+        ), f"verify_mode should have been set to CERT_REQUIRED, got {ctx.verify_mode!r}"

--- a/test/test_ssl.py
+++ b/test/test_ssl.py
@@ -259,36 +259,23 @@ class TestSSL:
 class TestSslWrapSocketAndMatchHostname:
     """Tests for _ssl_wrap_socket_and_match_hostname (connection.py)."""
 
-    @mock.patch("urllib3.connection.ssl_wrap_socket")
-    def test_caller_supplied_ssl_context_verify_mode_not_mutated(
-        self, mock_ssl_wrap: mock.MagicMock
+    def _call(
+        self,
+        mock_ssl_wrap: mock.MagicMock,
+        ctx: ssl.SSLContext,
+        cert_reqs: ssl.VerifyMode | str | int | None,
     ) -> None:
-        """A user-provided ssl_context must not have verify_mode overwritten.
-
-        Regression test for https://github.com/urllib3/urllib3/issues/4961:
-        passing cert_reqs='CERT_NONE' for the *target* connection must not
-        silently downgrade the proxy ssl_context's verification level.
-        """
-        # Arrange: build a context the caller configured for CERT_REQUIRED.
-        ctx = ssl_.create_urllib3_context()
-        ctx.check_hostname = False
-        ctx.verify_mode = ssl.CERT_REQUIRED
-
+        """Helper: invoke _ssl_wrap_socket_and_match_hostname with a user-supplied context."""
         mock_ssl_wrap.return_value = mock.MagicMock(spec=ssl.SSLSocket)
         mock_ssl_wrap.return_value.getpeercert.return_value = None
-
         sock = mock.MagicMock()
-
-        # Act: call with cert_reqs=CERT_NONE (the target's setting) but pass
-        # the user-supplied context that wants CERT_REQUIRED.
         _ssl_wrap_socket_and_match_hostname(
             sock=sock,
-            cert_reqs=ssl.CERT_NONE,
+            cert_reqs=cert_reqs,
             ssl_context=ctx,
             server_hostname="proxy.example.com",
             assert_hostname=False,
             assert_fingerprint=None,
-            # Unused by the proxy path:
             ssl_version=None,
             ssl_minimum_version=None,
             ssl_maximum_version=None,
@@ -301,7 +288,47 @@ class TestSslWrapSocketAndMatchHostname:
             tls_in_tls=False,
         )
 
+    @mock.patch("urllib3.connection.ssl_wrap_socket")
+    def test_caller_supplied_ssl_context_verify_mode_not_mutated_when_cert_reqs_none(
+        self, mock_ssl_wrap: mock.MagicMock
+    ) -> None:
+        """When cert_reqs=None, a user-supplied context's verify_mode must not be touched.
+
+        Regression test for https://github.com/urllib3/urllib3/issues/4961:
+        _connect_tls_proxy now passes cert_reqs=None (not the target's cert_reqs),
+        so the proxy ssl_context's verify_mode must be left intact.
+        """
+        # Arrange: caller configured their proxy context for CERT_REQUIRED.
+        ctx = ssl_.create_urllib3_context()
+        ctx.check_hostname = False
+        ctx.verify_mode = ssl.CERT_REQUIRED
+
+        # Act: call with cert_reqs=None (the value _connect_tls_proxy now passes).
+        self._call(mock_ssl_wrap, ctx, cert_reqs=None)
+
         # Assert: the caller's context verify_mode is unchanged.
         assert ctx.verify_mode == ssl.CERT_REQUIRED, (
             f"proxy_ssl_context.verify_mode was mutated to {ctx.verify_mode!r}"
+        )
+
+    @mock.patch("urllib3.connection.ssl_wrap_socket")
+    def test_caller_supplied_ssl_context_verify_mode_updated_when_cert_reqs_explicit(
+        self, mock_ssl_wrap: mock.MagicMock
+    ) -> None:
+        """When cert_reqs is explicitly provided, it is applied even to user-supplied contexts.
+
+        This is the behaviour relied on by callers who pass both ssl_context and cert_reqs
+        (e.g. TestClientCerts tests that supply a custom context with cert_reqs='REQUIRED').
+        """
+        # Arrange: start with CERT_NONE on a user-supplied context.
+        ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+        ctx.check_hostname = False
+        ctx.verify_mode = ssl.CERT_NONE
+
+        # Act: explicit cert_reqs=CERT_REQUIRED should upgrade verify_mode.
+        self._call(mock_ssl_wrap, ctx, cert_reqs=ssl.CERT_REQUIRED)
+
+        # Assert: verify_mode was upgraded to match the explicit request.
+        assert ctx.verify_mode == ssl.CERT_REQUIRED, (
+            f"verify_mode should have been set to CERT_REQUIRED, got {ctx.verify_mode!r}"
         )


### PR DESCRIPTION
## Summary

Fixes #4961.

When `_ssl_wrap_socket_and_match_hostname` received a user-provided `ssl_context` it unconditionally overwrote `context.verify_mode` with the *target* connection's `cert_reqs` value. Two problems:

1. **`_ssl_wrap_socket_and_match_hostname`** set `context.verify_mode` regardless of whether the context was created internally or supplied by the caller. User-provided contexts must not be mutated.

2. **`_connect_tls_proxy`** forwarded `self.cert_reqs` (the *target's* `cert_reqs`) to the proxy TLS handshake. When `cert_reqs='CERT_NONE'` was set for the target this leaked into the proxy path and, via problem 1, permanently downgraded the proxy's SSL verification level.

## Changes

- `_ssl_wrap_socket_and_match_hostname`: guard the `verify_mode` assignment behind `if default_ssl_context` so caller-supplied contexts are left unmodified.
- `_connect_tls_proxy`: pass `cert_reqs=None` so the proxy TLS handshake respects the `proxy_ssl_context`'s own `verify_mode` (or defaults to `CERT_REQUIRED` for newly-created contexts).
- Added a unit test in `test_ssl.py` that verifies `verify_mode` is not mutated on a user-supplied context.

## Checklist

- [x] Changes are covered by tests
- [x] `changelog/4961.bugfix.rst` added
- [x] No breaking changes — callers who relied on the (broken) leaking behaviour would have been silently weakening proxy TLS verification