### PR TITLE
reject CR/LF and NUL in multipart field headers

### DIFF
--- a/changelog/5119.bugfix.rst
+++ b/changelog/5119.bugfix.rst
@@ -1,0 +1,1 @@
+Rejected carriage return, line feed, and NUL characters in ``multipart/form-data`` field header names and values so an untrusted value (such as a forwarded upload ``Content-Type``) can no longer inject extra part headers into the request body.

--- a/src/urllib3/fields.py
+++ b/src/urllib3/fields.py
@@ -2,9 +2,14 @@ from __future__ import annotations
 
 import email.utils
 import mimetypes
+import re
 import typing
 
 _TYPE_FIELD_VALUE = typing.Union[str, bytes]
+
+# CR, LF, and NUL break out of a multipart field header line and are never
+# valid inside a header name or value.
+_HEADER_INVALID_CHAR_RE = re.compile(r"[\r\n\x00]")
 _TYPE_FIELD_VALUE_TUPLE = typing.Union[
     _TYPE_FIELD_VALUE,
     tuple[str, _TYPE_FIELD_VALUE],
@@ -74,6 +79,22 @@ def format_header_param_rfc2231(name: str, value: _TYPE_FIELD_VALUE) -> str:
     value = f"{name}*={value}"
 
     return value
+
+
+def _check_header(name: str, value: str | None) -> None:
+    """Reject a multipart field header whose name or value contains a
+    character that would break out of the rendered part header block.
+
+    ``format_multipart_header_param`` already escapes the ``name`` and
+    ``filename`` parameters, but the header values set by
+    :meth:`RequestField.make_multipart` (e.g. ``Content-Type``) and any
+    caller-supplied headers are emitted verbatim, so an untrusted value
+    could otherwise inject extra part headers or whole parts.
+    """
+    if _HEADER_INVALID_CHAR_RE.search(name):
+        raise ValueError(f"Invalid multipart header name {name!r}")
+    if value is not None and _HEADER_INVALID_CHAR_RE.search(value):
+        raise ValueError(f"Invalid multipart header value {value!r}")
 
 
 def format_multipart_header_param(name: str, value: _TYPE_FIELD_VALUE) -> str:
@@ -297,11 +318,13 @@ class RequestField:
         sort_keys = ["Content-Disposition", "Content-Type", "Content-Location"]
         for sort_key in sort_keys:
             if self.headers.get(sort_key, False):
+                _check_header(sort_key, self.headers[sort_key])
                 lines.append(f"{sort_key}: {self.headers[sort_key]}")
 
         for header_name, header_value in self.headers.items():
             if header_name not in sort_keys:
                 if header_value:
+                    _check_header(header_name, header_value)
                     lines.append(f"{header_name}: {header_value}")
 
         lines.append("\r\n")

--- a/test/test_fields.py
+++ b/test/test_fields.py
@@ -57,6 +57,36 @@ class TestRequestField:
             "\r\n"
         )
 
+    @pytest.mark.parametrize(
+        "content_type",
+        [
+            'image/png\r\nContent-Disposition: form-data; name="role"\r\n\r\nadmin',
+            "text/plain\nX-Injected: 1",
+            "text/plain\x00",
+        ],
+    )
+    def test_make_multipart_rejects_crlf_in_content_type(
+        self, content_type: str
+    ) -> None:
+        field = RequestField.from_tuples("file", ("a.png", b"data", content_type))
+        with pytest.raises(ValueError, match="Invalid multipart header value"):
+            field.render_headers()
+
+    @pytest.mark.parametrize(
+        "headers, match",
+        [
+            ({"X-A\r\nX-Injected": "1"}, "Invalid multipart header name"),
+            ({"X-A": "1\r\nX-Injected: 1"}, "Invalid multipart header value"),
+            ({"X-A": "1\x00"}, "Invalid multipart header value"),
+        ],
+    )
+    def test_render_headers_rejects_crlf(
+        self, headers: dict[str, str], match: str
+    ) -> None:
+        field = RequestField("somename", "data", headers=headers)
+        with pytest.raises(ValueError, match=match):
+            field.render_headers()
+
     def test_render_parts(self) -> None:
         field = RequestField("somename", "data")
         parts = field._render_parts({"name": "value", "filename": "value"})


### PR DESCRIPTION
RequestField only escapes the name and filename params through format_multipart_header_param, so the Content-Type/Content-Location values set by make_multipart and any caller-supplied header names/values are written into the multipart/form-data body unchecked. A CR/LF in an attacker-influenced value, such as a forwarded upload Content-Type, then injects extra part headers or whole parts into the request. render_headers now rejects CR, LF, and NUL in the header names and values it emits, matching the escaping already applied to name and filename.