### PR TITLE
Reject CRLF and null in multipart field header values

### DIFF
--- a/changelog/5082.bugfix.rst
+++ b/changelog/5082.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed ``RequestField.make_multipart()`` to reject carriage return, line feed and null characters in the ``content_type``, ``content_location`` and ``content_disposition`` values, preventing header injection into multipart request bodies.

--- a/src/urllib3/fields.py
+++ b/src/urllib3/fields.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import email.utils
 import mimetypes
+import re
 import typing
 
 _TYPE_FIELD_VALUE = typing.Union[str, bytes]
@@ -10,6 +11,10 @@ _TYPE_FIELD_VALUE_TUPLE = typing.Union[
     tuple[str, _TYPE_FIELD_VALUE],
     tuple[str, _TYPE_FIELD_VALUE, str],
 ]
+
+# Carriage return, line feed and null are not allowed in a multipart part
+# header value; otherwise they could inject extra headers into the body.
+_HEADER_VALUE_FORBIDDEN_RE = re.compile(r"[\r\n\x00]")
 
 
 def guess_content_type(
@@ -327,6 +332,15 @@ class RequestField:
             The 'Content-Location' of the request body.
 
         """
+        for header_value in (content_disposition, content_type, content_location):
+            if header_value is not None and _HEADER_VALUE_FORBIDDEN_RE.search(
+                header_value
+            ):
+                raise ValueError(
+                    f"Multipart header value {header_value!r} contains a carriage "
+                    "return, line feed, or null character"
+                )
+
         content_disposition = (content_disposition or "form-data") + "; ".join(
             [
                 "",

--- a/test/test_fields.py
+++ b/test/test_fields.py
@@ -57,6 +57,23 @@ class TestRequestField:
             "\r\n"
         )
 
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"content_type": "text/plain\r\nX-Injected: 1"},
+            {"content_location": "/test\r\nX-Injected: 1"},
+            {"content_disposition": "form-data\r\nX-Injected: 1"},
+            {"content_type": "text/plain\nX-Injected: 1"},
+            {"content_type": "text/plain\x00"},
+        ],
+    )
+    def test_make_multipart_rejects_header_injection(
+        self, kwargs: dict[str, str]
+    ) -> None:
+        field = RequestField("somename", "data")
+        with pytest.raises(ValueError, match="carriage return, line feed"):
+            field.make_multipart(**kwargs)
+
     def test_render_parts(self) -> None:
         field = RequestField("somename", "data")
         parts = field._render_parts({"name": "value", "filename": "value"})


### PR DESCRIPTION
1. `make_multipart` writes `content_type`, `content_location` and the `content_disposition` prefix into the part headers without checking them, while `name` and `filename` are already neutralized by `format_multipart_header_param`.
2. A CR, LF or NUL in any of those three values splits the part-header block and injects extra headers into the request body. A common trigger is an attacker-supplied upload Content-Type forwarded through the `(filename, data, content_type)` tuple API.

Added a check in `make_multipart` that rejects those characters with `ValueError`, keeping the three structured values consistent with the existing name/filename handling.

Repro before the change:

    fields = [("file", ("a.txt", b"DATA", "text/plain\r\nX-Injected: 1"))]
    body, _ = encode_multipart_formdata(fields)
    # body contains: Content-Type: text/plain\r\nX-Injected: 1\r\n