### PR TITLE
HTTPSConnection: Prefer proxy verify policy for the proxy connection

### DIFF
--- a/changelog/5093.bugfix.rst
+++ b/changelog/5093.bugfix.rst
@@ -1,2 +1,2 @@
 Fixed ``HTTPSConnection`` overriding the ``proxy_config``'s cert policy with the target request's SSL context.
-Including a ``proxy_config`` will now properly inherit ``verify_mode`` for the proxy connection and values for ``ca_certs``, ``ca_cert_dir``, and ``ca_cert_data`` will be ignored.
+Including a ``proxy_config`` will now properly inherit ``verify_mode`` for the proxy connection and values for ``ca_*`` ``ssl_*`` are ignored.

--- a/changelog/5093.bugfix.rst
+++ b/changelog/5093.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed ``HTTPSConnection`` overriding the ``proxy_config``'s cert policy with the target request's SSL context.
+Including a ``proxy_config`` will now properly inherit ``verify_mode`` for the proxy connection and values for ``ca_certs``, ``ca_cert_dir``, and ``ca_cert_data`` will be ignored.

--- a/changelog/5093.bugfix.rst
+++ b/changelog/5093.bugfix.rst
@@ -1,2 +1,11 @@
-Fixed ``HTTPSConnection`` overriding the ``proxy_config``'s cert policy with the target request's SSL context.
-Including a ``proxy_config`` will now properly inherit ``verify_mode`` for the proxy connection and values for ``ca_*`` ``ssl_*`` are ignored.
+Fixed ``HTTPSConnection.connect()`` overriding
+``ProxyConfig.ssl_context``'s certificate policy and proxy identity checks with
+the target connection's TLS settings when forwarding through an HTTPS proxy.
+``HTTPSConnection._connect_tls_proxy()`` now uses
+``ProxyConfig.ssl_context``, ``ProxyConfig.assert_hostname``, and
+``ProxyConfig.assert_fingerprint`` for the proxy handshake, while retaining the
+existing fallback to ``HTTPSConnection.ssl_context``, ``cert_reqs``, ``ca_*``,
+and ``ssl_*`` when ``ProxyConfig.ssl_context`` is ``None``.
+``HTTPSConnection`` no longer applies target SNI, assertions, or client
+credentials to forwarding proxy handshakes and continues to use its
+``ssl_context`` as a fallback when an HTTPS proxy forwards an HTTP target.

--- a/changelog/5093.bugfix.rst
+++ b/changelog/5093.bugfix.rst
@@ -1,11 +1,7 @@
 Fixed ``HTTPSConnection.connect()`` overriding
 ``ProxyConfig.ssl_context``'s certificate policy and proxy identity checks with
 the target connection's TLS settings when forwarding through an HTTPS proxy.
-``HTTPSConnection._connect_tls_proxy()`` now uses
-``ProxyConfig.ssl_context``, ``ProxyConfig.assert_hostname``, and
-``ProxyConfig.assert_fingerprint`` for the proxy handshake, while retaining the
-existing fallback to ``HTTPSConnection.ssl_context``, ``cert_reqs``, ``ca_*``,
-and ``ssl_*`` when ``ProxyConfig.ssl_context`` is ``None``.
+
 ``HTTPSConnection`` no longer applies target SNI, assertions, or client
 credentials to forwarding proxy handshakes and continues to use its
 ``ssl_context`` as a fallback when an HTTPS proxy forwards an HTTP target.

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -915,15 +915,29 @@ class HTTPSConnection(HTTPConnection):
         # `_connect_tls_proxy` is called when self._tunnel_host is truthy.
         proxy_config = typing.cast(ProxyConfig, self.proxy_config)
         ssl_context = proxy_config.ssl_context
+
+        if ssl_context is not None:
+            # Prefer the proxy's cert policy for the proxy connection
+            cert_reqs = ssl_context.verify_mode
+            ca_certs = None
+            ca_cert_dir = None
+            ca_cert_data = None
+        else:
+            # Otherwise we inherit the pool's cert policies
+            cert_reqs = self.cert_reqs
+            ca_certs = self.ca_certs
+            ca_cert_dir = self.ca_cert_dir
+            ca_cert_data = self.ca_cert_data
+
         sock_and_verified = _ssl_wrap_socket_and_match_hostname(
             sock,
-            cert_reqs=self.cert_reqs,
+            cert_reqs=cert_reqs,
             ssl_version=self.ssl_version,
             ssl_minimum_version=self.ssl_minimum_version,
             ssl_maximum_version=self.ssl_maximum_version,
-            ca_certs=self.ca_certs,
-            ca_cert_dir=self.ca_cert_dir,
-            ca_cert_data=self.ca_cert_data,
+            ca_certs=ca_certs,
+            ca_cert_dir=ca_cert_dir,
+            ca_cert_data=ca_cert_data,
             server_hostname=hostname,
             ssl_context=ssl_context,
             assert_hostname=proxy_config.assert_hostname,

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -838,14 +838,12 @@ class HTTPSConnection(HTTPConnection):
             # fall back to using the connection's SSL context until
             # urllib3 v3.0. Appropriate warning is emitted in
             # ``ProxyManager.__init__``.
+            wrapped_socket: ssl.SSLSocket | SSLTransport
             if self.proxy_is_forwarding and self.proxy_config is not None:
-                self.sock = sock = self._connect_tls_proxy(self.host, sock)
-                sock_and_verified = _WrappedAndVerifiedSocket(
-                    socket=sock,
-                    is_verified=self.proxy_is_verified is True,
-                )
+                wrapped_socket = self._connect_tls_proxy(self.host, sock)
+                is_verified = self.proxy_is_verified is True
             else:
-                sock_and_verified = _ssl_wrap_socket_and_match_hostname(
+                wrapped_socket, is_verified = _ssl_wrap_socket_and_match_hostname(
                     sock=sock,
                     cert_reqs=self.cert_reqs,
                     ssl_version=self.ssl_version,
@@ -863,7 +861,7 @@ class HTTPSConnection(HTTPConnection):
                     assert_hostname=self.assert_hostname,
                     assert_fingerprint=self.assert_fingerprint,
                 )
-            self.sock = sock_and_verified.socket
+            self.sock = wrapped_socket
 
         # If an error occurs during connection/handshake we may need to release
         # our lock so another connection can probe the origin.
@@ -884,7 +882,7 @@ class HTTPSConnection(HTTPConnection):
         # If this connection doesn't know if the origin supports HTTP/2
         # we report back to the HTTP/2 probe our result.
         if target_supports_http2 is None:
-            supports_http2 = sock_and_verified.socket.selected_alpn_protocol() == "h2"
+            supports_http2 = wrapped_socket.selected_alpn_protocol() == "h2"
             http2_probe.set_and_release(
                 host=probe_http2_host,
                 port=probe_http2_port,
@@ -898,7 +896,7 @@ class HTTPSConnection(HTTPConnection):
         if self.proxy_is_forwarding:
             self.is_verified = False
         else:
-            self.is_verified = sock_and_verified.is_verified
+            self.is_verified = is_verified
 
         # If there's a proxy to be connected to we are fully connected.
         # This is set twice (once above and here) due to forwarding proxies
@@ -908,7 +906,7 @@ class HTTPSConnection(HTTPConnection):
         # Set `self.proxy_is_verified` unless it's already set while
         # establishing a tunnel.
         if self._has_connected_to_proxy and self.proxy_is_verified is None:
-            self.proxy_is_verified = sock_and_verified.is_verified
+            self.proxy_is_verified = is_verified
 
     def _connect_tls_proxy(self, hostname: str, sock: socket.socket) -> ssl.SSLSocket:
         """

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -839,28 +839,30 @@ class HTTPSConnection(HTTPConnection):
             # urllib3 v3.0. Appropriate warning is emitted in
             # ``ProxyManager.__init__``.
             if self.proxy_is_forwarding and self.proxy_config is not None:
-                ssl_context = self.proxy_config.ssl_context
+                self.sock = sock = self._connect_tls_proxy(self.host, sock)
+                sock_and_verified = _WrappedAndVerifiedSocket(
+                    socket=sock,
+                    is_verified=self.proxy_is_verified is True,
+                )
             else:
-                ssl_context = self.ssl_context
-
-            sock_and_verified = _ssl_wrap_socket_and_match_hostname(
-                sock=sock,
-                cert_reqs=self.cert_reqs,
-                ssl_version=self.ssl_version,
-                ssl_minimum_version=self.ssl_minimum_version,
-                ssl_maximum_version=self.ssl_maximum_version,
-                ca_certs=self.ca_certs,
-                ca_cert_dir=self.ca_cert_dir,
-                ca_cert_data=self.ca_cert_data,
-                cert_file=self.cert_file,
-                key_file=self.key_file,
-                key_password=self.key_password,
-                server_hostname=server_hostname_rm_dot,
-                ssl_context=ssl_context,
-                tls_in_tls=tls_in_tls,
-                assert_hostname=self.assert_hostname,
-                assert_fingerprint=self.assert_fingerprint,
-            )
+                sock_and_verified = _ssl_wrap_socket_and_match_hostname(
+                    sock=sock,
+                    cert_reqs=self.cert_reqs,
+                    ssl_version=self.ssl_version,
+                    ssl_minimum_version=self.ssl_minimum_version,
+                    ssl_maximum_version=self.ssl_maximum_version,
+                    ca_certs=self.ca_certs,
+                    ca_cert_dir=self.ca_cert_dir,
+                    ca_cert_data=self.ca_cert_data,
+                    cert_file=self.cert_file,
+                    key_file=self.key_file,
+                    key_password=self.key_password,
+                    server_hostname=server_hostname_rm_dot,
+                    ssl_context=self.ssl_context,
+                    tls_in_tls=tls_in_tls,
+                    assert_hostname=self.assert_hostname,
+                    assert_fingerprint=self.assert_fingerprint,
+                )
             self.sock = sock_and_verified.socket
 
         # If an error occurs during connection/handshake we may need to release
@@ -910,16 +912,17 @@ class HTTPSConnection(HTTPConnection):
 
     def _connect_tls_proxy(self, hostname: str, sock: socket.socket) -> ssl.SSLSocket:
         """
-        Establish a TLS connection to the proxy using the provided SSL context.
+        Establish a TLS connection to the proxy using proxy-specific policy.
         """
-        # `_connect_tls_proxy` is called when self._tunnel_host is truthy.
         proxy_config = typing.cast(ProxyConfig, self.proxy_config)
-        ssl_context = proxy_config.ssl_context
+        proxy_ssl_context = proxy_config.ssl_context
 
+        ssl_context: ssl.SSLContext | None
         cert_reqs: int | str | None
-        if ssl_context is not None:
+        if proxy_ssl_context is not None:
             # Prefer the proxy's cert policy for the proxy connection
-            cert_reqs = ssl_context.verify_mode
+            ssl_context = proxy_ssl_context
+            cert_reqs = proxy_ssl_context.verify_mode
             ca_certs = None
             ca_cert_dir = None
             ca_cert_data = None
@@ -928,6 +931,7 @@ class HTTPSConnection(HTTPConnection):
             ssl_maximum_version = None
         else:
             # Otherwise we inherit the pool's cert policies
+            ssl_context = self.ssl_context if self.proxy_is_forwarding else None
             cert_reqs = self.cert_reqs
             ca_certs = self.ca_certs
             ca_cert_dir = self.ca_cert_dir

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -916,25 +916,32 @@ class HTTPSConnection(HTTPConnection):
         proxy_config = typing.cast(ProxyConfig, self.proxy_config)
         ssl_context = proxy_config.ssl_context
 
+        cert_reqs: int | str | None
         if ssl_context is not None:
             # Prefer the proxy's cert policy for the proxy connection
             cert_reqs = ssl_context.verify_mode
             ca_certs = None
             ca_cert_dir = None
             ca_cert_data = None
+            ssl_version = None
+            ssl_minimum_version = None
+            ssl_maximum_version = None
         else:
             # Otherwise we inherit the pool's cert policies
             cert_reqs = self.cert_reqs
             ca_certs = self.ca_certs
             ca_cert_dir = self.ca_cert_dir
             ca_cert_data = self.ca_cert_data
+            ssl_version = self.ssl_version
+            ssl_minimum_version = self.ssl_minimum_version
+            ssl_maximum_version = self.ssl_maximum_version
 
         sock_and_verified = _ssl_wrap_socket_and_match_hostname(
             sock,
             cert_reqs=cert_reqs,
-            ssl_version=self.ssl_version,
-            ssl_minimum_version=self.ssl_minimum_version,
-            ssl_maximum_version=self.ssl_maximum_version,
+            ssl_version=ssl_version,
+            ssl_minimum_version=ssl_minimum_version,
+            ssl_maximum_version=ssl_maximum_version,
             ca_certs=ca_certs,
             ca_cert_dir=ca_cert_dir,
             ca_cert_data=ca_cert_data,

--- a/src/urllib3/poolmanager.py
+++ b/src/urllib3/poolmanager.py
@@ -583,6 +583,9 @@ class ProxyManager(PoolManager):
         if proxy.scheme not in ("http", "https"):
             raise ProxySchemeUnknown(proxy.scheme)
 
+        # Keep the deprecated ssl_context fallback on the manager for
+        # compatibility, while passing only explicit proxy policy to connections.
+        self.proxy_ssl_context = proxy_ssl_context
         if (
             use_forwarding_for_https
             and proxy.scheme == "https"
@@ -595,8 +598,8 @@ class ProxyManager(PoolManager):
                 FutureWarning,
                 stacklevel=2,
             )
-            if proxy_ssl_context is None:
-                proxy_ssl_context = connection_pool_kw.get("ssl_context")
+            if self.proxy_ssl_context is None:
+                self.proxy_ssl_context = connection_pool_kw.get("ssl_context")
 
         if proxy.port is None:
             port = port_by_scheme.get(proxy.scheme, 80)
@@ -604,7 +607,6 @@ class ProxyManager(PoolManager):
 
         self.proxy = proxy
         self.proxy_headers = proxy_headers or {}
-        self.proxy_ssl_context = proxy_ssl_context
         self.proxy_config = ProxyConfig(
             proxy_ssl_context,
             use_forwarding_for_https,

--- a/test/with_dummyserver/test_proxy_poolmanager.py
+++ b/test/with_dummyserver/test_proxy_poolmanager.py
@@ -921,10 +921,11 @@ class TestHTTPSProxyVerification:
         destination_url = f"https://{server.host}:{server.port}"
 
         proxy_ctx = urllib3.util.ssl_.create_urllib3_context(verify_flags=0)
+        proxy_ctx.load_verify_locations(proxy.ca_certs)
         proxy_fingerprint = self._get_proxy_fingerprint_md5(proxy.ca_certs)
         with proxy_from_url(
             proxy_url,
-            ca_certs=proxy.ca_certs,
+            ca_certs=server.ca_certs,
             proxy_ssl_context=proxy_ctx,
             proxy_assert_fingerprint=proxy_fingerprint,
         ) as https:
@@ -938,13 +939,14 @@ class TestHTTPSProxyVerification:
         destination_url = f"https://{server.host}:{server.port}"
 
         proxy_ctx = urllib3.util.ssl_.create_urllib3_context(verify_flags=0)
+        proxy_ctx.load_verify_locations(proxy.ca_certs)
         proxy_fingerprint = self._get_proxy_fingerprint_md5(proxy.ca_certs)
         new_char = "b" if proxy_fingerprint[5] == "a" else "a"
         proxy_fingerprint = proxy_fingerprint[:5] + new_char + proxy_fingerprint[6:]
 
         with proxy_from_url(
             proxy_url,
-            ca_certs=proxy.ca_certs,
+            ca_certs=server.ca_certs,
             proxy_ssl_context=proxy_ctx,
             proxy_assert_fingerprint=proxy_fingerprint,
         ) as https:
@@ -1064,6 +1066,7 @@ class TestHTTPSProxyVerification:
         destination_url = f"https://{server.host}:{server.port}"
 
         proxy_ctx = urllib3.util.ssl_.create_urllib3_context(verify_flags=0)
+        proxy_ctx.load_verify_locations(proxy.ca_certs)
         try:
             proxy_ctx.hostname_checks_common_name = True
         # PyPy doesn't like us setting 'hostname_checks_common_name'
@@ -1074,6 +1077,6 @@ class TestHTTPSProxyVerification:
             pytest.skip("Test requires 'SSLContext.hostname_checks_common_name=True'")
 
         with proxy_from_url(
-            proxy_url, ca_certs=proxy.ca_certs, proxy_ssl_context=proxy_ctx
+            proxy_url, ca_certs=server.ca_certs, proxy_ssl_context=proxy_ctx
         ) as https:
             https.request("GET", destination_url)

--- a/test/with_dummyserver/test_proxy_poolmanager.py
+++ b/test/with_dummyserver/test_proxy_poolmanager.py
@@ -114,6 +114,13 @@ class TestHTTPProxyManager(HypercornDummyProxyTestCase):
             assert r.status == 200
             assert_is_verified(https, proxy=True, target=False)
 
+    def test_is_verified_https_proxy_to_http_target_without_proxy_config(self) -> None:
+        with proxy_from_url(self.https_proxy_url, ca_certs=DEFAULT_CA) as https:
+            https.connection_pool_kw["_proxy_config"] = None
+            r = https.request("GET", f"{self.http_url}/")
+            assert r.status == 200
+            assert_is_verified(https, proxy=True, target=False)
+
     def test_is_verified_https_proxy_to_https_target(self) -> None:
         with proxy_from_url(self.https_proxy_url, ca_certs=DEFAULT_CA) as https:
             r = https.request("GET", f"{self.https_url}/")

--- a/test/with_dummyserver/test_proxy_poolmanager.py
+++ b/test/with_dummyserver/test_proxy_poolmanager.py
@@ -145,6 +145,18 @@ class TestHTTPProxyManager(HypercornDummyProxyTestCase):
             assert r.status == 200
 
     @withPyOpenSSL
+    def test_https_proxy_with_proxy_ssl_context_pyopenssl(self) -> None:
+        proxy_ssl_context = create_urllib3_context()
+        proxy_ssl_context.load_verify_locations(DEFAULT_CA)
+
+        with proxy_from_url(
+            self.https_proxy_url,
+            proxy_ssl_context=proxy_ssl_context,
+        ) as https:
+            response = https.request("GET", f"{self.http_url}/")
+            assert response.status == 200
+
+    @withPyOpenSSL
     def test_https_proxy_pyopenssl_not_supported(self) -> None:
         with proxy_from_url(self.https_proxy_url, ca_certs=DEFAULT_CA) as https:
             r = https.request("GET", f"{self.http_url}/")
@@ -779,8 +791,8 @@ class TestHTTPProxyManager(HypercornDummyProxyTestCase):
         used for the proxy connection and ``ssl_context`` is ignored
         (with a warning).
         """
-        ssl_context = ssl.create_default_context(cafile=DEFAULT_CA)
-        proxy_ssl_context = ssl.create_default_context(cafile=DEFAULT_CA)
+        ssl_context = create_urllib3_context(cert_reqs=ssl.CERT_REQUIRED)
+        proxy_ssl_context = create_urllib3_context(cert_reqs=ssl.CERT_NONE)
 
         with pytest.warns(FutureWarning, match="ssl_context"):
             proxy = proxy_from_url(
@@ -797,6 +809,7 @@ class TestHTTPProxyManager(HypercornDummyProxyTestCase):
                 conn.connect()
                 assert isinstance(conn.sock, ssl.SSLSocket)
                 assert conn.sock.context is proxy_ssl_context
+                assert proxy_ssl_context.verify_mode == ssl.CERT_NONE
 
     @requires_network()
     def test_forwarding_proxy_ssl_context_fallback(self) -> None:
@@ -805,17 +818,40 @@ class TestHTTPProxyManager(HypercornDummyProxyTestCase):
         HTTPS proxy, a ``FutureWarning`` is emitted and ``ssl_context``
         is used as the proxy TLS context (fallback).
         """
-        ssl_context = ssl.create_default_context(cafile=DEFAULT_CA)
+        ssl_context = create_urllib3_context(cert_reqs=ssl.CERT_NONE)
 
         with pytest.warns(FutureWarning, match="ssl_context"):
             proxy = proxy_from_url(
                 self.https_proxy_url,
                 ssl_context=ssl_context,
+                cert_reqs=ssl.CERT_REQUIRED,
+                ca_certs=DEFAULT_CA,
                 use_forwarding_for_https=True,
             )
 
+        assert proxy.proxy_ssl_context is ssl_context
+        assert proxy.proxy_config is not None
+        assert proxy.proxy_config.ssl_context is None
+
         with proxy:
             pool = proxy.connection_from_url(self.https_url)
+            with contextlib.closing(pool._new_conn()) as conn:
+                conn = typing.cast(HTTPSConnection, conn)
+                conn.connect()
+                assert isinstance(conn.sock, ssl.SSLSocket)
+                assert conn.sock.context is ssl_context
+                assert ssl_context.verify_mode == ssl.CERT_REQUIRED
+
+    @requires_network()
+    def test_https_proxy_to_http_target_ssl_context_fallback(self) -> None:
+        ssl_context = create_urllib3_context()
+        ssl_context.load_verify_locations(DEFAULT_CA)
+
+        with proxy_from_url(
+            self.https_proxy_url,
+            ssl_context=ssl_context,
+        ) as proxy:
+            pool = proxy.connection_from_url(self.http_url)
             with contextlib.closing(pool._new_conn()) as conn:
                 conn = typing.cast(HTTPSConnection, conn)
                 conn.connect()
@@ -931,8 +967,11 @@ class TestHTTPSProxyVerification:
         ) as https:
             https.request("GET", destination_url)
 
+    @pytest.mark.parametrize("use_forwarding_for_https", [False, True])
     def test_https_proxy_assert_fingerprint_md5_non_matching(
-        self, no_san_proxy_with_server: tuple[ServerConfig, ServerConfig]
+        self,
+        no_san_proxy_with_server: tuple[ServerConfig, ServerConfig],
+        use_forwarding_for_https: bool,
     ) -> None:
         proxy, server = no_san_proxy_with_server
         proxy_url = f"https://{proxy.host}:{proxy.port}"
@@ -949,6 +988,7 @@ class TestHTTPSProxyVerification:
             ca_certs=server.ca_certs,
             proxy_ssl_context=proxy_ctx,
             proxy_assert_fingerprint=proxy_fingerprint,
+            use_forwarding_for_https=use_forwarding_for_https,
         ) as https:
             with pytest.raises(MaxRetryError) as e:
                 https.request("GET", destination_url)
@@ -966,8 +1006,11 @@ class TestHTTPSProxyVerification:
         ) as https:
             https.request("GET", destination_url)
 
+    @pytest.mark.parametrize("use_forwarding_for_https", [False, True])
     def test_https_proxy_assert_hostname_non_matching(
-        self, san_proxy_with_server: tuple[ServerConfig, ServerConfig]
+        self,
+        san_proxy_with_server: tuple[ServerConfig, ServerConfig],
+        use_forwarding_for_https: bool,
     ) -> None:
         proxy, server = san_proxy_with_server
         destination_url = f"https://{server.host}:{server.port}"
@@ -977,6 +1020,7 @@ class TestHTTPSProxyVerification:
             proxy.base_url,
             ca_certs=proxy.ca_certs,
             proxy_assert_hostname=proxy_hostname,
+            use_forwarding_for_https=use_forwarding_for_https,
         ) as https:
             with pytest.raises(MaxRetryError) as e:
                 https.request("GET", destination_url)
@@ -1080,3 +1124,83 @@ class TestHTTPSProxyVerification:
             proxy_url, ca_certs=server.ca_certs, proxy_ssl_context=proxy_ctx
         ) as https:
             https.request("GET", destination_url)
+
+    @pytest.mark.parametrize(
+        "target_tls_kwargs",
+        [
+            pytest.param({"server_hostname": "example.com"}, id="server-hostname"),
+            pytest.param({"assert_hostname": "example.com"}, id="assert-hostname"),
+            pytest.param({"assert_fingerprint": "00" * 32}, id="assert-fingerprint"),
+        ],
+    )
+    def test_https_proxy_forwarding_ignores_target_identity_settings(
+        self,
+        san_proxy_with_server: tuple[ServerConfig, ServerConfig],
+        target_tls_kwargs: dict[str, typing.Any],
+    ) -> None:
+        proxy, server = san_proxy_with_server
+        proxy_ctx = create_urllib3_context()
+        proxy_ctx.load_verify_locations(proxy.ca_certs)
+
+        with proxy_from_url(
+            proxy.base_url,
+            proxy_ssl_context=proxy_ctx,
+            proxy_assert_hostname=proxy.host,
+            use_forwarding_for_https=True,
+            **target_tls_kwargs,
+        ) as https:
+            pool = https.connection_from_url(server.base_url)
+            with contextlib.closing(pool._new_conn()) as conn:
+                conn = typing.cast(HTTPSConnection, conn)
+                conn.connect()
+                assert isinstance(conn.sock, ssl.SSLSocket)
+                assert conn.sock.context is proxy_ctx
+
+    def test_https_proxy_forwarding_ignores_target_client_certificate(
+        self,
+        san_proxy_with_server: tuple[ServerConfig, ServerConfig],
+    ) -> None:
+        proxy, server = san_proxy_with_server
+        proxy_ctx = create_urllib3_context()
+        proxy_ctx.load_verify_locations(proxy.ca_certs)
+        missing_cert = str(pathlib.Path(proxy.ca_certs).with_name("missing-cert.pem"))
+
+        with proxy_from_url(
+            proxy.base_url,
+            proxy_ssl_context=proxy_ctx,
+            cert_file=missing_cert,
+            use_forwarding_for_https=True,
+        ) as https:
+            pool = https.connection_from_url(server.base_url)
+            with contextlib.closing(pool._new_conn()) as conn:
+                conn = typing.cast(HTTPSConnection, conn)
+                conn.connect()
+                assert isinstance(conn.sock, ssl.SSLSocket)
+                assert conn.sock.context is proxy_ctx
+
+    def test_https_proxy_forwarding_ignores_target_tls_policy(
+        self,
+        san_proxy_with_server: tuple[ServerConfig, ServerConfig],
+    ) -> None:
+        proxy, server = san_proxy_with_server
+        proxy_ctx = create_urllib3_context(cert_reqs=ssl.CERT_REQUIRED)
+        proxy_ctx.load_verify_locations(proxy.ca_certs)
+        proxy_cert_store_stats = proxy_ctx.cert_store_stats()
+
+        with proxy_from_url(
+            proxy.base_url,
+            proxy_ssl_context=proxy_ctx,
+            cert_reqs=ssl.CERT_NONE,
+            ca_certs=DEFAULT_CA,
+            use_forwarding_for_https=True,
+        ) as https:
+            for target_url in (server.base_url, "https://example.com/"):
+                pool = https.connection_from_url(target_url)
+                with contextlib.closing(pool._new_conn()) as conn:
+                    conn = typing.cast(HTTPSConnection, conn)
+                    conn.connect()
+                    assert isinstance(conn.sock, ssl.SSLSocket)
+                    assert conn.sock.context is proxy_ctx
+
+        assert proxy_ctx.verify_mode == ssl.CERT_REQUIRED
+        assert proxy_ctx.cert_store_stats() == proxy_cert_store_stats


### PR DESCRIPTION
Fixed ``HTTPSConnection`` overriding the ``proxy_config``'s cert policy with the target request's SSL context.

Including a ``proxy_config`` will now properly inherit ``verify_mode`` for the proxy connection and values for ``ca_*`` ``ssl_*`` are ignored.