### PR TITLE
Treat an empty allowed_methods as allowing no method

### DIFF
--- a/changelog/5044.bugfix.rst
+++ b/changelog/5044.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed ``Retry`` treating an explicitly empty ``allowed_methods`` container as
+``None``, which retried on every method instead of on none of them.

--- a/src/urllib3/util/retry.py
+++ b/src/urllib3/util/retry.py
@@ -133,6 +133,9 @@ class Retry:
 
         Set to a ``None`` value to retry on any verb.
 
+        An empty container retries on no verb at all, which is the opposite of
+        ``None``.
+
     :param Collection status_forcelist:
         A set of integer HTTP status codes that we should force a retry on.
         A retry is initiated if the request method is in ``allowed_methods``
@@ -404,7 +407,9 @@ class Retry:
         """Checks if a given HTTP method should be retried upon, depending if
         it is included in the allowed_methods
         """
-        if self.allowed_methods and method.upper() not in self.allowed_methods:
+        if self.allowed_methods is None:
+            return True
+        if method.upper() not in self.allowed_methods:
             return False
         return True
 

--- a/test/test_retry.py
+++ b/test/test_retry.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import datetime
+from collections.abc import Collection
 from test import DUMMY_POOL
 from unittest import mock
 
@@ -281,7 +282,8 @@ class TestRetry:
         assert not retry.is_retry("POST", status_code=500)
 
         # Same for the other empty containers a caller might pass.
-        for empty in ([], frozenset(), ()):
+        empties: list[Collection[str]] = [[], frozenset(), ()]
+        for empty in empties:
             retry = Retry(status_forcelist=[500], allowed_methods=empty)
             assert not retry.is_retry("GET", status_code=500)
 

--- a/test/test_retry.py
+++ b/test/test_retry.py
@@ -263,7 +263,7 @@ class TestRetry:
         assert not retry.is_retry("GET", status_code=418)
 
     def test_allowed_methods_with_status_forcelist(self) -> None:
-        # Falsey allowed_methods means to retry on any method.
+        # ``None`` allowed_methods means to retry on any method.
         retry = Retry(status_forcelist=[500], allowed_methods=None)
         assert retry.is_retry("GET", status_code=500)
         assert retry.is_retry("POST", status_code=500)
@@ -272,6 +272,18 @@ class TestRetry:
         retry = Retry(status_forcelist=[500], allowed_methods=["POST"])
         assert not retry.is_retry("GET", status_code=500)
         assert retry.is_retry("POST", status_code=500)
+
+    def test_empty_allowed_methods(self) -> None:
+        # An explicitly empty container allows no method at all. It is falsey,
+        # but it is not ``None``, so it must not be read as "retry anything".
+        retry = Retry(status_forcelist=[500], allowed_methods=set())
+        assert not retry.is_retry("GET", status_code=500)
+        assert not retry.is_retry("POST", status_code=500)
+
+        # Same for the other empty containers a caller might pass.
+        for empty in ([], frozenset(), ()):
+            retry = Retry(status_forcelist=[500], allowed_methods=empty)
+            assert not retry.is_retry("GET", status_code=500)
 
     def test_exhausted(self) -> None:
         assert not Retry(0).is_exhausted()


### PR DESCRIPTION
Closes #5044.

### The bug

`_is_method_retryable` guarded on truthiness:

```python
if self.allowed_methods and method.upper() not in self.allowed_methods:
    return False
return True
```

An empty container is falsey, so it short-circuits to "retryable" — making an explicitly empty `allowed_methods` behave exactly like `None`. The docstring defines those as opposites: `None` means retry on any verb, so an empty container should mean retry on no verb.

Reproduced on `main` before touching anything:

```python
>>> r = Retry(status_forcelist=[500], allowed_methods=set())
>>> r.is_retry("POST", 500)
True     # expected False — nothing is allowed
>>> r.is_retry("GET", 500)
True     # expected False
```

The reporter's path to this is a typo that silently produces an empty set:

```python
Retry(allowed_methods=Retry.DEFAULT_ALLOWED_METHODS & {HTTPMethod.POST})   # & instead of |
```

That is meant to *narrow* retries and instead widens them to every method, POST included — the failure is silent and in the unsafe direction.

### The fix

Test the intent directly instead of leaning on truthiness:

```python
if self.allowed_methods is None:
    return True
if method.upper() not in self.allowed_methods:
    return False
return True
```

### Verification

The new test fails on the old code and passes on the new one — I checked by reverting the fix rather than assuming:

```
$ git stash    # restore the truthiness check
FAILED test/test_retry.py::TestRetry::test_empty_allowed_methods
  assert not True
   +  where True = is_retry('GET', status_code=500)
1 failed, 62 passed

$ git stash pop
63 passed
```

Full suite (excluding the dummyserver/contrib groups that need extra services): **1454 passed, 21 skipped**. `black`, `flake8`, `isort` clean; `mypy --strict` clean on the changed module.

`_is_method_retryable` has no callers outside `util/retry.py`, so the blast radius is this predicate.

### Note on the existing test

`test_allowed_methods_with_status_forcelist` was commented "Falsey allowed_methods means to retry on any method" while only ever exercising `None`. @textbook pointed at exactly this line in the issue. I narrowed the comment to `None` and added the empty-container case beside it, covering `set()`, `[]`, `frozenset()` and `()`.

I also added one line to the `allowed_methods` docstring spelling out that an empty container is the opposite of `None`, since the original wording only documented the `None` case.
