### PR TITLE
Resolve the default-timeout sentinel before assigning it to a connection

### DIFF
--- a/changelog/3595.misc.rst
+++ b/changelog/3595.misc.rst
@@ -1,0 +1,2 @@
+Resolved the default-timeout sentinel before assigning it to a connection in
+``HTTPConnectionPool.urlopen()``, matching what ``_new_conn()`` already does.

--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -765,7 +765,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         try:
             # Request a connection from the queue.
             conn = self._get_conn(timeout=pool_timeout)
-            conn.timeout = timeout_obj.connect_timeout  # type: ignore[assignment]
+            conn.timeout = Timeout.resolve_default_timeout(timeout_obj.connect_timeout)
 
             # Is this a closed/new connection that requires CONNECT tunnelling?
             if self.proxy is not None and http_tunnel_required and conn.is_closed:

--- a/test/test_connectionpool.py
+++ b/test/test_connectionpool.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import http.client as httplib
+import socket
 import ssl
 import typing
 from http.client import HTTPException
@@ -645,6 +646,34 @@ class TestConnectionPool:
                 timeout = Timeout(1, 1, 1)
                 with pytest.raises(ReadTimeoutError):
                     pool._make_request(conn, "", "", timeout=timeout)
+
+    @pytest.mark.parametrize("default_timeout", [None, 30.0])
+    def test_urlopen_resolves_default_connect_timeout(
+        self, default_timeout: float | None
+    ) -> None:
+        """``conn.timeout`` must never be handed the _DEFAULT_TIMEOUT sentinel.
+
+        ``Timeout().connect_timeout`` *is* the sentinel, and ``socket.settimeout``
+        rejects it with ``TypeError``. Resolve it the way ``_new_conn`` does.
+        """
+        old = socket.getdefaulttimeout()
+        socket.setdefaulttimeout(default_timeout)
+        try:
+            with HTTPConnectionPool(host="localhost", maxsize=1) as pool:
+                conn = Mock(spec=HTTPConnection)
+                conn.is_closed = False
+                conn.proxy = None
+                with (
+                    patch.object(pool, "_get_conn", return_value=conn),
+                    patch.object(
+                        pool, "_make_request", return_value=HTTPResponse(status=200)
+                    ),
+                ):
+                    pool.urlopen("GET", "/", retries=False)
+                assert conn.timeout == default_timeout
+                assert conn.timeout is not _DEFAULT_TIMEOUT
+        finally:
+            socket.setdefaulttimeout(old)
 
     @pytest.mark.parametrize(
         "path",


### PR DESCRIPTION
Found while checking whether #3595 still reproduces on 2.x. **It does not** — I posted the measurement on the issue — but this is the assignment that would bring it back, so it seemed worth tidying while the context was fresh.

### The inconsistency

Two places assign a connect timeout onto a connection. One resolves the sentinel, the other does not:

```python
# connectionpool.py:459, in _new_conn()
conn.timeout = Timeout.resolve_default_timeout(timeout_obj.connect_timeout)

# connectionpool.py:768, in urlopen()
conn.timeout = timeout_obj.connect_timeout  # type: ignore[assignment]
```

`Timeout().connect_timeout` **is** the sentinel — that is its documented return value ("a positive float or integer, the value None, or the default system timeout"):

```python
>>> Timeout().connect_timeout
<_TYPE_DEFAULT.token: -1>
```

and `settimeout` will not take it:

```python
>>> sock.settimeout(_DEFAULT_TIMEOUT)
TypeError: 'urllib3.util.timeout._TYPE_DEFAULT' object cannot be interpreted as an integer or float
```

### Why nothing is broken today

`_make_request()` overwrites `conn.timeout` with the resolved read timeout before the socket is touched, so the sentinel never survives to a `settimeout()`. I verified that rather than assuming it, by instrumenting `HTTPConnection.request` against a local server across two requests so the second reuses the socket:

```
request() sees self.timeout = None    is sentinel? False
request() sees self.timeout = None    is sentinel? False
```

**So this is a latent inconsistency, not a live bug.** I did not want to overstate it.

What is real is that `conn.timeout` briefly holds a value its own type does not allow — which is precisely what the `type: ignore[assignment]` was suppressing, since `connect_timeout` is `_TYPE_TIMEOUT` and `conn.timeout` is `float | None`. Resolving at the assignment site removes the ignore rather than silencing the checker.

It also makes the two paths agree on `socket.setdefaulttimeout()`:

```python
socket.setdefaulttimeout(30)
Timeout().connect_timeout                                  # <_TYPE_DEFAULT.token: -1>
Timeout.resolve_default_timeout(Timeout().connect_timeout) # 30.0
```

### Verification

The test fails without the change — checked by restoring the old line:

```
FAILED test_urlopen_resolves_default_connect_timeout[None]
FAILED test_urlopen_resolves_default_connect_timeout[30.0]
2 failed
```

and passes with it, parametrised over `setdefaulttimeout()` unset and set. Full local suite (minus the dummyserver/contrib groups needing extra services): **1455 passed, 21 skipped**. `mypy -p urllib3` and `mypy -p test` report nothing in either changed file; `black`, `isort`, `flake8` clean.

Filed as `.misc` rather than `.bugfix` since no user-visible behaviour changes today. Happy to drop the changelog entry entirely if you would rather not spend a line on it.
