### PR TITLE
Preserve invalid timeout errors in blocking pools

### DIFF
--- a/changelog/5059.bugfix.rst
+++ b/changelog/5059.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed ``HTTPConnectionPool.urlopen()`` masking invalid per-request timeout
+values with ``FullPoolError`` in blocking pools.

--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -761,9 +761,13 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         # for future rewinds in the event of a redirect/retry.
         body_pos = set_file_position(body, body_pos)
 
+        # Validate per-request timeouts before acquiring a connection. If this
+        # raises, no connection has been taken from the pool and the cleanup
+        # block below must not try to return one.
+        timeout_obj = self._get_timeout(timeout)
+
         try:
             # Request a connection from the queue.
-            timeout_obj = self._get_timeout(timeout)
             conn = self._get_conn(timeout=pool_timeout)
 
             conn.timeout = timeout_obj.connect_timeout  # type: ignore[assignment]

--- a/test/test_connectionpool.py
+++ b/test/test_connectionpool.py
@@ -427,6 +427,11 @@ class TestConnectionPool:
             assert pool.timeout._connect == SHORT_TIMEOUT
             assert pool.timeout.total is None
 
+    def test_urlopen_invalid_timeout(self) -> None:
+        with HTTPConnectionPool(host="localhost", block=True) as pool:
+            with pytest.raises(ValueError, match="Timeout value connect was 1"):
+                pool.urlopen("GET", "/", timeout="1")  # type: ignore[arg-type]
+
     def test_no_host(self) -> None:
         with pytest.raises(LocationValueError):
             HTTPConnectionPool(None)  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary

- validate per-request `timeout` before acquiring a pooled connection
- avoid returning a placeholder connection to a full blocking pool when timeout validation raises
- add a regression for string timeout values being reported as `ValueError` instead of `FullPoolError`
- add the `5059.bugfix.rst` changelog fragment

Fixes #5059.

## Validation

- Not run locally
- `git diff --check`
- `git diff --cached --check`
- `git diff --check HEAD~1..HEAD`
