### PR TITLE
[Bug] Add assert_hostname and assert_fingerprint to SSL_KEYWORDS

### DIFF
--- a/src/urllib3/poolmanager.py
+++ b/src/urllib3/poolmanager.py
@@ -47,6 +47,8 @@ SSL_KEYWORDS = (
     "ssl_context",
     "key_password",
     "server_hostname",
+    "assert_hostname",
+    "assert_fingerprint",
 )
 # Default value for `blocksize` - a new parameter introduced to
 # http.client.HTTPConnection & http.client.HTTPSConnection in Python 3.7


### PR DESCRIPTION
## Summary
`assert_hostname` and `assert_fingerprint` are SSL-only keyword arguments declared as parameters on `HTTPSConnection.__init__` but missing from the `SSL_KEYWORDS` allowlist in `PoolManager`. When a caller sets either on `PoolManager.connection_pool_kw` and then issues a plain-HTTP request, the kwarg leaks past the filter into `HTTPConnection.__init__`, where it is rejected.

## Related Issue
Closes #5077

## Changes
Add `"assert_hostname"` and `"assert_fingerprint"` to the `SSL_KEYWORDS` tuple in `poolmanager.py`.

## Type of Change
- [x] Bug fix (non-breaking change)
- [ ] New feature

## Checklist
- [ ] I have read the contributing guidelines.
- [x] My code follows the existing style.
- [ ] CI is green (passing all checks).