### PR TITLE
Treat malformed folded response headers as parse defects

### DIFF
--- a/src/urllib3/util/response.py
+++ b/src/urllib3/util/response.py
@@ -1,9 +1,16 @@
 from __future__ import annotations
 
 import http.client as httplib
-from email.errors import MultipartInvariantViolationDefect, StartBoundaryNotFoundDefect
+import re
+from email.errors import (
+    MessageDefect,
+    MultipartInvariantViolationDefect,
+    StartBoundaryNotFoundDefect,
+)
 
 from ..exceptions import HeaderParsingError
+
+_HEADER_FIELD_IN_FOLDED_VALUE_RE = re.compile(r"[\r\n]+[ \t]+[-!#$%&'*+.^_`|~0-9A-Za-z]+:")
 
 
 def is_fp_closed(obj: object) -> bool:
@@ -83,6 +90,15 @@ def assert_header_parsing(headers: httplib.HTTPMessage) -> None:
             defect, (StartBoundaryNotFoundDefect, MultipartInvariantViolationDefect)
         )
     ]
+
+    for name, value in headers.items():
+        if _HEADER_FIELD_IN_FOLDED_VALUE_RE.search(value):
+            defects.append(
+                MessageDefect(
+                    f"Header {name!r} contains a folded line that looks like a "
+                    "new header field"
+                )
+            )
 
     if defects or unparsed_data:
         raise HeaderParsingError(defects=defects, unparsed_data=unparsed_data)

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -2210,6 +2210,11 @@ class TestBrokenHeaders(SocketDummyServerTestCase):
             [b"Broken Header", b"Another: Header"], "Broken Header"
         )
 
+    def test_header_with_folded_header_field_in_value(self) -> None:
+        self._test_broken_header_parsing(
+            [b"Set-Cookie: foo=bar", b"\tXbNOjalT: Lte; path=/"]
+        )
+
 
 class TestHeaderParsingContentType(SocketDummyServerTestCase):
     def _test_okay_header_parsing(self, header: bytes) -> None:


### PR DESCRIPTION
## Summary

This adds regression coverage for #1362 and treats malformed folded response headers as parse defects when a folded continuation line appears to introduce a new header field.

The change is intentionally narrow: it only flags folded continuation lines that look like header field names, rather than treating all folded header values as invalid.

Fixes #1362.

## Verification

- TestBrokenHeaders: 4 passed
- Adjacent header parsing tests: 3 passed
- util response parsing tests: 4 passed
- socket-level suite excluding one unrelated SSL timing test: 116 passed, 9 skipped, 1 deselected

A full socket-level run previously produced an unrelated failure in `TestSSL.test_ssl_custom_validation_failure_terminates`; the new regression test and adjacent header parsing tests passed.