### PR TITLE
Preserve explicit port 0 in connection_from_url and HTTP/2 authority

### DIFF
--- a/changelog/5101.bugfix.rst
+++ b/changelog/5101.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed ``connection_from_url()`` and HTTP/2 request authority to preserve an
+explicit ``:0`` port instead of substituting the default 80 or 443 port.

--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -1139,7 +1139,8 @@ def connection_from_url(url: str, **kw: typing.Any) -> HTTPConnectionPool:
     """
     scheme, _, host, port, *_ = parse_url(url)
     scheme = scheme or "http"
-    port = port or port_by_scheme.get(scheme, 80)
+    if port is None:
+        port = port_by_scheme.get(scheme, 80)
     if scheme == "https":
         return HTTPSConnectionPool(host, port=port, **kw)  # type: ignore[arg-type]
     else:

--- a/src/urllib3/http2/connection.py
+++ b/src/urllib3/http2/connection.py
@@ -127,10 +127,11 @@ class HTTP2Connection(HTTPSConnection):
         self._request_url = url or "/"
         self._validate_path(url)  # type: ignore[attr-defined]
 
+        port = self.port if self.port is not None else 443
         if ":" in self.host:
-            authority = f"[{self.host}]:{self.port or 443}"
+            authority = f"[{self.host}]:{port}"
         else:
-            authority = f"{self.host}:{self.port or 443}"
+            authority = f"{self.host}:{port}"
 
         self._headers.append((b":scheme", b"https"))
         self._headers.append((b":method", method.encode()))

--- a/test/test_connectionpool.py
+++ b/test/test_connectionpool.py
@@ -262,6 +262,22 @@ class TestConnectionPool:
             assert not c.is_same_host("http://example.com:80/")
             assert not c.is_same_host("https://example.com:443/")
 
+    @pytest.mark.parametrize(
+        "url, expected_port",
+        [
+            ("http://example.com:0/", 0),
+            ("https://example.com:0/", 0),
+            ("http://example.com/", 80),
+            ("https://example.com/", 443),
+            ("http://example.com:8080/", 8080),
+        ],
+    )
+    def test_connection_from_url_preserves_port_zero(
+        self, url: str, expected_port: int
+    ) -> None:
+        with connection_from_url(url) as c:
+            assert c.port == expected_port
+
     def test_max_connections(self) -> None:
         with HTTPConnectionPool(host="localhost", maxsize=1, block=True) as pool:
             pool._get_conn(timeout=SHORT_TIMEOUT)

--- a/test/test_http2_connection.py
+++ b/test/test_http2_connection.py
@@ -271,6 +271,32 @@ class TestHTTP2Connection:
 
         close_connection.assert_called_with()
 
+    def test_request_authority_port_zero(self) -> None:
+        conn = HTTP2Connection("example.com", port=0)
+        conn.sock = mock.MagicMock(
+            sendall=mock.Mock(return_value=None),
+        )
+        conn._h2_conn._obj.data_to_send = mock.Mock(return_value=b"foo")  # type: ignore[method-assign]
+        send_headers = conn._h2_conn._obj.send_headers = mock.Mock(return_value=None)  # type: ignore[method-assign]
+        conn._h2_conn._obj.send_data = mock.Mock(return_value=None)  # type: ignore[method-assign]
+        conn._h2_conn._obj.get_next_available_stream_id = mock.Mock(return_value=1)  # type: ignore[method-assign]
+        conn._h2_conn._obj.close_connection = mock.Mock(return_value=None)  # type: ignore[method-assign]
+
+        conn.request("GET", "/")
+        conn.close()
+
+        send_headers.assert_called_with(
+            stream_id=1,
+            headers=[
+                (b":scheme", b"https"),
+                (b":method", b"GET"),
+                (b":authority", b"example.com:0"),
+                (b":path", b"/"),
+                (b"user-agent", _get_default_user_agent().encode()),
+            ],
+            end_stream=True,
+        )
+
     def test_request_POST(self) -> None:
         conn = HTTP2Connection("example.com")
         conn.sock = mock.MagicMock(


### PR DESCRIPTION
connection_from_url() and the HTTP/2 request authority build the port with a truthiness check, so an explicit :0 in the URL gets dropped and replaced by the default 80 or 443. This is the same handling #5071 corrected for URL parsing, pool selection, and proxy configuration, but these two call sites were left using `port or <default>`. Switching them to an explicit None check keeps an explicit port 0.