### PR TITLE
Strip fragments from absolute request targets

### DIFF
--- a/changelog/5079.bugfix.rst
+++ b/changelog/5079.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed ``HTTPConnectionPool.urlopen()`` and HTTP proxy forwarding to strip URL fragments from absolute request targets before sending requests.

--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -710,7 +710,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         else:
             parsed_url = parse_url(url)
             destination_scheme = parsed_url.scheme
-            url = to_str(parsed_url.url)
+            url = to_str(parsed_url._replace(fragment=None).url)
 
         if headers is None:
             headers = self.headers

--- a/src/urllib3/poolmanager.py
+++ b/src/urllib3/poolmanager.py
@@ -452,7 +452,7 @@ class PoolManager(RequestMethods):
             kw["headers"] = self.headers
 
         if self._proxy_requires_url_absolute_form(u):
-            response = conn.urlopen(method, url, **kw)
+            response = conn.urlopen(method, u._replace(fragment=None).url, **kw)
         else:
             response = conn.urlopen(method, u.request_uri, **kw)
 

--- a/test/test_connectionpool.py
+++ b/test/test_connectionpool.py
@@ -622,3 +622,60 @@ class TestConnectionPool:
             # Verify the URL isn't mangled
             actual_url = mock_request.call_args[0][2]
             assert actual_url == path
+
+    @pytest.mark.parametrize(
+        ("target_url", "expected_url"),
+        [
+            pytest.param(
+                "http://localhost/path#marker=value",
+                "http://localhost/path",
+                id="fragment-after-path",
+            ),
+            pytest.param(
+                "http://localhost/path?x=1#marker=value",
+                "http://localhost/path?x=1",
+                id="fragment-after-query",
+            ),
+            pytest.param(
+                "http://localhost/#marker=value",
+                "http://localhost/",
+                id="root-path-with-fragment",
+            ),
+            pytest.param(
+                "http://localhost/path?x=1#",
+                "http://localhost/path?x=1",
+                id="empty-fragment",
+            ),
+        ],
+    )
+    def test_absolute_url_request_target_strips_fragment(
+        self, target_url: str, expected_url: str
+    ) -> None:
+        with HTTPConnectionPool(host="localhost", port=80) as pool:
+            with patch.object(
+                pool, "_make_request", return_value=HTTPResponse(status=200)
+            ) as mock_request:
+                pool.urlopen("GET", target_url)
+
+            actual_url = mock_request.call_args[0][2]
+            assert actual_url == expected_url
+
+    def test_absolute_redirect_request_target_strips_fragment(self) -> None:
+        redirect_response = HTTPResponse(
+            status=302,
+            headers={"location": "http://localhost/next?x=1#marker=value"},
+        )
+        final_response = HTTPResponse(status=200)
+
+        with HTTPConnectionPool(host="localhost", port=80) as pool:
+            with patch.object(
+                pool,
+                "_make_request",
+                side_effect=[redirect_response, final_response],
+            ) as mock_request:
+                response = pool.urlopen("GET", "/", retries=1)
+
+            requested_urls = [call.args[2] for call in mock_request.call_args_list]
+
+        assert response.status == 200
+        assert requested_urls == ["/", "http://localhost/next?x=1"]

--- a/test/test_proxymanager.py
+++ b/test/test_proxymanager.py
@@ -4,6 +4,7 @@ import pytest
 
 from urllib3.exceptions import MaxRetryError, NewConnectionError, ProxyError
 from urllib3.poolmanager import ProxyManager
+from urllib3.response import HTTPResponse
 from urllib3.util.retry import Retry
 from urllib3.util.url import parse_url
 
@@ -69,6 +70,31 @@ class TestProxyManager:
         with ProxyManager("https://proxy:8080", use_forwarding_for_https=True) as p:
             assert p._proxy_requires_url_absolute_form(http_url)
             assert p._proxy_requires_url_absolute_form(https_url)
+
+    @pytest.mark.parametrize("proxy_scheme", ["http", "https"])
+    def test_absolute_form_request_target_strips_fragment_for_custom_pool(
+        self, proxy_scheme: str
+    ) -> None:
+        class CustomConnectionPool:
+            requested_urls: list[str] = []
+
+            def __init__(self, host: str, port: int | None = None, **kw: object):
+                pass
+
+            def urlopen(self, method: str, url: str, **kw: object) -> HTTPResponse:
+                self.requested_urls.append(url)
+                return HTTPResponse(status=200)
+
+        with ProxyManager(f"{proxy_scheme}://proxy:8080") as p:
+            p.pool_classes_by_scheme = p.pool_classes_by_scheme.copy()
+            p.pool_classes_by_scheme[proxy_scheme] = CustomConnectionPool
+            response = p.urlopen(
+                "GET",
+                "http://example.com/path?x=1#marker=value",
+            )
+
+        assert response.status == 200
+        assert CustomConnectionPool.requested_urls == ["http://example.com/path?x=1"]
 
     def test_proxy_connect_retry(self) -> None:
         retry = Retry(total=None, connect=False)

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -1091,7 +1091,44 @@ class TestSocketClosing(SocketDummyServerTestCase):
 
 
 class TestProxyManager(SocketDummyServerTestCase):
-    def test_simple(self) -> None:
+    @pytest.mark.parametrize(
+        ("target_url", "expected_request_line", "expected_host"),
+        [
+            pytest.param(
+                "http://google.com/",
+                b"GET http://google.com/ HTTP/1.1",
+                b"Host: google.com",
+                id="simple",
+            ),
+            pytest.param(
+                "http://example.com/path#marker=value",
+                b"GET http://example.com/path HTTP/1.1",
+                b"Host: example.com",
+                id="fragment-after-path",
+            ),
+            pytest.param(
+                "http://example.com/path?x=1#marker=value",
+                b"GET http://example.com/path?x=1 HTTP/1.1",
+                b"Host: example.com",
+                id="fragment-after-query",
+            ),
+            pytest.param(
+                "http://example.com/#marker=value",
+                b"GET http://example.com/ HTTP/1.1",
+                b"Host: example.com",
+                id="root-path-with-fragment",
+            ),
+            pytest.param(
+                "http://example.com/path?x=1#",
+                b"GET http://example.com/path?x=1 HTTP/1.1",
+                b"Host: example.com",
+                id="empty-fragment",
+            ),
+        ],
+    )
+    def test_simple(
+        self, target_url: str, expected_request_line: bytes, expected_host: bytes
+    ) -> None:
         def echo_socket_handler(listener: socket.socket) -> None:
             sock = listener.accept()[0]
 
@@ -1113,7 +1150,7 @@ class TestProxyManager(SocketDummyServerTestCase):
         self._start_server(echo_socket_handler)
         base_url = f"http://{self.host}:{self.port}"
         with proxy_from_url(base_url) as proxy:
-            r = proxy.request("GET", "http://google.com/")
+            r = proxy.request("GET", target_url)
 
             assert r.status == 200
             # FIXME: The order of the headers is not predictable right now. We
@@ -1121,8 +1158,8 @@ class TestProxyManager(SocketDummyServerTestCase):
             # OrderedDict/MultiDict).
             assert sorted(r.data.split(b"\r\n")) == sorted(
                 [
-                    b"GET http://google.com/ HTTP/1.1",
-                    b"Host: google.com",
+                    expected_request_line,
+                    expected_host,
                     b"Accept-Encoding: identity",
                     b"Accept: */*",
                     b"User-Agent: " + _get_default_user_agent().encode("utf-8"),


### PR DESCRIPTION
urllib3 could send URL fragments in absolute-form request targets for HTTPConnectionPool absolute URLs/absolute redirects and proxied HTTP requests, potentially leaking client-side fragment data to origin servers or proxies.

Relevant excerpts from the RFCs
> [3.2.2. ](https://datatracker.ietf.org/doc/html/rfc9112#section-3.2.2)[absolute-form](https://datatracker.ietf.org/doc/html/rfc9112#name-absolute-form)
When making a request to a proxy, other than a CONNECT or server-wide OPTIONS request (as detailed below), a client MUST send the target URI in "absolute-form" as the request-target.
>  absolute-form  = absolute-URI

> [4.3](https://datatracker.ietf.org/doc/html/rfc3986#section-4.3).  Absolute URI
>   Some protocol elements allow only the absolute form of a URI without
>   a fragment identifier.  For example, defining a base URI for later
>   use by relative references calls for an absolute-URI syntax rule that
>   does not allow a fragment.
>   absolute-URI  = scheme ":" hier-part [ "?" query ]