### PR TITLE
Resolve default pool queue lazily

### DIFF
--- a/changelog/3289.bugfix.rst
+++ b/changelog/3289.bugfix.rst
@@ -1,3 +1,5 @@
-Resolved the default connection pool queue class at pool creation time so
-monkey-patched ``queue.LifoQueue`` implementations can be used unless
-``QueueCls`` is explicitly overridden.
+Changed behavior of the default ``ConnectionPool.pool`` initialization.
+``LifoQueue`` is now resolved from the ``queue`` module after the ``ConnectionPool``
+is instantiated instead of using default cached ``QueueCls`` class property.
+This is done because sometimes the ``queue.LifoQueue`` is monkey-patched
+late in the program, such as by gevent.

--- a/changelog/3289.bugfix.rst
+++ b/changelog/3289.bugfix.rst
@@ -1,0 +1,3 @@
+Resolved the default connection pool queue class at pool creation time so
+monkey-patched ``queue.LifoQueue`` implementations can be used unless
+``QueueCls`` is explicitly overridden.

--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -116,7 +116,6 @@ class ConnectionPool:
     def _new_pool_queue(self, maxsize: int) -> queue.LifoQueue[typing.Any]:
         if self.QueueCls is _DEFAULT_QUEUE_CLASS:
             return queue.LifoQueue(maxsize)
-
         return self.QueueCls(maxsize)
 
 

--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -61,6 +61,7 @@ if typing.TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 _TYPE_TIMEOUT = typing.Union[Timeout, float, _TYPE_DEFAULT, None]
+_DEFAULT_QUEUE_CLASS = queue.LifoQueue
 
 
 # Pool objects
@@ -76,7 +77,7 @@ class ConnectionPool:
     """
 
     scheme: str | None = None
-    QueueCls = queue.LifoQueue
+    QueueCls = _DEFAULT_QUEUE_CLASS
 
     def __init__(self, host: str, port: int | None = None) -> None:
         if not host:
@@ -111,6 +112,12 @@ class ConnectionPool:
         """
         Close all pooled connections and disable the pool.
         """
+
+    def _new_pool_queue(self, maxsize: int) -> queue.LifoQueue[typing.Any]:
+        if self.QueueCls is _DEFAULT_QUEUE_CLASS:
+            return queue.LifoQueue(maxsize)
+
+        return self.QueueCls(maxsize)
 
 
 # This is taken from http://hg.python.org/cpython/file/7aaba721ebc0/Lib/socket.py#l252
@@ -198,7 +205,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         self.timeout = timeout
         self.retries = retries
 
-        self.pool: queue.LifoQueue[typing.Any] | None = self.QueueCls(maxsize)
+        self.pool: queue.LifoQueue[typing.Any] | None = self._new_pool_queue(maxsize)
         self.block = block
 
         self.proxy = _proxy

--- a/test/test_connectionpool.py
+++ b/test/test_connectionpool.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import http.client as httplib
+import queue
 import ssl
 import typing
 from http.client import HTTPException
@@ -592,6 +593,38 @@ class TestConnectionPool:
                 timeout = Timeout(1, 1, 1)
                 with pytest.raises(ReadTimeoutError):
                     pool._make_request(conn, "", "", timeout=timeout)
+
+    def test_default_queuecls_uses_current_lifoqueue(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        original_queue_cls = HTTPConnectionPool.QueueCls
+
+        class PatchedLifoQueue(queue.LifoQueue[typing.Any]):
+            pass
+
+        monkeypatch.setattr(queue, "LifoQueue", PatchedLifoQueue)
+
+        assert HTTPConnectionPool.QueueCls is original_queue_cls
+
+        with HTTPConnectionPool(host="localhost", maxsize=1) as pool:
+            assert isinstance(pool.pool, PatchedLifoQueue)
+
+    def test_queuecls_override_is_preserved(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        class CustomLifoQueue(queue.LifoQueue[typing.Any]):
+            pass
+
+        class PatchedLifoQueue(queue.LifoQueue[typing.Any]):
+            pass
+
+        class CustomQueueConnectionPool(HTTPConnectionPool):
+            QueueCls = CustomLifoQueue
+
+        monkeypatch.setattr(queue, "LifoQueue", PatchedLifoQueue)
+
+        with CustomQueueConnectionPool(host="localhost", maxsize=1) as pool:
+            assert isinstance(pool.pool, CustomLifoQueue)
 
     @pytest.mark.parametrize(
         "path",


### PR DESCRIPTION
This fixes #3289 by keeping `QueueCls` as the override point, but resolving the default queue class when a pool is created. If `queue.LifoQueue` has been monkey-patched after urllib3 was imported, new pools now pick up the patched class. Explicit `QueueCls` overrides still win.

I kept this narrower than #3729: no metaclass, no gevent-specific CI job. The regression test patches `queue.LifoQueue` directly, which is the behavior urllib3 needs to honor.

Verification
uv run --group test pytest test\test_connectionpool.py test\test_queue_monkeypatch.py
uv run --group mypy mypy src\urllib3\connectionpool.py test\test_connectionpool.py

Closes #3289.