### PR TITLE
Replace deprecated OpenSSL.crypto.X509.get_subject() with cryptography's X.509 API

### DIFF
--- a/changelog/5099.bugfix.rst
+++ b/changelog/5099.bugfix.rst
@@ -1,0 +1,6 @@
+Fixed the pyOpenSSL TLS backend (``urllib3.contrib.pyopenssl``) emitting a
+``DeprecationWarning`` from ``OpenSSL.crypto.X509.get_subject()`` on
+pyOpenSSL 26.3.0+ when reading a peer certificate's ``commonName`` in
+``getpeercert()``. The commonName is now read via ``cryptography``'s X.509
+API instead, matching the approach already used for subject alternative
+names.

--- a/src/urllib3/contrib/pyopenssl.py
+++ b/src/urllib3/contrib/pyopenssl.py
@@ -42,6 +42,7 @@ from __future__ import annotations
 
 import OpenSSL.SSL
 from cryptography import x509
+from cryptography.x509.oid import NameOID
 
 try:
     from cryptography.x509 import UnsupportedExtension  # type: ignore[attr-defined]

--- a/src/urllib3/contrib/pyopenssl.py
+++ b/src/urllib3/contrib/pyopenssl.py
@@ -270,6 +270,24 @@ def get_subj_alt_name(peer_cert: X509) -> list[tuple[str, str]]:
     return names
 
 
+def _common_name(peer_cert: X509) -> str | None:
+    """
+    Given a PyOpenSSL certificate, returns its subject's commonName, or None
+    if it doesn't have one.
+
+    OpenSSL.crypto.X509.get_subject() (and the X509Name object it returns) is
+    deprecated as of pyOpenSSL 26.3.0, so this goes through cryptography's
+    X.509 API instead, same as get_subj_alt_name() does above for the same
+    certificate.
+    """
+    cert = peer_cert.to_cryptography()
+    common_names = cert.subject.get_attributes_for_oid(NameOID.COMMON_NAME)
+    if not common_names:
+        return None
+    value = common_names[0].value
+    return value if isinstance(value, str) else value.decode("utf-8")
+
+
 class WrappedSocket:
     """API-compatibility wrapper for Python OpenSSL's Connection-class."""
 

--- a/src/urllib3/contrib/pyopenssl.py
+++ b/src/urllib3/contrib/pyopenssl.py
@@ -402,7 +402,7 @@ class WrappedSocket:
             return OpenSSL.crypto.dump_certificate(OpenSSL.crypto.FILETYPE_ASN1, x509)
 
         return {
-            "subject": ((("commonName", x509.get_subject().CN),),),  # type: ignore[dict-item]
+            "subject": ((("commonName", _common_name(x509)),),),  # type: ignore[dict-item]
             "subjectAltName": get_subj_alt_name(x509),
         }
 

--- a/test/contrib/test_pyopenssl.py
+++ b/test/contrib/test_pyopenssl.py
@@ -6,10 +6,19 @@ from unittest import mock
 import pytest
 
 try:
+    import datetime
+
     from cryptography import x509
+    from cryptography.hazmat.primitives import hashes
+    from cryptography.hazmat.primitives.asymmetric import rsa
+    from cryptography.x509.oid import NameOID
     from OpenSSL.crypto import FILETYPE_PEM, load_certificate
 
-    from urllib3.contrib.pyopenssl import _dnsname_to_stdlib, get_subj_alt_name
+    from urllib3.contrib.pyopenssl import (
+        _common_name,
+        _dnsname_to_stdlib,
+        get_subj_alt_name,
+    )
 except ImportError:
     pass
 
@@ -84,6 +93,47 @@ class TestPyOpenSSLHelpers:
         expected_result = "*.xn--p1b6ci4b4b3a.xn--11b5bs8d"
 
         assert _dnsname_to_stdlib(name) == expected_result
+
+    def _make_cert(self, common_name: str | None) -> Any:
+        """
+        Builds a minimal, self-signed, in-memory certificate for exercising
+        _common_name(), optionally with no commonName attribute at all.
+        """
+        key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        name = x509.Name(
+            [x509.NameAttribute(NameOID.COMMON_NAME, common_name)]
+            if common_name is not None
+            else []
+        )
+        now = datetime.datetime.now(datetime.timezone.utc)
+        cert = (
+            x509.CertificateBuilder()
+            .subject_name(name)
+            .issuer_name(name)
+            .public_key(key.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(now - datetime.timedelta(days=1))
+            .not_valid_after(now + datetime.timedelta(days=1))
+            .sign(key, hashes.SHA256())
+        )
+        return load_certificate(FILETYPE_PEM, cert.public_bytes(Encoding.PEM))
+
+    def test_common_name(self) -> None:
+        """
+        _common_name() reads the commonName off a certificate's subject via
+        cryptography's X.509 API, without going through the pyOpenSSL
+        get_subject() API deprecated in pyOpenSSL 26.3.0.
+        """
+        cert = self._make_cert("example.com")
+        assert _common_name(cert) == "example.com"
+
+    def test_common_name_missing(self) -> None:
+        """
+        _common_name() returns None for a certificate with no commonName,
+        matching the previous get_subject().CN behaviour.
+        """
+        cert = self._make_cert(None)
+        assert _common_name(cert) is None
 
     @mock.patch("urllib3.contrib.pyopenssl.log.warning")
     def test_get_subj_alt_name(self, mock_warning: mock.MagicMock) -> None:

--- a/test/contrib/test_pyopenssl.py
+++ b/test/contrib/test_pyopenssl.py
@@ -7,10 +7,12 @@ import pytest
 
 try:
     import datetime
+    from typing import Any
 
     from cryptography import x509
     from cryptography.hazmat.primitives import hashes
     from cryptography.hazmat.primitives.asymmetric import rsa
+    from cryptography.hazmat.primitives.serialization import Encoding
     from cryptography.x509.oid import NameOID
     from OpenSSL.crypto import FILETYPE_PEM, load_certificate
 

--- a/test/contrib/test_pyopenssl.py
+++ b/test/contrib/test_pyopenssl.py
@@ -101,7 +101,17 @@ class TestPyOpenSSLHelpers:
         Builds a minimal, self-signed, in-memory certificate for exercising
         _common_name(), optionally with no commonName attribute at all.
         """
-        key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        try:
+            # cryptography >= 3.1 makes `backend` optional.
+            key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        except TypeError:
+            # cryptography 2.3 (our documented minimum, pinned by the
+            # dev-min-pyopenssl dependency group) still requires it.
+            from cryptography.hazmat.backends import default_backend
+
+            key = rsa.generate_private_key(
+                public_exponent=65537, key_size=2048, backend=default_backend()
+            )
         name = x509.Name(
             [x509.NameAttribute(NameOID.COMMON_NAME, common_name)]
             if common_name is not None

--- a/test/contrib/test_pyopenssl.py
+++ b/test/contrib/test_pyopenssl.py
@@ -118,7 +118,7 @@ class TestPyOpenSSLHelpers:
             else []
         )
         now = datetime.datetime.now(datetime.timezone.utc)
-        cert = (
+        builder = (
             x509.CertificateBuilder()
             .subject_name(name)
             .issuer_name(name)
@@ -126,8 +126,16 @@ class TestPyOpenSSLHelpers:
             .serial_number(x509.random_serial_number())
             .not_valid_before(now - datetime.timedelta(days=1))
             .not_valid_after(now + datetime.timedelta(days=1))
-            .sign(key, hashes.SHA256())
         )
+        try:
+            # cryptography >= 3.1 makes `backend` optional.
+            cert = builder.sign(key, hashes.SHA256())
+        except TypeError:
+            # cryptography 2.3 (our documented minimum, pinned by the
+            # dev-min-pyopenssl dependency group) still requires it.
+            from cryptography.hazmat.backends import default_backend
+
+            cert = builder.sign(key, hashes.SHA256(), backend=default_backend())
         return load_certificate(FILETYPE_PEM, cert.public_bytes(Encoding.PEM))
 
     def test_common_name(self) -> None:


### PR DESCRIPTION
Fixes #5099

## Problem

With pyOpenSSL 26.3.0+, running urllib3's test suite (or any code using the `urllib3.contrib.pyopenssl` TLS backend) emits:

```
DeprecationWarning: X509.get_subject is deprecated. You should use cryptography's X.509 APIs instead.
```

## Root cause

`WrappedSocket.getpeercert()` in `src/urllib3/contrib/pyopenssl.py` was the only remaining caller of `OpenSSL.crypto.X509.get_subject()` in this module — it used `x509.get_subject().CN` to pull the peer certificate's commonName for the returned dict. pyOpenSSL 26.3.0 deprecated `get_subject()` (and the `X509Name` object it returns) in favor of `cryptography`'s own `x509` API.

`get_subj_alt_name()`, right above `getpeercert()` in the same file, already handles this correctly for the same certificate by calling `peer_cert.to_cryptography()` and working with `cryptography.x509` objects instead of pyOpenSSL's legacy `X509Name`.

## Fix

Added a `_common_name()` helper that mirrors `get_subj_alt_name()`'s approach: convert the pyOpenSSL certificate via `.to_cryptography()`, then pull the commonName via `subject.get_attributes_for_oid(NameOID.COMMON_NAME)`. `getpeercert()` now calls this instead of `x509.get_subject().CN`. Returns `None` when there's no commonName, matching the previous `X509Name.CN` behavior (`get_subject().CN` returns `None`, not an error, when unset).

## Tests

Added `test_common_name` / `test_common_name_missing` to `test/contrib/test_pyopenssl.py`, building minimal in-memory self-signed certs (with and without a commonName) via `cryptography`'s `CertificateBuilder` to exercise `_common_name()` directly, without needing a live TLS handshake.

## Changelog

Added `changelog/5099.bugfix.rst` per the towncrier convention used in this repo.