### PR TITLE
Honor custom default socket options for proxies

### DIFF
--- a/changelog/2936.bugfix.rst
+++ b/changelog/2936.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed ``ProxyManager`` to honor custom ``HTTPConnection.default_socket_options`` and ``HTTPSConnection.default_socket_options`` values while keeping Nagle's algorithm enabled for proxy connections by default.

--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import errno
 import logging
 import queue
+import socket
 import sys
 import typing
 import warnings
@@ -40,7 +41,7 @@ from .exceptions import (
     TimeoutError,
 )
 from .response import BaseHTTPResponse
-from .util.connection import is_connection_dropped
+from .util.connection import _TYPE_SOCKET_OPTIONS, is_connection_dropped
 from .util.proxy import connection_requires_http_tunnel
 from .util.request import _TYPE_BODY_POSITION, set_file_position
 from .util.retry import Retry
@@ -61,6 +62,16 @@ if typing.TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 _TYPE_TIMEOUT = typing.Union[Timeout, float, _TYPE_DEFAULT, None]
+
+
+def _proxy_default_socket_options(
+    socket_options: _TYPE_SOCKET_OPTIONS,
+) -> _TYPE_SOCKET_OPTIONS:
+    return [
+        socket_option
+        for socket_option in socket_options
+        if socket_option[:2] != (socket.IPPROTO_TCP, socket.TCP_NODELAY)
+    ]
 
 
 # Pool objects
@@ -216,9 +227,14 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
 
         if self.proxy:
             # Enable Nagle's algorithm for proxies, to avoid packet fragmentation.
-            # Defaulting `socket_options` to an empty list avoids it defaulting to
-            # ``HTTPConnection.default_socket_options``.
-            self.conn_kw.setdefault("socket_options", [])
+            # Filtering ``TCP_NODELAY`` avoids it being inherited from the
+            # default options, while still respecting user-added options.
+            self.conn_kw.setdefault(
+                "socket_options",
+                _proxy_default_socket_options(
+                    self.ConnectionCls.default_socket_options
+                ),
+            )
 
             self.conn_kw["proxy"] = self.proxy
             self.conn_kw["proxy_config"] = self.proxy_config

--- a/test/test_proxymanager.py
+++ b/test/test_proxymanager.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import socket
+
 import pytest
 
+from urllib3.connection import HTTPConnection, HTTPSConnection
 from urllib3.exceptions import MaxRetryError, NewConnectionError, ProxyError
 from urllib3.poolmanager import ProxyManager
 from urllib3.response import HTTPResponse
@@ -49,6 +52,57 @@ class TestProxyManager:
         with ProxyManager("https://something") as p:
             assert p.proxy is not None
             assert p.proxy.port == 443
+
+    @pytest.mark.parametrize("url", ["http://example.com", "https://example.com"])
+    def test_socket_options_default_to_empty_list_for_proxies(self, url: str) -> None:
+        with ProxyManager("http://proxy:8080") as p:
+            pool = p.connection_from_url(url)
+
+        assert pool.conn_kw["socket_options"] == []
+
+    @pytest.mark.parametrize("url", ["http://example.com", "https://example.com"])
+    def test_socket_options_respect_custom_defaults_for_proxies(
+        self, monkeypatch: pytest.MonkeyPatch, url: str
+    ) -> None:
+        keepalive = (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
+        monkeypatch.setattr(
+            HTTPConnection,
+            "default_socket_options",
+            HTTPConnection.default_socket_options + [keepalive],
+        )
+
+        with ProxyManager("http://proxy:8080") as p:
+            pool = p.connection_from_url(url)
+
+        assert pool.conn_kw["socket_options"] == [keepalive]
+
+    def test_socket_options_respect_https_custom_defaults_for_proxies(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        keepalive = (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
+        monkeypatch.setattr(
+            HTTPSConnection,
+            "default_socket_options",
+            HTTPSConnection.default_socket_options + [keepalive],
+        )
+
+        with ProxyManager("http://proxy:8080") as p:
+            pool = p.connection_from_url("https://example.com")
+
+        assert pool.conn_kw["socket_options"] == [keepalive]
+
+    def test_socket_options_override_default_for_proxies(self) -> None:
+        proxy_socket_options = [
+            (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1),
+            (socket.IPPROTO_TCP, socket.TCP_NODELAY, 1),
+        ]
+
+        with ProxyManager(
+            "http://proxy:8080", socket_options=proxy_socket_options
+        ) as p:
+            pool = p.connection_from_url("http://example.com")
+
+        assert pool.conn_kw["socket_options"] == proxy_socket_options
 
     def test_invalid_scheme(self) -> None:
         with pytest.raises(AssertionError):


### PR DESCRIPTION
Closes #2936.

## What changed
- Derived proxy default socket options from the connection class defaults while filtering out TCP_NODELAY, preserving Nagle's algorithm for proxies by default.
- Preserved user-added HTTPConnection and HTTPSConnection default socket options for proxied pools.
- Added ProxyManager coverage for default proxy options, custom class defaults, and explicit socket_options overrides.
- Added a changelog fragment.

This PR was prepared with Codex assistance and verified with the commands below.

## Tests
- .venv/bin/python -m pytest test/test_proxymanager.py test/test_connection.py test/test_poolmanager.py test/with_dummyserver/test_connectionpool.py test/with_dummyserver/test_proxy_poolmanager.py -q
- .venv/bin/python -m nox -rs format