### PR TITLE
Document retry backoff guidance

### DIFF
--- a/changelog/3677.misc.rst
+++ b/changelog/3677.misc.rst
@@ -1,0 +1,1 @@
+Documented configuring ``Retry.backoff_factor`` for production retry policies.

--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -585,14 +585,13 @@ To disable redirects but keep the retrying logic, specify ``redirect=False``:
 For more granular control you can use a :class:`~util.retry.Retry` instance.
 This class allows you far greater control of how requests are retried.
 
-When enabling retries in production, configure a non-zero ``backoff_factor``
-to avoid retrying repeatedly without any delay. urllib3 will sleep between
-retry attempts using an exponential backoff. For example,
-``backoff_factor=0.1`` sleeps for ``0.0s``, ``0.2s``, ``0.4s``, ``0.8s``,
-and so on between retries. urllib3 also respects the ``Retry-After`` response
-header by default when present for supported retry responses.
+When enabling retries against production services, consider configuring a
+non-zero ``backoff_factor`` so consecutive retry attempts do not happen
+back-to-back. This is especially important for status-code retries, where the
+remote service may already be rate limiting or overloaded. See
+:class:`~util.retry.Retry` for how backoff delays are calculated.
 
-For example, to retry transient server errors with backoff:
+For example, to retry rate-limit and transient server responses with backoff:
 
 .. code-block:: python
 
@@ -601,8 +600,8 @@ For example, to retry transient server errors with backoff:
         "https://httpbin.org/status/503",
         retries=urllib3.Retry(
             total=3,
-            status_forcelist={503},
-            backoff_factor=0.1,
+            status_forcelist={429, 500, 502, 503, 504},
+            backoff_factor=0.5,
         )
     )
 

--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -583,13 +583,8 @@ To disable redirects but keep the retrying logic, specify ``redirect=False``:
     # 302
 
 For more granular control you can use a :class:`~util.retry.Retry` instance.
-This class allows you far greater control of how requests are retried.
-
-When enabling retries against production services, consider configuring a
-non-zero ``backoff_factor`` so consecutive retry attempts do not happen
-back-to-back. This is especially important for status-code retries, where the
-remote service may already be rate limiting or overloaded. See
-:class:`~util.retry.Retry` for how backoff delays are calculated.
+This class allows you far greater control of how requests are retried,
+including status-code retries with backoff.
 
 For example, to retry rate-limit and transient server responses with backoff:
 

--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -585,6 +585,27 @@ To disable redirects but keep the retrying logic, specify ``redirect=False``:
 For more granular control you can use a :class:`~util.retry.Retry` instance.
 This class allows you far greater control of how requests are retried.
 
+When enabling retries in production, configure a non-zero ``backoff_factor``
+to avoid retrying repeatedly without any delay. urllib3 will sleep between
+retry attempts using an exponential backoff. For example,
+``backoff_factor=0.1`` sleeps for ``0.0s``, ``0.2s``, ``0.4s``, ``0.8s``,
+and so on between retries. urllib3 also respects the ``Retry-After`` response
+header by default when present for supported retry responses.
+
+For example, to retry transient server errors with backoff:
+
+.. code-block:: python
+
+    urllib3.request(
+        "GET",
+        "https://httpbin.org/status/503",
+        retries=urllib3.Retry(
+            total=3,
+            status_forcelist={503},
+            backoff_factor=0.1,
+        )
+    )
+
 For example, to do a total of 3 retries, but limit to only 2 redirects:
 
 .. code-block:: python


### PR DESCRIPTION
Closes #3677.

## Summary

- Documents why production retry policies should configure a non-zero `Retry.backoff_factor`.
- Adds a concrete status-retry example using `status_forcelist` with backoff.
- Adds a changelog fragment for the user-facing documentation update.

## Why

Issue #3677 asks whether urllib3 should change the default backoff behavior. A maintainer noted that changing the default may be surprising, but that the documentation should make the recommended production configuration clearer. This keeps runtime behavior unchanged and surfaces the guidance in the user guide where retry examples are introduced.

## Validation

- `git diff --check`
- `UV_CACHE_DIR=/private/tmp/uv-cache PATH="/Users/yash/Library/Python/3.14/bin:$PATH" python3 -m nox -s docs`
