### PR TITLE
Fix: treat empty allowed_methods as retrying no methods

### DIFF
--- a/src/urllib3/util/retry.py
+++ b/src/urllib3/util/retry.py
@@ -404,7 +404,7 @@ class Retry:
         """Checks if a given HTTP method should be retried upon, depending if
         it is included in the allowed_methods
         """
-        if self.allowed_methods and method.upper() not in self.allowed_methods:
+        if self.allowed_methods is not None and method.upper() not in self.allowed_methods:
             return False
         return True
 


### PR DESCRIPTION
## Description

An empty container for `allowed_methods` (e.g., `set()`) was previously treated the same as `None`, allowing retries on **all** HTTP methods. This is error-prone because users can accidentally produce an empty set (e.g., using `&` instead of `|` when combining allowed methods) without realizing the retry behavior is incorrect.

This fix changes the behavior so that an empty `allowed_methods` container means **no** methods are retryable, matching the intuitive expectation.

## Changes

- `src/urllib3/util/retry.py`: Changed `_is_method_retryable` to use `is not None` instead of truthiness check

## Testing

- `None` → all methods retryable (unchanged)
- `set()` → no methods retryable (fixed)
- `{"GET"}` → only GET retryable (unchanged)

Fixes #5044

---

Payment: PayPal n6085530@gmail.com