### PR TITLE
reject ambiguous Content-Length/Transfer-Encoding request framing

### DIFF
--- a/changelog/5122.bugfix.rst
+++ b/changelog/5122.bugfix.rst
@@ -1,0 +1,5 @@
+Fixed ``HTTPConnection.request()`` sending a request with both ``Content-Length``
+and ``Transfer-Encoding`` headers, which RFC 9112 Section 6.3 forbids because the
+framing of such a request is ambiguous. Supplying both headers, or passing
+``chunked=True`` together with a ``Content-Length`` header, now raises
+``ValueError`` before anything is sent.

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -493,6 +493,14 @@ class HTTPConnection(_HTTPConnection):
         if headers is None:
             headers = {}
         header_keys = frozenset(to_str(k.lower()) for k in headers)
+        if "content-length" in header_keys and (
+            chunked or "transfer-encoding" in header_keys
+        ):
+            raise ValueError(
+                "Content-Length and Transfer-Encoding can't both be set, "
+                "the framing of the request would be ambiguous "
+                "(RFC 9112 Section 6.3)"
+            )
         skip_accept_encoding = "accept-encoding" in header_keys
         skip_host = "host" in header_keys
         self.putrequest(

--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -271,6 +271,52 @@ class TestConnection:
         context.wrap_socket.return_value.close.assert_called_once_with()
 
     @pytest.mark.parametrize(
+        "headers, chunked",
+        [
+            ({"Content-Length": "5", "Transfer-Encoding": "chunked"}, False),
+            ({"content-length": "5", "transfer-encoding": "chunked"}, False),
+            ({b"Content-Length": "5", b"Transfer-Encoding": "chunked"}, False),
+            ({"Content-Length": "5"}, True),
+            ({b"Content-Length": "5"}, True),
+        ],
+    )
+    def test_request_rejects_ambiguous_framing(
+        self, headers: dict[typing.Any, str], chunked: bool
+    ) -> None:
+        with (
+            mock.patch("urllib3.util.connection.create_connection"),
+            mock.patch("urllib3.connection._HTTPConnection.putheader") as putheader,
+        ):
+            conn = HTTPConnection("")
+            with pytest.raises(ValueError, match="can't both be set"):
+                conn.request(
+                    "POST", "/", body=b"hello", headers=headers, chunked=chunked
+                )
+
+        putheader.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "headers, chunked",
+        [
+            ({"Content-Length": "5"}, False),
+            ({"Transfer-Encoding": "chunked"}, False),
+            ({"Transfer-Encoding": "chunked"}, True),
+            ({}, True),
+        ],
+    )
+    def test_request_allows_unambiguous_framing(
+        self, headers: dict[str, str], chunked: bool
+    ) -> None:
+        with (
+            mock.patch("urllib3.util.connection.create_connection"),
+            mock.patch("urllib3.connection._HTTPConnection.putheader"),
+            mock.patch("urllib3.connection._HTTPConnection.endheaders"),
+            mock.patch("urllib3.connection.HTTPConnection.send"),
+        ):
+            conn = HTTPConnection("")
+            conn.request("POST", "/", body=b"hello", headers=headers, chunked=chunked)
+
+    @pytest.mark.parametrize(
         "accept_encoding",
         [
             "Accept-Encoding",


### PR DESCRIPTION
`HTTPConnection.request()` picks one framing mode but never rejects a caller supplying both, so `headers={"Content-Length": "5", "Transfer-Encoding": "chunked"}` sends the body Content-Length-framed while still emitting the caller's `Transfer-Encoding: chunked` verbatim, and `chunked=True` alongside a caller-supplied `Content-Length` chunk-encodes the body while still emitting the `Content-Length`. Both put two framing headers on the wire, which RFC 9112 Section 6.3 tells senders not to do, and it matters when an application forwards client-supplied headers through urllib3 (a proxy or gateway), since a front-end honouring one header and a back-end honouring the other disagree on where the body ends. http.client has the same shape and doesn't reject it either, so the check has to live here, and it raises before `putrequest()` so nothing goes out; HTTP/2 already drops `transfer-encoding` and the emscripten path leaves framing to the browser, so this is the only affected path.