### PR TITLE
Revert "Switch to nightly PyPy3.11 in CI for now"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,9 +58,7 @@ jobs:
             experimental: false
             nox-session: test-3.12
           # pypy
-          # Nightly should be used until PyPy v7.3.23 is released.
-          # https://github.com/python-trio/trio/issues/3433#issuecomment-4349552625
-          - python-version: "pypy-3.11-nightly"
+          - python-version: "pypy-3.11"
             os: ubuntu-24.04
             experimental: false
             nox-session: test-pypy3.11


### PR DESCRIPTION
This reverts #4984 because PyPy v7.3.23 was released.

https://pypy.org/posts/2026/05/pypy-v7322-release.html