### PR TITLE
Normalize folded response header values

### DIFF
--- a/changelog/1362.bugfix.rst
+++ b/changelog/1362.bugfix.rst
@@ -1,0 +1,2 @@
+Normalized obsolete folded response header lines before exposing them through
+``HTTPResponse.headers``.

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -22,7 +22,7 @@ if typing.TYPE_CHECKING:
 
 from ._collections import HTTPHeaderDict
 from .http2 import probe as http2_probe
-from .util.response import assert_header_parsing
+from .util.response import assert_header_parsing, normalize_obs_fold
 from .util.timeout import _DEFAULT_TIMEOUT, _TYPE_TIMEOUT, Timeout
 from .util.util import to_str
 from .util.wait import wait_for_read
@@ -580,7 +580,10 @@ class HTTPConnection(_HTTPConnection):
                 exc_info=True,
             )
 
-        headers = HTTPHeaderDict(httplib_response.msg.items())
+        headers = HTTPHeaderDict(
+            (name, normalize_obs_fold(value))
+            for name, value in httplib_response.msg.items()
+        )
 
         response = HTTPResponse(
             body=httplib_response,

--- a/src/urllib3/util/response.py
+++ b/src/urllib3/util/response.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 import http.client as httplib
+import re
 from email.errors import MultipartInvariantViolationDefect, StartBoundaryNotFoundDefect
 
 from ..exceptions import HeaderParsingError
+
+_OBS_FOLD_RE = re.compile(r"\r\n[ \t]+")
 
 
 def is_fp_closed(obj: object) -> bool:
@@ -35,6 +38,11 @@ def is_fp_closed(obj: object) -> bool:
         pass
 
     raise ValueError("Unable to determine whether fp is closed.")
+
+
+def normalize_obs_fold(value: str) -> str:
+    """Replace obsolete folded HTTP header lines with a single space."""
+    return _OBS_FOLD_RE.sub(" ", value)
 
 
 def assert_header_parsing(headers: httplib.HTTPMessage) -> None:

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -88,6 +88,30 @@ class TestCookies(SocketDummyServerTestCase):
             assert r.headers == {"set-cookie": "foo=1, bar=1"}
             assert r.headers.getlist("set-cookie") == ["foo=1", "bar=1"]
 
+    def test_obs_fold_setcookie_is_unfolded(self) -> None:
+        def obs_fold_setcookie_response_handler(listener: socket.socket) -> None:
+            sock = listener.accept()[0]
+
+            buf = b""
+            while not buf.endswith(b"\r\n\r\n"):
+                buf += sock.recv(65536)
+
+            sock.send(
+                b"HTTP/1.1 200 OK\r\n"
+                b"Set-Cookie: ___utmvbtouVBFmB=gZg\r\n"
+                b"    XbNOjalT: Lte; path=/; Max-Age=900\r\n"
+                b"\r\n"
+            )
+            sock.close()
+
+        self._start_server(obs_fold_setcookie_response_handler)
+        with HTTPConnectionPool(self.host, self.port) as pool:
+            r = pool.request("GET", "/", retries=0)
+            assert (
+                r.headers["set-cookie"]
+                == "___utmvbtouVBFmB=gZg XbNOjalT: Lte; path=/; Max-Age=900"
+            )
+
 
 class TestSNI(SocketDummyServerTestCase):
     def test_hostname_in_first_request_packet(self) -> None:


### PR DESCRIPTION
## Summary

Fixes #1362.

This normalizes obsolete folded response header lines before converting `http.client.HTTPMessage` items into urllib3's `HTTPHeaderDict`. Python's parser preserves values like `
    X-Header: ...` inside the header value; replacing RFC 7230 obs-folds with a single space prevents that raw CRLF from leaking into downstream headers such as `Cookie`.

## Testing

- `python -m compileall -q src/urllib3/connection.py src/urllib3/util/response.py test/with_dummyserver/test_socketlevel.py`
- `python -m pytest test/with_dummyserver/test_socketlevel.py::TestCookies -q`
- Manual reproduction confirmed `normalize_obs_fold()` converts the folded `Set-Cookie` value from issue #1362 into a single-line value.

The pytest target passes locally: `2 passed in 0.11s`.