### PR TITLE
Handle tuple warning filter categories in tests

### DIFF
--- a/changelog/5053.bugfix.rst
+++ b/changelog/5053.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed test warning setup to handle global warning filters with tuple categories.

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -97,7 +97,11 @@ RESOLVES_LOCALHOST_FQDN = _can_resolve("localhost.")
 def clear_warnings(cls: type[Warning] = HTTPWarning) -> None:
     new_filters = []
     for f in warnings.filters:
-        if issubclass(f[2], cls):
+        category = f[2]
+        if isinstance(category, tuple):
+            if any(issubclass(item, cls) for item in category):
+                continue
+        elif issubclass(category, cls):
             continue
         new_filters.append(f)
     warnings.filters[:] = new_filters  # type: ignore[index]

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -640,6 +640,21 @@ class TestUtil:
             warnings.warn("This is a test.", InsecureRequestWarning)
             assert len(w) == 1
 
+    def test_clear_warnings_with_tuple_category_filter(self) -> None:
+        filters = typing.cast(
+            list[tuple[str, object, type[Warning], object, int]], warnings.filters
+        )
+        original_filters = filters[:]
+        category = typing.cast(type[Warning], (SyntaxWarning, DeprecationWarning))
+        try:
+            filters.insert(0, ("ignore", None, category, None, 0))
+
+            clear_warnings()
+
+            assert filters[0][2] is category
+        finally:
+            filters[:] = original_filters
+
     def _make_time_pass(
         self, seconds: int, timeout: Timeout, time_mock: Mock
     ) -> Timeout:


### PR DESCRIPTION
### Summary
- Update test warning filter cleanup to handle tuple-valued warning categories.
- Add a regression test for tuple category filters in `warnings.filters`.
- Add a changelog fragment for #5053.

Fixes #5053.

### Testing
- `uv run pytest test/test_util.py::TestUtil::test_clear_warnings_with_tuple_category_filter test/test_util.py::TestUtil::test_disable_warnings`
- `git diff --check`