### PR TITLE
Include explicit port 0 in Url.netloc and Url.authority

### DIFF
--- a/changelog/5088.bugfix.rst
+++ b/changelog/5088.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed :attr:`~urllib3.util.Url.netloc` and :attr:`~urllib3.util.Url.authority` dropping an explicit port ``0``.

--- a/src/urllib3/util/url.py
+++ b/src/urllib3/util/url.py
@@ -156,7 +156,7 @@ class Url(
         """
         if self.host is None:
             return None
-        if self.port:
+        if self.port is not None:
             return f"{self.host}:{self.port}"
         return self.host
 

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -388,6 +388,7 @@ class TestUtil:
         ("http://user:pass@localhost/path", "user:pass@localhost"),
         ("http://user:pass@localhost:80/path", "user:pass@localhost:80"),
         ("http://user@localhost:80/path", "user@localhost:80"),
+        ("http://user:pass@google.com:0/mail", "user:pass@google.com:0"),
     ]
 
     url_netloc_map = [
@@ -401,6 +402,7 @@ class TestUtil:
         ("http://localhost:80", "localhost:80"),
         ("google.com/foobar", "google.com"),
         ("google.com:12345", "google.com:12345"),
+        ("http://google.com:0/mail", "google.com:0"),
         ("/", None),
     ]
 


### PR DESCRIPTION
## Problem

`Url.netloc` (and `Url.authority`, which builds on it) silently drops an explicit
port `0`, because it uses a truthiness check:

```python
# src/urllib3/util/url.py
if self.port:
    return f"{self.host}:{self.port}"
return self.host
```

`0` is falsy, so a parsed `:0` is omitted. This contradicts:

- the sibling `url` property, which uses `if port is not None:` and explicitly
  documents the intent — *"We use 'is not None' [because] we want things to
  happen with empty strings (or 0 port)"*; and
- the stdlib-parity contract asserted by the existing
  `test_authority_matches_urllib_netloc`, since `urlparse("http://h:0/").netloc`
  keeps `"h:0"`.

`parse_url` already accepts `:0` (`_HOST_PORT_RE` matches it and sets
`.port == 0`), so this is reachable:

```python
>>> parse_url("http://example.com:0/path").url
'http://example.com:0/path'
>>> parse_url("http://example.com:0/path").netloc
'example.com'                     # bug: expected 'example.com:0'
>>> parse_url("http://u:p@example.com:0/path").authority
'u:p@example.com'                 # bug: expected 'u:p@example.com:0'
```

## Fix

Use `if self.port is not None:` in `netloc`, matching the `url` property and
stdlib behaviour.

## Tests

Added `:0` cases to the existing `url_authority_map` and `url_netloc_map`
parametrizations in `test/test_util.py`. They fail on `main`
(`test_netloc`/`test_authority` return the port-less form) and pass with the
fix; `test_authority_matches_urllib_netloc` confirms the expected values match
`urlparse().netloc`. `black`/`isort` clean.
