### PR TITLE
Normalize folded response header values

### DIFF
--- a/changelog/1362.bugfix.rst
+++ b/changelog/1362.bugfix.rst
@@ -1,0 +1,2 @@
+Normalized obsolete folded response header values before exposing them through
+``HTTPResponse.headers``.

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -22,7 +22,7 @@ if typing.TYPE_CHECKING:
 
 from ._collections import HTTPHeaderDict
 from .http2 import probe as http2_probe
-from .util.response import assert_header_parsing
+from .util.response import _normalize_header_items, assert_header_parsing
 from .util.timeout import _DEFAULT_TIMEOUT, _TYPE_TIMEOUT, Timeout
 from .util.util import to_str
 from .util.wait import wait_for_read
@@ -580,7 +580,7 @@ class HTTPConnection(_HTTPConnection):
                 exc_info=True,
             )
 
-        headers = HTTPHeaderDict(httplib_response.msg.items())
+        headers = HTTPHeaderDict(_normalize_header_items(httplib_response.msg.items()))
 
         response = HTTPResponse(
             body=httplib_response,

--- a/src/urllib3/util/response.py
+++ b/src/urllib3/util/response.py
@@ -1,9 +1,22 @@
 from __future__ import annotations
 
 import http.client as httplib
+import re
+import typing
 from email.errors import MultipartInvariantViolationDefect, StartBoundaryNotFoundDefect
 
 from ..exceptions import HeaderParsingError
+
+_OBS_FOLD_RE = re.compile(r"\r\n[ \t]+")
+
+
+def _normalize_header_items(
+    headers: typing.Iterable[tuple[str, str]],
+) -> typing.Iterator[tuple[str, str]]:
+    """Normalize obsolete folded header lines before exposing response headers."""
+
+    for key, value in headers:
+        yield key, _OBS_FOLD_RE.sub(" ", value)
 
 
 def is_fp_closed(obj: object) -> bool:

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -2210,6 +2210,22 @@ class TestBrokenHeaders(SocketDummyServerTestCase):
             [b"Broken Header", b"Another: Header"], "Broken Header"
         )
 
+    def test_folded_header_value_is_normalized(self) -> None:
+        self.start_response_handler(
+            b"HTTP/1.1 200 OK\r\n"
+            b"Content-Length: 0\r\n"
+            b"Set-Cookie: ___utmvbtouVBFmB=gZg\r\n"
+            b"    XbNOjalT: Lte; path=/; Max-Age=900\r\n"
+            b"\r\n"
+        )
+
+        with HTTPConnectionPool(self.host, self.port, retries=False) as pool:
+            response = pool.request("GET", "/")
+
+        set_cookie = response.headers["Set-Cookie"]
+        assert "\r\n" not in set_cookie
+        assert set_cookie == "___utmvbtouVBFmB=gZg XbNOjalT: Lte; path=/; Max-Age=900"
+
 
 class TestHeaderParsingContentType(SocketDummyServerTestCase):
     def _test_okay_header_parsing(self, header: bytes) -> None:


### PR DESCRIPTION
## Summary

This normalizes obsolete folded response header values before exposing them through `HTTPHeaderDict`.

`http.client.parse_headers()` preserves obs-fold sequences like `\r\n    ` inside parsed header values. For malformed `Set-Cookie` responses this can leak CRLF into `response.headers`, which is the behavior reported in #1362.

The change replaces RFC 7230 obs-fold sequences with a single space while building urllib3 response headers, so downstream consumers no longer receive embedded CRLF in header values.

Closes #1362.

## Verification

```text
uv run --group test pytest test\with_dummyserver\test_socketlevel.py::TestBrokenHeaders
```

```text
4 passed
```

## Notes

The helper is private and only used for parsed response headers, so this does not expand urllib3's public API.
