### PR TITLE
Validate HTTP header names and unfold response headers

### DIFF
--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -77,6 +77,25 @@ port_by_scheme = {"http": 80, "https": 443}
 RECENT_DATE = datetime.date(2025, 1, 1)
 
 _CONTAINS_CONTROL_CHAR_RE = re.compile(r"[^-!#$%&'*+.^_`|~0-9a-zA-Z]")
+_OBS_FOLD_RE = re.compile(r"\r\n[ \t]+")
+
+
+def _is_legal_header_name(header: str | bytes) -> bool:
+    try:
+        if isinstance(header, bytes):
+            header = header.decode("ascii")
+        elif isinstance(header, str):
+            header.encode("ascii")
+        else:
+            return False
+    except UnicodeError:
+        return False
+
+    return bool(header) and not _CONTAINS_CONTROL_CHAR_RE.search(header)
+
+
+def _normalize_header_value(value: str) -> str:
+    return _OBS_FOLD_RE.sub(" ", value)
 
 
 class HTTPConnection(_HTTPConnection):
@@ -409,6 +428,9 @@ class HTTPConnection(_HTTPConnection):
 
     def putheader(self, header: str, *values: str) -> None:  # type: ignore[override]
         """"""
+        if not _is_legal_header_name(header):
+            raise ValueError(f"Invalid header name {header!r}")
+
         if not any(isinstance(v, str) and v == SKIP_HEADER for v in values):
             super().putheader(header, *values)
         elif to_str(header.lower()) not in SKIPPABLE_HEADERS:
@@ -580,7 +602,10 @@ class HTTPConnection(_HTTPConnection):
                 exc_info=True,
             )
 
-        headers = HTTPHeaderDict(httplib_response.msg.items())
+        headers = HTTPHeaderDict(
+            (key, _normalize_header_value(value))
+            for key, value in httplib_response.msg.items()
+        )
 
         response = HTTPResponse(
             body=httplib_response,

--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -326,3 +326,14 @@ class TestConnection:
             assert "User-Agent" in request_headers
         else:
             assert user_agent not in request_headers
+
+    @pytest.mark.parametrize(
+        "header",
+        ["Bad Header", "Bad\tHeader", "Bad Header ", b"Bad Header"],
+    )
+    def test_reject_header_names_with_whitespace(self, header: str | bytes) -> None:
+        with mock.patch("urllib3.util.connection.create_connection"):
+            conn = HTTPConnection("")
+
+            with pytest.raises(ValueError, match="Invalid header name"):
+                conn.request("GET", "/headers", headers={header: "value"})

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -88,6 +88,20 @@ class TestCookies(SocketDummyServerTestCase):
             assert r.headers == {"set-cookie": "foo=1, bar=1"}
             assert r.headers.getlist("set-cookie") == ["foo=1", "bar=1"]
 
+    def test_folded_setcookie_header_is_unfolded(self) -> None:
+        self.start_response_handler(
+            b"HTTP/1.1 200 OK\r\n"
+            b"Content-Length: 0\r\n"
+            b"Set-Cookie: foo=bar\r\n"
+            b"\tInjected: bad\r\n"
+            b"\r\n"
+        )
+
+        with HTTPConnectionPool(self.host, self.port) as pool:
+            r = pool.request("GET", "/", retries=0)
+
+        assert r.headers["set-cookie"] == "foo=bar Injected: bad"
+
 
 class TestSNI(SocketDummyServerTestCase):
     def test_hostname_in_first_request_packet(self) -> None:


### PR DESCRIPTION
## Summary

This PR addresses #1362 by tightening request header-name validation and normalizing folded response header values before exposing them through `HTTPHeaderDict`.

## Changes

- Reject outbound HTTP header names containing whitespace or other non-token characters before delegating to `http.client`.
- Normalize obsolete folded response header values (`CRLF` followed by SP/HTAB) to a single space before storing them in urllib3's response headers.
- Add regression tests for invalid outbound header names and folded `Set-Cookie` response headers.

## Validation

```bash
.venv\Scripts\python.exe -B -m pytest -q test\test_connection.py::TestConnection::test_reject_header_names_with_whitespace test\with_dummyserver\test_socketlevel.py::TestCookies::test_folded_setcookie_header_is_unfolded --tb=short -p no:cacheprovider
# 5 passed in 0.25s

.venv\Scripts\python.exe -B -m pytest -q test\with_dummyserver\test_socketlevel.py::TestCookies --tb=short -p no:cacheprovider
# 2 passed in 0.15s

.venv\Scripts\python.exe -B -m pytest -q test\test_connection.py --tb=short -p no:cacheprovider
# 283 passed in 0.97s
```