### PR TITLE
Encode HTTP/2 header names and values with latin-1, matching HTTP/1.1

### DIFF
--- a/changelog/5138.bugfix.rst
+++ b/changelog/5138.bugfix.rst
@@ -1,0 +1,5 @@
+Fixed HTTP/2 requests encoding header names and values as UTF-8 while HTTP/1.1
+requests encode them as latin-1, which could put different bytes on the wire for
+the same request depending on the negotiated protocol version. Header values that
+cannot be encoded with latin-1 now raise ``UnicodeEncodeError`` over HTTP/2, as
+they already did over HTTP/1.1.

--- a/src/urllib3/http2/connection.py
+++ b/src/urllib3/http2/connection.py
@@ -142,13 +142,15 @@ class HTTP2Connection(HTTPSConnection):
 
     def putheader(self, header: str | bytes, *values: str | bytes) -> None:  # type: ignore[override]
         # TODO SKIPPABLE_HEADERS from urllib3 are ignored.
-        header = header.encode() if isinstance(header, str) else header
+        # Match the HTTP/1.1 path: http.client encodes header names and values
+        # with latin-1, so the same value must not reach the wire as UTF-8 here.
+        header = header.encode("latin-1") if isinstance(header, str) else header
         header = header.lower()  # A lot of upstream code uses capitalized headers.
         if not _is_legal_header_name(header):
             raise ValueError(f"Illegal header name {str(header)}")
 
         for value in values:
-            value = value.encode() if isinstance(value, str) else value
+            value = value.encode("latin-1") if isinstance(value, str) else value
             if _is_illegal_header_value(value):
                 raise ValueError(f"Illegal header value {str(value)}")
             self._headers.append((header, value))

--- a/test/test_http2_connection.py
+++ b/test/test_http2_connection.py
@@ -85,6 +85,20 @@ class TestHTTP2Connection:
         conn.putheader("foo", "bar")
         assert conn._headers == [(b"foo", b"bar")]
 
+    def test_putheader_str_values_use_latin1_like_http1(self) -> None:
+        # http.client encodes HTTP/1.1 header names and values with latin-1, so
+        # the same str must not reach the wire as UTF-8 over HTTP/2.
+        conn = HTTP2Connection("example.com")
+        conn.putheader("x-test", "Sch\u00f6nefeld/1.18.0")
+        assert conn._headers == [(b"x-test", b"Sch\xf6nefeld/1.18.0")]
+
+    def test_putheader_str_values_reject_what_http1_rejects(self) -> None:
+        # http.client raises UnicodeEncodeError for values outside latin-1;
+        # HTTP/2 used to silently send them as UTF-8 instead.
+        conn = HTTP2Connection("example.com")
+        with pytest.raises(UnicodeEncodeError):
+            conn.putheader("x-test", "\u2192")
+
     def test_request_putheader(self) -> None:
         conn = HTTP2Connection("example.com")
         conn.sock = mock.MagicMock(


### PR DESCRIPTION
### What

`src/urllib3/http2/connection.py` encodes header names and values with a bare `.encode()`, which is UTF-8. The HTTP/1.1 path goes through `http.client`, which encodes them with latin-1. The same request therefore puts different octets on the wire depending on the negotiated protocol version.

### Measured on unmodified main (`6276365`)

Same call, `headers={"x-test": "Schönefeld/1.18.0"}` (the value from #3072):

| path | octets of the value |
| --- | --- |
| HTTP/1.1 — real socket, raw request head | `536368 f6 6e6566656c642f312e31382e30` |
| HTTP/2 — real frames, HPACK-decoded with `raw=True` | `536368 c3b6 6e6566656c642f312e31382e30` |

An ASCII control value is byte-identical on both paths, so what differs is the codec, not the measuring rig.

The divergence also changes the *class* of outcome: `"→"` raises `UnicodeEncodeError` over HTTP/1.1 and is silently sent as `e28692` over HTTP/2.

This is reachable through the public API, not only by calling `putheader()` directly — `HTTP2Connection.request(headers={...})` produces the same UTF-8 octets.

### The change

Two `.encode()` calls become `.encode("latin-1")`. After it, all four measured values put identical octets on the wire on both paths.

Trade-off, stated plainly: values outside latin-1 now raise `UnicodeEncodeError` over HTTP/2, as they already do over HTTP/1.1. That is a behaviour change for code sending UTF-8 header values over HTTP/2 — but that code already breaks whenever the connection is not HTTP/2.

Deliberately out of scope: the `:authority` and `:path` pseudo-headers in `putrequest()` also use a bare `.encode()`. They are constrained by URL parsing and validation, so I did not widen the diff — glad to include them if you would prefer one change.

### Why this may matter beyond the bug itself

In #3072 @sethmlarson wrote "I'm not sure how exactly that would work internally", and in #3279 @pquentin wrote "we can do the right thing for HTTP/2, using the `header_encoding` h2 parameter, whatever the right thing is". Once both paths agree on latin-1, latin-1 is byte-transparent end to end: decoding a bytes value to `str` and re-encoding it on the way out is the identity over all 256 byte values (checked explicitly, unlike UTF-8, which cannot even decode 128 of them). That reduces the bytes-value question to a small, protocol-independent one.

This PR does **not** implement bytes values. The four open PRs for #3072 (#3279, #3792, #5006, #5114) all change `_collections.py` and are unaffected by this diff.

### Tests

Two tests added. Both fail on main and pass with the patch (checked by reverting only the source change and re-running). Full unit suite on my machine: 1427 passed, 51 skipped.

---

Disclosure: I am an AI-assisted contributor working openly as such. Every number above comes from a run I can hand over — the rig is a real TCP server for HTTP/1.1 and real h2 frames with HPACK decoding for HTTP/2, with an ASCII positive control. Happy to attach it or to adjust the scope of the change.
