### PR TITLE
validate Content-Length and chunk-size before int conversion

### DIFF
--- a/changelog/5083.bugfix.rst
+++ b/changelog/5083.bugfix.rst
@@ -1,0 +1,1 @@
+Tightened response framing parsing to reject ``Content-Length`` and chunked transfer ``chunk-size`` values that are not valid per RFC 9112 (for example ``Content-Length: 1_000`` or a ``0x``-prefixed chunk size), which ``int()`` would otherwise accept.

--- a/src/urllib3/response.py
+++ b/src/urllib3/response.py
@@ -888,9 +888,6 @@ class HTTPResponse(BaseHTTPResponse):
                 length = lengths.pop()
             except ValueError:
                 length = None
-            else:
-                if length < 0:
-                    length = None
 
         else:  # if content_length is None
             length = None

--- a/src/urllib3/response.py
+++ b/src/urllib3/response.py
@@ -4,6 +4,7 @@ import collections
 import io
 import json as _json
 import logging
+import re
 import socket
 import sys
 import typing
@@ -52,6 +53,13 @@ log = logging.getLogger(__name__)
 
 # Read in 64 KiB chunks
 _READ_CHUNK_SIZE = 2**16
+
+# RFC 9112 defines Content-Length as 1*DIGIT (section 6.3) and a chunk-size as
+# 1*HEXDIG (section 7.1). Python's int() additionally accepts leading signs,
+# underscores, surrounding whitespace and a "0x" prefix, so the raw field has to
+# be validated before conversion to avoid disagreeing with a stricter peer.
+_CONTENT_LENGTH_RE = re.compile(r"[0-9]+")
+_CHUNK_SIZE_RE = re.compile(rb"[0-9A-Fa-f]+")
 
 
 class ContentDecoder:
@@ -864,7 +872,14 @@ class HTTPResponse(BaseHTTPResponse):
                 # (e.g. Content-Length: 42, 42). This line ensures the values
                 # are all valid ints and that as long as the `set` length is 1,
                 # all values are the same. Otherwise, the header is invalid.
-                lengths = {int(val) for val in content_length.split(",")}
+                lengths = set()
+                for val in content_length.split(","):
+                    # Only optional whitespace may surround each value; reject
+                    # signs, underscores and unicode digits that int() accepts.
+                    val = val.strip()
+                    if not _CONTENT_LENGTH_RE.fullmatch(val):
+                        raise ValueError
+                    lengths.add(int(val))
                 if len(lengths) > 1:
                     raise InvalidHeader(
                         "Content-Length contained multiple "
@@ -1347,7 +1362,12 @@ class HTTPResponse(BaseHTTPResponse):
         line = self._fp.fp.readline()  # type: ignore[union-attr]
         line = line.split(b";", 1)[0]
         try:
-            self.chunk_left = int(line, 16)
+            # Strip the trailing CRLF, then require a bare hex chunk-size and
+            # reject the signs, underscores and "0x" prefix that int() allows.
+            chunk_size = line.strip()
+            if not _CHUNK_SIZE_RE.fullmatch(chunk_size):
+                raise ValueError
+            self.chunk_left = int(chunk_size, 16)
         except ValueError:
             self.close()
             if line:

--- a/test/test_response.py
+++ b/test/test_response.py
@@ -1598,6 +1598,15 @@ class TestResponse:
         resp = HTTPResponse(fp, headers=garbage, preload_content=False)
         assert resp.length_remaining is None
 
+    @pytest.mark.parametrize("value", ["1_000", "+5", "0x10", "0o10", "१२३"])
+    def test_length_w_non_rfc_header(self, value: str) -> None:
+        # int() accepts these forms but RFC 9112 section 6.3 only allows 1*DIGIT.
+        fp = BytesIO(b"12345")
+        resp = HTTPResponse(
+            fp, headers={"content-length": value}, preload_content=False
+        )
+        assert resp.length_remaining is None
+
     def test_length_when_chunked(self) -> None:
         # This is expressly forbidden in RFC 7230 sec 3.3.2
         # We fall back to chunked in this case and try to
@@ -1810,6 +1819,23 @@ class TestResponse:
         assert str(ctx.value) == msg
         assert isinstance(orig_ex, InvalidChunkLength)
         assert orig_ex.length == fp.BAD_LENGTH_LINE.encode()
+
+    def test_non_rfc_chunk_length(self) -> None:
+        stream = [b"foooo", b"bbbbaaaaar"]
+        fp = MockChunkedNonRfcChunkLength(stream)
+        r = httplib.HTTPResponse(MockSock)  # type: ignore[arg-type]
+        r.fp = fp  # type: ignore[assignment]
+        r.chunked = True
+        r.chunk_left = None
+        resp = HTTPResponse(
+            r, preload_content=False, headers={"transfer-encoding": "chunked"}
+        )
+        with pytest.raises(ProtocolError) as ctx:
+            next(resp.read_chunked())
+
+        orig_ex = ctx.value.args[1]
+        assert isinstance(orig_ex, InvalidChunkLength)
+        assert orig_ex.length == b"0x5\r\n"
 
     def test_truncated_before_chunk(self) -> None:
         stream = [b"foooo", b"bbbbaaaaar"]
@@ -2097,6 +2123,13 @@ class MockChunkedInvalidChunkLength(MockChunkedEncodingResponse):
 
     def _encode_chunk(self, chunk: bytes) -> bytes:
         return f"{self.BAD_LENGTH_LINE}{chunk.decode()}\r\n".encode()
+
+
+class MockChunkedNonRfcChunkLength(MockChunkedEncodingResponse):
+    # "0x"-prefixed chunk-size, which int(line, 16) accepts but RFC 9112
+    # section 7.1 forbids (chunk-size = 1*HEXDIG).
+    def _encode_chunk(self, chunk: bytes) -> bytes:
+        return f"0x{len(chunk):X}\r\n{chunk.decode()}\r\n".encode()
 
 
 class MockChunkedEncodingWithoutCRLFOnEnd(MockChunkedEncodingResponse):


### PR DESCRIPTION
1. Content-Length is converted with `int()`, which also accepts `+5`, `1_000` and unicode digits that RFC 9112 section 6.3 (`1*DIGIT`) forbids.
2. chunk-size is converted with `int(line, 16)`, which also accepts a `0x` prefix, signs and underscores that RFC 9112 section 7.1 (`1*HEXDIG`) forbids.
3. Either case lets a server or intermediary frame a response that urllib3 reads with a different length than a stricter peer.

Validated both fields against a strict pattern in `_init_length` and `_update_chunk_length` before the conversion. Optional whitespace around comma-separated Content-Length values and chunk extensions still parse as before.