### PR TITLE
Improve typing for bytes request headers

### DIFF
--- a/changelog/3047.bugfix.rst
+++ b/changelog/3047.bugfix.rst
@@ -1,0 +1,1 @@
+Improved header typing so request and pool entry points accepted byte-keyed and byte-valued header mappings consistently with urllib3's existing runtime behavior.

--- a/src/urllib3/__init__.py
+++ b/src/urllib3/__init__.py
@@ -13,7 +13,7 @@ from logging import NullHandler
 
 from . import exceptions
 from ._base_connection import _TYPE_BODY
-from ._collections import HTTPHeaderDict
+from ._collections import HTTPHeaderDict, _TYPE_HTTP_HEADER_MAPPING
 from ._version import __version__
 from .connectionpool import HTTPConnectionPool, HTTPSConnectionPool, connection_from_url
 from .filepost import _TYPE_FIELDS, encode_multipart_formdata
@@ -120,7 +120,7 @@ def request(
     *,
     body: _TYPE_BODY | None = None,
     fields: _TYPE_FIELDS | None = None,
-    headers: typing.Mapping[str, str] | None = None,
+    headers: _TYPE_HTTP_HEADER_MAPPING | None = None,
     preload_content: bool | None = True,
     decode_content: bool | None = True,
     redirect: bool | None = True,

--- a/src/urllib3/__init__.py
+++ b/src/urllib3/__init__.py
@@ -13,7 +13,7 @@ from logging import NullHandler
 
 from . import exceptions
 from ._base_connection import _TYPE_BODY
-from ._collections import HTTPHeaderDict, _TYPE_HTTP_HEADER_MAPPING
+from ._collections import _TYPE_HTTP_HEADER_MAPPING, HTTPHeaderDict
 from ._version import __version__
 from .connectionpool import HTTPConnectionPool, HTTPSConnectionPool, connection_from_url
 from .filepost import _TYPE_FIELDS, encode_multipart_formdata

--- a/src/urllib3/_base_connection.py
+++ b/src/urllib3/_base_connection.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import typing
 
+from ._collections import _TYPE_HTTP_HEADER_MAPPING
 from .util.connection import _TYPE_SOCKET_OPTIONS
 from .util.timeout import _DEFAULT_TIMEOUT, _TYPE_TIMEOUT
 from .util.url import Url
@@ -70,7 +71,7 @@ if typing.TYPE_CHECKING:
             self,
             host: str,
             port: int | None = None,
-            headers: typing.Mapping[str, str] | None = None,
+            headers: _TYPE_HTTP_HEADER_MAPPING | None = None,
             scheme: str = "http",
         ) -> None: ...
 
@@ -81,7 +82,7 @@ if typing.TYPE_CHECKING:
             method: str,
             url: str,
             body: _TYPE_BODY | None = None,
-            headers: typing.Mapping[str, str] | None = None,
+            headers: _TYPE_HTTP_HEADER_MAPPING | None = None,
             # We know *at least* botocore is depending on the order of the
             # first 3 parameters so to be safe we only mark the later ones
             # as keyword-only to ensure we have space to extend.

--- a/src/urllib3/_collections.py
+++ b/src/urllib3/_collections.py
@@ -15,7 +15,7 @@ if typing.TYPE_CHECKING:
     class HasGettableStringKeys(Protocol):
         def keys(self) -> typing.Iterator[str]: ...
 
-        def __getitem__(self, key: str) -> str: ...
+        def __getitem__(self, key: str) -> _TYPE_HTTP_HEADER_VALUE: ...
 
 
 __all__ = ["RecentlyUsedContainer", "HTTPHeaderDict"]
@@ -28,16 +28,33 @@ _VT = typing.TypeVar("_VT")
 # Default type
 _DT = typing.TypeVar("_DT")
 
-ValidHTTPHeaderSource = typing.Union[
+_TYPE_HTTP_HEADER_KEY = str | bytes
+_TYPE_HTTP_HEADER_VALUE = str | bytes
+_TYPE_HTTP_HEADER = tuple[_TYPE_HTTP_HEADER_KEY, _TYPE_HTTP_HEADER_VALUE]
+_TYPE_HTTP_HEADER_PLAIN_MAPPING = (
+    typing.Mapping[str, _TYPE_HTTP_HEADER_VALUE]
+    | typing.Mapping[bytes, _TYPE_HTTP_HEADER_VALUE]
+)
+_TYPE_HTTP_HEADER_MAPPING = typing.Union[
     "HTTPHeaderDict",
-    typing.Mapping[str, str],
-    typing.Iterable[tuple[str, str]],
+    _TYPE_HTTP_HEADER_PLAIN_MAPPING,
+]
+
+ValidHTTPHeaderSource = typing.Union[
+    _TYPE_HTTP_HEADER_MAPPING,
+    typing.Iterable[_TYPE_HTTP_HEADER],
     "HasGettableStringKeys",
 ]
 
 
 class _Sentinel(Enum):
     not_passed = auto()
+
+
+def _ensure_str(header_part: _TYPE_HTTP_HEADER_KEY | _TYPE_HTTP_HEADER_VALUE) -> str:
+    if isinstance(header_part, bytes):
+        return header_part.decode("latin-1")
+    return header_part
 
 
 def ensure_can_construct_http_header_dict(
@@ -48,12 +65,12 @@ def ensure_can_construct_http_header_dict(
     elif isinstance(potential, typing.Mapping):
         # Full runtime checking of the contents of a Mapping is expensive, so for the
         # purposes of typechecking, we assume that any Mapping is the right shape.
-        return typing.cast(typing.Mapping[str, str], potential)
+        return typing.cast(_TYPE_HTTP_HEADER_PLAIN_MAPPING, potential)
     elif isinstance(potential, typing.Iterable):
         # Similarly to Mapping, full runtime checking of the contents of an Iterable is
         # expensive, so for the purposes of typechecking, we assume that any Iterable
         # is the right shape.
-        return typing.cast(typing.Iterable[tuple[str, str]], potential)
+        return typing.cast(typing.Iterable[_TYPE_HTTP_HEADER], potential)
     elif hasattr(potential, "keys") and hasattr(potential, "__getitem__"):
         return typing.cast("HasGettableStringKeys", potential)
     else:
@@ -201,7 +218,7 @@ class HTTPHeaderDictItemView(set[tuple[str, str]]):
         return False
 
 
-class HTTPHeaderDict(typing.MutableMapping[str, str]):
+class HTTPHeaderDict(typing.MutableMapping[_TYPE_HTTP_HEADER_KEY, str]):
     """
     :param headers:
         An iterable of field-value pairs. Must not contain multiple field names
@@ -237,7 +254,9 @@ class HTTPHeaderDict(typing.MutableMapping[str, str]):
 
     _container: typing.MutableMapping[str, list[str]]
 
-    def __init__(self, headers: ValidHTTPHeaderSource | None = None, **kwargs: str):
+    def __init__(
+        self, headers: ValidHTTPHeaderSource | None = None, **kwargs: _TYPE_HTTP_HEADER_VALUE
+    ):
         super().__init__()
         self._container = {}  # 'dict' is insert-ordered
         if headers is not None:
@@ -248,21 +267,21 @@ class HTTPHeaderDict(typing.MutableMapping[str, str]):
         if kwargs:
             self.extend(kwargs)
 
-    def __setitem__(self, key: str, val: str) -> None:
-        # avoid a bytes/str comparison by decoding before httplib
-        if isinstance(key, bytes):
-            key = key.decode("latin-1")
+    def __setitem__(
+        self, key: _TYPE_HTTP_HEADER_KEY, val: _TYPE_HTTP_HEADER_VALUE
+    ) -> None:
+        # Avoid bytes/str comparisons by decoding before storage.
+        key = _ensure_str(key)
+        val = _ensure_str(val)
         self._container[key.lower()] = [key, val]
 
-    def __getitem__(self, key: str) -> str:
-        if isinstance(key, bytes):
-            key = key.decode("latin-1")
+    def __getitem__(self, key: _TYPE_HTTP_HEADER_KEY) -> str:
+        key = _ensure_str(key)
         val = self._container[key.lower()]
         return ", ".join(val[1:])
 
-    def __delitem__(self, key: str) -> None:
-        if isinstance(key, bytes):
-            key = key.decode("latin-1")
+    def __delitem__(self, key: _TYPE_HTTP_HEADER_KEY) -> None:
+        key = _ensure_str(key)
         del self._container[key.lower()]
 
     def __contains__(self, key: object) -> bool:
@@ -272,8 +291,12 @@ class HTTPHeaderDict(typing.MutableMapping[str, str]):
             return key.lower() in self._container
         return False
 
-    def setdefault(self, key: str, default: str = "") -> str:
-        return super().setdefault(key, default)
+    def setdefault(
+        self, key: _TYPE_HTTP_HEADER_KEY, default: _TYPE_HTTP_HEADER_VALUE = ""
+    ) -> str:
+        if key not in self:
+            self[key] = default
+        return self[key]
 
     def __eq__(self, other: object) -> bool:
         maybe_constructable = ensure_can_construct_http_header_dict(other)
@@ -297,13 +320,15 @@ class HTTPHeaderDict(typing.MutableMapping[str, str]):
         for vals in self._container.values():
             yield vals[0]
 
-    def discard(self, key: str) -> None:
+    def discard(self, key: _TYPE_HTTP_HEADER_KEY) -> None:
         try:
             del self[key]
         except KeyError:
             pass
 
-    def add(self, key: str, val: str, *, combine: bool = False) -> None:
+    def add(
+        self, key: _TYPE_HTTP_HEADER_KEY, val: _TYPE_HTTP_HEADER_VALUE, *, combine: bool = False
+    ) -> None:
         """Adds a (name, value) pair, doesn't overwrite the value if it already
         exists.
 
@@ -322,9 +347,8 @@ class HTTPHeaderDict(typing.MutableMapping[str, str]):
         >>> list(headers.items())
         [('foo', 'bar, baz, quz')]
         """
-        # avoid a bytes/str comparison by decoding before httplib
-        if isinstance(key, bytes):
-            key = key.decode("latin-1")
+        key = _ensure_str(key)
+        val = _ensure_str(val)
         key_lower = key.lower()
         new_vals = [key, val]
         # Keep the common case aka no item present as fast as possible
@@ -338,7 +362,9 @@ class HTTPHeaderDict(typing.MutableMapping[str, str]):
             else:
                 vals.append(val)
 
-    def extend(self, *args: ValidHTTPHeaderSource, **kwargs: str) -> None:
+    def extend(
+        self, *args: ValidHTTPHeaderSource, **kwargs: _TYPE_HTTP_HEADER_VALUE
+    ) -> None:
         """Generic import function for any type of header-like object.
         Adapted version of MutableMapping.update in order to insert items
         with self.add instead of self.__setitem__
@@ -350,14 +376,14 @@ class HTTPHeaderDict(typing.MutableMapping[str, str]):
         other = args[0] if len(args) >= 1 else ()
 
         if isinstance(other, HTTPHeaderDict):
-            for key, val in other.iteritems():
-                self.add(key, val)
+            for header_key, header_value in other.iteritems():
+                self.add(header_key, header_value)
         elif isinstance(other, typing.Mapping):
-            for key, val in other.items():
-                self.add(key, val)
+            for header_item in other.items():
+                self.add(header_item[0], header_item[1])
         elif isinstance(other, typing.Iterable):
-            for key, value in other:
-                self.add(key, value)
+            for header_item in other:
+                self.add(header_item[0], header_item[1])
         elif hasattr(other, "keys") and hasattr(other, "__getitem__"):
             # THIS IS NOT A TYPESAFE BRANCH
             # In this branch, the object has a `keys` attr but is not a Mapping or any of
@@ -371,18 +397,19 @@ class HTTPHeaderDict(typing.MutableMapping[str, str]):
             self.add(key, value)
 
     @typing.overload
-    def getlist(self, key: str) -> list[str]: ...
+    def getlist(self, key: _TYPE_HTTP_HEADER_KEY) -> list[str]: ...
 
     @typing.overload
-    def getlist(self, key: str, default: _DT) -> list[str] | _DT: ...
+    def getlist(self, key: _TYPE_HTTP_HEADER_KEY, default: _DT) -> list[str] | _DT: ...
 
     def getlist(
-        self, key: str, default: _Sentinel | _DT = _Sentinel.not_passed
+        self,
+        key: _TYPE_HTTP_HEADER_KEY,
+        default: _Sentinel | _DT = _Sentinel.not_passed,
     ) -> list[str] | _DT:
         """Returns a list of all the values for the named field. Returns an
         empty list if the key doesn't exist."""
-        if isinstance(key, bytes):
-            key = key.decode("latin-1")
+        key = _ensure_str(key)
         try:
             vals = self._container[key.lower()]
         except KeyError:
@@ -451,7 +478,13 @@ class HTTPHeaderDict(typing.MutableMapping[str, str]):
     def items(self) -> HTTPHeaderDictItemView:  # type: ignore[override]
         return HTTPHeaderDictItemView(self)
 
-    def _has_value_for_header(self, header_name: str, potential_value: str) -> bool:
+    def _has_value_for_header(
+        self,
+        header_name: _TYPE_HTTP_HEADER_KEY,
+        potential_value: _TYPE_HTTP_HEADER_VALUE,
+    ) -> bool:
+        header_name = _ensure_str(header_name)
+        potential_value = _ensure_str(potential_value)
         if header_name in self:
             return potential_value in self._container[header_name.lower()][1:]
         return False

--- a/src/urllib3/_collections.py
+++ b/src/urllib3/_collections.py
@@ -34,6 +34,7 @@ _TYPE_HTTP_HEADER = tuple[_TYPE_HTTP_HEADER_KEY, _TYPE_HTTP_HEADER_VALUE]
 _TYPE_HTTP_HEADER_PLAIN_MAPPING = (
     typing.Mapping[str, _TYPE_HTTP_HEADER_VALUE]
     | typing.Mapping[bytes, _TYPE_HTTP_HEADER_VALUE]
+    | typing.Mapping[_TYPE_HTTP_HEADER_KEY, _TYPE_HTTP_HEADER_VALUE]
 )
 _TYPE_HTTP_HEADER_MAPPING = typing.Union[
     "HTTPHeaderDict",
@@ -255,7 +256,9 @@ class HTTPHeaderDict(typing.MutableMapping[_TYPE_HTTP_HEADER_KEY, str]):
     _container: typing.MutableMapping[str, list[str]]
 
     def __init__(
-        self, headers: ValidHTTPHeaderSource | None = None, **kwargs: _TYPE_HTTP_HEADER_VALUE
+        self,
+        headers: ValidHTTPHeaderSource | None = None,
+        **kwargs: _TYPE_HTTP_HEADER_VALUE,
     ):
         super().__init__()
         self._container = {}  # 'dict' is insert-ordered
@@ -327,7 +330,11 @@ class HTTPHeaderDict(typing.MutableMapping[_TYPE_HTTP_HEADER_KEY, str]):
             pass
 
     def add(
-        self, key: _TYPE_HTTP_HEADER_KEY, val: _TYPE_HTTP_HEADER_VALUE, *, combine: bool = False
+        self,
+        key: _TYPE_HTTP_HEADER_KEY,
+        val: _TYPE_HTTP_HEADER_VALUE,
+        *,
+        combine: bool = False,
     ) -> None:
         """Adds a (name, value) pair, doesn't overwrite the value if it already
         exists.

--- a/src/urllib3/_request_methods.py
+++ b/src/urllib3/_request_methods.py
@@ -5,7 +5,7 @@ import typing
 from urllib.parse import urlencode
 
 from ._base_connection import _TYPE_BODY
-from ._collections import HTTPHeaderDict
+from ._collections import HTTPHeaderDict, _TYPE_HTTP_HEADER_MAPPING
 from .filepost import _TYPE_FIELDS, encode_multipart_formdata
 from .response import BaseHTTPResponse
 
@@ -48,7 +48,7 @@ class RequestMethods:
 
     _encode_url_methods = {"DELETE", "GET", "HEAD", "OPTIONS"}
 
-    def __init__(self, headers: typing.Mapping[str, str] | None = None) -> None:
+    def __init__(self, headers: _TYPE_HTTP_HEADER_MAPPING | None = None) -> None:
         self.headers = headers or {}
 
     def urlopen(
@@ -56,7 +56,7 @@ class RequestMethods:
         method: str,
         url: str,
         body: _TYPE_BODY | None = None,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HTTP_HEADER_MAPPING | None = None,
         encode_multipart: bool = True,
         multipart_boundary: str | None = None,
         **kw: typing.Any,
@@ -72,7 +72,7 @@ class RequestMethods:
         url: str,
         body: _TYPE_BODY | None = None,
         fields: _TYPE_FIELDS | None = None,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HTTP_HEADER_MAPPING | None = None,
         json: typing.Any | None = None,
         **urlopen_kw: typing.Any,
     ) -> BaseHTTPResponse:
@@ -120,9 +120,10 @@ class RequestMethods:
             if headers is None:
                 headers = self.headers
 
-            if not ("content-type" in map(str.lower, headers.keys())):
-                headers = HTTPHeaderDict(headers)
-                headers["Content-Type"] = "application/json"
+            header_dict = HTTPHeaderDict(headers)
+            if "content-type" not in header_dict:
+                header_dict["Content-Type"] = "application/json"
+            headers = header_dict
 
             body = _json.dumps(json, separators=(",", ":"), ensure_ascii=False).encode(
                 "utf-8"
@@ -149,7 +150,7 @@ class RequestMethods:
         method: str,
         url: str,
         fields: _TYPE_ENCODE_URL_FIELDS | None = None,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HTTP_HEADER_MAPPING | None = None,
         **urlopen_kw: str,
     ) -> BaseHTTPResponse:
         """
@@ -186,7 +187,7 @@ class RequestMethods:
         method: str,
         url: str,
         fields: _TYPE_FIELDS | None = None,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HTTP_HEADER_MAPPING | None = None,
         encode_multipart: bool = True,
         multipart_boundary: str | None = None,
         **urlopen_kw: str,

--- a/src/urllib3/_request_methods.py
+++ b/src/urllib3/_request_methods.py
@@ -5,7 +5,7 @@ import typing
 from urllib.parse import urlencode
 
 from ._base_connection import _TYPE_BODY
-from ._collections import HTTPHeaderDict, _TYPE_HTTP_HEADER_MAPPING
+from ._collections import _TYPE_HTTP_HEADER_MAPPING, HTTPHeaderDict
 from .filepost import _TYPE_FIELDS, encode_multipart_formdata
 from .response import BaseHTTPResponse
 

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -21,10 +21,9 @@ if typing.TYPE_CHECKING:
     from .util.ssltransport import SSLTransport
 
 from ._collections import (
-    HTTPHeaderDict,
     _TYPE_HTTP_HEADER_KEY,
     _TYPE_HTTP_HEADER_MAPPING,
-    _TYPE_HTTP_HEADER_VALUE,
+    HTTPHeaderDict,
 )
 from .http2 import probe as http2_probe
 from .util.response import assert_header_parsing
@@ -412,9 +411,7 @@ class HTTPConnection(_HTTPConnection):
             method, url, skip_host=skip_host, skip_accept_encoding=skip_accept_encoding
         )
 
-    def putheader(
-        self, header: _TYPE_HTTP_HEADER_KEY, *values: typing.Any
-    ) -> None:
+    def putheader(self, header: _TYPE_HTTP_HEADER_KEY, *values: typing.Any) -> None:
         """"""
         if not any(isinstance(v, str) and v == SKIP_HEADER for v in values):
             super().putheader(

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -20,7 +20,12 @@ if typing.TYPE_CHECKING:
     from .util.ssl_ import _TYPE_PEER_CERT_RET_DICT
     from .util.ssltransport import SSLTransport
 
-from ._collections import HTTPHeaderDict
+from ._collections import (
+    HTTPHeaderDict,
+    _TYPE_HTTP_HEADER_KEY,
+    _TYPE_HTTP_HEADER_MAPPING,
+    _TYPE_HTTP_HEADER_VALUE,
+)
 from .http2 import probe as http2_probe
 from .util.response import assert_header_parsing
 from .util.timeout import _DEFAULT_TIMEOUT, _TYPE_TIMEOUT, Timeout
@@ -228,14 +233,14 @@ class HTTPConnection(_HTTPConnection):
         self,
         host: str,
         port: int | None = None,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HTTP_HEADER_MAPPING | None = None,
         scheme: str = "http",
     ) -> None:
         if scheme not in ("http", "https"):
             raise ValueError(
                 f"Invalid proxy scheme for tunneling: {scheme!r}, must be either 'http' or 'https'"
             )
-        super().set_tunnel(host, port=port, headers=headers)
+        super().set_tunnel(host, port=port, headers=typing.cast(typing.Any, headers))
         self._tunnel_scheme = scheme
 
     if sys.version_info < (3, 11, 9) or ((3, 12) <= sys.version_info < (3, 12, 3)):
@@ -407,10 +412,15 @@ class HTTPConnection(_HTTPConnection):
             method, url, skip_host=skip_host, skip_accept_encoding=skip_accept_encoding
         )
 
-    def putheader(self, header: str, *values: str) -> None:  # type: ignore[override]
+    def putheader(
+        self, header: _TYPE_HTTP_HEADER_KEY, *values: typing.Any
+    ) -> None:
         """"""
         if not any(isinstance(v, str) and v == SKIP_HEADER for v in values):
-            super().putheader(header, *values)
+            super().putheader(
+                typing.cast(typing.Any, header),
+                *values,
+            )
         elif to_str(header.lower()) not in SKIPPABLE_HEADERS:
             skippable_headers = "', '".join(
                 [str.title(header) for header in sorted(SKIPPABLE_HEADERS)]
@@ -426,7 +436,7 @@ class HTTPConnection(_HTTPConnection):
         method: str,
         url: str,
         body: _TYPE_BODY | None = None,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HTTP_HEADER_MAPPING | None = None,
         *,
         chunked: bool = False,
         preload_content: bool = True,
@@ -523,7 +533,7 @@ class HTTPConnection(_HTTPConnection):
         method: str,
         url: str,
         body: _TYPE_BODY | None = None,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HTTP_HEADER_MAPPING | None = None,
     ) -> None:
         """
         Alternative to the common request method, which sends the

--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -11,7 +11,7 @@ from socket import timeout as SocketTimeout
 from types import TracebackType
 
 from ._base_connection import _TYPE_BODY
-from ._collections import HTTPHeaderDict, _TYPE_HTTP_HEADER_MAPPING
+from ._collections import _TYPE_HTTP_HEADER_MAPPING, HTTPHeaderDict
 from ._request_methods import RequestMethods
 from .connection import (
     BaseSSLError,

--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -11,7 +11,7 @@ from socket import timeout as SocketTimeout
 from types import TracebackType
 
 from ._base_connection import _TYPE_BODY
-from ._collections import HTTPHeaderDict
+from ._collections import HTTPHeaderDict, _TYPE_HTTP_HEADER_MAPPING
 from ._request_methods import RequestMethods
 from .connection import (
     BaseSSLError,
@@ -179,10 +179,10 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         timeout: _TYPE_TIMEOUT | None = _DEFAULT_TIMEOUT,
         maxsize: int = 1,
         block: bool = False,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HTTP_HEADER_MAPPING | None = None,
         retries: Retry | bool | int | None = None,
         _proxy: Url | None = None,
-        _proxy_headers: typing.Mapping[str, str] | None = None,
+        _proxy_headers: _TYPE_HTTP_HEADER_MAPPING | None = None,
         _proxy_config: ProxyConfig | None = None,
         **conn_kw: typing.Any,
     ):
@@ -380,7 +380,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         method: str,
         url: str,
         body: _TYPE_BODY | None = None,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HTTP_HEADER_MAPPING | None = None,
         retries: Retry | None = None,
         timeout: _TYPE_TIMEOUT = _DEFAULT_TIMEOUT,
         chunked: bool = False,
@@ -594,7 +594,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         method: str,
         url: str,
         body: _TYPE_BODY | None = None,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HTTP_HEADER_MAPPING | None = None,
         retries: Retry | bool | int | None = None,
         redirect: bool = True,
         assert_same_host: bool = True,
@@ -746,8 +746,9 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         # have to copy the headers dict so we can safely change it without those
         # changes being reflected in anyone else's copy.
         if not http_tunnel_required:
-            headers = headers.copy()  # type: ignore[attr-defined]
-            headers.update(self.proxy_headers)  # type: ignore[union-attr]
+            headers = HTTPHeaderDict(headers)
+            for header_name, header_value in self.proxy_headers.items():
+                headers[header_name] = header_value
 
         # Must keep the exception bound to a separate variable or else Python 3
         # complains about UnboundLocalError.
@@ -903,9 +904,9 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
             if retries.remove_headers_on_redirect and not self.is_same_host(
                 redirect_location
             ):
-                new_headers = headers.copy()  # type: ignore[union-attr]
+                new_headers = HTTPHeaderDict(headers)
                 for header in headers:
-                    if header.lower() in retries.remove_headers_on_redirect:
+                    if to_str(header.lower()) in retries.remove_headers_on_redirect:
                         new_headers.pop(header, None)
                 headers = new_headers
 
@@ -997,10 +998,10 @@ class HTTPSConnectionPool(HTTPConnectionPool):
         timeout: _TYPE_TIMEOUT | None = _DEFAULT_TIMEOUT,
         maxsize: int = 1,
         block: bool = False,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HTTP_HEADER_MAPPING | None = None,
         retries: Retry | bool | int | None = None,
         _proxy: Url | None = None,
-        _proxy_headers: typing.Mapping[str, str] | None = None,
+        _proxy_headers: _TYPE_HTTP_HEADER_MAPPING | None = None,
         key_file: str | None = None,
         cert_file: str | None = None,
         cert_reqs: int | str | None = None,

--- a/src/urllib3/contrib/emscripten/connection.py
+++ b/src/urllib3/contrib/emscripten/connection.py
@@ -8,6 +8,7 @@ from http.client import HTTPException as HTTPException  # noqa: F401
 from http.client import ResponseNotReady
 
 from ..._base_connection import _TYPE_BODY
+from ..._collections import _TYPE_HTTP_HEADER_MAPPING
 from ...connection import HTTPConnection, ProxyConfig, port_by_scheme
 from ...exceptions import TimeoutError
 from ...response import BaseHTTPResponse
@@ -74,7 +75,7 @@ class EmscriptenHTTPConnection:
         self,
         host: str,
         port: int | None = 0,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HTTP_HEADER_MAPPING | None = None,
         scheme: str = "http",
     ) -> None:
         pass
@@ -87,7 +88,7 @@ class EmscriptenHTTPConnection:
         method: str,
         url: str,
         body: _TYPE_BODY | None = None,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HTTP_HEADER_MAPPING | None = None,
         # We know *at least* botocore is depending on the order of the
         # first 3 parameters so to be safe we only mark the later ones
         # as keyword-only to ensure we have space to extend.

--- a/src/urllib3/contrib/emscripten/request.py
+++ b/src/urllib3/contrib/emscripten/request.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 
 from ..._base_connection import _TYPE_BODY
+from ..._collections import _TYPE_HTTP_HEADER_KEY, _TYPE_HTTP_HEADER_VALUE
 
 
 @dataclass
@@ -15,7 +16,13 @@ class EmscriptenRequest:
     timeout: float = 0
     decode_content: bool = True
 
-    def set_header(self, name: str, value: str) -> None:
+    def set_header(
+        self, name: _TYPE_HTTP_HEADER_KEY, value: _TYPE_HTTP_HEADER_VALUE
+    ) -> None:
+        if isinstance(name, bytes):
+            name = name.decode("latin-1")
+        if isinstance(value, bytes):
+            value = value.decode("latin-1")
         self.headers[name.capitalize()] = value
 
     def set_body(self, body: _TYPE_BODY | None) -> None:

--- a/src/urllib3/contrib/socks.py
+++ b/src/urllib3/contrib/socks.py
@@ -60,6 +60,7 @@ except ImportError:
 import typing
 from socket import timeout as SocketTimeout
 
+from .._collections import _TYPE_HTTP_HEADER_MAPPING
 from ..connection import HTTPConnection, HTTPSConnection
 from ..connectionpool import HTTPConnectionPool, HTTPSConnectionPool
 from ..exceptions import ConnectTimeoutError, NewConnectionError
@@ -187,7 +188,7 @@ class SOCKSProxyManager(PoolManager):
         username: str | None = None,
         password: str | None = None,
         num_pools: int = 10,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HTTP_HEADER_MAPPING | None = None,
         **connection_pool_kw: typing.Any,
     ):
         parsed = parse_url(proxy_url)

--- a/src/urllib3/fields.py
+++ b/src/urllib3/fields.py
@@ -4,6 +4,8 @@ import email.utils
 import mimetypes
 import typing
 
+from ._collections import _TYPE_HTTP_HEADER_MAPPING
+
 _TYPE_FIELD_VALUE = typing.Union[str, bytes]
 _TYPE_FIELD_VALUE_TUPLE = typing.Union[
     _TYPE_FIELD_VALUE,
@@ -173,7 +175,7 @@ class RequestField:
         name: str,
         data: _TYPE_FIELD_VALUE,
         filename: str | None = None,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HTTP_HEADER_MAPPING | None = None,
         header_formatter: typing.Callable[[str, _TYPE_FIELD_VALUE], str] | None = None,
     ):
         self._name = name
@@ -181,7 +183,12 @@ class RequestField:
         self.data = data
         self.headers: dict[str, str | None] = {}
         if headers:
-            self.headers = dict(headers)
+            self.headers = {
+                k.decode("latin-1") if isinstance(k, bytes) else k: (
+                    v.decode("latin-1") if isinstance(v, bytes) else v
+                )
+                for k, v in headers.items()
+            }
 
         if header_formatter is not None:
             import warnings

--- a/src/urllib3/http2/connection.py
+++ b/src/urllib3/http2/connection.py
@@ -11,7 +11,7 @@ import h2.connection
 import h2.events
 
 from .._base_connection import _TYPE_BODY
-from .._collections import HTTPHeaderDict, _TYPE_HTTP_HEADER_MAPPING
+from .._collections import _TYPE_HTTP_HEADER_MAPPING, HTTPHeaderDict
 from ..connection import HTTPSConnection, _get_default_user_agent
 from ..exceptions import ConnectionError
 from ..response import BaseHTTPResponse

--- a/src/urllib3/http2/connection.py
+++ b/src/urllib3/http2/connection.py
@@ -11,7 +11,7 @@ import h2.connection
 import h2.events
 
 from .._base_connection import _TYPE_BODY
-from .._collections import HTTPHeaderDict
+from .._collections import HTTPHeaderDict, _TYPE_HTTP_HEADER_MAPPING
 from ..connection import HTTPSConnection, _get_default_user_agent
 from ..exceptions import ConnectionError
 from ..response import BaseHTTPResponse
@@ -216,7 +216,7 @@ class HTTP2Connection(HTTPSConnection):
         self,
         host: str,
         port: int | None = None,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HTTP_HEADER_MAPPING | None = None,
         scheme: str = "http",
     ) -> None:
         raise NotImplementedError(
@@ -270,7 +270,7 @@ class HTTP2Connection(HTTPSConnection):
         method: str,
         url: str,
         body: _TYPE_BODY | None = None,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HTTP_HEADER_MAPPING | None = None,
         *,
         preload_content: bool = True,
         decode_content: bool = True,

--- a/src/urllib3/poolmanager.py
+++ b/src/urllib3/poolmanager.py
@@ -7,7 +7,12 @@ import warnings
 from types import TracebackType
 from urllib.parse import urljoin
 
-from ._collections import HTTPHeaderDict, RecentlyUsedContainer
+from ._collections import (
+    HTTPHeaderDict,
+    RecentlyUsedContainer,
+    _TYPE_HTTP_HEADER,
+    _TYPE_HTTP_HEADER_MAPPING,
+)
 from ._request_methods import RequestMethods
 from .connection import ProxyConfig
 from .connectionpool import HTTPConnectionPool, HTTPSConnectionPool, port_by_scheme
@@ -80,9 +85,9 @@ class PoolKey(typing.NamedTuple):
     key_ca_cert_dir: str | None
     key_ssl_context: ssl.SSLContext | None
     key_maxsize: int | None
-    key_headers: frozenset[tuple[str, str]] | None
+    key_headers: frozenset[_TYPE_HTTP_HEADER] | None
     key__proxy: Url | None
-    key__proxy_headers: frozenset[tuple[str, str]] | None
+    key__proxy_headers: frozenset[_TYPE_HTTP_HEADER] | None
     key__proxy_config: ProxyConfig | None
     key_socket_options: _TYPE_SOCKET_OPTIONS | None
     key__socks_options: frozenset[tuple[str, str]] | None
@@ -199,7 +204,7 @@ class PoolManager(RequestMethods):
     def __init__(
         self,
         num_pools: int = 10,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HTTP_HEADER_MAPPING | None = None,
         **connection_pool_kw: typing.Any,
     ) -> None:
         super().__init__(headers)
@@ -482,7 +487,11 @@ class PoolManager(RequestMethods):
         ):
             new_headers = kw["headers"].copy()
             for header in kw["headers"]:
-                if header.lower() in retries.remove_headers_on_redirect:
+                if (
+                    header.lower()
+                    if isinstance(header, str)
+                    else header.decode("latin-1").lower()
+                ) in retries.remove_headers_on_redirect:
                     new_headers.pop(header, None)
             kw["headers"] = new_headers
 
@@ -564,8 +573,8 @@ class ProxyManager(PoolManager):
         self,
         proxy_url: str,
         num_pools: int = 10,
-        headers: typing.Mapping[str, str] | None = None,
-        proxy_headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HTTP_HEADER_MAPPING | None = None,
+        proxy_headers: _TYPE_HTTP_HEADER_MAPPING | None = None,
         proxy_ssl_context: ssl.SSLContext | None = None,
         use_forwarding_for_https: bool = False,
         proxy_assert_hostname: None | str | typing.Literal[False] = None,
@@ -618,20 +627,22 @@ class ProxyManager(PoolManager):
         )
 
     def _set_proxy_headers(
-        self, url: str, headers: typing.Mapping[str, str] | None = None
-    ) -> typing.Mapping[str, str]:
+        self, url: str, headers: _TYPE_HTTP_HEADER_MAPPING | None = None
+    ) -> _TYPE_HTTP_HEADER_MAPPING:
         """
         Sets headers needed by proxies: specifically, the Accept and Host
         headers. Only sets headers not provided by the user.
         """
-        headers_ = {"Accept": "*/*"}
+        headers_ = HTTPHeaderDict()
+        headers_["Accept"] = "*/*"
 
         netloc = parse_url(url).netloc
         if netloc:
             headers_["Host"] = netloc
 
         if headers:
-            headers_.update(headers)
+            for header_name, header_value in headers.items():
+                headers_[header_name] = header_value
         return headers_
 
     def urlopen(  # type: ignore[override]

--- a/src/urllib3/poolmanager.py
+++ b/src/urllib3/poolmanager.py
@@ -8,10 +8,10 @@ from types import TracebackType
 from urllib.parse import urljoin
 
 from ._collections import (
-    HTTPHeaderDict,
-    RecentlyUsedContainer,
     _TYPE_HTTP_HEADER,
     _TYPE_HTTP_HEADER_MAPPING,
+    HTTPHeaderDict,
+    RecentlyUsedContainer,
 )
 from ._request_methods import RequestMethods
 from .connection import ProxyConfig

--- a/src/urllib3/response.py
+++ b/src/urllib3/response.py
@@ -27,7 +27,7 @@ except ImportError:
 
 from . import util
 from ._base_connection import _TYPE_BODY
-from ._collections import HTTPHeaderDict, _TYPE_HTTP_HEADER_MAPPING
+from ._collections import _TYPE_HTTP_HEADER_MAPPING, HTTPHeaderDict
 from .connection import BaseSSLError, HTTPConnection, HTTPException
 from .exceptions import (
     BodyNotHttplibCompatible,

--- a/src/urllib3/response.py
+++ b/src/urllib3/response.py
@@ -27,7 +27,7 @@ except ImportError:
 
 from . import util
 from ._base_connection import _TYPE_BODY
-from ._collections import HTTPHeaderDict
+from ._collections import HTTPHeaderDict, _TYPE_HTTP_HEADER_MAPPING
 from .connection import BaseSSLError, HTTPConnection, HTTPException
 from .exceptions import (
     BodyNotHttplibCompatible,
@@ -469,7 +469,7 @@ class BaseHTTPResponse(io.IOBase):
     def __init__(
         self,
         *,
-        headers: typing.Mapping[str, str] | typing.Mapping[bytes, bytes] | None = None,
+        headers: _TYPE_HTTP_HEADER_MAPPING | None = None,
         status: int,
         version: int,
         version_string: str,
@@ -481,7 +481,7 @@ class BaseHTTPResponse(io.IOBase):
         if isinstance(headers, HTTPHeaderDict):
             self.headers = headers
         else:
-            self.headers = HTTPHeaderDict(headers)  # type: ignore[arg-type]
+            self.headers = HTTPHeaderDict(headers)
         self.status = status
         self.version = version
         self.version_string = version_string
@@ -725,7 +725,7 @@ class HTTPResponse(BaseHTTPResponse):
     def __init__(
         self,
         body: _TYPE_BODY = "",
-        headers: typing.Mapping[str, str] | typing.Mapping[bytes, bytes] | None = None,
+        headers: _TYPE_HTTP_HEADER_MAPPING | None = None,
         status: int = 0,
         version: int = 0,
         version_string: str = "HTTP/?",

--- a/test/contrib/emscripten/test_emscripten.py
+++ b/test/contrib/emscripten/test_emscripten.py
@@ -1343,10 +1343,8 @@ def test_pool_bytes_headers(selenium_coverage: typing.Any) -> None:
 
     def send_request(request: EmscriptenRequest) -> EmscriptenResponse:
         assert request.url == "http://example.com/"
-        assert request.headers == {
-            "X-test": "value",
-            "Another": "header",
-        }
+        assert request.headers["X-test"] == "value"
+        assert request.headers["Another"] == "header"
         return EmscriptenResponse(
             status_code=200, headers={}, body=b"", request=request
         )

--- a/test/contrib/emscripten/test_emscripten.py
+++ b/test/contrib/emscripten/test_emscripten.py
@@ -1331,3 +1331,38 @@ def test_pool_no_port(selenium_coverage: typing.Any) -> None:
         pool = HTTPConnectionPool("example.com", maxsize=10, block=True)
 
         pool.request("GET", "/")
+
+
+@run_in_pyodide  # type: ignore[untyped-decorator]
+def test_pool_bytes_headers(selenium_coverage: typing.Any) -> None:
+    from unittest.mock import patch
+
+    from urllib3 import HTTPConnectionPool
+    from urllib3.contrib.emscripten.request import EmscriptenRequest
+    from urllib3.contrib.emscripten.response import EmscriptenResponse
+
+    def send_request(request: EmscriptenRequest) -> EmscriptenResponse:
+        assert request.url == "http://example.com/"
+        assert request.headers == {
+            "X-test": "value",
+            "Another": "header",
+        }
+        return EmscriptenResponse(
+            status_code=200, headers={}, body=b"", request=request
+        )
+
+    with patch("urllib3.contrib.emscripten.connection.send_request", new=send_request):
+        pool = HTTPConnectionPool("example.com", maxsize=10, block=True)
+        headers = typing.cast(
+            typing.Mapping[str | bytes, str | bytes],
+            {
+                b"x-test": b"value",
+                "another": "header",
+            },
+        )
+
+        pool.request(
+            "GET",
+            "/",
+            headers=headers,
+        )

--- a/test/contrib/emscripten/test_emscripten.py
+++ b/test/contrib/emscripten/test_emscripten.py
@@ -1331,36 +1331,3 @@ def test_pool_no_port(selenium_coverage: typing.Any) -> None:
         pool = HTTPConnectionPool("example.com", maxsize=10, block=True)
 
         pool.request("GET", "/")
-
-
-@run_in_pyodide  # type: ignore[untyped-decorator]
-def test_connection_bytes_headers(selenium_coverage: typing.Any) -> None:
-    from unittest.mock import patch
-
-    from urllib3.contrib.emscripten.connection import EmscriptenHTTPConnection
-    from urllib3.contrib.emscripten.request import EmscriptenRequest
-    from urllib3.contrib.emscripten.response import EmscriptenResponse
-
-    def send_request(request: EmscriptenRequest) -> EmscriptenResponse:
-        assert request.url == "http://example.com:0/"
-        assert request.headers["X-test"] == "value"
-        assert request.headers["Another"] == "header"
-        return EmscriptenResponse(
-            status_code=200, headers={}, body=b"", request=request
-        )
-
-    with patch("urllib3.contrib.emscripten.connection.send_request", new=send_request):
-        conn = EmscriptenHTTPConnection("example.com")
-        headers = typing.cast(
-            typing.Mapping[str | bytes, str | bytes],
-            {
-                b"x-test": b"value",
-                "another": "header",
-            },
-        )
-
-        conn.request(
-            "GET",
-            "/",
-            headers=headers,
-        )

--- a/test/contrib/emscripten/test_emscripten.py
+++ b/test/contrib/emscripten/test_emscripten.py
@@ -1334,15 +1334,15 @@ def test_pool_no_port(selenium_coverage: typing.Any) -> None:
 
 
 @run_in_pyodide  # type: ignore[untyped-decorator]
-def test_pool_bytes_headers(selenium_coverage: typing.Any) -> None:
+def test_connection_bytes_headers(selenium_coverage: typing.Any) -> None:
     from unittest.mock import patch
 
-    from urllib3 import HTTPConnectionPool
+    from urllib3.contrib.emscripten.connection import EmscriptenHTTPConnection
     from urllib3.contrib.emscripten.request import EmscriptenRequest
     from urllib3.contrib.emscripten.response import EmscriptenResponse
 
     def send_request(request: EmscriptenRequest) -> EmscriptenResponse:
-        assert request.url == "http://example.com/"
+        assert request.url == "http://example.com:0/"
         assert request.headers["X-test"] == "value"
         assert request.headers["Another"] == "header"
         return EmscriptenResponse(
@@ -1350,7 +1350,7 @@ def test_pool_bytes_headers(selenium_coverage: typing.Any) -> None:
         )
 
     with patch("urllib3.contrib.emscripten.connection.send_request", new=send_request):
-        pool = HTTPConnectionPool("example.com", maxsize=10, block=True)
+        conn = EmscriptenHTTPConnection("example.com")
         headers = typing.cast(
             typing.Mapping[str | bytes, str | bytes],
             {
@@ -1359,7 +1359,7 @@ def test_pool_bytes_headers(selenium_coverage: typing.Any) -> None:
             },
         )
 
-        pool.request(
+        conn.request(
             "GET",
             "/",
             headers=headers,

--- a/test/test_collections.py
+++ b/test/test_collections.py
@@ -131,6 +131,13 @@ class TestLRUContainer:
         with pytest.raises(NotImplementedError):
             d.__iter__()
 
+    def test_keys(self) -> None:
+        d: Container[int, str] = Container()
+        d[1] = "one"
+        d[2] = "two"
+
+        assert d.keys() == {1, 2}
+
 
 class NonMappingHeaderContainer:
     def __init__(self, **kwargs: str) -> None:

--- a/test/test_collections.py
+++ b/test/test_collections.py
@@ -212,10 +212,10 @@ class TestHTTPHeaderDict:
 
     def test_setitem(self, d: HTTPHeaderDict) -> None:
         d["Cookie"] = "foo"
-        # The bytes value gets converted to str. The API is typed for str only,
-        # but the implementation continues supports bytes.
-        d[b"Cookie"] = "bar"  # type: ignore[index]
+        d[b"Cookie"] = "bar"
+        d["Another"] = b"baz"
         assert d["cookie"] == "bar"
+        assert d["another"] == "baz"
         d["cookie"] = "with, comma"
         assert d.getlist("cookie") == ["with, comma"]
 
@@ -231,7 +231,7 @@ class TestHTTPHeaderDict:
         assert "COOKIE" not in d
 
     def test_delitem_with_bytes_key(self, d: HTTPHeaderDict) -> None:
-        del d[b"cookie"]  # type: ignore[arg-type]
+        del d[b"cookie"]
         assert "cookie" not in d
 
     def test_add_well_known_multiheader(self, d: HTTPHeaderDict) -> None:
@@ -241,10 +241,8 @@ class TestHTTPHeaderDict:
 
     def test_add_comma_separated_multiheader(self, d: HTTPHeaderDict) -> None:
         d.add("bar", "foo")
-        # The bytes value gets converted to str. The API is typed for str only,
-        # but the implementation continues supports bytes.
-        d.add(b"BAR", "bar")  # type: ignore[arg-type]
-        d.add("Bar", "asdf")
+        d.add(b"BAR", "bar")
+        d.add("Bar", b"asdf")
         assert d.getlist("bar") == ["foo", "bar", "asdf"]
         assert d["bar"] == "foo, bar, asdf"
 
@@ -323,18 +321,18 @@ class TestHTTPHeaderDict:
         assert d.getlist("b") == ["asdf"]
 
     def test_getlist_with_bytes_key(self, d: HTTPHeaderDict) -> None:
-        assert d.getlist(b"cookie") == ["foo", "bar"]  # type: ignore[call-overload]
+        assert d.getlist(b"cookie") == ["foo", "bar"]
 
     def test_getitem_with_bytes(self, d: HTTPHeaderDict) -> None:
         d["Content-Type"] = "application/json"
         d.add("Content-Type", "charset=utf-8")
-        result = d[b"Content-Type"]  # type: ignore[index]
+        result = d[b"Content-Type"]
         assert result == "application/json, charset=utf-8"
 
     def test_contains_with_bytes(self, d: HTTPHeaderDict) -> None:
         d["Content-Type"] = "application/json"
-        assert b"Content-Type" in d  # type: ignore[comparison-overlap]
-        assert b"X-Not-There" not in d  # type: ignore[comparison-overlap]
+        assert b"Content-Type" in d
+        assert b"X-Not-There" not in d
 
     def test_getlist_after_copy(self, d: HTTPHeaderDict) -> None:
         assert d.getlist("cookie") == HTTPHeaderDict(d).getlist("cookie")

--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 import datetime
+import importlib
 import socket
+import sys
+import types
 import typing
 from http.client import ResponseNotReady
 from unittest import mock
@@ -327,3 +330,70 @@ class TestConnection:
             assert "User-Agent" in request_headers
         else:
             assert user_agent not in request_headers
+
+    def test_emscripten_connection_normalizes_bytes_headers(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        js = types.ModuleType("js")
+        js.window = object()  # type: ignore[attr-defined]
+        js.self = js.window  # type: ignore[attr-defined]
+
+        pyodide = types.ModuleType("pyodide")
+        ffi = types.ModuleType("pyodide.ffi")
+
+        class JsArray:
+            pass
+
+        class JsProxy:
+            pass
+
+        class JsException(Exception):
+            pass
+
+        def to_js(value: object, *, dict_converter: object | None = None) -> object:
+            return value
+
+        ffi.JsArray = JsArray  # type: ignore[attr-defined]
+        ffi.JsException = JsException  # type: ignore[attr-defined]
+        ffi.JsProxy = JsProxy  # type: ignore[attr-defined]
+        ffi.to_js = to_js  # type: ignore[attr-defined]
+        pyodide.ffi = ffi  # type: ignore[attr-defined]
+
+        monkeypatch.setitem(sys.modules, "js", js)
+        monkeypatch.setitem(sys.modules, "pyodide", pyodide)
+        monkeypatch.setitem(sys.modules, "pyodide.ffi", ffi)
+        for module_name in list(sys.modules):
+            if module_name.startswith("urllib3.contrib.emscripten"):
+                monkeypatch.delitem(sys.modules, module_name, raising=False)
+
+        emscripten_connection = importlib.import_module(
+            "urllib3.contrib.emscripten.connection"
+        )
+        emscripten_response = importlib.import_module(
+            "urllib3.contrib.emscripten.response"
+        )
+
+        captured_requests: list[object] = []
+
+        def send_request(request: object) -> object:
+            captured_requests.append(request)
+            return emscripten_response.EmscriptenResponse(
+                status_code=200,
+                headers={},
+                body=b"",
+                request=request,
+            )
+
+        monkeypatch.setattr(emscripten_connection, "send_request", send_request)
+
+        connection = emscripten_connection.EmscriptenHTTPConnection("example.com")
+        headers: dict[str | bytes, str | bytes] = {
+            b"x-test": b"value",
+            "another": "header",
+        }
+        connection.request("GET", "/", headers=headers)
+
+        assert len(captured_requests) == 1
+        request = captured_requests[0]
+        assert request.url == "http://example.com:0/"
+        assert request.headers == {"X-test": "value", "Another": "header"}

--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -8,6 +8,7 @@ from unittest import mock
 
 import pytest
 
+from urllib3._collections import HTTPHeaderDict
 from urllib3.connection import (  # type: ignore[attr-defined]
     RECENT_DATE,
     CertificateError,
@@ -287,12 +288,12 @@ class TestConnection:
     @pytest.mark.parametrize("chunked", [True, False])
     def test_skip_header(
         self,
-        accept_encoding: str | None,
-        host: str | None,
-        user_agent: str | None,
+        accept_encoding: str | bytes | None,
+        host: str | bytes | None,
+        user_agent: str | bytes | None,
         chunked: bool,
     ) -> None:
-        headers = {}
+        headers = HTTPHeaderDict()
         if accept_encoding is not None:
             headers[accept_encoding] = SKIP_HEADER
         if host is not None:

--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -35,6 +35,10 @@ from urllib3.util.ssl_match_hostname import (
 if typing.TYPE_CHECKING:
     from urllib3.util.ssl_ import _TYPE_PEER_CERT_RET_DICT
 
+    class _EmscriptenRequestLike(typing.Protocol):
+        url: str
+        headers: dict[str, str]
+
 
 class TestConnection:
     """
@@ -373,9 +377,9 @@ class TestConnection:
             "urllib3.contrib.emscripten.response"
         )
 
-        captured_requests: list[object] = []
+        captured_requests: list[_EmscriptenRequestLike] = []
 
-        def send_request(request: object) -> object:
+        def send_request(request: _EmscriptenRequestLike) -> object:
             captured_requests.append(request)
             return emscripten_response.EmscriptenResponse(
                 status_code=200,

--- a/test/with_dummyserver/test_connectionpool.py
+++ b/test/with_dummyserver/test_connectionpool.py
@@ -1112,7 +1112,7 @@ class TestConnectionPool(HypercornDummyServerTestCase):
 
     def test_bytes_header(self) -> None:
         with HTTPConnectionPool(self.host, self.port) as pool:
-            headers = {"User-Agent": "test header"}
+            headers: dict[bytes, bytes] = {b"User-Agent": b"test header"}
             r = pool.request("GET", "/headers", headers=headers)
             request_headers = r.json()
             assert "User-Agent" in request_headers
@@ -1121,7 +1121,7 @@ class TestConnectionPool(HypercornDummyServerTestCase):
     @pytest.mark.parametrize(
         "user_agent", ["Schönefeld/1.18.0", "Schönefeld/1.18.0".encode("iso-8859-1")]
     )
-    def test_user_agent_non_ascii_user_agent(self, user_agent: str) -> None:
+    def test_user_agent_non_ascii_user_agent(self, user_agent: str | bytes) -> None:
         with HTTPConnectionPool(self.host, self.port, retries=False) as pool:
             r = pool.urlopen(
                 "GET",


### PR DESCRIPTION
## Summary
- align urllib3's header input typing around `str | bytes` values and accept byte-keyed header mappings across the request/connection/pool entry points
- normalize byte header parts in `HTTPHeaderDict` and related helper paths so the widened types match the existing runtime behavior
- update regression coverage to exercise byte-keyed and byte-valued request headers without type ignores

Fixes #3047.

## Testing
- `uv run --group mypy mypy src/urllib3/_collections.py src/urllib3/_base_connection.py src/urllib3/_request_methods.py src/urllib3/connection.py src/urllib3/connectionpool.py src/urllib3/poolmanager.py src/urllib3/response.py src/urllib3/fields.py src/urllib3/http2/connection.py src/urllib3/__init__.py src/urllib3/contrib/emscripten/connection.py src/urllib3/contrib/emscripten/request.py src/urllib3/contrib/socks.py test/test_collections.py test/test_connection.py test/with_dummyserver/test_connectionpool.py`
- `uv run --group test pytest test/test_collections.py test/test_connection.py test/test_response.py test/test_proxymanager.py test/test_http2_connection.py test/with_dummyserver/test_connectionpool.py test/with_dummyserver/test_poolmanager.py test/with_dummyserver/test_proxy_poolmanager.py`