### PR TITLE
Fix pyOpenSSL context reuse for multiple connections

### DIFF
--- a/changelog/5107.bugfix.rst
+++ b/changelog/5107.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed ``urllib3.contrib.pyopenssl`` failing to reuse an SSL context for
+multiple connections with pyOpenSSL 26.2.0+.

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -1007,7 +1007,9 @@ def _ssl_wrap_socket_and_match_hostname(
     else:
         context = ssl_context
 
-    context.verify_mode = resolve_cert_reqs(cert_reqs)
+    verify_mode = resolve_cert_reqs(cert_reqs)
+    if context.verify_mode != verify_mode:
+        context.verify_mode = verify_mode
 
     # In some cases, we want to verify hostnames ourselves
     if (

--- a/src/urllib3/contrib/pyopenssl.py
+++ b/src/urllib3/contrib/pyopenssl.py
@@ -442,6 +442,7 @@ class PyOpenSSLContext:
         self._minimum_version: int = ssl.TLSVersion.MINIMUM_SUPPORTED
         self._maximum_version: int = ssl.TLSVersion.MAXIMUM_SUPPORTED
         self._verify_flags: int = ssl.VERIFY_X509_TRUSTED_FIRST
+        self._alpn_protocols: list[bytes] | None = None
 
     @property
     def options(self) -> int:
@@ -523,8 +524,11 @@ class PyOpenSSLContext:
             raise ssl.SSLError(f"Unable to load certificate chain: {e!r}") from e
 
     def set_alpn_protocols(self, protocols: list[bytes | str]) -> None:
-        protocols = [util.util.to_bytes(p, "ascii") for p in protocols]
-        return self._ctx.set_alpn_protos(protocols)  # type: ignore[arg-type]
+        protocols_bytes = [util.util.to_bytes(p, "ascii") for p in protocols]
+        if protocols_bytes == self._alpn_protocols:
+            return
+        self._ctx.set_alpn_protos(protocols_bytes)
+        self._alpn_protocols = protocols_bytes
 
     def wrap_socket(
         self,

--- a/test/contrib/test_pyopenssl.py
+++ b/test/contrib/test_pyopenssl.py
@@ -1,9 +1,14 @@
 from __future__ import annotations
 
 import os
+import ssl
+from test.conftest import ServerConfig
 from unittest import mock
 
 import pytest
+
+from urllib3 import HTTPSConnectionPool
+from urllib3.util import ssl_
 
 try:
     from cryptography import x509
@@ -99,3 +104,29 @@ class TestPyOpenSSLHelpers:
 
         assert mock_warning.call_count == 1
         assert isinstance(mock_warning.call_args[0][1], x509.DuplicateExtension)
+
+
+def test_reuse_ssl_context_for_multiple_connections(san_server: ServerConfig) -> None:
+    """
+    Ensure one PyOpenSSL context can establish multiple simultaneous
+    connections.
+    """
+    context = ssl_.create_urllib3_context(cert_reqs=ssl.CERT_REQUIRED)
+    context.load_verify_locations(san_server.ca_certs)
+    pool = HTTPSConnectionPool(
+        san_server.host,
+        san_server.port,
+        cert_reqs="CERT_REQUIRED",
+        ssl_context=context,
+        maxsize=1,
+    )
+    first_response = pool.request("GET", "/", preload_content=False, release_conn=False)
+    assert first_response.status == 200
+    try:
+        second_response = pool.request("GET", "/")
+        second_response.release_conn()
+    finally:
+        first_response.release_conn()
+        pool.close()
+    assert second_response.status == 200
+    assert pool.num_connections == 2


### PR DESCRIPTION
Fixes #5107 by preventing unneeded mutations to a pyOpenSSL context in `_ssl_wrap_socket_and_match_hostname` and `ssl_wrap_socket`.