### PR TITLE
Document that `default_socket_options` is not supposed to be changed

### DIFF
--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -108,9 +108,13 @@ class HTTPConnection(_HTTPConnection):
 
     #: Disable Nagle's algorithm by default.
     #: ``[(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)]``
-    default_socket_options: typing.ClassVar[connection._TYPE_SOCKET_OPTIONS] = [
-        (socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
-    ]
+    #:
+    #: Use the ``socket_options`` parameter of :class:`urllib3.PoolManager`,
+    #: :class:`urllib3.ProxyManager`, or :class:`urllib3.HTTPConnectionPool` to
+    #: change this behavior.
+    default_socket_options: typing.ClassVar[
+        typing.Final[connection._TYPE_SOCKET_OPTIONS]
+    ] = [(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)]
 
     #: Whether this connection verifies the host's certificate.
     is_verified: bool = False

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -109,9 +109,9 @@ class HTTPConnection(_HTTPConnection):
     #: Disable Nagle's algorithm by default.
     #: ``[(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)]``
     #:
-    #: Use the ``socket_options`` parameter of :class:`urllib3.PoolManager`,
-    #: :class:`urllib3.ProxyManager`, or :class:`urllib3.HTTPConnectionPool` to
-    #: change this behavior.
+    #: Use the ``socket_options`` parameter of :class:`~urllib3.PoolManager`,
+    #: :class:`~urllib3.ProxyManager`, or :class:`~urllib3.HTTPConnectionPool`
+    #: to change this behavior.
     default_socket_options: typing.ClassVar[
         typing.Final[connection._TYPE_SOCKET_OPTIONS]
     ] = [(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)]


### PR DESCRIPTION
Closes #2936 and closes #3789 by documenting that the `socket_options` parameter should be used instead of changing `HTTPConnection.default_socket_options`.