### PR TITLE
Implement Happy Eyeballs connection fallback

### DIFF
--- a/changelog/797.feature.rst
+++ b/changelog/797.feature.rst
@@ -1,0 +1,1 @@
+Added Happy Eyeballs-style fallback for connection attempts when a host resolves to multiple IPv4 and IPv6 addresses.

--- a/src/urllib3/util/connection.py
+++ b/src/urllib3/util/connection.py
@@ -1,12 +1,22 @@
 from __future__ import annotations
 
+import errno
+import ipaddress
+import selectors
 import socket
+import time
 import typing
 
 from ..exceptions import LocationParseError
 from .timeout import _DEFAULT_TIMEOUT, _TYPE_TIMEOUT
 
-_TYPE_SOCKET_OPTIONS = list[tuple[int, int, typing.Union[int, bytes]]]
+_TYPE_SOCKET_OPTIONS = list[tuple[int, int, int | bytes]]
+_HAPPY_EYEBALLS_DELAY = 0.25
+_CONNECT_IN_PROGRESS_ERRORS = {
+    errno.EINPROGRESS,
+    errno.EWOULDBLOCK,
+    errno.EALREADY,
+}
 
 if typing.TYPE_CHECKING:
     from .._base_connection import BaseHTTPConnection
@@ -45,7 +55,6 @@ def create_connection(
     host, port = address
     if host.startswith("["):
         host = host.strip("[]")
-    err = None
 
     # Using the value from allowed_gai_family() in the context of getaddrinfo lets
     # us select whether to work with IPv4 DNS records, IPv6 records, or both.
@@ -57,7 +66,36 @@ def create_connection(
     except UnicodeError:
         raise LocationParseError(f"'{host}', label empty or too long") from None
 
-    for res in socket.getaddrinfo(host, port, family, socket.SOCK_STREAM):
+    addrinfo = socket.getaddrinfo(host, port, family, socket.SOCK_STREAM)
+    if len(addrinfo) == 1 or _is_loopback_host(host):
+        return _connect_to_resolved_addresses(
+            addrinfo, timeout, source_address, socket_options
+        )
+
+    return _happy_eyeballs_connect(
+        _interleave_addrinfo_by_family(addrinfo),
+        timeout,
+        source_address,
+        socket_options,
+    )
+
+
+def _connect_to_resolved_addresses(
+    addrinfo: list[
+        tuple[
+            socket.AddressFamily,
+            socket.SocketKind,
+            int,
+            str,
+            tuple[typing.Any, ...],
+        ]
+    ],
+    timeout: _TYPE_TIMEOUT,
+    source_address: tuple[str, int] | None,
+    socket_options: _TYPE_SOCKET_OPTIONS | None,
+) -> socket.socket:
+    err = None
+    for res in addrinfo:
         af, socktype, proto, canonname, sa = res
         sock = None
         try:
@@ -86,8 +124,213 @@ def create_connection(
         finally:
             # Break explicitly a reference cycle
             err = None
-    else:
+    raise OSError("getaddrinfo returns an empty list")
+
+
+def _happy_eyeballs_connect(
+    addrinfo: list[
+        tuple[
+            socket.AddressFamily,
+            socket.SocketKind,
+            int,
+            str,
+            tuple[typing.Any, ...],
+        ]
+    ],
+    timeout: _TYPE_TIMEOUT,
+    source_address: tuple[str, int] | None,
+    socket_options: _TYPE_SOCKET_OPTIONS | None,
+) -> socket.socket:
+    if not addrinfo:
         raise OSError("getaddrinfo returns an empty list")
+
+    timeout_value = (
+        socket.getdefaulttimeout() if timeout is _DEFAULT_TIMEOUT else timeout
+    )
+    deadline = None if timeout_value is None else time.monotonic() + timeout_value
+    next_attempt_at = time.monotonic()
+    pending = list(addrinfo)
+    active: dict[int, socket.socket] = {}
+    selector = selectors.DefaultSelector()
+    err: OSError | None = None
+
+    try:
+        while pending or active:
+            now = time.monotonic()
+            while pending and now >= next_attempt_at:
+                try:
+                    sock, connected = _start_connect_attempt(
+                        pending.pop(0),
+                        source_address,
+                        socket_options,
+                    )
+                except OSError as e:
+                    err = e
+                    continue
+
+                if connected:
+                    _close_active_sockets(active)
+                    _restore_socket_timeout(sock, timeout)
+                    return sock
+
+                try:
+                    selector.register(sock, selectors.EVENT_WRITE)
+                    active[sock.fileno()] = sock
+                except BaseException:
+                    sock.close()
+                    raise
+                next_attempt_at = now + _HAPPY_EYEBALLS_DELAY
+
+            if deadline is not None and now >= deadline:
+                raise TimeoutError("timed out")
+
+            if not active:
+                break
+
+            select_timeout = None
+            if pending:
+                select_timeout = max(0.0, next_attempt_at - now)
+            if deadline is not None:
+                deadline_timeout = max(0.0, deadline - now)
+                select_timeout = (
+                    deadline_timeout
+                    if select_timeout is None
+                    else min(select_timeout, deadline_timeout)
+                )
+
+            events = selector.select(select_timeout)
+            for key, _ in events:
+                sock = typing.cast(socket.socket, key.fileobj)
+                selector.unregister(sock)
+                active.pop(sock.fileno(), None)
+                connect_error = sock.getsockopt(socket.SOL_SOCKET, socket.SO_ERROR)
+                if connect_error == 0:
+                    _close_active_sockets(active)
+                    _restore_socket_timeout(sock, timeout)
+                    return sock
+                sock.close()
+                err = OSError(
+                    connect_error, errno.errorcode.get(connect_error, "error")
+                )
+                if pending:
+                    next_attempt_at = time.monotonic()
+
+        if err is not None:
+            raise err
+        raise OSError("getaddrinfo returns an empty list")  # pragma: no cover
+    finally:
+        selector.close()
+        _close_sockets(active.values())
+
+
+def _interleave_addrinfo_by_family(
+    addrinfo: list[
+        tuple[
+            socket.AddressFamily,
+            socket.SocketKind,
+            int,
+            str,
+            tuple[typing.Any, ...],
+        ]
+    ],
+) -> list[
+    tuple[
+        socket.AddressFamily,
+        socket.SocketKind,
+        int,
+        str,
+        tuple[typing.Any, ...],
+    ]
+]:
+    by_family: dict[
+        socket.AddressFamily,
+        list[
+            tuple[
+                socket.AddressFamily,
+                socket.SocketKind,
+                int,
+                str,
+                tuple[typing.Any, ...],
+            ]
+        ],
+    ] = {}
+    family_order = []
+    for res in addrinfo:
+        family = res[0]
+        if family not in by_family:
+            by_family[family] = []
+            family_order.append(family)
+        by_family[family].append(res)
+
+    if len(family_order) < 2:
+        return addrinfo
+
+    interleaved = []
+    while by_family:
+        for family in list(family_order):
+            family_results = by_family[family]
+            interleaved.append(family_results.pop(0))
+            if not family_results:
+                by_family.pop(family)
+                family_order.remove(family)
+    return interleaved
+
+
+def _start_connect_attempt(
+    res: tuple[
+        socket.AddressFamily,
+        socket.SocketKind,
+        int,
+        str,
+        tuple[typing.Any, ...],
+    ],
+    source_address: tuple[str, int] | None,
+    socket_options: _TYPE_SOCKET_OPTIONS | None,
+) -> tuple[socket.socket, bool]:
+    af, socktype, proto, canonname, sa = res
+    sock = socket.socket(af, socktype, proto)
+    try:
+        _set_socket_options(sock, socket_options)
+        if source_address:
+            sock.bind(source_address)
+        sock.setblocking(False)
+        connect_error = sock.connect_ex(sa)
+        if connect_error == 0:
+            return sock, True
+        if connect_error in _CONNECT_IN_PROGRESS_ERRORS:
+            return sock, False
+    except OSError:
+        sock.close()
+        raise
+
+    sock.close()
+    raise OSError(connect_error, errno.errorcode.get(connect_error, "error"))
+
+
+def _restore_socket_timeout(sock: socket.socket, timeout: _TYPE_TIMEOUT) -> None:
+    if timeout is _DEFAULT_TIMEOUT:
+        sock.settimeout(socket.getdefaulttimeout())
+    else:
+        sock.settimeout(timeout)
+
+
+def _is_loopback_host(host: str) -> bool:
+    if host == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        return False
+
+
+def _close_sockets(sockets: typing.Iterable[socket.socket]) -> None:
+    for sock in sockets:
+        sock.close()
+
+
+def _close_active_sockets(active: dict[int, socket.socket]) -> None:
+    _close_sockets(active.values())
+    active.clear()
 
 
 def _set_socket_options(

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -5,6 +5,7 @@ import logging
 import socket
 import ssl
 import sys
+import threading
 import typing
 import warnings
 from itertools import chain
@@ -24,7 +25,16 @@ from urllib3.exceptions import (
     UnrewindableBodyError,
 )
 from urllib3.util import is_fp_closed
-from urllib3.util.connection import _has_ipv6, allowed_gai_family, create_connection
+from urllib3.util.connection import (
+    _connect_to_resolved_addresses,
+    _happy_eyeballs_connect,
+    _has_ipv6,
+    _interleave_addrinfo_by_family,
+    _restore_socket_timeout,
+    _start_connect_attempt,
+    allowed_gai_family,
+    create_connection,
+)
 from urllib3.util.proxy import connection_requires_http_tunnel
 from urllib3.util.request import _FAILEDTELL, make_headers, rewind_body
 from urllib3.util.response import assert_header_parsing
@@ -922,6 +932,234 @@ class TestUtil:
         create_connection(("a::b%iface", 80))
         assert getaddrinfo.call_args[0][0] == "a::b%iface"
         fake_sock.connect.assert_called_once_with(fake_scoped_sa6)
+
+    @patch("socket.getaddrinfo")
+    def test_create_connection_uses_next_address_when_first_family_fails(
+        self, getaddrinfo: MagicMock
+    ) -> None:
+        server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        server.settimeout(3)
+        server.bind(("127.0.0.1", 0))
+        server.listen(1)
+        _, port = server.getsockname()
+        accepted = []
+
+        def accept_once() -> None:
+            conn, _ = server.accept()
+            accepted.append(True)
+            conn.close()
+
+        thread = threading.Thread(target=accept_once)
+        thread.start()
+        getaddrinfo.return_value = [
+            (
+                socket.AF_INET6,
+                socket.SOCK_STREAM,
+                0,
+                "",
+                ("::1", port, 0, 0),
+            ),
+            (
+                socket.AF_INET,
+                socket.SOCK_STREAM,
+                0,
+                "",
+                ("127.0.0.1", port),
+            ),
+        ]
+
+        try:
+            sock = create_connection(("example.test", port), timeout=2)
+            assert sock.family == socket.AF_INET
+            sock.close()
+        finally:
+            thread.join(3)
+            server.close()
+
+        assert accepted == [True]
+
+    @patch("socket.getaddrinfo")
+    def test_create_connection_preserves_source_address_and_socket_options(
+        self, getaddrinfo: MagicMock
+    ) -> None:
+        server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        server.settimeout(3)
+        server.bind(("127.0.0.1", 0))
+        server.listen(1)
+        _, port = server.getsockname()
+        accepted_peer = []
+
+        def accept_once() -> None:
+            conn, peer = server.accept()
+            accepted_peer.append(peer)
+            conn.close()
+
+        thread = threading.Thread(target=accept_once)
+        thread.start()
+
+        getaddrinfo.return_value = [
+            (
+                socket.AF_INET6,
+                socket.SOCK_STREAM,
+                socket.IPPROTO_TCP,
+                "",
+                ("2001:db8::1", port, 0, 0),
+            ),
+            (
+                socket.AF_INET,
+                socket.SOCK_STREAM,
+                socket.IPPROTO_TCP,
+                "",
+                ("127.0.0.1", port),
+            ),
+        ]
+
+        try:
+            sock = create_connection(
+                ("example.test", port),
+                timeout=2,
+                source_address=("127.0.0.1", 0),
+                socket_options=[(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)],
+            )
+            try:
+                assert sock.getsockname()[0] == "127.0.0.1"
+            finally:
+                sock.close()
+        finally:
+            thread.join(3)
+            server.close()
+
+        assert len(accepted_peer) == 1
+
+    def test_interleave_addrinfo_by_family(self) -> None:
+        addrinfo = [
+            (socket.AF_INET6, socket.SOCK_STREAM, 0, "", ("::1", 80, 0, 0)),
+            (socket.AF_INET6, socket.SOCK_STREAM, 0, "", ("::2", 80, 0, 0)),
+            (socket.AF_INET, socket.SOCK_STREAM, 0, "", ("127.0.0.1", 80)),
+            (socket.AF_INET, socket.SOCK_STREAM, 0, "", ("127.0.0.2", 80)),
+            (socket.AF_INET6, socket.SOCK_STREAM, 0, "", ("::3", 80, 0, 0)),
+        ]
+
+        assert _interleave_addrinfo_by_family(addrinfo) == [
+            (socket.AF_INET6, socket.SOCK_STREAM, 0, "", ("::1", 80, 0, 0)),
+            (socket.AF_INET, socket.SOCK_STREAM, 0, "", ("127.0.0.1", 80)),
+            (socket.AF_INET6, socket.SOCK_STREAM, 0, "", ("::2", 80, 0, 0)),
+            (socket.AF_INET, socket.SOCK_STREAM, 0, "", ("127.0.0.2", 80)),
+            (socket.AF_INET6, socket.SOCK_STREAM, 0, "", ("::3", 80, 0, 0)),
+        ]
+
+    def test_interleave_addrinfo_by_family_preserves_single_family_order(self) -> None:
+        addrinfo = [
+            (socket.AF_INET, socket.SOCK_STREAM, 0, "", ("127.0.0.1", 80)),
+            (socket.AF_INET, socket.SOCK_STREAM, 0, "", ("127.0.0.2", 80)),
+            (socket.AF_INET, socket.SOCK_STREAM, 0, "", ("127.0.0.3", 80)),
+        ]
+
+        assert _interleave_addrinfo_by_family(addrinfo) == addrinfo
+
+    def test_connect_to_resolved_addresses_with_empty_addrinfo(self) -> None:
+        with pytest.raises(OSError, match="getaddrinfo returns an empty list"):
+            _connect_to_resolved_addresses([], _DEFAULT_TIMEOUT, None, None)
+
+    @patch("urllib3.util.connection._start_connect_attempt")
+    def test_happy_eyeballs_connect_returns_immediate_connection(
+        self, start_connect_attempt: MagicMock
+    ) -> None:
+        addrinfo = [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("127.0.0.1", 80))]
+        start_connect_attempt.return_value = (sock := MagicMock(), True)
+
+        assert _happy_eyeballs_connect(addrinfo, 1, None, None) is sock
+        sock.settimeout.assert_called_once_with(1)
+
+    @patch("urllib3.util.connection.selectors.DefaultSelector")
+    @patch("urllib3.util.connection._start_connect_attempt")
+    def test_happy_eyeballs_connect_closes_on_selector_register_error(
+        self, start_connect_attempt: MagicMock, default_selector: MagicMock
+    ) -> None:
+        addrinfo = [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("127.0.0.1", 80))]
+        start_connect_attempt.return_value = (sock := MagicMock(), False)
+        selector = default_selector.return_value
+        selector.register.side_effect = RuntimeError("boom")
+
+        with pytest.raises(RuntimeError, match="boom"):
+            _happy_eyeballs_connect(addrinfo, 1, None, None)
+
+        sock.close.assert_called_once()
+        selector.close.assert_called_once()
+
+    @patch("urllib3.util.connection.selectors.DefaultSelector")
+    @patch("urllib3.util.connection._start_connect_attempt")
+    def test_happy_eyeballs_connect_times_out(
+        self, start_connect_attempt: MagicMock, default_selector: MagicMock
+    ) -> None:
+        addrinfo = [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("127.0.0.1", 80))]
+        start_connect_attempt.return_value = (sock := MagicMock(), False)
+        selector = default_selector.return_value
+        selector.select.return_value = []
+
+        with pytest.raises(TimeoutError, match="timed out"):
+            _happy_eyeballs_connect(addrinfo, 0, None, None)
+
+        sock.close.assert_called_once()
+
+    @patch("urllib3.util.connection._start_connect_attempt")
+    def test_happy_eyeballs_connect_raises_last_start_error(
+        self, start_connect_attempt: MagicMock
+    ) -> None:
+        addrinfo = [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("127.0.0.1", 80))]
+        start_connect_attempt.side_effect = OSError("refused")
+
+        with pytest.raises(OSError, match="refused"):
+            _happy_eyeballs_connect(addrinfo, 1, None, None)
+
+    @patch("socket.socket")
+    def test_start_connect_attempt_returns_connected_socket(
+        self, socket_: MagicMock
+    ) -> None:
+        socket_.return_value = sock = MagicMock()
+        sock.connect_ex.return_value = 0
+        addrinfo = (socket.AF_INET, socket.SOCK_STREAM, 0, "", ("127.0.0.1", 80))
+
+        assert _start_connect_attempt(addrinfo, None, None) == (sock, True)
+
+    def test_restore_socket_timeout_uses_default_timeout(self) -> None:
+        sock = MagicMock()
+
+        _restore_socket_timeout(sock, _DEFAULT_TIMEOUT)
+
+        sock.settimeout.assert_called_once_with(socket.getdefaulttimeout())
+
+    @patch("urllib3.util.connection._happy_eyeballs_connect")
+    @patch("socket.getaddrinfo")
+    @patch("socket.socket")
+    def test_create_connection_uses_blocking_path_for_localhost(
+        self,
+        socket_: MagicMock,
+        getaddrinfo: MagicMock,
+        happy_eyeballs_connect: MagicMock,
+    ) -> None:
+        getaddrinfo.return_value = [
+            (
+                socket.AF_INET6,
+                socket.SOCK_STREAM,
+                socket.IPPROTO_TCP,
+                "",
+                ("::1", 80, 0, 0),
+            ),
+            (
+                socket.AF_INET,
+                socket.SOCK_STREAM,
+                socket.IPPROTO_TCP,
+                "",
+                ("127.0.0.1", 80),
+            ),
+        ]
+        socket_.return_value = fake_sock = MagicMock()
+
+        create_connection(("localhost", 80))
+
+        happy_eyeballs_connect.assert_not_called()
+        fake_sock.connect.assert_called_once_with(("::1", 80, 0, 0))
 
     @pytest.mark.parametrize(
         "input,params,expected",


### PR DESCRIPTION
## Summary

This PR updates urllib3's connection creation to use a Happy Eyeballs-style fallback when DNS returns multiple stream addresses. The single-address path keeps the previous blocking connect behavior, while the multi-address path interleaves address families, starts non-blocking connect attempts with a 250 ms delay, returns the first successful socket, restores the requested timeout, and closes losing sockets.

Fixes #797.

## Changes

- Add address-family interleaving so IPv4 candidates are not blocked behind multiple IPv6 candidates.
- Add a multi-address non-blocking connect path using selectors.DefaultSelector.
- Preserve source_address binding and socket_options behavior.
- Restore the requested timeout on the winning socket before returning it.
- Close losing sockets and cleanup newly opened sockets when setup or selector registration fails.
- Add regression coverage for IPv6-to-IPv4 fallback, source address/socket options, interleaving, and same-family ordering.

## Local verification

- python -m pytest test/test_util.py::TestUtil::test_create_connection_uses_next_address_when_first_family_fails test/test_util.py::TestUtil::test_create_connection_preserves_source_address_and_socket_options test/test_util.py::TestUtil::test_interleave_addrinfo_by_family test/test_util.py::TestUtil::test_interleave_addrinfo_by_family_preserves_single_family_order -q
  - 4 passed
- python -m pytest test/test_util.py -q
  - 328 passed, 6 skipped
