### PR TITLE
Reject invalid URL hosts

### DIFF
--- a/changelog/5095.bugfix.rst
+++ b/changelog/5095.bugfix.rst
@@ -1,0 +1,7 @@
+Fixed URL parsing to more strictly enforce RFC 3986 host syntax, rejecting
+invalid host input such as raw spaces and control characters, malformed
+percent-encodings, and percent-encoded control characters in HTTP(S) hosts and
+IPv6 zone identifiers, including proxy CONNECT tunnel targets. Host
+normalization now also follows RFC 3986 normalization rules for percent-encoded
+octets by decoding percent-encoded unreserved characters and uppercasing the
+hexadecimal case of retained percent-encoded octets.

--- a/src/urllib3/util/url.py
+++ b/src/urllib3/util/url.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import re
 import typing
+from functools import partial
 
 from ..exceptions import LocationParseError
 from .util import to_str
@@ -13,7 +14,9 @@ _NORMALIZABLE_SCHEMES = ("http", "https", None)
 # Almost all of these patterns were derived from the
 # 'rfc3986' module: https://github.com/python-hyper/rfc3986
 _PERCENT_RE = re.compile(r"%[a-fA-F0-9]{2}")
+_HOST_PERCENT_RE = re.compile(r"%[a-fA-F0-9]{2}|%")
 _SCHEME_RE = re.compile(r"^(?:[a-zA-Z][a-zA-Z0-9+-]*:|/)")
+_HOST_INVALID_CHAR_RE = re.compile(r"[\x00-\x20\x7f]")
 _URI_RE = re.compile(
     r"^(?:([a-zA-Z][a-zA-Z0-9+.-]*):)?"
     r"(?://([^\\/?#]*))?"
@@ -302,6 +305,12 @@ def _normalize_host(host: str, scheme: str | None) -> str: ...
 
 def _normalize_host(host: str | None, scheme: str | None) -> str | None:
     if host:
+        invalid_host_char = _HOST_INVALID_CHAR_RE.search(host)
+        if invalid_host_char:
+            raise LocationParseError(
+                f"Host {host!r} contains invalid character "
+                f"{invalid_host_char.group()!r}"
+            )
         if scheme in _NORMALIZABLE_SCHEMES:
             is_ipv6 = _IPV6_ADDRZ_RE.match(host)
             if is_ipv6:
@@ -317,16 +326,52 @@ def _normalize_host(host: str | None, scheme: str | None) -> str | None:
                         zone_id = zone_id[3:]
                     else:
                         zone_id = zone_id[1:]
+                    zone_id = _PERCENT_RE.sub(
+                        partial(_normalize_zone_id_percent_encoding, error_host=host),
+                        zone_id,
+                    )
                     zone_id = _encode_invalid_chars(zone_id, _UNRESERVED_CHARS)
                     return f"{host[:start].lower()}%{zone_id}{host[end:]}"
                 else:
                     return host.lower()
             elif not _IPV4_RE.match(host):
+                if "%" in host:
+                    host = _HOST_PERCENT_RE.sub(_normalize_host_percent_encoding, host)
                 return to_str(
                     b".".join([_idna_encode(label) for label in host.split(".")]),
                     "ascii",
                 )
     return host
+
+
+def _decode_percent_encoding(match: re.Match[str], *, error_host: str) -> str:
+    percent_encoded_octet = match.group(0)
+    decoded_octet = chr(int(percent_encoded_octet[1:], 16))
+    # Keep this narrower than _HOST_INVALID_CHAR_RE because "%20" is valid
+    # percent-encoding and remains encoded.
+    if decoded_octet < "\x20" or decoded_octet == "\x7f":
+        raise LocationParseError(
+            f"Host {error_host!r} contains invalid percent-encoded "
+            f"control character {percent_encoded_octet!r}"
+        )
+    return decoded_octet
+
+
+def _normalize_host_percent_encoding(match: re.Match[str]) -> str:
+    # Reject invalid percent encodings
+    if match.group(0) == "%":
+        raise LocationParseError(f"{match.string!r} is not a valid host")
+    decoded_octet = _decode_percent_encoding(match, error_host=match.string)
+    if decoded_octet in _UNRESERVED_CHARS:
+        return decoded_octet
+    return match.group(0).upper()
+
+
+def _normalize_zone_id_percent_encoding(
+    match: re.Match[str], *, error_host: str
+) -> str:
+    _decode_percent_encoding(match, error_host=error_host)
+    return match.group(0).upper()
 
 
 def _idna_encode(name: str) -> bytes:
@@ -345,7 +390,9 @@ def _idna_encode(name: str) -> bytes:
                 f"Name '{name}' is not a valid IDNA label"
             ) from None
 
-    return name.lower().encode("ascii")
+    return _PERCENT_RE.sub(lambda match: match.group(0).upper(), name.lower()).encode(
+        "ascii"
+    )
 
 
 def _encode_target(target: str) -> str:
@@ -398,7 +445,6 @@ def parse_url(url: str) -> Url:
         # Empty
         return Url()
 
-    source_url = url
     if not _SCHEME_RE.search(url):
         url = "//" + url
 
@@ -412,43 +458,48 @@ def parse_url(url: str) -> Url:
     query: str | None
     fragment: str | None
 
-    try:
-        scheme, authority, path, query, fragment = _URI_RE.match(url).groups()  # type: ignore[union-attr]
-        normalize_uri = scheme is None or scheme.lower() in _NORMALIZABLE_SCHEMES
+    scheme, authority, path, query, fragment = _URI_RE.match(url).groups()  # type: ignore[union-attr]
+    normalize_uri = scheme is None or scheme.lower() in _NORMALIZABLE_SCHEMES
 
-        if scheme:
-            scheme = scheme.lower()
+    if scheme:
+        scheme = scheme.lower()
 
-        if authority:
-            auth, _, host_port = authority.rpartition("@")
-            auth = auth or None
-            host, port = _HOST_PORT_RE.match(host_port).groups()  # type: ignore[union-attr]
-            if auth and normalize_uri:
-                auth = _encode_invalid_chars(auth, _USERINFO_CHARS)
-            if port == "":
-                port = None
-        else:
-            auth, host, port = None, None, None
+    if authority:
+        auth, _, host_port = authority.rpartition("@")
+        auth = auth or None
+        host_port_match = _HOST_PORT_RE.fullmatch(host_port)
+        if not host_port_match:
+            invalid_host_char = _HOST_INVALID_CHAR_RE.search(host_port)
+            if invalid_host_char:
+                raise LocationParseError(
+                    f"Host {host_port!r} contains invalid character "
+                    f"{invalid_host_char.group()!r}"
+                )
+            raise LocationParseError(f"{host_port!r} is not a valid host or port")
+        host, port = host_port_match.groups()
+        if auth and normalize_uri:
+            auth = _encode_invalid_chars(auth, _USERINFO_CHARS)
+        if port == "":
+            port = None
+    else:
+        auth, host, port = None, None, None
 
-        if port is not None:
-            port_int = int(port)
-            if not (0 <= port_int <= 65535):
-                raise LocationParseError(url)
-        else:
-            port_int = None
+    if port is not None:
+        port_int = int(port)
+        if not (0 <= port_int <= 65535):
+            raise LocationParseError(url)
+    else:
+        port_int = None
 
-        host = _normalize_host(host, scheme)
+    host = _normalize_host(host, scheme)
 
-        if normalize_uri and path:
-            path = _remove_path_dot_segments(path)
-            path = _encode_invalid_chars(path, _PATH_CHARS)
-        if normalize_uri and query:
-            query = _encode_invalid_chars(query, _QUERY_CHARS)
-        if normalize_uri and fragment:
-            fragment = _encode_invalid_chars(fragment, _FRAGMENT_CHARS)
-
-    except (ValueError, AttributeError) as e:
-        raise LocationParseError(source_url) from e
+    if normalize_uri and path:
+        path = _remove_path_dot_segments(path)
+        path = _encode_invalid_chars(path, _PATH_CHARS)
+    if normalize_uri and query:
+        query = _encode_invalid_chars(query, _QUERY_CHARS)
+    if normalize_uri and fragment:
+        fragment = _encode_invalid_chars(fragment, _FRAGMENT_CHARS)
 
     # For the sake of backwards compatibility we put empty
     # string values for path if there are any defined values

--- a/test/test_connectionpool.py
+++ b/test/test_connectionpool.py
@@ -26,6 +26,7 @@ from urllib3.exceptions import (
     EmptyPoolError,
     FullPoolError,
     HostChangedError,
+    LocationParseError,
     LocationValueError,
     MaxRetryError,
     ProtocolError,
@@ -153,6 +154,42 @@ class TestConnectionPool:
         # never initializes ConnectionPool objects with port=None.
         with HTTPSConnectionPool(a) as c:
             assert c.is_same_host(b)
+
+    @pytest.mark.parametrize(
+        "host",
+        [
+            "127.0.0.1\n",
+            "127.0.0.1 ",
+            "::1\n",
+            "[::1]\n",
+        ],
+    )
+    def test_control_characters_in_host_raise(self, host: str) -> None:
+        with pytest.raises(LocationParseError):
+            HTTPConnectionPool(host)
+
+    @pytest.mark.parametrize("host", ["foo%.example", "foo%zz.example"])
+    def test_malformed_percent_escapes_in_host_raise(self, host: str) -> None:
+        with pytest.raises(LocationParseError):
+            HTTPConnectionPool(host)
+
+    @pytest.mark.parametrize(
+        "host, expected_host, expected_tunnel_host",
+        [
+            ("EXAMPLE%2Ecom%2E", "example.com.", "example.com."),
+            (
+                "[2607:f8b0:4005:805::200e%25eth0]",
+                "2607:f8b0:4005:805::200e%eth0",
+                "[2607:f8b0:4005:805::200e%eth0]",
+            ),
+        ],
+    )
+    def test_host_and_tunnel_host_are_normalized(
+        self, host: str, expected_host: str, expected_tunnel_host: str
+    ) -> None:
+        with HTTPSConnectionPool(host) as pool:
+            assert pool.host == expected_host
+            assert pool._tunnel_host == expected_tunnel_host
 
     @pytest.mark.parametrize(
         "a, b",

--- a/test/test_proxymanager.py
+++ b/test/test_proxymanager.py
@@ -2,7 +2,12 @@ from __future__ import annotations
 
 import pytest
 
-from urllib3.exceptions import MaxRetryError, NewConnectionError, ProxyError
+from urllib3.exceptions import (
+    LocationParseError,
+    MaxRetryError,
+    NewConnectionError,
+    ProxyError,
+)
 from urllib3.poolmanager import ProxyManager
 from urllib3.response import HTTPResponse
 from urllib3.util.retry import Retry
@@ -100,6 +105,28 @@ class TestProxyManager:
 
         assert response.status == 200
         assert CustomConnectionPool.requested_urls == ["http://example.com/path?x=1"]
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://victim.example\r\nInjected/path",
+            "https://[::1%25%0d%0a]/",
+        ],
+    )
+    def test_proxy_connect_rejects_control_characters_in_tunnel_host(
+        self, url: str
+    ) -> None:
+        with ProxyManager("http://proxy:8080") as p:
+            with pytest.raises(LocationParseError):
+                p.connection_from_url(url)
+
+    @pytest.mark.parametrize("host", ["foo%.example", "foo%zz.example"])
+    def test_proxy_connect_rejects_malformed_percent_escapes_in_tunnel_host(
+        self, host: str
+    ) -> None:
+        with ProxyManager("http://proxy:8080") as p:
+            with pytest.raises(LocationParseError):
+                p.connection_from_host(host, scheme="https")
 
     def test_proxy_connect_retry(self) -> None:
         retry = Retry(total=None, connect=False)

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -160,6 +160,8 @@ class TestUtil:
             "http://google.com:-80",
             "http://google.com:65536",
             "http://google.com:\xb2\xb2",  # \xb2 = ^2
+            "http://foo%.example/",
+            "http://foo%zz.example/",
             # Invalid IDNA labels
             "http://\ud7ff.com",
             "http://❤️",
@@ -190,6 +192,7 @@ class TestUtil:
             # non-standard (unquoted %) variants.
             ("[::1%zone]", "[::1%zone]"),
             ("[::1%25zone]", "[::1%zone]"),
+            ("[::1%0d]", "[::1%0d]"),
             ("[::1%25]", "[::1%25]"),
             ("[::Ff%etH0%Ff]/%ab%Af", "[::ff%etH0%FF]/%AB%AF"),
             (
@@ -231,6 +234,134 @@ class TestUtil:
             query="query" + percent_char,
             fragment="fragment" + percent_char,
         )
+
+    @pytest.mark.parametrize(
+        "url_template",
+        [
+            "http://victim.example{}Injected/path",
+            "gopher://victim.example{}Injected/path",
+            "victim.example{}Injected/path",
+            "http://127.0.0.1{}/path",
+            "http://[::1]{}/path",
+        ],
+    )
+    @pytest.mark.parametrize("char", [chr(i) for i in range(0x00, 0x21)] + ["\x7f"])
+    def test_control_characters_in_host_raise(
+        self, url_template: str, char: str
+    ) -> None:
+        with pytest.raises(LocationParseError, match="contains invalid character"):
+            parse_url(url_template.format(char))
+
+    @pytest.mark.parametrize(
+        "url, expected_host",
+        [
+            ("http://Königsgäßchen.de/path", "xn--knigsgchen-b4a3dun.de"),
+            ("http://例え.テスト/path", "xn--r8jz45g.xn--zckzah"),
+        ],
+    )
+    def test_non_ascii_hosts_are_idna_encoded(
+        self, url: str, expected_host: str
+    ) -> None:
+        assert parse_url(url).host == expected_host
+
+    @pytest.mark.parametrize(
+        "url, expected_host",
+        [
+            (
+                "http://K%C3%B6nigsg%C3%A4%C3%9Fchen.de/path",
+                "k%C3%B6nigsg%C3%A4%C3%9Fchen.de",
+            ),
+            (
+                "http://%E4%BE%8B%E3%81%88.%E3%83%86%E3%82%B9%E3%83%88/path",
+                "%E4%BE%8B%E3%81%88.%E3%83%86%E3%82%B9%E3%83%88",
+            ),
+        ],
+    )
+    def test_percent_encoded_non_unreserved_hosts_are_preserved(
+        self, url: str, expected_host: str
+    ) -> None:
+        assert parse_url(url).host == expected_host
+
+    @pytest.mark.parametrize(
+        "url, expected_host",
+        [
+            ("http://%65xample.com/path", "example.com"),
+            ("http://example.com%2E/path", "example.com."),
+            ("http://EXAMPLE%2Ecom%2E/path", "example.com."),
+            ("http://%2eexample.com/path", ".example.com"),
+            ("http://example%2e%2ecom/path", "example..com"),
+            ("http://foo%7Ebar.com/path", "foo~bar.com"),
+            ("http://%31%32%37.0.0.1/path", "127.0.0.1"),
+        ],
+    )
+    def test_percent_encoded_unreserved_hosts_are_decoded(
+        self, url: str, expected_host: str
+    ) -> None:
+        assert parse_url(url).host == expected_host
+
+    @pytest.mark.parametrize(
+        "url, expected_host",
+        [
+            ("http://%FF.example/", "%FF.example"),
+            ("http://%C3%28.example/", "%C3%28.example"),
+            ("http://%ED%A0%80.example/", "%ED%A0%80.example"),
+        ],
+    )
+    def test_percent_encoded_hosts_that_are_not_valid_utf8_are_preserved(
+        self, url: str, expected_host: str
+    ) -> None:
+        assert parse_url(url).host == expected_host
+
+    @pytest.mark.parametrize(
+        "url, expected_host",
+        [
+            ("http://foo%20bar.com/", "foo%20bar.com"),
+            ("http://%20.example/", "%20.example"),
+            ("http://example%2F.com/", "example%2F.com"),
+            ("http://victim%40evil.com/", "victim%40evil.com"),
+            ("http://example%5C.com/", "example%5C.com"),
+            ("http://example%5B.com/", "example%5B.com"),
+            ("http://example%5D.com/", "example%5D.com"),
+            ("http://example%3A80.com/", "example%3A80.com"),
+            ("http://example%3Fquery.com/", "example%3Fquery.com"),
+            ("http://example%23fragment.com/", "example%23fragment.com"),
+            ("http://a%25b.example/", "a%25b.example"),
+        ],
+    )
+    def test_percent_encoded_reserved_hosts_are_preserved(
+        self, url: str, expected_host: str
+    ) -> None:
+        assert parse_url(url).host == expected_host
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "http://%00.example/",
+            "http://%1F.example/",
+            "http://%7F.example/",
+        ],
+    )
+    def test_percent_encoded_control_hosts_raise(self, url: str) -> None:
+        with pytest.raises(
+            LocationParseError, match="invalid percent-encoded control character"
+        ):
+            parse_url(url)
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "http://[::1%25%00]/",
+            "http://[::1%25%1F]/",
+            "http://[::1%25%7F]/",
+            "http://[::1%25%0d%0a]/",
+            "http://[::1%%0d%0a]/",
+        ],
+    )
+    def test_percent_encoded_control_ipv6_zone_ids_raise(self, url: str) -> None:
+        with pytest.raises(
+            LocationParseError, match="invalid percent-encoded control character"
+        ):
+            parse_url(url)
 
     parse_url_host_map = [
         ("http://google.com/mail", Url("http", host="google.com", path="/mail")),
@@ -438,7 +569,7 @@ class TestUtil:
         # CVE-2016-5699
         (
             "http://127.0.0.1%0d%0aConnection%3a%20keep-alive",
-            Url("http", host="127.0.0.1%0d%0aconnection%3a%20keep-alive"),
+            False,
         ),
         # NodeJS unicode -> double dot
         (
@@ -1105,7 +1236,43 @@ class TestUtilWithoutIdna:
         sys.meta_path.remove(idna_blocker)
         module_stash.pop()
 
-    def test_parse_url_without_idna(self) -> None:
-        url = "http://\ud7ff.com"
-        with pytest.raises(LocationParseError, match=f"Failed to parse: {url}"):
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "http://\ud7ff.com/",
+            "http://Königsgäßchen.de/path",
+        ],
+    )
+    def test_parse_url_raw_non_ascii_without_idna_raises(self, url: str) -> None:
+        with pytest.raises(
+            LocationParseError, match="Unable to parse URL without the 'idna' module"
+        ):
             parse_url(url)
+
+    @pytest.mark.parametrize(
+        "url, expected_host",
+        [
+            ("http://%ED%9F%BF.com/", "%ED%9F%BF.com"),
+            (
+                "http://K%C3%B6nigsg%C3%A4%C3%9Fchen.de/path",
+                "k%C3%B6nigsg%C3%A4%C3%9Fchen.de",
+            ),
+            ("http://%65x%C3%A4mple.com/", "ex%C3%A4mple.com"),
+        ],
+    )
+    def test_parse_url_percent_encoded_non_ascii_without_idna(
+        self, url: str, expected_host: str
+    ) -> None:
+        assert parse_url(url).host == expected_host
+
+    @pytest.mark.parametrize(
+        "url, expected_host",
+        [
+            ("http://%65xample.com/", "example.com"),
+            ("http://example.com%2E/", "example.com."),
+        ],
+    )
+    def test_parse_url_percent_encoded_ascii_without_idna(
+        self, url: str, expected_host: str
+    ) -> None:
+        assert parse_url(url).host == expected_host


### PR DESCRIPTION
Fixed URL parsing to more strictly enforce RFC 3986 host syntax, rejecting
invalid host input such as raw spaces and control characters, malformed
percent-encodings, and percent-encoded control characters in HTTP(S) hosts and
IPv6 zone identifiers, including proxy CONNECT tunnel targets. Host
normalization now also follows RFC 3986 normalization rules for percent-encoded
octets by decoding percent-encoded unreserved characters and uppercasing the
hexadecimal case of retained percent-encoded octets.

---

William Tan from Trail of Bits in collaboration with OpenAI.