### PR TITLE
Fix header typing for bytes-compatible headers

### DIFF
--- a/src/urllib3/__init__.py
+++ b/src/urllib3/__init__.py
@@ -12,7 +12,7 @@ import warnings
 from logging import NullHandler
 
 from . import exceptions
-from ._base_connection import _TYPE_BODY
+from ._base_connection import _TYPE_BODY, _TYPE_HEADERS
 from ._collections import HTTPHeaderDict
 from ._version import __version__
 from .connectionpool import HTTPConnectionPool, HTTPSConnectionPool, connection_from_url
@@ -120,7 +120,7 @@ def request(
     *,
     body: _TYPE_BODY | None = None,
     fields: _TYPE_FIELDS | None = None,
-    headers: typing.Mapping[str, str] | None = None,
+    headers: _TYPE_HEADERS | None = None,
     preload_content: bool | None = True,
     decode_content: bool | None = True,
     redirect: bool | None = True,

--- a/src/urllib3/_base_connection.py
+++ b/src/urllib3/_base_connection.py
@@ -9,6 +9,11 @@ from .util.url import Url
 _TYPE_BODY = typing.Union[
     bytes, typing.IO[typing.Any], typing.Iterable[bytes | str], str
 ]
+_TYPE_HEADERS = (
+    typing.Mapping[str, str]
+    | typing.Mapping[bytes, bytes]
+    | typing.Mapping[str | bytes, str | bytes]
+)
 
 
 class ProxyConfig(typing.NamedTuple):
@@ -81,7 +86,7 @@ if typing.TYPE_CHECKING:
             method: str,
             url: str,
             body: _TYPE_BODY | None = None,
-            headers: typing.Mapping[str, str] | None = None,
+            headers: _TYPE_HEADERS | None = None,
             # We know *at least* botocore is depending on the order of the
             # first 3 parameters so to be safe we only mark the later ones
             # as keyword-only to ensure we have space to extend.

--- a/src/urllib3/_collections.py
+++ b/src/urllib3/_collections.py
@@ -12,10 +12,10 @@ if typing.TYPE_CHECKING:
 
     from typing_extensions import Self
 
-    class HasGettableStringKeys(Protocol):
-        def keys(self) -> typing.Iterator[str]: ...
+    class HasGettableHeaderKeys(Protocol):
+        def keys(self) -> typing.Iterator[str | bytes]: ...
 
-        def __getitem__(self, key: str) -> str: ...
+        def __getitem__(self, key: str | bytes) -> str | bytes: ...
 
 
 __all__ = ["RecentlyUsedContainer", "HTTPHeaderDict"]
@@ -31,8 +31,12 @@ _DT = typing.TypeVar("_DT")
 ValidHTTPHeaderSource = typing.Union[
     "HTTPHeaderDict",
     typing.Mapping[str, str],
+    typing.Mapping[bytes, bytes],
+    typing.Mapping[str | bytes, str | bytes],
     typing.Iterable[tuple[str, str]],
-    "HasGettableStringKeys",
+    typing.Iterable[tuple[bytes, bytes]],
+    typing.Iterable[tuple[str | bytes, str | bytes]],
+    "HasGettableHeaderKeys",
 ]
 
 
@@ -48,14 +52,14 @@ def ensure_can_construct_http_header_dict(
     elif isinstance(potential, typing.Mapping):
         # Full runtime checking of the contents of a Mapping is expensive, so for the
         # purposes of typechecking, we assume that any Mapping is the right shape.
-        return typing.cast(typing.Mapping[str, str], potential)
+        return typing.cast(typing.Mapping[str | bytes, str | bytes], potential)
     elif isinstance(potential, typing.Iterable):
         # Similarly to Mapping, full runtime checking of the contents of an Iterable is
         # expensive, so for the purposes of typechecking, we assume that any Iterable
         # is the right shape.
-        return typing.cast(typing.Iterable[tuple[str, str]], potential)
+        return typing.cast(typing.Iterable[tuple[str | bytes, str | bytes]], potential)
     elif hasattr(potential, "keys") and hasattr(potential, "__getitem__"):
-        return typing.cast("HasGettableStringKeys", potential)
+        return typing.cast("HasGettableHeaderKeys", potential)
     else:
         return None
 
@@ -248,10 +252,12 @@ class HTTPHeaderDict(typing.MutableMapping[str, str]):
         if kwargs:
             self.extend(kwargs)
 
-    def __setitem__(self, key: str, val: str) -> None:
+    def __setitem__(self, key: str, val: str | bytes) -> None:
         # avoid a bytes/str comparison by decoding before httplib
         if isinstance(key, bytes):
             key = key.decode("latin-1")
+        if isinstance(val, bytes):
+            val = val.decode("latin-1")
         self._container[key.lower()] = [key, val]
 
     def __getitem__(self, key: str) -> str:
@@ -303,7 +309,9 @@ class HTTPHeaderDict(typing.MutableMapping[str, str]):
         except KeyError:
             pass
 
-    def add(self, key: str, val: str, *, combine: bool = False) -> None:
+    def add(
+        self, key: str | bytes, val: str | bytes, *, combine: bool = False
+    ) -> None:
         """Adds a (name, value) pair, doesn't overwrite the value if it already
         exists.
 
@@ -325,6 +333,8 @@ class HTTPHeaderDict(typing.MutableMapping[str, str]):
         # avoid a bytes/str comparison by decoding before httplib
         if isinstance(key, bytes):
             key = key.decode("latin-1")
+        if isinstance(val, bytes):
+            val = val.decode("latin-1")
         key_lower = key.lower()
         new_vals = [key, val]
         # Keep the common case aka no item present as fast as possible
@@ -350,25 +360,25 @@ class HTTPHeaderDict(typing.MutableMapping[str, str]):
         other = args[0] if len(args) >= 1 else ()
 
         if isinstance(other, HTTPHeaderDict):
-            for key, val in other.iteritems():
-                self.add(key, val)
+            for item_key, item_value in other.iteritems():
+                self.add(item_key, item_value)
         elif isinstance(other, typing.Mapping):
-            for key, val in other.items():
-                self.add(key, val)
-        elif isinstance(other, typing.Iterable):
-            for key, value in other:
-                self.add(key, value)
+            for mapping_key, mapping_value in other.items():
+                self.add(mapping_key, mapping_value)
         elif hasattr(other, "keys") and hasattr(other, "__getitem__"):
             # THIS IS NOT A TYPESAFE BRANCH
             # In this branch, the object has a `keys` attr but is not a Mapping or any of
             # the other types indicated in the method signature. We do some stuff with
             # it as though it partially implements the Mapping interface, but we're not
             # doing that stuff safely AT ALL.
-            for key in other.keys():
-                self.add(key, other[key])
+            for gettable_key in other.keys():
+                self.add(gettable_key, other[gettable_key])
+        elif isinstance(other, typing.Iterable):
+            for iterable_key, iterable_value in other:
+                self.add(iterable_key, iterable_value)
 
-        for key, value in kwargs.items():
-            self.add(key, value)
+        for header_key, header_value in kwargs.items():
+            self.add(header_key, header_value)
 
     @typing.overload
     def getlist(self, key: str) -> list[str]: ...

--- a/src/urllib3/_request_methods.py
+++ b/src/urllib3/_request_methods.py
@@ -4,10 +4,11 @@ import json as _json
 import typing
 from urllib.parse import urlencode
 
-from ._base_connection import _TYPE_BODY
+from ._base_connection import _TYPE_BODY, _TYPE_HEADERS
 from ._collections import HTTPHeaderDict
 from .filepost import _TYPE_FIELDS, encode_multipart_formdata
 from .response import BaseHTTPResponse
+from .util.util import to_str
 
 __all__ = ["RequestMethods"]
 
@@ -48,7 +49,7 @@ class RequestMethods:
 
     _encode_url_methods = {"DELETE", "GET", "HEAD", "OPTIONS"}
 
-    def __init__(self, headers: typing.Mapping[str, str] | None = None) -> None:
+    def __init__(self, headers: _TYPE_HEADERS | None = None) -> None:
         self.headers = headers or {}
 
     def urlopen(
@@ -56,7 +57,7 @@ class RequestMethods:
         method: str,
         url: str,
         body: _TYPE_BODY | None = None,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADERS | None = None,
         encode_multipart: bool = True,
         multipart_boundary: str | None = None,
         **kw: typing.Any,
@@ -72,7 +73,7 @@ class RequestMethods:
         url: str,
         body: _TYPE_BODY | None = None,
         fields: _TYPE_FIELDS | None = None,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADERS | None = None,
         json: typing.Any | None = None,
         **urlopen_kw: typing.Any,
     ) -> BaseHTTPResponse:
@@ -120,7 +121,7 @@ class RequestMethods:
             if headers is None:
                 headers = self.headers
 
-            if not ("content-type" in map(str.lower, headers.keys())):
+            if not ("content-type" in (to_str(k).lower() for k in headers.keys())):
                 headers = HTTPHeaderDict(headers)
                 headers["Content-Type"] = "application/json"
 
@@ -149,7 +150,7 @@ class RequestMethods:
         method: str,
         url: str,
         fields: _TYPE_ENCODE_URL_FIELDS | None = None,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADERS | None = None,
         **urlopen_kw: str,
     ) -> BaseHTTPResponse:
         """
@@ -186,7 +187,7 @@ class RequestMethods:
         method: str,
         url: str,
         fields: _TYPE_FIELDS | None = None,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADERS | None = None,
         encode_multipart: bool = True,
         multipart_boundary: str | None = None,
         **urlopen_kw: str,

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -20,6 +20,7 @@ if typing.TYPE_CHECKING:
     from .util.ssl_ import _TYPE_PEER_CERT_RET_DICT
     from .util.ssltransport import SSLTransport
 
+from ._base_connection import _TYPE_BODY, _TYPE_HEADERS
 from ._collections import HTTPHeaderDict
 from .http2 import probe as http2_probe
 from .util.response import assert_header_parsing
@@ -426,7 +427,7 @@ class HTTPConnection(_HTTPConnection):
         method: str,
         url: str,
         body: _TYPE_BODY | None = None,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADERS | None = None,
         *,
         chunked: bool = False,
         preload_content: bool = True,
@@ -496,7 +497,7 @@ class HTTPConnection(_HTTPConnection):
         if "user-agent" not in header_keys:
             self.putheader("User-Agent", _get_default_user_agent())
         for header, value in headers.items():
-            self.putheader(header, value)
+            self.putheader(header, value)  # type: ignore[arg-type]
         self.endheaders()
 
         # If we're given a body we start sending that in chunks.
@@ -523,7 +524,7 @@ class HTTPConnection(_HTTPConnection):
         method: str,
         url: str,
         body: _TYPE_BODY | None = None,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADERS | None = None,
     ) -> None:
         """
         Alternative to the common request method, which sends the

--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -10,7 +10,7 @@ import weakref
 from socket import timeout as SocketTimeout
 from types import TracebackType
 
-from ._base_connection import _TYPE_BODY
+from ._base_connection import _TYPE_BODY, _TYPE_HEADERS
 from ._collections import HTTPHeaderDict
 from ._request_methods import RequestMethods
 from .connection import (
@@ -179,10 +179,10 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         timeout: _TYPE_TIMEOUT | None = _DEFAULT_TIMEOUT,
         maxsize: int = 1,
         block: bool = False,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADERS | None = None,
         retries: Retry | bool | int | None = None,
         _proxy: Url | None = None,
-        _proxy_headers: typing.Mapping[str, str] | None = None,
+        _proxy_headers: _TYPE_HEADERS | None = None,
         _proxy_config: ProxyConfig | None = None,
         **conn_kw: typing.Any,
     ):
@@ -380,7 +380,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         method: str,
         url: str,
         body: _TYPE_BODY | None = None,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADERS | None = None,
         retries: Retry | None = None,
         timeout: _TYPE_TIMEOUT = _DEFAULT_TIMEOUT,
         chunked: bool = False,
@@ -594,7 +594,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         method: str,
         url: str,
         body: _TYPE_BODY | None = None,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADERS | None = None,
         retries: Retry | bool | int | None = None,
         redirect: bool = True,
         assert_same_host: bool = True,
@@ -746,8 +746,8 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         # have to copy the headers dict so we can safely change it without those
         # changes being reflected in anyone else's copy.
         if not http_tunnel_required:
-            headers = headers.copy()  # type: ignore[attr-defined]
-            headers.update(self.proxy_headers)  # type: ignore[union-attr]
+            headers = HTTPHeaderDict(headers)
+            headers.extend(self.proxy_headers)
 
         # Must keep the exception bound to a separate variable or else Python 3
         # complains about UnboundLocalError.
@@ -997,10 +997,10 @@ class HTTPSConnectionPool(HTTPConnectionPool):
         timeout: _TYPE_TIMEOUT | None = _DEFAULT_TIMEOUT,
         maxsize: int = 1,
         block: bool = False,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADERS | None = None,
         retries: Retry | bool | int | None = None,
         _proxy: Url | None = None,
-        _proxy_headers: typing.Mapping[str, str] | None = None,
+        _proxy_headers: _TYPE_HEADERS | None = None,
         key_file: str | None = None,
         cert_file: str | None = None,
         cert_reqs: int | str | None = None,
@@ -1050,7 +1050,7 @@ class HTTPSConnectionPool(HTTPConnectionPool):
             scheme=tunnel_scheme,
             host=self._tunnel_host,
             port=self.port,
-            headers=self.proxy_headers,
+            headers=typing.cast(typing.Mapping[str, str], self.proxy_headers),
         )
         conn.connect()
 

--- a/src/urllib3/contrib/emscripten/connection.py
+++ b/src/urllib3/contrib/emscripten/connection.py
@@ -7,13 +7,14 @@ import typing
 from http.client import HTTPException as HTTPException  # noqa: F401
 from http.client import ResponseNotReady
 
-from ..._base_connection import _TYPE_BODY
+from ..._base_connection import _TYPE_BODY, _TYPE_HEADERS
 from ...connection import HTTPConnection, ProxyConfig, port_by_scheme
 from ...exceptions import TimeoutError
 from ...response import BaseHTTPResponse
 from ...util.connection import _TYPE_SOCKET_OPTIONS
 from ...util.timeout import _DEFAULT_TIMEOUT, _TYPE_TIMEOUT
 from ...util.url import Url
+from ...util.util import to_str
 from .fetch import _RequestError, _TimeoutError, send_request, send_streaming_request
 from .request import EmscriptenRequest
 from .response import EmscriptenHttpResponseWrapper, EmscriptenResponse
@@ -74,7 +75,7 @@ class EmscriptenHTTPConnection:
         self,
         host: str,
         port: int | None = 0,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADERS | None = None,
         scheme: str = "http",
     ) -> None:
         pass
@@ -87,7 +88,7 @@ class EmscriptenHTTPConnection:
         method: str,
         url: str,
         body: _TYPE_BODY | None = None,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADERS | None = None,
         # We know *at least* botocore is depending on the order of the
         # first 3 parameters so to be safe we only mark the later ones
         # as keyword-only to ensure we have space to extend.
@@ -114,7 +115,7 @@ class EmscriptenHTTPConnection:
         request.set_body(body)
         if headers:
             for k, v in headers.items():
-                request.set_header(k, v)
+                request.set_header(to_str(k), to_str(v))
         self._response = None
         try:
             if not preload_content:

--- a/src/urllib3/contrib/socks.py
+++ b/src/urllib3/contrib/socks.py
@@ -60,6 +60,7 @@ except ImportError:
 import typing
 from socket import timeout as SocketTimeout
 
+from .._base_connection import _TYPE_HEADERS
 from ..connection import HTTPConnection, HTTPSConnection
 from ..connectionpool import HTTPConnectionPool, HTTPSConnectionPool
 from ..exceptions import ConnectTimeoutError, NewConnectionError
@@ -187,7 +188,7 @@ class SOCKSProxyManager(PoolManager):
         username: str | None = None,
         password: str | None = None,
         num_pools: int = 10,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADERS | None = None,
         **connection_pool_kw: typing.Any,
     ):
         parsed = parse_url(proxy_url)

--- a/src/urllib3/http2/connection.py
+++ b/src/urllib3/http2/connection.py
@@ -10,7 +10,7 @@ import h2.config
 import h2.connection
 import h2.events
 
-from .._base_connection import _TYPE_BODY
+from .._base_connection import _TYPE_BODY, _TYPE_HEADERS
 from .._collections import HTTPHeaderDict
 from ..connection import HTTPSConnection, _get_default_user_agent
 from ..exceptions import ConnectionError
@@ -270,7 +270,7 @@ class HTTP2Connection(HTTPSConnection):
         method: str,
         url: str,
         body: _TYPE_BODY | None = None,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADERS | None = None,
         *,
         preload_content: bool = True,
         decode_content: bool = True,

--- a/src/urllib3/poolmanager.py
+++ b/src/urllib3/poolmanager.py
@@ -7,6 +7,7 @@ import warnings
 from types import TracebackType
 from urllib.parse import urljoin
 
+from ._base_connection import _TYPE_HEADERS
 from ._collections import HTTPHeaderDict, RecentlyUsedContainer
 from ._request_methods import RequestMethods
 from .connection import ProxyConfig
@@ -199,7 +200,7 @@ class PoolManager(RequestMethods):
     def __init__(
         self,
         num_pools: int = 10,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADERS | None = None,
         **connection_pool_kw: typing.Any,
     ) -> None:
         super().__init__(headers)
@@ -564,8 +565,8 @@ class ProxyManager(PoolManager):
         self,
         proxy_url: str,
         num_pools: int = 10,
-        headers: typing.Mapping[str, str] | None = None,
-        proxy_headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADERS | None = None,
+        proxy_headers: _TYPE_HEADERS | None = None,
         proxy_ssl_context: ssl.SSLContext | None = None,
         use_forwarding_for_https: bool = False,
         proxy_assert_hostname: None | str | typing.Literal[False] = None,
@@ -618,20 +619,20 @@ class ProxyManager(PoolManager):
         )
 
     def _set_proxy_headers(
-        self, url: str, headers: typing.Mapping[str, str] | None = None
-    ) -> typing.Mapping[str, str]:
+        self, url: str, headers: _TYPE_HEADERS | None = None
+    ) -> _TYPE_HEADERS:
         """
         Sets headers needed by proxies: specifically, the Accept and Host
         headers. Only sets headers not provided by the user.
         """
-        headers_ = {"Accept": "*/*"}
+        headers_: dict[str | bytes, str | bytes] = {"Accept": "*/*"}
 
         netloc = parse_url(url).netloc
         if netloc:
             headers_["Host"] = netloc
 
         if headers:
-            headers_.update(headers)
+            headers_.update(dict(headers.items()))
         return headers_
 
     def urlopen(  # type: ignore[override]

--- a/src/urllib3/response.py
+++ b/src/urllib3/response.py
@@ -26,7 +26,7 @@ except ImportError:
     brotli = None
 
 from . import util
-from ._base_connection import _TYPE_BODY
+from ._base_connection import _TYPE_BODY, _TYPE_HEADERS
 from ._collections import HTTPHeaderDict
 from .connection import BaseSSLError, HTTPConnection, HTTPException
 from .exceptions import (
@@ -466,7 +466,7 @@ class BaseHTTPResponse(io.IOBase):
     def __init__(
         self,
         *,
-        headers: typing.Mapping[str, str] | typing.Mapping[bytes, bytes] | None = None,
+        headers: _TYPE_HEADERS | None = None,
         status: int,
         version: int,
         version_string: str,
@@ -478,7 +478,7 @@ class BaseHTTPResponse(io.IOBase):
         if isinstance(headers, HTTPHeaderDict):
             self.headers = headers
         else:
-            self.headers = HTTPHeaderDict(headers)  # type: ignore[arg-type]
+            self.headers = HTTPHeaderDict(headers)
         self.status = status
         self.version = version
         self.version_string = version_string
@@ -722,7 +722,7 @@ class HTTPResponse(BaseHTTPResponse):
     def __init__(
         self,
         body: _TYPE_BODY = "",
-        headers: typing.Mapping[str, str] | typing.Mapping[bytes, bytes] | None = None,
+        headers: _TYPE_HEADERS | None = None,
         status: int = 0,
         version: int = 0,
         version_string: str = "HTTP/?",

--- a/test/test_collections.py
+++ b/test/test_collections.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import typing
+from email.message import Message
 
 import pytest
 
@@ -233,6 +234,21 @@ class TestHTTPHeaderDict:
     def test_delitem_with_bytes_key(self, d: HTTPHeaderDict) -> None:
         del d[b"cookie"]  # type: ignore[arg-type]
         assert "cookie" not in d
+
+    def test_construct_with_bytes_headers(self) -> None:
+        h = HTTPHeaderDict({b"Content-Type": b"text/plain"})
+
+        assert "content-type" in h
+        assert h["content-type"] == "text/plain"
+        assert list(h.items()) == [("Content-Type", "text/plain")]
+
+    def test_construct_with_header_like_object(self) -> None:
+        headers = Message()
+        headers["X-Token"] = "hello"
+
+        h = HTTPHeaderDict(headers)
+
+        assert h["x-token"] == "hello"
 
     def test_add_well_known_multiheader(self, d: HTTPHeaderDict) -> None:
         d.add("COOKIE", "asdf")


### PR DESCRIPTION
Closes #3047.
Fixes #3676.

This updates urllib3's public header typing to reflect the existing runtime support for bytes-compatible request headers. It introduces a shared header mapping type and applies it across request, connection, pool, and response APIs.

It also makes HTTPHeaderDict normalize bytes header keys and values using latin-1, and handles header-like objects that expose keys() and __getitem__ without requiring a concrete Mapping.copy() implementation.

Verification:
- mypy on the touched urllib3 modules
- pytest test/test_collections.py and relevant connection pool header tests
- python -m compileall -q src/urllib3
- git diff --check