### PR TITLE
Normalize folded response header values

### DIFF
--- a/changelog/1362.bugfix.rst
+++ b/changelog/1362.bugfix.rst
@@ -1,0 +1,1 @@
+Normalized obsolete line-folded response header values before exposing them to users.

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -22,7 +22,7 @@ if typing.TYPE_CHECKING:
 
 from ._collections import HTTPHeaderDict
 from .http2 import probe as http2_probe
-from .util.response import assert_header_parsing
+from .util.response import _normalize_header_value, assert_header_parsing
 from .util.timeout import _DEFAULT_TIMEOUT, _TYPE_TIMEOUT, Timeout
 from .util.util import to_str
 from .util.wait import wait_for_read
@@ -580,7 +580,10 @@ class HTTPConnection(_HTTPConnection):
                 exc_info=True,
             )
 
-        headers = HTTPHeaderDict(httplib_response.msg.items())
+        headers = HTTPHeaderDict(
+            (name, _normalize_header_value(value))
+            for name, value in httplib_response.msg.items()
+        )
 
         response = HTTPResponse(
             body=httplib_response,

--- a/src/urllib3/util/response.py
+++ b/src/urllib3/util/response.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 import http.client as httplib
+import re
 from email.errors import MultipartInvariantViolationDefect, StartBoundaryNotFoundDefect
 
 from ..exceptions import HeaderParsingError
+
+_HEADER_VALUE_FOLD_RE = re.compile(r"\r\n[ \t]+")
 
 
 def is_fp_closed(obj: object) -> bool:
@@ -86,6 +89,17 @@ def assert_header_parsing(headers: httplib.HTTPMessage) -> None:
 
     if defects or unparsed_data:
         raise HeaderParsingError(defects=defects, unparsed_data=unparsed_data)
+
+
+def _normalize_header_value(value: str) -> str:
+    """
+    Replace obsolete line folding in header values with a single space.
+
+    RFC 7230 section 3.2.4 requires recipients to parse obs-fold as SP octets
+    before interpreting the field value.
+    """
+
+    return _HEADER_VALUE_FOLD_RE.sub(" ", value)
 
 
 def is_response_to_head(response: httplib.HTTPResponse) -> bool:

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -2098,6 +2098,28 @@ class TestHeaders(SocketDummyServerTestCase):
             ]
             assert expected_response_headers == actual_response_headers
 
+    def test_response_header_obs_fold_is_normalized(self) -> None:
+        def socket_handler(listener: socket.socket) -> None:
+            sock = listener.accept()[0]
+
+            buf = b""
+            while not buf.endswith(b"\r\n\r\n"):
+                buf += sock.recv(65536)
+
+            sock.send(
+                b"HTTP/1.1 200 OK\r\n"
+                b"Content-Length: 0\r\n"
+                b"Set-Cookie: session=abc\r\n"
+                b"    X-Injected: nope\r\n"
+                b"\r\n"
+            )
+            sock.close()
+
+        self._start_server(socket_handler)
+        with HTTPConnectionPool(self.host, self.port) as pool:
+            r = pool.request("GET", "/", retries=0)
+            assert r.headers["Set-Cookie"] == "session=abc X-Injected: nope"
+
     @pytest.mark.parametrize(
         "method_type, body_type",
         [


### PR DESCRIPTION
## Summary

- Normalize obsolete line-folded response header values before exposing them through `HTTPResponse.headers`
- Add a socket-level regression test for a folded `Set-Cookie` header
- Add a changelog fragment for #1362

## Testing

- `.venv/bin/python -m pytest test/with_dummyserver/test_socketlevel.py::TestHeaders::test_response_header_obs_fold_is_normalized -q`
- `.venv/bin/python -m pytest test/with_dummyserver/test_socketlevel.py::TestHeaders::test_response_headers_are_returned_in_the_original_order test/with_dummyserver/test_socketlevel.py::TestBrokenHeaders -q`

Closes #1362
