### PR TITLE
cap chunk-size and trailer line length in read_chunked

### DIFF
--- a/changelog/5112.bugfix.rst
+++ b/changelog/5112.bugfix.rst
@@ -1,0 +1,4 @@
+Bounded the length of the chunk-size line and trailer lines read while
+decoding a chunked response, matching the limit :mod:`http.client` already
+applies, so a malicious server can no longer make ``read_chunked`` or
+``stream`` buffer an unbounded single line in memory.

--- a/src/urllib3/response.py
+++ b/src/urllib3/response.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import collections
+import http.client
 import io
 import json as _json
 import logging
@@ -1344,7 +1345,11 @@ class HTTPResponse(BaseHTTPResponse):
         # we'll try to read it from socket.
         if self.chunk_left is not None:
             return None
-        line = self._fp.fp.readline()  # type: ignore[union-attr]
+        _MAXLINE = http.client._MAXLINE  # type: ignore[attr-defined]
+        line = self._fp.fp.readline(_MAXLINE + 1)  # type: ignore[union-attr]
+        if len(line) > _MAXLINE:
+            self.close()
+            raise http.client.LineTooLong("chunk size")
         line = line.split(b";", 1)[0]
         try:
             self.chunk_left = int(line, 16)
@@ -1454,8 +1459,11 @@ class HTTPResponse(BaseHTTPResponse):
                     yield decoded
 
             # Chunk content ends with \r\n: discard it.
+            _MAXLINE = http.client._MAXLINE  # type: ignore[attr-defined]
             while self._fp is not None:
-                line = self._fp.fp.readline()
+                line = self._fp.fp.readline(_MAXLINE + 1)
+                if len(line) > _MAXLINE:
+                    raise http.client.LineTooLong("trailer line")
                 if not line:
                     # Some sites may not end with '\r\n'.
                     break

--- a/test/test_response.py
+++ b/test/test_response.py
@@ -1811,6 +1811,32 @@ class TestResponse:
         assert isinstance(orig_ex, InvalidChunkLength)
         assert orig_ex.length == fp.BAD_LENGTH_LINE.encode()
 
+    def _read_chunked_with_fp(self, payload: bytes) -> list[bytes]:
+        r = httplib.HTTPResponse(MockSock)  # type: ignore[arg-type]
+        r.fp = MockRawChunkedFp(payload)  # type: ignore[assignment]
+        r.chunked = True
+        r.chunk_left = None
+        resp = HTTPResponse(
+            r, preload_content=False, headers={"transfer-encoding": "chunked"}
+        )
+        return list(resp.read_chunked())
+
+    def test_oversized_chunk_size_line(self) -> None:
+        # A chunk-size line longer than http.client._MAXLINE must be rejected
+        # instead of being buffered unbounded.
+        payload = b"1" * (httplib._MAXLINE + 1) + b"\r\nx\r\n0\r\n\r\n"
+        with pytest.raises(ProtocolError) as ctx:
+            self._read_chunked_with_fp(payload)
+        assert isinstance(ctx.value.args[1], httplib.LineTooLong)
+
+    def test_oversized_chunk_trailer_line(self) -> None:
+        payload = (
+            b"1\r\nx\r\n0\r\nTrailer: " + b"A" * (httplib._MAXLINE + 1) + b"\r\n\r\n"
+        )
+        with pytest.raises(ProtocolError) as ctx:
+            self._read_chunked_with_fp(payload)
+        assert isinstance(ctx.value.args[1], httplib.LineTooLong)
+
     def test_truncated_before_chunk(self) -> None:
         stream = [b"foooo", b"bbbbaaaaar"]
         fp = MockChunkedNoChunks(stream)
@@ -2071,7 +2097,13 @@ class MockChunkedEncodingResponse:
             return chunk_part
 
     def readline(self, amt: int = -1) -> bytes:
-        return self.pop_current_chunk(amt, till_crlf=amt < 0)
+        # Emulate a real file object's readline: return bytes up to and
+        # including the next b"\n", or at most `amt` bytes when `amt` >= 0.
+        line = self.pop_current_chunk(till_crlf=True)
+        if amt >= 0 and len(line) > amt:
+            self.cur_chunk = line[amt:] + self.cur_chunk
+            line = line[:amt]
+        return line
 
     def read(self, amt: int = -1) -> bytes:
         return self.pop_current_chunk(amt)
@@ -2116,6 +2148,27 @@ class MockChunkedEncodingWithExtensions(MockChunkedEncodingResponse):
 class MockChunkedNoChunks(MockChunkedEncodingResponse):
     def _encode_chunk(self, chunk: bytes) -> bytes:
         return b""
+
+
+class MockRawChunkedFp:
+    """Minimal ``http.client`` fp stand-in whose ``readline`` honors the size
+    argument, matching a real socket file object. Lets tests feed raw
+    chunked bytes (including malformed framing) verbatim."""
+
+    def __init__(self, payload: bytes) -> None:
+        self._buf = BytesIO(payload)
+
+    def readline(self, amt: int = -1) -> bytes:
+        return self._buf.readline() if amt < 0 else self._buf.readline(amt)
+
+    def read(self, amt: int = -1) -> bytes:
+        return self._buf.read() if amt < 0 else self._buf.read(amt)
+
+    def flush(self) -> None:
+        pass
+
+    def close(self) -> None:
+        pass
 
 
 class MockSock:


### PR DESCRIPTION
On a chunked response, urllib3's own reader takes the chunk-size line and the trailer lines without the length bound that http.client applies:

    # HTTPResponse._update_chunk_length / read_chunked trailer loop
    line = self._fp.fp.readline()      # unbounded; stdlib uses readline(_MAXLINE + 1)

A malicious server can then make `.stream()`/`.read_chunked()` buffer an arbitrarily large single line into memory before any length check. This applies the same `_MAXLINE + 1` / `LineTooLong` guard that #5091 added to the tunnel reader to both readline sites in the chunked path.