### PR TITLE
Don't parameterize tests using non-Collection iterables

### DIFF
--- a/changelog/5094.bugfix.rst
+++ b/changelog/5094.bugfix.rst
@@ -1,0 +1,1 @@
+Fix test failures with pytest >= 9.1.

--- a/changelog/5094.bugfix.rst
+++ b/changelog/5094.bugfix.rst
@@ -1,1 +1,0 @@
-Fix test failures with pytest >= 9.1.

--- a/changelog/5094.misc.rst
+++ b/changelog/5094.misc.rst
@@ -1,0 +1,1 @@
+Fixed test failures with pytest >= 9.1.

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -307,7 +307,7 @@ class TestUtil:
 
     @pytest.mark.parametrize(
         "url, expected_url",
-        list(chain(parse_url_host_map, non_round_tripping_parse_url_host_map)),
+        [*parse_url_host_map, *non_round_tripping_parse_url_host_map],
     )
     def test_parse_url(self, url: str, expected_url: Url) -> None:
         returned_url = parse_url(url)

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -307,7 +307,7 @@ class TestUtil:
 
     @pytest.mark.parametrize(
         "url, expected_url",
-        chain(parse_url_host_map, non_round_tripping_parse_url_host_map),
+        list(chain(parse_url_host_map, non_round_tripping_parse_url_host_map)),
     )
     def test_parse_url(self, url: str, expected_url: Url) -> None:
         returned_url = parse_url(url)

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -7,7 +7,6 @@ import ssl
 import sys
 import typing
 import warnings
-from itertools import chain
 from test import ImportBlocker, ModuleStash, notBrotli, notZstd, onlyBrotli, onlyZstd
 from unittest import mock
 from unittest.mock import MagicMock, Mock, patch

--- a/uv.lock
+++ b/uv.lock
@@ -1707,7 +1707,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "9.0.3"
+version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'group-7-urllib3-dev' and extra == 'group-7-urllib3-dev-min-pyopenssl') or (extra == 'group-7-urllib3-dev-min-pyopenssl' and extra == 'group-7-urllib3-mypy')" },
@@ -1718,9 +1718,9 @@ dependencies = [
     { name = "pygments" },
     { name = "tomli", marker = "python_full_version < '3.11' or (extra == 'group-7-urllib3-dev' and extra == 'group-7-urllib3-dev-min-pyopenssl') or (extra == 'group-7-urllib3-dev-min-pyopenssl' and extra == 'group-7-urllib3-mypy')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This is deprecated as of pytest 9.1; see
https://docs.pytest.org/en/stable/deprecations.html#class-scoped-fixture-as-instance-method.

<!---
Thanks for your contribution! ♥️

If this is your first PR to urllib3 please review the Contributing Guide:
https://urllib3.readthedocs.io/en/latest/contributing.html

Adhering to the Contributing Guide means we can review, merge, and release your change faster! :)
--->
