### PR TITLE
Validate response header names

### DIFF
--- a/src/urllib3/_collections.py
+++ b/src/urllib3/_collections.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import re
 import typing
 from collections import OrderedDict
 from enum import Enum, auto
 from threading import RLock
+
+from .exceptions import InvalidHeader
 
 if typing.TYPE_CHECKING:
     # We can only import Protocol if TYPE_CHECKING because it's a development
@@ -27,6 +30,8 @@ _KT = typing.TypeVar("_KT")
 _VT = typing.TypeVar("_VT")
 # Default type
 _DT = typing.TypeVar("_DT")
+
+_HEADER_NAME_RE = re.compile(r"[^-!#$%&'*+.^_`|~0-9a-zA-Z]")
 
 ValidHTTPHeaderSource = typing.Union[
     "HTTPHeaderDict",
@@ -252,6 +257,8 @@ class HTTPHeaderDict(typing.MutableMapping[str, str]):
         # avoid a bytes/str comparison by decoding before httplib
         if isinstance(key, bytes):
             key = key.decode("latin-1")
+        if _HEADER_NAME_RE.search(key):
+            raise InvalidHeader(f"Invalid header name {key!r}")
         self._container[key.lower()] = [key, val]
 
     def __getitem__(self, key: str) -> str:
@@ -325,6 +332,8 @@ class HTTPHeaderDict(typing.MutableMapping[str, str]):
         # avoid a bytes/str comparison by decoding before httplib
         if isinstance(key, bytes):
             key = key.decode("latin-1")
+        if _HEADER_NAME_RE.search(key):
+            raise InvalidHeader(f"Invalid header name {key!r}")
         key_lower = key.lower()
         new_vals = [key, val]
         # Keep the common case aka no item present as fast as possible

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -20,6 +20,7 @@ from urllib3.connection import ProxyConfig
 from urllib3.exceptions import (
     InsecureRequestWarning,
     LocationParseError,
+    InvalidHeader,
     TimeoutStateError,
     UnrewindableBodyError,
 )
@@ -851,6 +852,12 @@ class TestUtil:
         )
         header_msg.seek(0)
         assert_header_parsing(client.parse_headers(header_msg))
+
+    def test_http_header_dict_rejects_invalid_header_name(self) -> None:
+        from urllib3._collections import HTTPHeaderDict
+
+        with pytest.raises(InvalidHeader):
+            HTTPHeaderDict({"bad header": "value"})
 
     @pytest.mark.parametrize("host", [".localhost", "...", "t" * 64])
     def test_create_connection_with_invalid_idna_labels(self, host: str) -> None:

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -46,6 +46,7 @@ from urllib3.connection import HTTPConnection, _get_default_user_agent
 from urllib3.connectionpool import _url_from_pool
 from urllib3.exceptions import (
     InsecureRequestWarning,
+    InvalidHeader,
     MaxRetryError,
     ProtocolError,
     ProxyError,
@@ -87,6 +88,27 @@ class TestCookies(SocketDummyServerTestCase):
             r = pool.request("GET", "/", retries=0)
             assert r.headers == {"set-cookie": "foo=1, bar=1"}
             assert r.headers.getlist("set-cookie") == ["foo=1", "bar=1"]
+
+    def test_invalid_header_name_raises(self) -> None:
+        def invalid_header_response_handler(listener: socket.socket) -> None:
+            sock = listener.accept()[0]
+
+            buf = b""
+            while not buf.endswith(b"\r\n\r\n"):
+                buf += sock.recv(65536)
+
+            sock.send(
+                b"HTTP/1.1 200 OK\r\n"
+                b"Bad Header: value\r\n"
+                b"Content-Length: 0\r\n"
+                b"\r\n"
+            )
+            sock.close()
+
+        self._start_server(invalid_header_response_handler)
+        with HTTPConnectionPool(self.host, self.port) as pool:
+            with pytest.raises(InvalidHeader, match="Invalid header name"):
+                pool.request("GET", "/", retries=0)
 
 
 class TestSNI(SocketDummyServerTestCase):


### PR DESCRIPTION
Fixes issue #1362 by rejecting illegal HTTP header names up front and adds regression coverage for both direct header dict construction and response parsing.