### PR TITLE
Construct auth headers from URL credentials

### DIFF
--- a/changelog/1999.bugfix.rst
+++ b/changelog/1999.bugfix.rst
@@ -1,0 +1,2 @@
+Added support for constructing ``Authorization`` and ``Proxy-Authorization``
+headers from URL userinfo when username and password credentials are provided.

--- a/src/urllib3/poolmanager.py
+++ b/src/urllib3/poolmanager.py
@@ -5,13 +5,14 @@ import logging
 import typing
 import warnings
 from types import TracebackType
-from urllib.parse import urljoin
+from urllib.parse import unquote, urljoin
 
 from ._collections import HTTPHeaderDict, RecentlyUsedContainer
 from ._request_methods import RequestMethods
 from .connection import ProxyConfig
 from .connectionpool import HTTPConnectionPool, HTTPSConnectionPool, port_by_scheme
 from .exceptions import (
+    InvalidHeader,
     LocationValueError,
     MaxRetryError,
     ProxySchemeUnknown,
@@ -20,6 +21,7 @@ from .exceptions import (
 from .response import BaseHTTPResponse
 from .util.connection import _TYPE_SOCKET_OPTIONS
 from .util.proxy import connection_requires_http_tunnel
+from .util.request import make_headers
 from .util.retry import Retry
 from .util.timeout import Timeout
 from .util.url import Url, parse_url
@@ -157,6 +159,42 @@ key_fn_by_scheme = {
 }
 
 pool_classes_by_scheme = {"http": HTTPConnectionPool, "https": HTTPSConnectionPool}
+
+
+def _basic_auth_str_from_url_auth(auth: str) -> str:
+    username, separator, password = auth.partition(":")
+    password = unquote(password) if separator else ""
+    return f"{unquote(username)}:{password}"
+
+
+def _authorization_header_from_url_auth(auth: str | None) -> str | None:
+    if auth is None:
+        return None
+    return make_headers(basic_auth=_basic_auth_str_from_url_auth(auth))["authorization"]
+
+
+def _proxy_authorization_header_from_url_auth(auth: str | None) -> str | None:
+    if auth is None:
+        return None
+    return make_headers(proxy_basic_auth=_basic_auth_str_from_url_auth(auth))[
+        "proxy-authorization"
+    ]
+
+
+def _headers_with_url_auth(
+    headers: typing.Mapping[str, str] | None, header_name: str, header_value: str
+) -> HTTPHeaderDict:
+    headers_ = HTTPHeaderDict(headers or {})
+
+    if header_name in headers_:
+        if headers_[header_name] != header_value:
+            raise InvalidHeader(
+                f"{header_name} header from URL conflicts with supplied header"
+            )
+        return headers_
+
+    headers_[header_name] = header_value
+    return headers_
 
 
 class PoolManager(RequestMethods):
@@ -451,8 +489,15 @@ class PoolManager(RequestMethods):
         if "headers" not in kw:
             kw["headers"] = self.headers
 
+        url_auth_header = _authorization_header_from_url_auth(u.auth)
+        if url_auth_header is not None:
+            kw["headers"] = _headers_with_url_auth(
+                kw["headers"], "authorization", url_auth_header
+            )
+
         if self._proxy_requires_url_absolute_form(u):
-            response = conn.urlopen(method, u._replace(fragment=None).url, **kw)
+            url = u._replace(auth=None, fragment=None).url
+            response = conn.urlopen(method, url, **kw)
         else:
             response = conn.urlopen(method, u.request_uri, **kw)
 
@@ -599,6 +644,17 @@ class ProxyManager(PoolManager):
         if proxy.port is None:
             port = port_by_scheme.get(proxy.scheme, 80)
             proxy = proxy._replace(port=port)
+
+        proxy_auth_header = _proxy_authorization_header_from_url_auth(proxy.auth)
+        if proxy_auth_header is not None:
+            if headers is not None:
+                _headers_with_url_auth(
+                    headers, "proxy-authorization", proxy_auth_header
+                )
+            proxy_headers = _headers_with_url_auth(
+                proxy_headers, "proxy-authorization", proxy_auth_header
+            )
+            proxy = proxy._replace(auth=None)
 
         self.proxy = proxy
         self.proxy_headers = proxy_headers or {}

--- a/test/test_proxymanager.py
+++ b/test/test_proxymanager.py
@@ -2,7 +2,12 @@ from __future__ import annotations
 
 import pytest
 
-from urllib3.exceptions import MaxRetryError, NewConnectionError, ProxyError
+from urllib3.exceptions import (
+    InvalidHeader,
+    MaxRetryError,
+    NewConnectionError,
+    ProxyError,
+)
 from urllib3.poolmanager import ProxyManager
 from urllib3.response import HTTPResponse
 from urllib3.util.retry import Retry
@@ -54,6 +59,46 @@ class TestProxyManager:
         with ProxyManager("http://proxy:0") as p:
             assert p.proxy is not None
             assert p.proxy.port == 0
+
+    @pytest.mark.parametrize("proxy_scheme", ["http", "https"])
+    def test_proxy_url_auth_sets_proxy_authorization_header(
+        self, proxy_scheme: str
+    ) -> None:
+        proxy_url = f"{proxy_scheme}://user:password@something:1234"
+
+        with ProxyManager(proxy_url) as p:
+            assert p.proxy is not None
+            assert p.proxy.auth is None
+            assert (
+                p.proxy_headers["Proxy-Authorization"] == "Basic dXNlcjpwYXNzd29yZA=="
+            )
+
+    def test_proxy_url_auth_allows_matching_proxy_authorization_header(self) -> None:
+        proxy_headers = {"Proxy-Authorization": "Basic dXNlcjpwYXNzd29yZA=="}
+
+        with ProxyManager(
+            "http://user:password@something:1234", proxy_headers=proxy_headers
+        ) as p:
+            assert (
+                p.proxy_headers["Proxy-Authorization"] == "Basic dXNlcjpwYXNzd29yZA=="
+            )
+            assert proxy_headers == {
+                "Proxy-Authorization": "Basic dXNlcjpwYXNzd29yZA=="
+            }
+
+    def test_proxy_url_auth_rejects_conflicting_proxy_header(self) -> None:
+        proxy_headers = {"Proxy-Authorization": "Basic ZGlmZmVyZW50"}
+
+        with pytest.raises(InvalidHeader, match="proxy-authorization"):
+            ProxyManager(
+                "http://user:password@something:1234", proxy_headers=proxy_headers
+            )
+
+    def test_proxy_url_auth_rejects_conflicting_default_header(self) -> None:
+        headers = {"Proxy-Authorization": "Basic ZGlmZmVyZW50"}
+
+        with pytest.raises(InvalidHeader, match="proxy-authorization"):
+            ProxyManager("http://user:password@something:1234", headers=headers)
 
     def test_invalid_scheme(self) -> None:
         with pytest.raises(AssertionError):

--- a/test/with_dummyserver/test_poolmanager.py
+++ b/test/with_dummyserver/test_poolmanager.py
@@ -14,7 +14,7 @@ from dummyserver.testcase import (
 )
 from urllib3 import HTTPHeaderDict, HTTPResponse, request
 from urllib3.connectionpool import port_by_scheme
-from urllib3.exceptions import MaxRetryError, URLSchemeUnknown
+from urllib3.exceptions import InvalidHeader, MaxRetryError, URLSchemeUnknown
 from urllib3.poolmanager import PoolManager
 from urllib3.util.retry import Retry
 
@@ -289,6 +289,38 @@ class TestPoolManager(HypercornDummyServerTestCase):
             assert "Proxy-Authorization" not in data
             assert "cookie" not in data
             assert "Cookie" not in data
+
+    def test_url_auth_sets_authorization_header(self) -> None:
+        with PoolManager() as http:
+            r = http.request(
+                "GET", f"http://user:password@{self.host}:{self.port}/headers"
+            )
+
+            assert r.status == 200
+            assert r.json()["Authorization"] == "Basic dXNlcjpwYXNzd29yZA=="
+
+    def test_url_auth_allows_matching_authorization_header(self) -> None:
+        headers = {"Authorization": "Basic dXNlcjpwYXNzd29yZA=="}
+
+        with PoolManager() as http:
+            r = http.request(
+                "GET",
+                f"http://user:password@{self.host}:{self.port}/headers",
+                headers=headers,
+            )
+
+            assert r.status == 200
+            assert r.json()["Authorization"] == "Basic dXNlcjpwYXNzd29yZA=="
+            assert headers == {"Authorization": "Basic dXNlcjpwYXNzd29yZA=="}
+
+    def test_url_auth_rejects_conflicting_authorization_header(self) -> None:
+        with PoolManager() as http:
+            with pytest.raises(InvalidHeader, match="authorization"):
+                http.request(
+                    "GET",
+                    f"http://user:password@{self.host}:{self.port}/headers",
+                    headers={"Authorization": "Basic ZGlmZmVyZW50"},
+                )
 
     def test_redirect_cross_host_no_remove_headers(self) -> None:
         with PoolManager() as http:

--- a/test/with_dummyserver/test_proxy_poolmanager.py
+++ b/test/with_dummyserver/test_proxy_poolmanager.py
@@ -30,6 +30,7 @@ from urllib3.connectionpool import connection_from_url
 from urllib3.exceptions import (
     ConnectTimeoutError,
     InsecureRequestWarning,
+    InvalidHeader,
     MaxRetryError,
     ProxyError,
     ProxySchemeUnknown,
@@ -87,6 +88,35 @@ class TestHTTPProxyManager(HypercornDummyProxyTestCase):
 
             r = http.request("GET", f"{self.https_url}/")
             assert r.status == 200
+
+    def test_proxy_url_auth(self) -> None:
+        proxy_url = f"http://user:password@{self.proxy_host}:{int(self.proxy_port)}"
+
+        with proxy_from_url(proxy_url, ca_certs=DEFAULT_CA) as http:
+            r = http.request("GET", f"{self.http_url}/headers")
+
+        assert r.status == 200
+        assert r.json()["Proxy-Authorization"] == "Basic dXNlcjpwYXNzd29yZA=="
+
+    def test_proxy_url_auth_rejects_conflicting_proxy_header(self) -> None:
+        proxy_url = f"http://user:password@{self.proxy_host}:{int(self.proxy_port)}"
+
+        with pytest.raises(InvalidHeader, match="proxy-authorization"):
+            proxy_from_url(
+                proxy_url,
+                ca_certs=DEFAULT_CA,
+                proxy_headers={"Proxy-Authorization": "Basic ZGlmZmVyZW50"},
+            )
+
+    def test_proxy_url_auth_rejects_conflicting_default_header(self) -> None:
+        proxy_url = f"http://user:password@{self.proxy_host}:{int(self.proxy_port)}"
+
+        with pytest.raises(InvalidHeader, match="proxy-authorization"):
+            proxy_from_url(
+                proxy_url,
+                ca_certs=DEFAULT_CA,
+                headers={"Proxy-Authorization": "Basic ZGlmZmVyZW50"},
+            )
 
     def test_https_proxy(self) -> None:
         with proxy_from_url(self.https_proxy_url, ca_certs=DEFAULT_CA) as https:


### PR DESCRIPTION
## Summary

Closes #1999 by deriving Basic authentication headers from URL userinfo when credentials are provided:

- construct `Authorization` from request URL userinfo for normal `PoolManager` requests
- construct `Proxy-Authorization` from proxy URL userinfo for `ProxyManager`
- remove proxy credentials from the stored proxy URL after converting them into headers
- reject conflicting explicit `Authorization` / `Proxy-Authorization` headers instead of silently overriding them

## Tests

- `.venv312/bin/python -m pytest test/test_proxymanager.py -q`
- `.venv312/bin/python -m pytest test/with_dummyserver/test_poolmanager.py test/with_dummyserver/test_proxy_poolmanager.py -q`
- `.venv312/bin/flake8 src/urllib3/poolmanager.py test/test_proxymanager.py test/with_dummyserver/test_poolmanager.py test/with_dummyserver/test_proxy_poolmanager.py`
- `.venv312/bin/mypy src/urllib3/poolmanager.py`
- `git diff --check`

Note: the full affected dummyserver run uses urllib3's Hypercorn fork from `https://github.com/urllib3/hypercorn@urllib3-changes`, matching the project test configuration.
