### PR TITLE
Use lazy queue creation for default connection pools

### DIFF
--- a/changelog/3289.bugfix.rst
+++ b/changelog/3289.bugfix.rst
@@ -1,0 +1,2 @@
+Used the monkey-patched ``queue.LifoQueue`` when creating default connection pools,
+improving compatibility with gevent while still respecting custom queue classes.

--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -76,7 +76,7 @@ class ConnectionPool:
     """
 
     scheme: str | None = None
-    QueueCls = queue.LifoQueue
+    QueueCls: type[queue.LifoQueue[typing.Any]] | None = None
 
     def __init__(self, host: str, port: int | None = None) -> None:
         if not host:
@@ -111,6 +111,12 @@ class ConnectionPool:
         """
         Close all pooled connections and disable the pool.
         """
+
+    def _make_queue(
+        self, *args: typing.Any, **kwargs: typing.Any
+    ) -> queue.LifoQueue[typing.Any]:
+        queue_cls = self.QueueCls or queue.LifoQueue
+        return queue_cls(*args, **kwargs)
 
 
 # This is taken from http://hg.python.org/cpython/file/7aaba721ebc0/Lib/socket.py#l252
@@ -198,7 +204,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         self.timeout = timeout
         self.retries = retries
 
-        self.pool: queue.LifoQueue[typing.Any] | None = self.QueueCls(maxsize)
+        self.pool: queue.LifoQueue[typing.Any] | None = self._make_queue(maxsize)
         self.block = block
 
         self.proxy = _proxy

--- a/test/test_connectionpool.py
+++ b/test/test_connectionpool.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import http.client as httplib
+import queue
 import ssl
 import typing
 from http.client import HTTPException
@@ -90,6 +91,39 @@ class TestConnectionPool:
     def test_same_host(self, a: str, b: str) -> None:
         with connection_from_url(a) as c:
             assert c.is_same_host(b)
+
+    def test_default_queue_class_is_late_bound(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        class LateBoundLifoQueue(queue.LifoQueue[typing.Any]):
+            pass
+
+        monkeypatch.setattr(
+            "urllib3.connectionpool.queue.LifoQueue", LateBoundLifoQueue
+        )
+
+        with HTTPConnectionPool("localhost") as pool:
+            assert isinstance(pool.pool, LateBoundLifoQueue)
+
+    def test_custom_queue_class_is_respected(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        class CustomLifoQueue(queue.LifoQueue[typing.Any]):
+            pass
+
+        class LateBoundLifoQueue(queue.LifoQueue[typing.Any]):
+            pass
+
+        class CustomQueueHTTPConnectionPool(HTTPConnectionPool):
+            QueueCls = CustomLifoQueue
+
+        monkeypatch.setattr(
+            "urllib3.connectionpool.queue.LifoQueue", LateBoundLifoQueue
+        )
+
+        with CustomQueueHTTPConnectionPool("localhost") as pool:
+            assert isinstance(pool.pool, CustomLifoQueue)
+            assert not isinstance(pool.pool, LateBoundLifoQueue)
 
     @pytest.mark.parametrize(
         "a, b",


### PR DESCRIPTION
Fixes #3289.

## Summary
- Default `ConnectionPool.QueueCls` to `None` so the pool constructor resolves `queue.LifoQueue` lazily after any runtime patching.
- Add `_make_queue()` to keep the default queue path late-bound while preserving explicit custom `QueueCls` overrides.
- Add regression coverage for late-bound default queues and custom queue classes.
- Add the bugfix changelog fragment.

## Validation
- `.venv\Scripts\python.exe -m pytest test\test_connectionpool.py -k queue_class` - 2 passed
- `.venv\Scripts\python.exe -m pytest test\test_connectionpool.py` - 88 passed
- `git diff --check` - passed

The issue carries the $100 OpenCollective bounty label; happy to coordinate payout details after acceptance.