### PR TITLE
Fix reusable pyOpenSSL contexts with pyOpenSSL 26.2.0+

### DIFF
--- a/changelog/5107.bugfix.rst
+++ b/changelog/5107.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed ``urllib3.contrib.pyopenssl`` to allow reusing an SSL context across
+multiple connections with pyOpenSSL 26.2.0+.

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -1007,8 +1007,6 @@ def _ssl_wrap_socket_and_match_hostname(
     else:
         context = ssl_context
 
-    context.verify_mode = resolve_cert_reqs(cert_reqs)
-
     # In some cases, we want to verify hostnames ourselves
     if (
         # `ssl` can't verify fingerprints or alternate hostnames
@@ -1053,6 +1051,7 @@ def _ssl_wrap_socket_and_match_hostname(
         ca_certs=ca_certs,
         ca_cert_dir=ca_cert_dir,
         ca_cert_data=ca_cert_data,
+        cert_reqs=resolve_cert_reqs(cert_reqs),
         server_hostname=server_hostname,
         ssl_context=context,
         tls_in_tls=tls_in_tls,

--- a/src/urllib3/contrib/pyopenssl.py
+++ b/src/urllib3/contrib/pyopenssl.py
@@ -55,6 +55,7 @@ except ImportError:
 
 import logging
 import ssl
+import threading
 import typing
 from socket import socket as socket_cls
 
@@ -89,6 +90,13 @@ _stdlib_to_openssl_verify = {
     + OpenSSL.SSL.VERIFY_FAIL_IF_NO_PEER_CERT,
 }
 _openssl_to_stdlib_verify = {v: k for k, v in _stdlib_to_openssl_verify.items()}
+
+_PYOPENSSL_VERSION = tuple(
+    int(part) for part in OpenSSL.__version__.split(".", maxsplit=2)[:2]
+)
+
+# pyOpenSSL 26.2.0+ rejects every Context mutation after first use.
+_PYOPENSSL_CONTEXT_IS_IMMUTABLE = _PYOPENSSL_VERSION >= (26, 2)
 
 # The SSLvX values are the most likely to be missing in the future
 # but we check them all just to be sure.
@@ -436,6 +444,8 @@ class PyOpenSSLContext:
     to calls into PyOpenSSL.
     """
 
+    _urllib3_context_is_immutable = _PYOPENSSL_CONTEXT_IS_IMMUTABLE
+
     def __init__(self, protocol: int) -> None:
         self.protocol = _openssl_versions[protocol]
         self._ctx = OpenSSL.SSL.Context(self.protocol)
@@ -444,6 +454,10 @@ class PyOpenSSLContext:
         self._minimum_version: int = ssl.TLSVersion.MINIMUM_SUPPORTED
         self._maximum_version: int = ssl.TLSVersion.MAXIMUM_SUPPORTED
         self._verify_flags: int = ssl.VERIFY_X509_TRUSTED_FIRST
+        # Serialize urllib3's one-time setup with first Connection creation and
+        # remember its inputs so later connections can avoid mutating the context.
+        self._urllib3_lock = threading.RLock()
+        self._urllib3_configuration: util.ssl_._SSLContextConfig | None = None
 
     @property
     def options(self) -> int:
@@ -508,9 +522,9 @@ class PyOpenSSLContext:
                 if not isinstance(password, bytes):
                     password = password.encode("utf-8")
                 # pyOpenSSL added cryptography-key support in 24.3.0.
-                # Keep using the older password-callback path until 2026's
-                # versions because set_passwd_cb() became deprecated in 26.3.0.
-                if int(OpenSSL.__version__.split(".")[0]) >= 26:
+                # Keep using the older password-callback path until
+                # set_passwd_cb() became deprecated in 26.3.0.
+                if _PYOPENSSL_VERSION >= (26, 3):
                     with open(keyfile or certfile, "rb") as key_file:
                         private_key = load_pem_private_key(key_file.read(), password)
                     # cryptography's loader returns a wider private-key union
@@ -537,6 +551,53 @@ class PyOpenSSLContext:
         server_hostname: bytes | str | None = None,
     ) -> WrappedSocket:
         cnx = OpenSSL.SSL.Connection(self._ctx, sock)
+        return self._wrap_socket(cnx, sock, server_hostname)
+
+    def _urllib3_wrap_socket(
+        self,
+        sock: socket_cls,
+        server_hostname: bytes | str | None,
+        configuration: util.ssl_._SSLContextConfig,
+    ) -> WrappedSocket:
+        """
+        Configure an immutable context and create a Connection atomically.
+
+        pyOpenSSL 26.2.0+ freezes a Context as soon as a Connection is created.
+        Holding the lock across both operations prevents another thread from
+        freezing a partially configured context. Identical later configurations
+        skip setup; incompatible reuse is rejected explicitly.
+        """
+        with self._urllib3_lock:
+            if self._urllib3_configuration is None:
+                if getattr(self._ctx, "_used", False):
+                    raise ValueError(
+                        "Cannot configure a pyOpenSSL context that was already used "
+                        "outside urllib3"
+                    )
+                util.ssl_._configure_context(
+                    typing.cast("ssl.SSLContext", self), configuration
+                )
+            elif self._urllib3_configuration != configuration:
+                raise ValueError(
+                    "Cannot reuse a pyOpenSSL context with a different urllib3 "
+                    "TLS configuration"
+                )
+
+            try:
+                cnx = OpenSSL.SSL.Connection(self._ctx, sock)
+            finally:
+                if getattr(self._ctx, "_used", False):
+                    self._urllib3_configuration = configuration
+
+        # Handshakes don't mutate the Context and can proceed concurrently.
+        return self._wrap_socket(cnx, sock, server_hostname)
+
+    def _wrap_socket(
+        self,
+        cnx: OpenSSL.SSL.Connection,
+        sock: socket_cls,
+        server_hostname: bytes | str | None,
+    ) -> WrappedSocket:
 
         # If server_hostname is an IP, don't use it for SNI, per RFC6066 Section 3
         if server_hostname and not util.ssl_.is_ipaddress(server_hostname):

--- a/src/urllib3/util/ssl_.py
+++ b/src/urllib3/util/ssl_.py
@@ -324,6 +324,78 @@ def create_urllib3_context(
     return context
 
 
+class _SSLContextConfig(typing.NamedTuple):
+    """
+    TLS context mutations urllib3 applies before wrapping a socket.
+
+    Keeping these inputs in a comparable value lets immutable TLS backends skip
+    repeated setup for the same configuration and reject incompatible reuse.
+    """
+
+    cert_reqs: int | None
+    ca_certs: str | None
+    ca_cert_dir: str | None
+    ca_cert_data: None | str | bytes
+    certfile: str | None
+    keyfile: str | None
+    key_password: str | None
+    load_default_certs: bool
+    alpn_protocols: tuple[str, ...]
+
+
+def _configure_context(
+    context: ssl.SSLContext, configuration: _SSLContextConfig
+) -> None:
+    """
+    Apply urllib3's connection-level TLS configuration to a context.
+
+    This is shared by the normal wrapping path and backends which must perform
+    all context mutations atomically before creating their first connection.
+    """
+
+    if configuration.cert_reqs is not None:
+        context.verify_mode = typing.cast("ssl.VerifyMode", configuration.cert_reqs)
+
+    if (
+        configuration.ca_certs
+        or configuration.ca_cert_dir
+        or configuration.ca_cert_data
+    ):
+        try:
+            context.load_verify_locations(
+                configuration.ca_certs,
+                configuration.ca_cert_dir,
+                configuration.ca_cert_data,
+            )
+        except OSError as e:
+            raise SSLError(e) from e
+    elif configuration.load_default_certs and hasattr(context, "load_default_certs"):
+        # try to load OS default certs; works well on Windows.
+        context.load_default_certs()
+
+    # Attempt to detect if we get the goofy behavior of the
+    # keyfile being encrypted and OpenSSL asking for the
+    # passphrase via the terminal and instead error out.
+    if (
+        configuration.keyfile
+        and configuration.key_password is None
+        and _is_key_file_encrypted(configuration.keyfile)
+    ):
+        raise SSLError("Client private key is encrypted, password is required")
+
+    if configuration.certfile:
+        if configuration.key_password is None:
+            context.load_cert_chain(configuration.certfile, configuration.keyfile)
+        else:
+            context.load_cert_chain(
+                configuration.certfile,
+                configuration.keyfile,
+                configuration.key_password,
+            )
+
+    context.set_alpn_protocols(list(configuration.alpn_protocols))
+
+
 @typing.overload
 def ssl_wrap_socket(
     sock: socket.socket,
@@ -406,29 +478,36 @@ def ssl_wrap_socket(
         # We should consider deprecating and removing this code.
         context = create_urllib3_context(ssl_version, cert_reqs, ciphers=ciphers)
 
-    if ca_certs or ca_cert_dir or ca_cert_data:
-        try:
-            context.load_verify_locations(ca_certs, ca_cert_dir, ca_cert_data)
-        except OSError as e:
-            raise SSLError(e) from e
+    configuration = _SSLContextConfig(
+        cert_reqs=cert_reqs,
+        ca_certs=ca_certs,
+        ca_cert_dir=ca_cert_dir,
+        ca_cert_data=ca_cert_data,
+        certfile=certfile,
+        keyfile=keyfile,
+        key_password=key_password,
+        load_default_certs=ssl_context is None,
+        alpn_protocols=tuple(ALPN_PROTOCOLS),
+    )
 
-    elif ssl_context is None and hasattr(context, "load_default_certs"):
-        # try to load OS default certs; works well on Windows.
-        context.load_default_certs()
+    # pyOpenSSL 26.2.0+ freezes a context when its first Connection is created.
+    # Let that backend keep setup and Connection creation in one atomic operation.
+    urllib3_wrap_socket = getattr(context, "_urllib3_wrap_socket", None)
+    if (
+        getattr(context, "_urllib3_context_is_immutable", False) is True
+        and urllib3_wrap_socket is not None
+        and not tls_in_tls
+    ):
+        return typing.cast(
+            "ssl.SSLSocket | SSLTransportType",
+            urllib3_wrap_socket(
+                sock,
+                server_hostname=server_hostname,
+                configuration=configuration,
+            ),
+        )
 
-    # Attempt to detect if we get the goofy behavior of the
-    # keyfile being encrypted and OpenSSL asking for the
-    # passphrase via the terminal and instead error out.
-    if keyfile and key_password is None and _is_key_file_encrypted(keyfile):
-        raise SSLError("Client private key is encrypted, password is required")
-
-    if certfile:
-        if key_password is None:
-            context.load_cert_chain(certfile, keyfile)
-        else:
-            context.load_cert_chain(certfile, keyfile, key_password)
-
-    context.set_alpn_protocols(ALPN_PROTOCOLS)
+    _configure_context(context, configuration)
 
     ssl_sock = _ssl_wrap_socket_impl(sock, context, tls_in_tls, server_hostname)
     return ssl_sock

--- a/test/contrib/test_pyopenssl.py
+++ b/test/contrib/test_pyopenssl.py
@@ -1,15 +1,24 @@
 from __future__ import annotations
 
 import os
+import ssl
+import threading
 from unittest import mock
 
 import pytest
 
 try:
+    import OpenSSL.SSL
     from cryptography import x509
     from OpenSSL.crypto import FILETYPE_PEM, load_certificate
 
-    from urllib3.contrib.pyopenssl import _dnsname_to_stdlib, get_subj_alt_name
+    from urllib3.contrib.pyopenssl import (
+        _PYOPENSSL_CONTEXT_IS_IMMUTABLE,
+        PyOpenSSLContext,
+        _dnsname_to_stdlib,
+        get_subj_alt_name,
+    )
+    from urllib3.util import ssl_ as ssl_util
 except ImportError:
     pass
 
@@ -99,3 +108,164 @@ class TestPyOpenSSLHelpers:
 
         assert mock_warning.call_count == 1
         assert isinstance(mock_warning.call_args[0][1], x509.DuplicateExtension)
+
+
+class TestPyOpenSSLContext:
+    def context(self) -> PyOpenSSLContext:
+        return PyOpenSSLContext(ssl.PROTOCOL_TLS_CLIENT)
+
+    def configuration(self) -> ssl_util._SSLContextConfig:
+        return ssl_util._SSLContextConfig(
+            cert_reqs=ssl.CERT_REQUIRED,
+            ca_certs=None,
+            ca_cert_dir=None,
+            ca_cert_data=None,
+            certfile=None,
+            keyfile=None,
+            key_password=None,
+            load_default_certs=False,
+            alpn_protocols=("http/1.1",),
+        )
+
+    @pytest.mark.skipif(
+        not _PYOPENSSL_CONTEXT_IS_IMMUTABLE,
+        reason="requires immutable pyOpenSSL contexts",
+    )
+    def test_same_configuration_is_set_up_once(self) -> None:
+        context = self.context()
+        configuration = self.configuration()
+
+        with (
+            mock.patch(
+                "urllib3.util.ssl_._configure_context",
+                wraps=ssl_util._configure_context,
+            ) as configure_context,
+            mock.patch.object(context, "_wrap_socket", return_value=mock.sentinel.sock),
+        ):
+            first = context._urllib3_wrap_socket(
+                None, None, configuration  # type: ignore[arg-type]
+            )
+            second = context._urllib3_wrap_socket(
+                None, None, configuration  # type: ignore[arg-type]
+            )
+
+        assert first is mock.sentinel.sock
+        assert second is mock.sentinel.sock
+        configure_context.assert_called_once_with(context, configuration)
+
+    @pytest.mark.skipif(
+        not _PYOPENSSL_CONTEXT_IS_IMMUTABLE,
+        reason="requires immutable pyOpenSSL contexts",
+    )
+    def test_different_configuration_is_rejected(self) -> None:
+        context = self.context()
+        first_configuration = self.configuration()
+        second_configuration = first_configuration._replace(cert_reqs=ssl.CERT_NONE)
+
+        with (
+            mock.patch(
+                "urllib3.util.ssl_._configure_context",
+                wraps=ssl_util._configure_context,
+            ) as configure_context,
+            mock.patch.object(context, "_wrap_socket", return_value=mock.sentinel.sock),
+        ):
+            context._urllib3_wrap_socket(
+                None, None, first_configuration  # type: ignore[arg-type]
+            )
+            with pytest.raises(ValueError, match="different urllib3 TLS configuration"):
+                context._urllib3_wrap_socket(
+                    None, None, second_configuration  # type: ignore[arg-type]
+                )
+
+        configure_context.assert_called_once_with(context, first_configuration)
+
+    @pytest.mark.skipif(
+        not _PYOPENSSL_CONTEXT_IS_IMMUTABLE,
+        reason="requires immutable pyOpenSSL contexts",
+    )
+    def test_context_used_outside_urllib3_is_rejected(self) -> None:
+        context = self.context()
+        OpenSSL.SSL.Connection(context._ctx, None)
+
+        with (
+            mock.patch("urllib3.util.ssl_._configure_context") as configure_context,
+            pytest.raises(ValueError, match="already used outside urllib3"),
+        ):
+            context._urllib3_wrap_socket(
+                None,  # type: ignore[arg-type]
+                None,
+                self.configuration(),
+            )
+
+        configure_context.assert_not_called()
+
+    def test_mutable_context_is_set_up_each_time(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        context = self.context()
+        monkeypatch.setattr(context, "_urllib3_context_is_immutable", False)
+
+        with (
+            mock.patch(
+                "urllib3.util.ssl_._configure_context",
+                wraps=ssl_util._configure_context,
+            ) as configure_context,
+            mock.patch(
+                "urllib3.util.ssl_._ssl_wrap_socket_impl",
+                return_value=mock.sentinel.sock,
+            ),
+        ):
+            ssl_util.ssl_wrap_socket(
+                mock.Mock(), ssl_context=context  # type: ignore[call-overload]
+            )
+            ssl_util.ssl_wrap_socket(
+                mock.Mock(), ssl_context=context  # type: ignore[call-overload]
+            )
+
+        assert configure_context.call_count == 2
+
+    @pytest.mark.skipif(
+        not _PYOPENSSL_CONTEXT_IS_IMMUTABLE,
+        reason="requires immutable pyOpenSSL contexts",
+    )
+    def test_setup_and_connection_creation_are_atomic(self) -> None:
+        context = self.context()
+        configuration = self.configuration()
+        setup_started = threading.Event()
+        release_setup = threading.Event()
+        second_finished = threading.Event()
+        errors: list[BaseException] = []
+
+        def setup(*_: object) -> None:
+            setup_started.set()
+            if not release_setup.wait(1):
+                raise AssertionError("Timed out waiting to release context setup")
+
+        def wrap(second: bool) -> None:
+            try:
+                context._urllib3_wrap_socket(
+                    None, None, configuration  # type: ignore[arg-type]
+                )
+            except BaseException as e:
+                errors.append(e)
+            finally:
+                if second:
+                    second_finished.set()
+
+        with (
+            mock.patch("urllib3.util.ssl_._configure_context", side_effect=setup),
+            mock.patch.object(context, "_wrap_socket", return_value=mock.sentinel.sock),
+        ):
+            first_thread = threading.Thread(target=wrap, args=(False,))
+            second_thread = threading.Thread(target=wrap, args=(True,))
+            first_thread.start()
+            assert setup_started.wait(1)
+            second_thread.start()
+            assert not second_finished.wait(0.1)
+            release_setup.set()
+            first_thread.join(1)
+            second_thread.join(1)
+
+        assert not first_thread.is_alive()
+        assert not second_thread.is_alive()
+        assert errors == []

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -1236,7 +1236,7 @@ class TestUtilSSL:
 
     def test_ssl_wrap_socket_loads_the_cert_chain(self) -> None:
         socket = Mock()
-        mock_context = Mock()
+        mock_context = Mock(spec=ssl.SSLContext)
         ssl_wrap_socket(
             ssl_context=mock_context, sock=socket, certfile="/path/to/certfile"
         )
@@ -1254,7 +1254,7 @@ class TestUtilSSL:
 
     def test_ssl_wrap_socket_loads_verify_locations(self) -> None:
         socket = Mock()
-        mock_context = Mock()
+        mock_context = Mock(spec=ssl.SSLContext)
         ssl_wrap_socket(ssl_context=mock_context, ca_certs="/path/to/pem", sock=socket)
         mock_context.load_verify_locations.assert_called_once_with(
             "/path/to/pem", None, None
@@ -1262,7 +1262,7 @@ class TestUtilSSL:
 
     def test_ssl_wrap_socket_loads_certificate_directories(self) -> None:
         socket = Mock()
-        mock_context = Mock()
+        mock_context = Mock(spec=ssl.SSLContext)
         ssl_wrap_socket(
             ssl_context=mock_context, ca_cert_dir="/path/to/pems", sock=socket
         )
@@ -1272,7 +1272,7 @@ class TestUtilSSL:
 
     def test_ssl_wrap_socket_loads_certificate_data(self) -> None:
         socket = Mock()
-        mock_context = Mock()
+        mock_context = Mock(spec=ssl.SSLContext)
         ssl_wrap_socket(
             ssl_context=mock_context, ca_cert_data="TOTALLY PEM DATA", sock=socket
         )
@@ -1283,7 +1283,7 @@ class TestUtilSSL:
     def _wrap_socket_and_mock_warn(
         self, sock: socket.socket, server_hostname: str | None
     ) -> tuple[Mock, MagicMock]:
-        mock_context = Mock()
+        mock_context = Mock(spec=ssl.SSLContext)
         with patch("warnings.warn") as warn:
             ssl_wrap_socket(
                 ssl_context=mock_context,

--- a/test/with_dummyserver/test_https.py
+++ b/test/with_dummyserver/test_https.py
@@ -1177,6 +1177,91 @@ class BaseTestHTTPS(HTTPSHypercornDummyServerTestCase):
                 == str(cm.value.reason)
             )
 
+    # pyOpenSSL 25.1.0 through 26.1.x warn when a Context is mutated after
+    # creating a Connection. pytest otherwise treats this warning as an error.
+    @pytest.mark.filterwarnings(
+        "ignore:Attempting to mutate a Context after a Connection was created"
+        ":DeprecationWarning"
+    )
+    def test_reusable_context_with_client_intermediate(self) -> None:
+        # 19.1.0 raised pyOpenSSL's minimum cryptography version to 2.8. The
+        # supported 19.0.0/cryptography 2.3 pair cannot complete this fixture's
+        # client-certificate handshake.
+        if util.IS_PYOPENSSL:
+            from urllib3.contrib.pyopenssl import _PYOPENSSL_VERSION
+
+            if _PYOPENSSL_VERSION < (19, 1):
+                pytest.skip("requires pyOpenSSL 19.1.0+")
+
+        context = util.ssl_.create_urllib3_context(
+            ssl_minimum_version=self.tls_version()
+        )
+        context.load_verify_locations(cafile=DEFAULT_CA)
+        pool = HTTPSConnectionPool(
+            self.host,
+            self.port,
+            ssl_context=context,
+            key_file=os.path.join(self.certs_dir, CLIENT_INTERMEDIATE_KEY),
+            cert_file=os.path.join(self.certs_dir, CLIENT_INTERMEDIATE_PEM),
+        )
+        with pool:
+            first_response = second_response = None
+            try:
+                first_response = pool.request(
+                    "GET",
+                    "/certificate",
+                    preload_content=False,
+                    release_conn=False,
+                )
+                second_response = pool.request("GET", "/certificate")
+                second_status = second_response.status
+                subject = second_response.json()
+                num_connections = pool.num_connections
+            finally:
+                if first_response is not None:
+                    first_response.close()
+                if second_response is not None:
+                    second_response.close()
+
+        assert second_status == 200
+        assert subject["organizationalUnitName"].startswith("Testing cert")
+        assert num_connections == 2
+
+    # pyOpenSSL 25.1.0 through 26.1.x warn when a Context is mutated after
+    # creating a Connection. pytest otherwise treats this warning as an error.
+    @pytest.mark.filterwarnings(
+        "ignore:Attempting to mutate a Context after a Connection was created"
+        ":DeprecationWarning"
+    )
+    def test_reusable_context_combines_with_ca_certs(self) -> None:
+        context = util.ssl_.create_urllib3_context(
+            cert_reqs=ssl.CERT_REQUIRED,
+            ssl_minimum_version=self.tls_version(),
+        )
+        pool = HTTPSConnectionPool(
+            self.host,
+            self.port,
+            ca_certs=DEFAULT_CA,
+            ssl_context=context,
+        )
+        with pool:
+            first_response = second_response = None
+            try:
+                first_response = pool.request(
+                    "GET", "/", preload_content=False, release_conn=False
+                )
+                second_response = pool.request("GET", "/")
+                second_status = second_response.status
+                num_connections = pool.num_connections
+            finally:
+                if first_response is not None:
+                    first_response.close()
+                if second_response is not None:
+                    second_response.close()
+
+        assert second_status == 200
+        assert num_connections == 2
+
 
 @pytest.mark.usefixtures("requires_tlsv1")
 class TestHTTPS_TLSv1(BaseTestHTTPS):


### PR DESCRIPTION
Fixes #5107

urllib3 repeats SSL context setup for every connection. This fails with pyOpenSSL 26.2.0+, where a context can no longer be mutated after it has created its first connection.

This change adds a private method to the pyOpenSSL context that applies configuration once, atomically with the first connection creation, and reuses it for subsequent connections with the same settings. It also adds coverage for reusable contexts with client certificate chains and custom CA certificates across supported pyOpenSSL versions.

An [alternative implementation](https://github.com/illia-v/urllib3/commit/443d92d02d3c1c89679efdc26ceced7358350c76) made each setup operation individually idempotent and added locking to every context mutation. However, it required substantially more changes and per-operation state tracking, while still not making the entire setup sequence atomic with connection creation. The selected approach keeps that compatibility logic contained in a single method.