### PR TITLE
Honor custom default socket options for proxies

### DIFF
--- a/changelog/2936.bugfix.rst
+++ b/changelog/2936.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed ``ProxyManager`` losing user-added ``HTTPConnection.default_socket_options`` such as TCP keepalive.

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -77,6 +77,7 @@ port_by_scheme = {"http": 80, "https": 443}
 RECENT_DATE = datetime.date(2025, 1, 1)
 
 _CONTAINS_CONTROL_CHAR_RE = re.compile(r"[^-!#$%&'*+.^_`|~0-9a-zA-Z]")
+_DEFAULT_SOCKET_OPTIONS: typing.Final[object] = object()
 
 
 class HTTPConnection(_HTTPConnection):
@@ -137,9 +138,9 @@ class HTTPConnection(_HTTPConnection):
         timeout: _TYPE_TIMEOUT = _DEFAULT_TIMEOUT,
         source_address: tuple[str, int] | None = None,
         blocksize: int = 16384,
-        socket_options: None | (
-            connection._TYPE_SOCKET_OPTIONS
-        ) = default_socket_options,
+        socket_options: (
+            None | connection._TYPE_SOCKET_OPTIONS | object
+        ) = _DEFAULT_SOCKET_OPTIONS,
         proxy: Url | None = None,
         proxy_config: ProxyConfig | None = None,
     ) -> None:
@@ -150,7 +151,11 @@ class HTTPConnection(_HTTPConnection):
             source_address=source_address,
             blocksize=blocksize,
         )
-        self.socket_options = socket_options
+        if socket_options is _DEFAULT_SOCKET_OPTIONS:
+            socket_options = type(self).default_socket_options
+        self.socket_options = typing.cast(
+            connection._TYPE_SOCKET_OPTIONS | None, socket_options
+        )
         self.proxy = proxy
         self.proxy_config = proxy_config
 
@@ -626,9 +631,9 @@ class HTTPSConnection(HTTPConnection):
         timeout: _TYPE_TIMEOUT = _DEFAULT_TIMEOUT,
         source_address: tuple[str, int] | None = None,
         blocksize: int = 16384,
-        socket_options: None | (
-            connection._TYPE_SOCKET_OPTIONS
-        ) = HTTPConnection.default_socket_options,
+        socket_options: (
+            None | connection._TYPE_SOCKET_OPTIONS | object
+        ) = _DEFAULT_SOCKET_OPTIONS,
         proxy: Url | None = None,
         proxy_config: ProxyConfig | None = None,
         cert_reqs: int | str | None = None,

--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import errno
 import logging
 import queue
+import socket
 import sys
 import typing
 import warnings
@@ -216,9 +217,11 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
 
         if self.proxy:
             # Enable Nagle's algorithm for proxies, to avoid packet fragmentation.
-            # Defaulting `socket_options` to an empty list avoids it defaulting to
-            # ``HTTPConnection.default_socket_options``.
-            self.conn_kw.setdefault("socket_options", [])
+            # Defaulting `socket_options` to the connection defaults without
+            # TCP_NODELAY avoids dropping user-added defaults like TCP keepalive.
+            self.conn_kw.setdefault(
+                "socket_options", self._proxy_default_socket_options()
+            )
 
             self.conn_kw["proxy"] = self.proxy
             self.conn_kw["proxy_config"] = self.proxy_config
@@ -252,6 +255,15 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
             **self.conn_kw,
         )
         return conn
+
+    def _proxy_default_socket_options(
+        self,
+    ) -> list[tuple[int, int, int | bytes]]:
+        return [
+            option
+            for option in self.ConnectionCls.default_socket_options
+            if option[:2] != (socket.IPPROTO_TCP, socket.TCP_NODELAY)
+        ]
 
     def _get_conn(self, timeout: float | None = None) -> BaseHTTPConnection:
         """

--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -213,6 +213,18 @@ class TestConnection:
         conn = HTTPSConnection("not.a.real.host", port=443)
         assert conn.socket_options == [(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)]
 
+    def test_HTTPConnection_uses_updated_default_socket_options(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        socket_options = HTTPConnection.default_socket_options + [
+            (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
+        ]
+        monkeypatch.setattr(HTTPConnection, "default_socket_options", socket_options)
+
+        conn = HTTPConnection("not.a.real.host", port=80)
+
+        assert conn.socket_options == socket_options
+
     @pytest.mark.parametrize(
         "proxy_scheme, err_part",
         [

--- a/test/test_poolmanager.py
+++ b/test/test_poolmanager.py
@@ -9,12 +9,14 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from urllib3 import connection_from_url
+from urllib3.connection import HTTPConnection
 from urllib3.connectionpool import HTTPSConnectionPool
 from urllib3.exceptions import LocationValueError
 from urllib3.poolmanager import (
     _DEFAULT_BLOCKSIZE,
     PoolKey,
     PoolManager,
+    ProxyManager,
     key_fn_by_scheme,
 )
 from urllib3.util import retry, timeout
@@ -376,6 +378,18 @@ class TestPoolManager:
 
         assert default_pool.conn_kw["socket_options"] == []
         assert override_pool.conn_kw["socket_options"] == override_opts
+
+    def test_proxy_manager_uses_updated_default_socket_options(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        keepalive = (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
+        socket_options = HTTPConnection.default_socket_options + [keepalive]
+        monkeypatch.setattr(HTTPConnection, "default_socket_options", socket_options)
+
+        p = ProxyManager("http://proxy.example")
+        pool = p.connection_from_host("example.com", scheme="http")
+
+        assert pool.conn_kw["socket_options"] == [keepalive]
 
     def test_merge_pool_kwargs(self) -> None:
         """Assert _merge_pool_kwargs works in the happy case"""


### PR DESCRIPTION
Fixes #2936.

## Summary

- make `HTTPConnection`/`HTTPSConnection` read `default_socket_options` at instantiation time instead of binding the original class value in the function signature
- keep Nagle enabled for proxied connections by filtering the default `TCP_NODELAY` option, while preserving user-added defaults such as `SO_KEEPALIVE`
- add regression coverage for updated connection defaults and ProxyManager default socket options
- add a changelog fragment for the OpenCollective bounty issue

## Testing

- `uv run --group test pytest -q test/test_connection.py test/test_poolmanager.py`
- `uvx nox -s lint`

Bounty: $100 OpenCollective bounty on #2936.