### PR TITLE
Raise when iterating closed responses

### DIFF
--- a/changelog/1780.bugfix.rst
+++ b/changelog/1780.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed iteration over a closed ``HTTPResponse`` to raise ``ValueError`` instead
+of silently producing no data.

--- a/src/urllib3/response.py
+++ b/src/urllib3/response.py
@@ -1480,6 +1480,9 @@ class HTTPResponse(BaseHTTPResponse):
         self._request_url = url
 
     def __iter__(self) -> typing.Iterator[bytes]:
+        if self.closed:
+            raise ValueError("I/O operation on closed file.")
+
         buffer: list[bytes] = []
         for chunk in self.stream(decode_content=True):
             if b"\n" in chunk:

--- a/test/test_response.py
+++ b/test/test_response.py
@@ -1050,6 +1050,13 @@ class TestResponse:
         with pytest.raises(IOError):
             resp3.fileno()
 
+    def test_iter_closed_response(self) -> None:
+        response = HTTPResponse(BytesIO(b"foo"), preload_content=False)
+        response.close()
+
+        with pytest.raises(ValueError, match="I/O operation on closed file"):
+            list(response)
+
     def test_io_closed_consistently_by_read(self, sock: socket.socket) -> None:
         try:
             hlr = httplib.HTTPResponse(sock)


### PR DESCRIPTION
<!---
Thanks for your contribution! ♥️

If this is your first PR to urllib3 please review the Contributing Guide:
https://urllib3.readthedocs.io/en/latest/contributing.html

Adhering to the Contributing Guide means we can review, merge, and release your change faster! :)
--->

Fixes #1780.

Iterating an already-closed `HTTPResponse` now raises the standard `ValueError: I/O operation on closed file.` instead of silently appearing empty. The regression test fails without the source change; `test/test_response.py` and the full suite pass locally (2231 passed, 333 skipped, 45 xfailed).

Prepared with AI assistance.
