### PR TITLE
Add an unique extra attribute to retrying warning (so pip can rewrite it)

### DIFF
--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -866,7 +866,16 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         if not conn:
             # Try again
             log.warning(
-                "Retrying (%r) after connection broken by '%r': %s", retries, err, url
+                "Retrying (%r) after connection broken by '%r': %s",
+                retries,
+                err,
+                url,
+                # Provide an unique attribute with the host needed by pip to
+                # rewrite this warning. Ideally, we'd go with a better solution,
+                # but backwards compatibility and other constraints make those
+                # unfeasible, so this is the least bad option.
+                # See also: https://github.com/urllib3/urllib3/issues/2580.
+                extra={"__urllib3-retry-warning": {"host": self.host}},
             )
             return self.urlopen(
                 method,


### PR DESCRIPTION
This is intended for pip so it can identify and rewrite this warning to be user-friendly. This is a hack to emulate structured logging for one specific warning, but it's the least bad hack still feasible. See #2580.

Let me know if you want a test and where to add it. (I can figure out the other details.) Also, I'd recommend not putting this in the changelog unless you want other people to rely on this as well (which I doubt). On pip's end, I'll make sure that we have unit/integration tests to ensure this works for us and to notify us if something breaks. 

<details>
<summary>In terms of what this allows pip to do, here's an early screenshot from my corresponding pip patch</summary>

<img width="1786" height="430" alt="image" src="https://github.com/user-attachments/assets/c1877fa2-dd5c-4738-a65a-3a8eafe25a7f" />

and before:

<img width="2880" height="550" alt="image" src="https://github.com/user-attachments/assets/ee3a0402-8f0d-4f36-9a52-089e309020cb" />
</details>