### PR TITLE
Do not re-apply unchanged options to a used PyOpenSSL context (#5107)

### DIFF
--- a/changelog/5107.bugfix.rst
+++ b/changelog/5107.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed ``ValueError`` (``Context has already been used to create a Connection``) when reusing a ``ssl_context`` across multiple connections with the ``pyopenssl`` contrib module. Re-applying unchanged ``options``, ``minimum_version`` and ``maximum_version`` on the wrapped context is now a no-op.

--- a/src/urllib3/contrib/pyopenssl.py
+++ b/src/urllib3/contrib/pyopenssl.py
@@ -438,6 +438,11 @@ class PyOpenSSLContext:
 
     @options.setter
     def options(self, value: int) -> None:
+        if value == self._options:
+            # Re-applying the same value would call ``set_options`` again, which
+            # raises once the context has been used to create a connection. See
+            # https://github.com/urllib3/urllib3/issues/5107.
+            return
         self._options = value
         self._set_ctx_options()
 
@@ -547,6 +552,8 @@ class PyOpenSSLContext:
 
     @minimum_version.setter
     def minimum_version(self, minimum_version: int) -> None:
+        if minimum_version == self._minimum_version:
+            return
         self._minimum_version = minimum_version
         self._set_ctx_options()
 
@@ -556,6 +563,8 @@ class PyOpenSSLContext:
 
     @maximum_version.setter
     def maximum_version(self, maximum_version: int) -> None:
+        if maximum_version == self._maximum_version:
+            return
         self._maximum_version = maximum_version
         self._set_ctx_options()
 

--- a/test/contrib/test_pyopenssl.py
+++ b/test/contrib/test_pyopenssl.py
@@ -85,6 +85,34 @@ class TestPyOpenSSLHelpers:
 
         assert _dnsname_to_stdlib(name) == expected_result
 
+    def test_reapplying_unchanged_options_after_use(self) -> None:
+        """Re-applying unchanged TLS settings must not fail after the context
+        has been used to create a connection (see GH-5107).
+
+        A connection pool re-applies the same ``ssl_context`` settings for every
+        new connection, but OpenSSL forbids mutating a context once it has been
+        used, so the no-op assignments must be skipped.
+        """
+        import ssl
+
+        import OpenSSL.SSL
+
+        from urllib3.contrib.pyopenssl import PyOpenSSLContext
+
+        ctx = PyOpenSSLContext(ssl.PROTOCOL_TLS_CLIENT)
+        ctx.minimum_version = ssl.TLSVersion.TLSv1_2
+        ctx.maximum_version = ssl.TLSVersion.TLSv1_3
+        ctx.options |= ssl.OP_NO_COMPRESSION
+
+        # Using the context to create a connection freezes it.
+        OpenSSL.SSL.Connection(ctx._ctx)
+
+        # Re-applying the current values (as a pool does per connection) is a
+        # no-op and must not raise.
+        ctx.minimum_version = ctx.minimum_version
+        ctx.maximum_version = ctx.maximum_version
+        ctx.options = ctx.options
+
     @mock.patch("urllib3.contrib.pyopenssl.log.warning")
     def test_get_subj_alt_name(self, mock_warning: mock.MagicMock) -> None:
         """


### PR DESCRIPTION
## Summary

Fixes #5107. With the `pyopenssl` contrib module and a custom `ssl_context`, creating a **second** connection from a pool raised:

```
ValueError: Context has already been used to create a Connection, it cannot be mutated again
```

(Reported as the root cause of an Apache Beam pipeline failure.)

## Root cause

`PyOpenSSLContext.options`, `minimum_version` and `maximum_version` setters each call `_set_ctx_options()` → `self._ctx.set_options(...)`. A connection pool re-applies the same `ssl_context` settings for **every** new connection, but once the context has been used to create an `OpenSSL.SSL.Connection` (in `wrap_socket`), OpenSSL forbids any further mutation — so the second connection's (unchanged) re-assignment raised.

## Fix

Skip the mutation when the value is unchanged, so re-applying the same settings is a no-op. A genuine change on a not-yet-used context still applies as before.

## Verification

- Added `test_reapplying_unchanged_options_after_use` (a unit test): it reproduces the exact `ValueError` on `main` and passes with this change.
- `TestPyOpenSSLHelpers` unit tests pass (5). The `pyopenssl` integration tests that need a live TLS dummyserver fail identically with and without this change in my environment (unrelated).
- `ruff check` / `ruff format --check` clean. Added `changelog/5107.bugfix.rst`.

---

*Disclosure: prepared with AI assistance; reviewed and verified locally.*
