### PR TITLE
Add assert_hostname and assert_fingerprint to SSL_KEYWORDS

### DIFF
--- a/changelog/5077.bugfix.rst
+++ b/changelog/5077.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed a bug where ``PoolManager`` passed the ``assert_hostname`` and
+``assert_fingerprint`` parameters to HTTP connection pools.

--- a/src/urllib3/poolmanager.py
+++ b/src/urllib3/poolmanager.py
@@ -47,6 +47,8 @@ SSL_KEYWORDS = (
     "ssl_context",
     "key_password",
     "server_hostname",
+    "assert_hostname",
+    "assert_fingerprint",
 )
 # Default value for `blocksize` - a new parameter introduced to
 # http.client.HTTPConnection & http.client.HTTPSConnection in Python 3.7

--- a/test/test_poolmanager.py
+++ b/test/test_poolmanager.py
@@ -247,6 +247,19 @@ class TestPoolManager:
         assert pool.assert_hostname
         assert fingerprint == pool.assert_fingerprint
 
+    def test_ssl_keywords_filtered_on_http(self) -> None:
+        """Assert SSL-specific kwargs are filtered when creating HTTP pools."""
+        fingerprint = "92:81:FE:85:F7:0C:26:60:EC:D6:B3:BF:93:CF:F9:71:CC:07:7D:0A"
+        p = PoolManager(assert_hostname=True, assert_fingerprint=fingerprint)
+        pool = p.connection_from_url("http://example.com/")
+        assert 1 == len(p.pools)
+        assert not isinstance(pool, HTTPSConnectionPool)
+        # HTTP pool should not receive SSL_KEYWORDS kwargs
+        with pytest.raises(AttributeError):
+            _ = pool.assert_hostname  # type: ignore[attr-defined]
+        with pytest.raises(AttributeError):
+            _ = pool.assert_fingerprint  # type: ignore[attr-defined]
+
     def test_http_connection_from_context_case_insensitive(self) -> None:
         """Assert scheme case is ignored when getting the https key class."""
         p = PoolManager()


### PR DESCRIPTION
## Summary

Adds `assert_hostname` and `assert_fingerprint` to the `SSL_KEYWORDS` allowlist so they are properly stripped when constructing HTTP (non-HTTPS) connection pools.

Fixes #5077

## Problem

When a caller sets `assert_hostname` or `assert_fingerprint` on `PoolManager.connection_pool_kw` and then issues a plain-HTTP request, the kwarg leaks past the `SSL_KEYWORDS` filter into `HTTPConnection.__init__`, which raises a `TypeError`.

## Fix

Add both to `SSL_KEYWORDS`, matching the existing intent of the filter.

## Verification

- Reproduced the issue with the reproducer from the issue report.
- Verified the fix: with the change, both kwargs are correctly stripped before reaching `HTTPConnection.__init__`.

## Disclosure

Prepared with AI assistance (Claude Code); I reviewed and verified the change and test results, and will respond to review feedback personally.