### PR TITLE
Port "Reject CR/LF in HTTP tunnel request headers"

### DIFF
--- a/changelog/5091.bugfix.rst
+++ b/changelog/5091.bugfix.rst
@@ -1,0 +1,2 @@
+Added safeguards to the proxy tunneling code to prevent potential security issues when handling invalid characters in the proxy host and HTTP headers.
+This change affects users of Python 3.10; those on other versions should upgrade to the latest patch releases of supported Python versions to get the same security fixes (CPython 3.13.14+ and 3.14.5+ are patched; fixes for CPython 3.11 and 3.12 are pending).

--- a/changelog/5091.bugfix.rst
+++ b/changelog/5091.bugfix.rst
@@ -1,2 +1,2 @@
 Added safeguards to the proxy tunneling code to prevent potential security issues when handling invalid characters in the proxy host and HTTP headers.
-This change affects users of Python 3.10; those on other versions should upgrade to the latest patch releases of supported Python versions to get the same security fixes (CPython 3.13.14+ and 3.14.5+ are patched; fixes for CPython 3.11 and 3.12 are pending).
+This change affects users of Python 3.10, Python 3.11, and Python 3.12 when the standard library does not contain the fix; those on newer Python versions should upgrade to 3.13.14+ or 3.14.5+ to get the same security fixes.

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -261,7 +261,7 @@ class HTTPConnection(_HTTPConnection):
             # `_tunnel` copied from 3.11.15 backporting
             # https://github.com/python/cpython/commit/0d4026432591d43185568dd31cef6a034c4b9261
             # and https://github.com/python/cpython/commit/6fbc61070fda2ffb8889e77e3b24bca4249ab4d1
-            # plus a fix from https://github.com/python/cpython/pull/148351
+            # plus a fix from https://github.com/python/cpython/commit/56b7100b04e44ea27989242b176beb8f016b2c53
             def _tunnel(self) -> None:
                 if self._contains_disallowed_url_pchar_re.search(self._tunnel_host):  # type: ignore[arg-type]
                     raise ValueError(

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -242,9 +242,10 @@ class HTTPConnection(_HTTPConnection):
         super().set_tunnel(host, port=port, headers=headers)
         self._tunnel_scheme = scheme
 
-    if sys.version_info < (3, 11, 9) or ((3, 12) <= sys.version_info < (3, 12, 3)):
+    if sys.version_info < (3, 11, 16) or ((3, 12) <= sys.version_info < (3, 12, 14)):
         # Taken from python/cpython#100986 which was backported in 3.11.9 and 3.12.3.
         # When using connection_from_host, host will come without brackets.
+        # With a security patch from python/cpython#146211.
         def _wrap_ipv6(self, ip: bytes) -> bytes:
             if b":" in ip and ip[0] != b"["[0]:
                 return b"[" + ip + b"]"
@@ -257,7 +258,7 @@ class HTTPConnection(_HTTPConnection):
         )
         _contains_disallowed_url_pchar_re = re.compile("[\x00-\x20\x7f]")
 
-        if sys.version_info < (3, 11, 9):
+        if sys.version_info < (3, 11, 16):
             # `_tunnel` copied from 3.11.15 backporting
             # https://github.com/python/cpython/commit/0d4026432591d43185568dd31cef6a034c4b9261
             # and https://github.com/python/cpython/commit/6fbc61070fda2ffb8889e77e3b24bca4249ab4d1
@@ -313,7 +314,7 @@ class HTTPConnection(_HTTPConnection):
                 finally:
                     response.close()
 
-        elif (3, 12) <= sys.version_info < (3, 12, 3):
+        elif (3, 12) <= sys.version_info < (3, 12, 14):
             # `_tunnel` copied from 3.12.13 backporting
             # https://github.com/python/cpython/commit/23aef575c7629abcd4aaf028ebd226fb41a4b3c8
             # plus a fix from https://github.com/python/cpython/commit/c00c386faa579ad71196d33408644478488e43ec

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -250,11 +250,24 @@ class HTTPConnection(_HTTPConnection):
                 return b"[" + ip + b"]"
             return ip
 
+        # Copied from CPython 3.12.13 Lib/http/client.py
+        _is_legal_header_name = staticmethod(re.compile(rb"[^:\s][^:\r\n]*").fullmatch)
+        _is_illegal_header_value = staticmethod(
+            re.compile(rb"\n(?![ \t])|\r(?![ \t\n])").search
+        )
+        _contains_disallowed_url_pchar_re = re.compile("[\x00-\x20\x7f]")
+
         if sys.version_info < (3, 11, 9):
-            # `_tunnel` copied from 3.11.13 backporting
+            # `_tunnel` copied from 3.11.15 backporting
             # https://github.com/python/cpython/commit/0d4026432591d43185568dd31cef6a034c4b9261
             # and https://github.com/python/cpython/commit/6fbc61070fda2ffb8889e77e3b24bca4249ab4d1
+            # plus a fix from https://github.com/python/cpython/pull/148351
             def _tunnel(self) -> None:
+                if self._contains_disallowed_url_pchar_re.search(self._tunnel_host):  # type: ignore[arg-type]
+                    raise ValueError(
+                        "Tunnel host can't contain control characters %r"
+                        % (self._tunnel_host,)
+                    )
                 _MAXLINE = http.client._MAXLINE  # type: ignore[attr-defined]
                 connect = b"CONNECT %s:%d HTTP/1.0\r\n" % (  # type: ignore[str-format]
                     self._wrap_ipv6(self._tunnel_host.encode("ascii")),  # type: ignore[union-attr]
@@ -262,7 +275,13 @@ class HTTPConnection(_HTTPConnection):
                 )
                 headers = [connect]
                 for header, value in self._tunnel_headers.items():  # type: ignore[attr-defined]
-                    headers.append(f"{header}: {value}\r\n".encode("latin-1"))
+                    header_bytes = header.encode("latin-1")
+                    value_bytes = value.encode("latin-1")
+                    if not self._is_legal_header_name(header_bytes):
+                        raise ValueError(f"Invalid header name {header_bytes!r}")
+                    if self._is_illegal_header_value(value_bytes):
+                        raise ValueError(f"Invalid header value {value_bytes!r}")
+                    headers.append(b"%s: %s\r\n" % (header_bytes, value_bytes))
                 headers.append(b"\r\n")
                 # Making a single send() call instead of one per line encourages
                 # the host OS to use a more optimal packet size instead of
@@ -295,16 +314,28 @@ class HTTPConnection(_HTTPConnection):
                     response.close()
 
         elif (3, 12) <= sys.version_info < (3, 12, 3):
-            # `_tunnel` copied from 3.12.11 backporting
+            # `_tunnel` copied from 3.12.13 backporting
             # https://github.com/python/cpython/commit/23aef575c7629abcd4aaf028ebd226fb41a4b3c8
+            # plus a fix from https://github.com/python/cpython/commit/c00c386faa579ad71196d33408644478488e43ec
             def _tunnel(self) -> None:  # noqa: F811
+                if self._contains_disallowed_url_pchar_re.search(self._tunnel_host):  # type: ignore[arg-type]
+                    raise ValueError(
+                        "Tunnel host can't contain control characters %r"
+                        % (self._tunnel_host,)
+                    )
                 connect = b"CONNECT %s:%d HTTP/1.1\r\n" % (  # type: ignore[str-format]
                     self._wrap_ipv6(self._tunnel_host.encode("idna")),  # type: ignore[union-attr]
                     self._tunnel_port,
                 )
                 headers = [connect]
                 for header, value in self._tunnel_headers.items():  # type: ignore[attr-defined]
-                    headers.append(f"{header}: {value}\r\n".encode("latin-1"))
+                    header_bytes = header.encode("latin-1")
+                    value_bytes = value.encode("latin-1")
+                    if not self._is_legal_header_name(header_bytes):
+                        raise ValueError(f"Invalid header name {header_bytes!r}")
+                    if self._is_illegal_header_value(value_bytes):
+                        raise ValueError(f"Invalid header value {value_bytes!r}")
+                    headers.append(b"%s: %s\r\n" % (header_bytes, value_bytes))
                 headers.append(b"\r\n")
                 # Making a single send() call instead of one per line encourages
                 # the host OS to use a more optimal packet size instead of

--- a/test/with_dummyserver/test_connection.py
+++ b/test/with_dummyserver/test_connection.py
@@ -140,6 +140,57 @@ def test_invalid_tunnel_scheme(pool: HTTPConnectionPool) -> None:
     )
 
 
+@pytest.mark.parametrize(
+    "name,value",
+    [
+        ("Invalid\r\nName", "ValidValue"),
+        ("Invalid\rName", "ValidValue"),
+        ("Invalid\nName", "ValidValue"),
+        ("\r\nInvalidName", "ValidValue"),
+        ("\rInvalidName", "ValidValue"),
+        ("\nInvalidName", "ValidValue"),
+        (" InvalidName", "ValidValue"),
+        ("\tInvalidName", "ValidValue"),
+        ("Invalid:Name", "ValidValue"),
+        (":InvalidName", "ValidValue"),
+        ("ValidName", "Invalid\r\nValue"),
+        ("ValidName", "Invalid\rValue"),
+        ("ValidName", "Invalid\nValue"),
+        ("ValidName", "InvalidValue\r\n"),
+        ("ValidName", "InvalidValue\r"),
+        ("ValidName", "InvalidValue\n"),
+    ],
+)
+def test_invalid_tunnel_headers(
+    pool: HTTPConnectionPool, name: str, value: str
+) -> None:
+    conn = pool._get_conn()
+    conn.set_tunnel("tunnel", headers={name: value})
+    with pytest.raises(ValueError, match="Invalid header"):
+        conn._tunnel()
+    conn.close()
+
+
+@pytest.mark.parametrize(
+    "tunnel_host",
+    [
+        "invalid\r.host",
+        "\ninvalid.host",
+        "invalid.host\r\n",
+        "invalid.host\x00",
+        "invalid host",
+    ],
+)
+def test_invalid_tunnel_host(pool: HTTPConnectionPool, tunnel_host: str) -> None:
+    conn = pool._get_conn()
+    conn.set_tunnel(tunnel_host)
+    with pytest.raises(
+        ValueError, match="Tunnel host can't contain control characters"
+    ):
+        conn._tunnel()
+    conn.close()
+
+
 def test_response_after_drain_conn(pool: HTTPConnectionPool) -> None:
     """
     Test that a connection can be reused after calling `drain_conn` on

--- a/test/with_dummyserver/test_connection.py
+++ b/test/with_dummyserver/test_connection.py
@@ -13,15 +13,24 @@ from urllib3 import HTTPConnectionPool
 from urllib3.response import HTTPResponse
 
 # See https://github.com/python/cpython/issues/146211
-# Control character validation in tunnel is missing on:
-# - Python 3.11 (all versions)
-# - Python 3.12 before 3.12.14
-# - Python 3.13 before 3.13.14
-# - Python 3.14 before 3.14.5
+# Control character validation in tunnel is missing on Python versions where:
+# 1. The Python stdlib version itself lacks the fix
+# 2. urllib3 doesn't have a ported _tunnel implementation (see connection.py)
+# We have ported fixed implementations for:
+# - Python < 3.11.9
+# - Python 3.12 < 3.12.3
 _MISSING_TUNNEL_CONTROL_CHAR_FIX = (
-    sys.version_info[:2] == (3, 11)
-    or (sys.version_info[:2] == (3, 12) and sys.version_info[2] < 14)
+    # 3.11.9+ missing fix (3.11.0-3.11.8 have the ported implementation)
+    (sys.version_info[:2] == (3, 11) and sys.version_info[2] >= 9)
+    # 3.12.3+ before 3.12.14 missing fix (3.12.0-3.12.2 have the ported implementation)
+    or (
+        sys.version_info[:2] == (3, 12)
+        and sys.version_info[2] >= 3
+        and sys.version_info[2] < 14
+    )
+    # 3.13 before 3.13.14 missing fix (no ported implementation for this version)
     or (sys.version_info[:2] == (3, 13) and sys.version_info[2] < 14)
+    # 3.14 before 3.14.5 missing fix (no ported implementation for this version)
     or (sys.version_info[:2] == (3, 14) and sys.version_info[2] < 5)
 )
 

--- a/test/with_dummyserver/test_connection.py
+++ b/test/with_dummyserver/test_connection.py
@@ -167,7 +167,7 @@ def test_invalid_tunnel_headers(
     conn = pool._get_conn()
     conn.set_tunnel("tunnel", headers={name: value})
     with pytest.raises(ValueError, match="Invalid header"):
-        conn._tunnel()
+        conn.connect()
     conn.close()
 
 
@@ -187,7 +187,7 @@ def test_invalid_tunnel_host(pool: HTTPConnectionPool, tunnel_host: str) -> None
     with pytest.raises(
         ValueError, match="Tunnel host can't contain control characters"
     ):
-        conn._tunnel()
+        conn.connect()
     conn.close()
 
 

--- a/test/with_dummyserver/test_connection.py
+++ b/test/with_dummyserver/test_connection.py
@@ -13,27 +13,11 @@ from urllib3 import HTTPConnectionPool
 from urllib3.response import HTTPResponse
 
 # See https://github.com/python/cpython/issues/146211
-# Control character validation in tunnel is missing on Python versions where:
-# 1. The Python stdlib version itself lacks the fix
-# 2. urllib3 doesn't have a ported _tunnel implementation (see connection.py)
-# We have ported fixed implementations for:
-# - Python < 3.11.9
-# - Python 3.12 < 3.12.3
+# Xfail only on Python versions where neither the stdlib nor urllib3's
+# compatibility _tunnel implementation rejects invalid tunnel input.
 _MISSING_TUNNEL_CONTROL_CHAR_FIX = (
-    # 3.11.9+ before 3.11.16 missing fix (3.11.0-3.11.8 have the ported implementation)
-    (
-        sys.version_info[:2] == (3, 11)
-        and sys.version_info[2] >= 9
-        and sys.version_info[2] < 16
-    )
-    # 3.12.3+ before 3.12.14 missing fix (3.12.0-3.12.2 have the ported implementation)
-    or (
-        sys.version_info[:2] == (3, 12)
-        and sys.version_info[2] >= 3
-        and sys.version_info[2] < 14
-    )
     # 3.13 before 3.13.14 missing fix (no ported implementation for this version)
-    or (sys.version_info[:2] == (3, 13) and sys.version_info[2] < 14)
+    (sys.version_info[:2] == (3, 13) and sys.version_info[2] < 14)
     # 3.14 before 3.14.5 missing fix (no ported implementation for this version)
     or (sys.version_info[:2] == (3, 14) and sys.version_info[2] < 5)
 )

--- a/test/with_dummyserver/test_connection.py
+++ b/test/with_dummyserver/test_connection.py
@@ -20,8 +20,12 @@ from urllib3.response import HTTPResponse
 # - Python < 3.11.9
 # - Python 3.12 < 3.12.3
 _MISSING_TUNNEL_CONTROL_CHAR_FIX = (
-    # 3.11.9+ missing fix (3.11.0-3.11.8 have the ported implementation)
-    (sys.version_info[:2] == (3, 11) and sys.version_info[2] >= 9)
+    # 3.11.9+ before 3.11.16 missing fix (3.11.0-3.11.8 have the ported implementation)
+    (
+        sys.version_info[:2] == (3, 11)
+        and sys.version_info[2] >= 9
+        and sys.version_info[2] < 16
+    )
     # 3.12.3+ before 3.12.14 missing fix (3.12.0-3.12.2 have the ported implementation)
     or (
         sys.version_info[:2] == (3, 12)

--- a/test/with_dummyserver/test_connection.py
+++ b/test/with_dummyserver/test_connection.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import contextlib
+import sys
 import typing
 from http.client import ResponseNotReady
 from unittest import mock
@@ -10,6 +11,19 @@ import pytest
 from dummyserver.testcase import HypercornDummyServerTestCase as server
 from urllib3 import HTTPConnectionPool
 from urllib3.response import HTTPResponse
+
+# See https://github.com/python/cpython/issues/146211
+# Control character validation in tunnel is missing on:
+# - Python 3.11 (all versions)
+# - Python 3.12 before 3.12.14
+# - Python 3.13 before 3.13.14
+# - Python 3.14 before 3.14.5
+_MISSING_TUNNEL_CONTROL_CHAR_FIX = (
+    sys.version_info[:2] == (3, 11)
+    or (sys.version_info[:2] == (3, 12) and sys.version_info[2] < 14)
+    or (sys.version_info[:2] == (3, 13) and sys.version_info[2] < 14)
+    or (sys.version_info[:2] == (3, 14) and sys.version_info[2] < 5)
+)
 
 
 @pytest.fixture()
@@ -161,6 +175,10 @@ def test_invalid_tunnel_scheme(pool: HTTPConnectionPool) -> None:
         ("ValidName", "InvalidValue\n"),
     ],
 )
+@pytest.mark.xfail(
+    _MISSING_TUNNEL_CONTROL_CHAR_FIX,
+    reason="Control characters in tunnel headers not rejected in older Python versions",
+)
 def test_invalid_tunnel_headers(
     pool: HTTPConnectionPool, name: str, value: str
 ) -> None:
@@ -180,6 +198,10 @@ def test_invalid_tunnel_headers(
         "invalid.host\x00",
         "invalid host",
     ],
+)
+@pytest.mark.xfail(
+    _MISSING_TUNNEL_CONTROL_CHAR_FIX,
+    reason="Control characters in tunnel host not rejected in older Python versions",
 )
 def test_invalid_tunnel_host(pool: HTTPConnectionPool, tunnel_host: str) -> None:
     conn = pool._get_conn()


### PR DESCRIPTION
This ports fixes from https://github.com/python/cpython/issues/146211 to our copies of the code for older Python versions.