### PR TITLE
Deal with ssl.PROTOCOL_TLSv1 removal from Python built with OpenSSL 4+

### DIFF
--- a/changelog/5097.bugfix.rst
+++ b/changelog/5097.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed an ``AttributeError`` on Python built with OpenSSL 4+, where
+``ssl.PROTOCOL_TLSv1`` no longer exists.

--- a/src/urllib3/contrib/pyopenssl.py
+++ b/src/urllib3/contrib/pyopenssl.py
@@ -68,8 +68,10 @@ __all__ = ["inject_into_urllib3", "extract_from_urllib3"]
 _openssl_versions: dict[int, int] = {
     util.ssl_.PROTOCOL_TLS: OpenSSL.SSL.SSLv23_METHOD,  # type: ignore[attr-defined]
     util.ssl_.PROTOCOL_TLS_CLIENT: OpenSSL.SSL.SSLv23_METHOD,  # type: ignore[attr-defined]
-    ssl.PROTOCOL_TLSv1: OpenSSL.SSL.TLSv1_METHOD,
 }
+
+if hasattr(ssl, "PROTOCOL_TLSv1") and hasattr(OpenSSL.SSL, "TLSv1_METHOD"):
+    _openssl_versions[ssl.PROTOCOL_TLSv1] = OpenSSL.SSL.TLSv1_METHOD
 
 if hasattr(ssl, "PROTOCOL_TLSv1_1") and hasattr(OpenSSL.SSL, "TLSv1_1_METHOD"):
     _openssl_versions[ssl.PROTOCOL_TLSv1_1] = OpenSSL.SSL.TLSv1_1_METHOD

--- a/test/test_ssl.py
+++ b/test/test_ssl.py
@@ -176,19 +176,21 @@ class TestSSL:
 
         context.set_ciphers.assert_not_called()
 
+    # PROTOCOL_TLS_SERVER is used as a stand-in for any non-default ssl_version.
+    # PROTOCOL_TLSv1/TLSv1_2 are unavailable when Python is built with OpenSSL 4+.
     @pytest.mark.parametrize(
         "kwargs",
         [
             {
-                "ssl_version": ssl.PROTOCOL_TLSv1,
+                "ssl_version": ssl.PROTOCOL_TLS_SERVER,
                 "ssl_minimum_version": ssl.TLSVersion.MINIMUM_SUPPORTED,
             },
             {
-                "ssl_version": ssl.PROTOCOL_TLSv1,
+                "ssl_version": ssl.PROTOCOL_TLS_SERVER,
                 "ssl_maximum_version": ssl.TLSVersion.TLSv1,
             },
             {
-                "ssl_version": ssl.PROTOCOL_TLSv1,
+                "ssl_version": ssl.PROTOCOL_TLS_SERVER,
                 "ssl_minimum_version": ssl.TLSVersion.MINIMUM_SUPPORTED,
                 "ssl_maximum_version": ssl.TLSVersion.MAXIMUM_SUPPORTED,
             },
@@ -229,10 +231,10 @@ class TestSSL:
     @pytest.mark.parametrize(
         "kwargs",
         [
-            {"ssl_version": ssl.PROTOCOL_TLSv1, "ssl_minimum_version": None},
-            {"ssl_version": ssl.PROTOCOL_TLSv1, "ssl_maximum_version": None},
+            {"ssl_version": ssl.PROTOCOL_TLS_SERVER, "ssl_minimum_version": None},
+            {"ssl_version": ssl.PROTOCOL_TLS_SERVER, "ssl_maximum_version": None},
             {
-                "ssl_version": ssl.PROTOCOL_TLSv1,
+                "ssl_version": ssl.PROTOCOL_TLS_SERVER,
                 "ssl_minimum_version": None,
                 "ssl_maximum_version": None,
             },

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -1216,15 +1216,21 @@ class TestUtilSSL:
     ) -> None:
         assert resolve_cert_reqs(candidate) == requirements
 
-    @pytest.mark.parametrize(
-        "candidate, version",
-        [
-            (ssl.PROTOCOL_TLSv1, ssl.PROTOCOL_TLSv1),
-            ("PROTOCOL_TLSv1", ssl.PROTOCOL_TLSv1),
-            ("TLSv1", ssl.PROTOCOL_TLSv1),
-            (ssl.PROTOCOL_SSLv23, ssl.PROTOCOL_SSLv23),
-        ],
-    )
+    candidate_version = [
+        (ssl.PROTOCOL_SSLv23, ssl.PROTOCOL_SSLv23),
+        ("PROTOCOL_SSLv23", ssl.PROTOCOL_SSLv23),
+        ("SSLv23", ssl.PROTOCOL_SSLv23),
+    ]
+    if hasattr(ssl, "PROTOCOL_TLSv1"):
+        candidate_version.extend(
+            [
+                (ssl.PROTOCOL_TLSv1, ssl.PROTOCOL_TLSv1),
+                ("PROTOCOL_TLSv1", ssl.PROTOCOL_TLSv1),
+                ("TLSv1", ssl.PROTOCOL_TLSv1),
+            ]
+        )
+
+    @pytest.mark.parametrize("candidate, version", candidate_version)
     def test_resolve_ssl_version(self, candidate: int | str, version: int) -> None:
         assert resolve_ssl_version(candidate) == version
 


### PR DESCRIPTION
https://github.com/python/cpython/commit/3364e7e62fa24d0e19133fb0f90b1c24ef1110c5
removed ssl.PROTOCOL_TLSv1 when python is built with OpenSSL 4+.

We are hitting this error in Fedora (where we already updated OpenSSL):

    ImportError while loading conftest '/builddir/build/BUILD/python-urllib3-2.7.0-build/urllib3-2.7.0/test/conftest.py'.
    test/__init__.py:42: in <module>
        import urllib3.contrib.pyopenssl as pyopenssl
    ../BUILDROOT/usr/lib/python3.15/site-packages/urllib3/contrib/pyopenssl.py:72: in <module>
        ssl.PROTOCOL_TLSv1: OpenSSL.SSL.TLSv1_METHOD,
        ^^^^^^^^^^^^^^^^^^
    E   AttributeError: module 'ssl' has no attribute 'PROTOCOL_TLSv1'. Did you mean '.PROTOCOL_TLS' instead of '.PROTOCOL_TLSv1'?

Used LLM to figure out what to use as a replacement protocol in tests.

Assisted-By: Claude Opus 4.6