### PR TITLE
Normalize folded response headers

### DIFF
--- a/src/urllib3/response.py
+++ b/src/urllib3/response.py
@@ -4,6 +4,7 @@ import collections
 import io
 import json as _json
 import logging
+import re
 import socket
 import sys
 import typing
@@ -52,6 +53,13 @@ log = logging.getLogger(__name__)
 
 # Read in 64 KiB chunks
 _READ_CHUNK_SIZE = 2**16
+_OBS_FOLD_RE = re.compile(r"\r?\n[ \t]+")
+
+
+def _normalize_header_value(value: str | bytes) -> str:
+    if isinstance(value, bytes):
+        value = value.decode("latin-1")
+    return _OBS_FOLD_RE.sub(" ", value)
 
 
 class ContentDecoder:
@@ -478,10 +486,18 @@ class BaseHTTPResponse(io.IOBase):
         request_url: str | None,
         retries: Retry | None = None,
     ) -> None:
-        if isinstance(headers, HTTPHeaderDict):
-            self.headers = headers
+        if headers is None:
+            self.headers = HTTPHeaderDict()
+        elif isinstance(headers, HTTPHeaderDict):
+            self.headers = HTTPHeaderDict(
+                (key, _normalize_header_value(value))
+                for key, value in headers.iteritems()
+            )
         else:
-            self.headers = HTTPHeaderDict(headers)  # type: ignore[arg-type]
+            self.headers = HTTPHeaderDict(
+                (key, _normalize_header_value(value))
+                for key, value in headers.items()  # type: ignore[union-attr]
+            )
         self.status = status
         self.version = version
         self.version_string = version_string

--- a/test/test_compatibility.py
+++ b/test/test_compatibility.py
@@ -25,6 +25,29 @@ class TestCookiejar:
         cookiejar.extract_cookies(response, request)  # type: ignore[arg-type]
         assert len(cookiejar) == len(cookies)
 
+    def test_extract_obsolete_folded_set_cookie(self) -> None:
+        request = urllib.request.Request("http://google.com")
+        cookiejar = http.cookiejar.CookieJar()
+        response = HTTPResponse(
+            headers={
+                "set-cookie": "___utmvbtouVBFmB=gZg\r\n    XbNOjalT: Lte; path=/; Max-Age=900"
+            },
+            status=200,
+            version=11,
+            version_string="HTTP/1.1",
+            reason="OK",
+            preload_content=False,
+            decode_content=False,
+        )
+
+        cookiejar.extract_cookies(response, request)  # type: ignore[arg-type]
+
+        assert len(cookiejar) == 1
+        cookie = next(iter(cookiejar))
+        assert cookie.value == "gZg XbNOjalT: Lte"
+        assert "\r" not in cookie.value
+        assert "\n" not in cookie.value
+
 
 class TestInitialization:
     @mock.patch("urllib3.http2.version")


### PR DESCRIPTION
## Summary
- Normalize obsolete folded response header values before urllib3 stores them on HTTPResponse objects.
- This prevents folded `Set-Cookie` values from carrying raw CRLF into cookie handling.
- Add a regression test that confirms the cookie value is flattened and contains no CRLF.

## Why
Malformed response headers with obs-fold can leak `\r\n` into downstream cookie parsing. RFC 7230 requires obs-fold to be replaced with SPs before interpreting the field value.

## Validation
- `python -m compileall src/urllib3/response.py test/test_compatibility.py`
- `./.venv/bin/python -m pytest test/test_compatibility.py -q` -> `3 passed`
- Manual reproduction with `HTTPResponse(headers={...})` and `cookiejar.extract_cookies(...)`

Refs #1362
