### PR TITLE
Use patched queue for default connection pools

### DIFF
--- a/changelog/3289.bugfix.rst
+++ b/changelog/3289.bugfix.rst
@@ -1,0 +1,2 @@
+Used the monkey-patched ``queue.LifoQueue`` when creating default connection pools,
+improving compatibility with gevent while still respecting custom queue classes.

--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -76,7 +76,7 @@ class ConnectionPool:
     """
 
     scheme: str | None = None
-    QueueCls = queue.LifoQueue
+    QueueCls: type[queue.LifoQueue[typing.Any]] = queue.LifoQueue
 
     def __init__(self, host: str, port: int | None = None) -> None:
         if not host:
@@ -198,7 +198,11 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         self.timeout = timeout
         self.retries = retries
 
-        self.pool: queue.LifoQueue[typing.Any] | None = self.QueueCls(maxsize)
+        queue_cls = self.QueueCls
+        if queue_cls is ConnectionPool.QueueCls:
+            queue_cls = queue.LifoQueue
+
+        self.pool: queue.LifoQueue[typing.Any] | None = queue_cls(maxsize)
         self.block = block
 
         self.proxy = _proxy

--- a/test/test_connectionpool.py
+++ b/test/test_connectionpool.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import http.client as httplib
+import queue
 import ssl
 import typing
 from http.client import HTTPException
@@ -90,6 +91,39 @@ class TestConnectionPool:
     def test_same_host(self, a: str, b: str) -> None:
         with connection_from_url(a) as c:
             assert c.is_same_host(b)
+
+    def test_default_queue_class_is_late_bound(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        class LateBoundLifoQueue(queue.LifoQueue[typing.Any]):
+            pass
+
+        monkeypatch.setattr(
+            "urllib3.connectionpool.queue.LifoQueue", LateBoundLifoQueue
+        )
+
+        with HTTPConnectionPool("localhost") as pool:
+            assert isinstance(pool.pool, LateBoundLifoQueue)
+
+    def test_custom_queue_class_is_respected(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        class CustomLifoQueue(queue.LifoQueue[typing.Any]):
+            pass
+
+        class LateBoundLifoQueue(queue.LifoQueue[typing.Any]):
+            pass
+
+        class CustomQueueHTTPConnectionPool(HTTPConnectionPool):
+            QueueCls = CustomLifoQueue
+
+        monkeypatch.setattr(
+            "urllib3.connectionpool.queue.LifoQueue", LateBoundLifoQueue
+        )
+
+        with CustomQueueHTTPConnectionPool("localhost") as pool:
+            assert isinstance(pool.pool, CustomLifoQueue)
+            assert not isinstance(pool.pool, LateBoundLifoQueue)
 
     @pytest.mark.parametrize(
         "a, b",


### PR DESCRIPTION
Fixes #3289.

## Summary
- Resolve the default pool queue class at connection-pool construction time so gevent-style monkey patching of `queue.LifoQueue` is honored.
- Keep explicit `QueueCls` overrides working for custom queue implementations.
- Add regression coverage for both the late-bound default queue and custom queue path.
- Add a changelog fragment for the fix.

## Validation
- `.venv\Scripts\python -m pytest test\test_connectionpool.py` (87 passed)
- `git diff --check`

The issue is labeled with the $100 OpenCollective bounty; happy to coordinate payout details after acceptance.