### PR TITLE
Handle HTTP/2 stream reset and connection termination events

### DIFF
--- a/changelog/3291.bugfix.rst
+++ b/changelog/3291.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed HTTP/2 connections to raise a protocol error instead of hanging when a peer resets a stream, terminates the connection, or closes the socket before completing a response.

--- a/src/urllib3/http2/connection.py
+++ b/src/urllib3/http2/connection.py
@@ -8,6 +8,7 @@ import typing
 
 import h2.config
 import h2.connection
+import h2.errors
 import h2.events
 
 from .._base_connection import _TYPE_BODY
@@ -49,6 +50,18 @@ def _is_illegal_header_value(value: bytes) -> bool:
     0x20 or 0x09)." (https://httpwg.org/specs/rfc9113.html#n-field-validity)
     """
     return bool(RE_IS_ILLEGAL_HEADER_VALUE.search(value))
+
+
+def _format_h2_error_code(error_code: h2.errors.ErrorCodes | int | None) -> str:
+    """Return a stable, useful representation for an HTTP/2 error code."""
+    if error_code is None:
+        return "unknown error code None"
+
+    try:
+        error_code = h2.errors.ErrorCodes(int(error_code))
+    except (TypeError, ValueError):
+        return f"unknown error code {error_code}"
+    return f"{error_code.name} (0x{error_code.value:x})"
 
 
 class _LockedObject(typing.Generic[T]):
@@ -232,27 +245,47 @@ class HTTP2Connection(HTTPSConnection):
             end_stream = False
             while not end_stream:
                 # TODO: Arbitrary read value.
-                if received_data := self.sock.recv(65535):
-                    events = conn.receive_data(received_data)
-                    for event in events:
-                        if isinstance(event, h2.events.ResponseReceived):
-                            headers = HTTPHeaderDict()
-                            for header, value in event.headers:
-                                if header == b":status":
-                                    status = int(value.decode())
-                                else:
-                                    headers.add(
-                                        header.decode("ascii"), value.decode("ascii")
-                                    )
+                received_data = self.sock.recv(65535)
+                if not received_data:
+                    self.close()
+                    raise ConnectionError(
+                        "Connection closed before receiving an HTTP/2 response"
+                    )
 
-                        elif isinstance(event, h2.events.DataReceived):
-                            data += event.data
-                            conn.acknowledge_received_data(
-                                event.flow_controlled_length, event.stream_id
-                            )
+                events = conn.receive_data(received_data)
+                for event in events:
+                    if isinstance(event, h2.events.ResponseReceived):
+                        headers = HTTPHeaderDict()
+                        for header, value in event.headers:
+                            if header == b":status":
+                                status = int(value.decode())
+                            else:
+                                headers.add(
+                                    header.decode("ascii"), value.decode("ascii")
+                                )
 
-                        elif isinstance(event, h2.events.StreamEnded):
-                            end_stream = True
+                    elif isinstance(event, h2.events.DataReceived):
+                        data += event.data
+                        conn.acknowledge_received_data(
+                            event.flow_controlled_length, event.stream_id
+                        )
+
+                    elif isinstance(event, h2.events.StreamEnded):
+                        end_stream = True
+
+                    elif isinstance(event, h2.events.StreamReset):
+                        self.close()
+                        raise ConnectionError(
+                            f"HTTP/2 stream {event.stream_id} was reset: "
+                            f"{_format_h2_error_code(event.error_code)}"
+                        )
+
+                    elif isinstance(event, h2.events.ConnectionTerminated):
+                        self.close()
+                        raise ConnectionError(
+                            "HTTP/2 connection was terminated: "
+                            f"{_format_h2_error_code(event.error_code)}"
+                        )
 
                 if data_to_send := conn.data_to_send():
                     self.sock.sendall(data_to_send)

--- a/src/urllib3/http2/connection.py
+++ b/src/urllib3/http2/connection.py
@@ -281,7 +281,7 @@ class HTTP2Connection(HTTPSConnection):
                         )
 
                     elif isinstance(event, h2.events.ConnectionTerminated):
-                        self.close()
+                        self._close_http2_connection(send_goaway=False)
                         raise ConnectionError(
                             "HTTP/2 connection was terminated: "
                             f"{_format_h2_error_code(event.error_code)}"
@@ -337,14 +337,15 @@ class HTTP2Connection(HTTPSConnection):
         else:
             self.endheaders()
 
-    def close(self) -> None:
-        with self._h2_conn as conn:
-            try:
-                conn.close_connection()
-                if data := conn.data_to_send():
-                    self.sock.sendall(data)
-            except Exception:
-                pass
+    def _close_http2_connection(self, *, send_goaway: bool) -> None:
+        if send_goaway:
+            with self._h2_conn as conn:
+                try:
+                    conn.close_connection()
+                    if data := conn.data_to_send():
+                        self.sock.sendall(data)
+                except Exception:
+                    pass
 
         # Reset all our HTTP/2 connection state.
         self._h2_conn = self._new_h2_conn()
@@ -352,6 +353,9 @@ class HTTP2Connection(HTTPSConnection):
         self._headers = []
 
         super().close()
+
+    def close(self) -> None:
+        self._close_http2_connection(send_goaway=True)
 
 
 class HTTP2Response(BaseHTTPResponse):

--- a/test/test_http2_connection.py
+++ b/test/test_http2_connection.py
@@ -433,7 +433,7 @@ class TestHTTP2Connection:
         ):
             conn.getresponse()
 
-        close_connection.assert_called_once_with()
+        close_connection.assert_not_called()
         assert conn.is_closed
 
     def test_getresponse_EOF(self) -> None:

--- a/test/test_http2_connection.py
+++ b/test/test_http2_connection.py
@@ -11,6 +11,7 @@ from urllib3.connection import _get_default_user_agent
 from urllib3.exceptions import ConnectionError
 from urllib3.http2.connection import (
     HTTP2Connection,
+    _format_h2_error_code,
     _is_illegal_header_value,
     _is_legal_header_name,
 )
@@ -101,6 +102,19 @@ class TestHTTP2Connection:
         assert _is_illegal_header_value(b"\tfoo"), "\\tfoo"
         assert _is_illegal_header_value(b"foo\t"), "foo\\t"
         assert _is_illegal_header_value(b"foo\x09"), "foo\\x09"
+
+    @pytest.mark.parametrize(
+        ("error_code", "expected"),
+        [
+            (None, "unknown error code None"),
+            (99, "unknown error code 99"),
+            (h2.errors.ErrorCodes.REFUSED_STREAM, "REFUSED_STREAM (0x7)"),
+        ],
+    )
+    def test_format_h2_error_code(
+        self, error_code: h2.errors.ErrorCodes | int | None, expected: str
+    ) -> None:
+        assert _format_h2_error_code(error_code) == expected
 
     def test_default_socket_options(self) -> None:
         conn = HTTP2Connection("example.com")

--- a/test/test_http2_connection.py
+++ b/test/test_http2_connection.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import socket
 from unittest import mock
 
+import h2.errors
+import h2.events
 import pytest
 
 from urllib3.connection import _get_default_user_agent
@@ -17,6 +19,31 @@ from urllib3.http2.connection import (
 
 
 class TestHTTP2Connection:
+    @staticmethod
+    def _new_http2_event(event_type: type[object], **attributes: object) -> object:
+        """Create h2 events compatibly across its supported 4.x releases."""
+        event = object.__new__(event_type)
+        for name, value in attributes.items():
+            setattr(event, name, value)
+        return event
+
+    @staticmethod
+    def _connection_with_events(
+        *events: object,
+    ) -> tuple[HTTP2Connection, mock.Mock, mock.Mock]:
+        conn = HTTP2Connection("example.com")
+        conn._h2_stream = 1
+        recv = mock.Mock(return_value=b"server response")
+        conn.sock = mock.MagicMock(
+            recv=recv,
+            sendall=mock.Mock(return_value=None),
+        )
+        h2_conn = conn._h2_conn._obj
+        h2_conn.receive_data = mock.Mock(return_value=list(events))  # type: ignore[method-assign]
+        h2_conn.data_to_send = mock.Mock(return_value=b"")  # type: ignore[method-assign]
+        h2_conn.close_connection = mock.Mock(return_value=None)  # type: ignore[method-assign]
+        return conn, h2_conn.close_connection, recv
+
     def test__is_legal_header_name(self) -> None:
         assert _is_legal_header_name(b"foo"), "foo"
         assert _is_legal_header_name(b"foo-bar"), "foo-bar"
@@ -358,3 +385,52 @@ class TestHTTP2Connection:
         )
 
         close_connection.assert_called_with()
+
+    def test_getresponse_StreamReset(self) -> None:
+        event = self._new_http2_event(
+            h2.events.StreamReset,
+            stream_id=1,
+            error_code=h2.errors.ErrorCodes.REFUSED_STREAM,
+            remote_reset=True,
+        )
+        conn, close_connection, _ = self._connection_with_events(event)
+
+        with pytest.raises(
+            ConnectionError,
+            match=r"HTTP/2 stream 1 was reset: REFUSED_STREAM \(0x7\)",
+        ):
+            conn.getresponse()
+
+        close_connection.assert_called_once_with()
+        assert conn.is_closed
+
+    def test_getresponse_ConnectionTerminated(self) -> None:
+        event = self._new_http2_event(
+            h2.events.ConnectionTerminated,
+            error_code=h2.errors.ErrorCodes.ENHANCE_YOUR_CALM,
+            last_stream_id=0,
+            additional_data=b"",
+        )
+        conn, close_connection, _ = self._connection_with_events(event)
+
+        with pytest.raises(
+            ConnectionError,
+            match=r"HTTP/2 connection was terminated: ENHANCE_YOUR_CALM \(0xb\)",
+        ):
+            conn.getresponse()
+
+        close_connection.assert_called_once_with()
+        assert conn.is_closed
+
+    def test_getresponse_EOF(self) -> None:
+        conn, close_connection, recv = self._connection_with_events()
+        recv.return_value = b""
+
+        with pytest.raises(
+            ConnectionError,
+            match="Connection closed before receiving an HTTP/2 response",
+        ):
+            conn.getresponse()
+
+        close_connection.assert_called_once_with()
+        assert conn.is_closed


### PR DESCRIPTION
Fixes #3291.

## Summary
- raise retry-compatible protocol errors for HTTP/2 stream resets and connection termination
- close unusable HTTP/2 connections before surfacing the error
- prevent the response loop from hanging after peer EOF
- add regression coverage for RST_STREAM, GOAWAY, and EOF

## Verification
- python -m pytest test/test_http2_connection.py
- ruff check
- mypy src/urllib3/http2/connection.py
- towncrier build --draft