### PR TITLE
Fix Url.url dropping the // authority prefix for scheme-less authorities

### DIFF
--- a/changelog/5100.bugfix.rst
+++ b/changelog/5100.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed ``Url.url`` dropping the ``//`` that introduces an authority when the ``Url`` has a host but no scheme, so a scheme-less authority such as ``Url(host="localhost", port=8080)`` now serializes as ``//localhost:8080`` and round-trips through ``parse_url`` instead of being misread as ``scheme:path``.

--- a/src/urllib3/util/url.py
+++ b/src/urllib3/util/url.py
@@ -240,7 +240,13 @@ class Url(
 
         # We use "is not None" we want things to happen with empty strings (or 0 port)
         if scheme is not None:
-            url += scheme + "://"
+            url += scheme + ":"
+        # An authority (host, plus optional userinfo/port) is introduced by "//"
+        # per RFC 3986, independently of the scheme. Without this, a scheme-less
+        # authority such as "//host:port" would serialize as "host:port" and be
+        # misread as "scheme:path" when parsed again.
+        if auth is not None or host is not None or port is not None:
+            url += "//"
         if auth is not None:
             url += auth + "@"
         if host is not None:

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -189,11 +189,13 @@ class TestUtil:
             ("Https://Example.Com/#Fragment", "https://example.com/#Fragment"),
             # IPv6 addresses with zone IDs. Both RFC 6874 (%25) as well as
             # non-standard (unquoted %) variants.
-            ("[::1%zone]", "[::1%zone]"),
-            ("[::1%25zone]", "[::1%zone]"),
-            ("[::1%0d]", "[::1%0d]"),
-            ("[::1%25]", "[::1%25]"),
-            ("[::Ff%etH0%Ff]/%ab%Af", "[::ff%etH0%FF]/%AB%AF"),
+            # Scheme-less inputs keep their authority: parse_url(...).url emits
+            # the RFC 3986 "//" network-path prefix so the result round-trips.
+            ("[::1%zone]", "//[::1%zone]"),
+            ("[::1%25zone]", "//[::1%zone]"),
+            ("[::1%0d]", "//[::1%0d]"),
+            ("[::1%25]", "//[::1%25]"),
+            ("[::Ff%etH0%Ff]/%ab%Af", "//[::ff%etH0%FF]/%AB%AF"),
             (
                 "http://user:pass@[AaAa::Ff%25etH0%Ff]/%ab%Af",
                 "http://user:pass@[aaaa::ff%etH0%FF]/%AB%AF",
@@ -366,7 +368,7 @@ class TestUtil:
         ("http://google.com/mail", Url("http", host="google.com", path="/mail")),
         ("http://google.com/mail/", Url("http", host="google.com", path="/mail/")),
         ("http://google.com/mail", Url("http", host="google.com", path="mail")),
-        ("google.com/mail", Url(host="google.com", path="/mail")),
+        ("//google.com/mail", Url(host="google.com", path="/mail")),
         ("http://google.com/", Url("http", host="google.com", path="/")),
         ("http://google.com", Url("http", host="google.com")),
         ("http://google.com?foo", Url("http", host="google.com", path="", query="foo")),
@@ -447,6 +449,33 @@ class TestUtil:
     @pytest.mark.parametrize("url, expected_url", parse_url_host_map)
     def test_unparse_url(self, url: str, expected_url: Url) -> None:
         assert url == expected_url.url
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "//localhost:8080",
+            "//user@localhost:8080",
+            "//[::1%zone]",
+            "//google.com/mail",
+            "https://user:pass@example.com:443/p?q#f",
+            "http://example.com/p",
+            "/just/a/path",
+        ],
+    )
+    def test_url_round_trips_scheme_less_authority(self, url: str) -> None:
+        # A scheme-less authority must serialize with the RFC 3986 "//" prefix,
+        # otherwise "//host:port" would collapse to "host:port" and be reparsed
+        # as "scheme:path". Url.url must round-trip these.
+        assert parse_url(url).url == url
+
+    def test_url_authority_requires_double_slash(self) -> None:
+        # The "//" that introduces an authority is tied to the authority, not to
+        # the scheme (RFC 3986 section 3), so a scheme-less authority keeps it.
+        assert Url(host="localhost", port=8080).url == "//localhost:8080"
+        assert Url(host="example.com").url == "//example.com"
+        assert Url(scheme="https", host="h", path="/x").url == "https://h/x"
+        # No authority means no "//".
+        assert Url(path="/just/a/path").url == "/just/a/path"
 
     @pytest.mark.parametrize(
         ["url", "expected_url"],


### PR DESCRIPTION
`Url.url` emitted `//` only as part of `scheme://`:

```python
if scheme is not None:
    url += scheme + "://"
```

So a `Url` that has an authority but no scheme serialized without the `//` that introduces an authority, and no longer round-tripped:

```python
>>> from urllib3.util import Url, parse_url
>>> str(Url(host="localhost", port=8080))
'localhost:8080'            # expected '//localhost:8080'
>>> parse_url(str(Url(host="localhost", port=8080)))
Url(scheme='localhost', ...)   # 'localhost' misread as a scheme
```

Per RFC 3986 §3, the authority component is introduced by `//` independently of the scheme, and §4.2 defines exactly this `//`-prefixed relative-reference form. This decouples the `//` from the scheme so an authority is always preceded by `//`:

```python
if scheme is not None:
    url += scheme + ":"
if auth is not None or host is not None or port is not None:
    url += "//"
```

Six existing assertions changed because their expected output was previously non-round-tripping:

- `test_unparse_url` for `//google.com/mail`: the constructed `Url` now serializes with the leading `//` (and `str(parse_url(x)) == x` holds).
- Five `test_parse_url_normalization` IPv6 cases: the normalized authority now keeps its `//`, so re-parsing yields the same `Url`.

Two tests are added: a parametrized `str(parse_url(x)) == x` round-trip for scheme-less authorities (including IPv6 zone-id), and an explicit check that an authority-only `Url` serializes with `//`. Full `test/test_util.py` url/parse suite passes (136).