### PR TITLE
Reject invalid ASCII characters in URL hosts

### DIFF
--- a/changelog/5095.bugfix.rst
+++ b/changelog/5095.bugfix.rst
@@ -1,7 +1,10 @@
 Fixed URL parsing to more strictly enforce RFC 3986 host syntax, rejecting
-invalid host input such as raw spaces and control characters, malformed
-percent-encodings, and percent-encoded control characters in HTTP(S) hosts and
-IPv6 zone identifiers, including proxy CONNECT tunnel targets. Host
+invalid host input such as characters outside the registered-name grammar,
+raw spaces and control characters, malformed percent-encodings, and
+percent-encoded control characters in HTTP(S) hosts and IPv6 zone identifiers,
+including proxy CONNECT tunnel targets. Host
 normalization now also follows RFC 3986 normalization rules for percent-encoded
 octets by decoding percent-encoded unreserved characters and uppercasing the
 hexadecimal case of retained percent-encoded octets.
+
+TODO: mention both PRs #5095 and #5143 in the final changelog.

--- a/src/urllib3/util/url.py
+++ b/src/urllib3/util/url.py
@@ -20,7 +20,7 @@ _SCHEME_RE = re.compile(r"^(?:[a-zA-Z][a-zA-Z0-9+-]*:|/)")
 _HOST_INVALID_CHAR_RE = re.compile(r"[\x00-\x20\x7f]")
 _URI_RE = re.compile(
     r"^(?:([a-zA-Z][a-zA-Z0-9+.-]*):)?"
-    r"(?://([^\\/?#]*))?"
+    r"(?://([^/?#]*))?"
     r"([^?#]*)"
     r"(?:\?([^#]*))?"
     r"(?:#(.*))?$",
@@ -56,7 +56,13 @@ _UNRESERVED_PAT = r"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz01234567
 _IPV6_PAT = "(?:" + "|".join([x % _subs for x in _variations]) + ")"
 _ZONE_ID_PAT = "(?:%25|%)(?:[" + _UNRESERVED_PAT + "]|%[a-fA-F0-9]{2})+"
 _IPV6_ADDRZ_PAT = r"\[" + _IPV6_PAT + r"(?:" + _ZONE_ID_PAT + r")?\]"
-_REG_NAME_PAT = r"(?:[^\[\]%:/?#]|%[a-fA-F0-9]{2})*"
+_SUB_DELIM_PAT = "!$&'()*+,;="
+# RFC 3986 section 3.2.2 allows only unreserved characters, percent-encoded
+# octets, and sub-delimiters in a registered name. We additionally accept
+# non-ASCII characters so they can be normalized to IDNA by _normalize_host().
+_REG_NAME_PAT = (
+    rf"(?:[{_UNRESERVED_PAT}{_SUB_DELIM_PAT}]|[^\x00-\x7f]|%[a-fA-F0-9]{{2}})*"
+)
 _TARGET_RE = re.compile(r"^(/[^?#]*)(?:\?([^#]*))?(?:#.*)?$")
 
 _IPV4_RE = re.compile(
@@ -77,7 +83,7 @@ _HOST_PORT_RE = re.compile(_HOST_PORT_PAT, re.UNICODE | re.DOTALL)
 _UNRESERVED_CHARS = set(
     "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789._-~"
 )
-_SUB_DELIM_CHARS = set("!$&'()*+,;=")
+_SUB_DELIM_CHARS = set(_SUB_DELIM_PAT)
 _USERINFO_CHARS = _UNRESERVED_CHARS | _SUB_DELIM_CHARS | {":"}
 _PATH_CHARS = _USERINFO_CHARS | {"@", "/"}
 _QUERY_CHARS = _FRAGMENT_CHARS = _PATH_CHARS | {"?"}

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -252,6 +252,17 @@ class TestUtil:
             parse_url(url_template.format(char))
 
     @pytest.mark.parametrize(
+        "url_template",
+        ["http://victim.example{}Injected/path", "victim.example{}Injected"],
+    )
+    @pytest.mark.parametrize("char", ['"', "<", ">", "\\", "^", "`", "{", "|", "}"])
+    def test_non_rfc3986_ascii_characters_in_host_raise(
+        self, url_template: str, char: str
+    ) -> None:
+        with pytest.raises(LocationParseError, match="is not a valid host or port"):
+            parse_url(url_template.format(char))
+
+    @pytest.mark.parametrize(
         "url, expected_host",
         [
             ("http://Königsgäßchen.de/path", "xn--knigsgchen-b4a3dun.de"),
@@ -665,14 +676,7 @@ class TestUtil:
         # See https://bugs.xdavidhu.me/google/2020/03/08/the-unexpected-google-wide-domain-check-bypass/
         (
             "https://user:pass@xdavidhu.me\\test.corp.google.com:8080/path/to/something?param=value#hash",
-            Url(
-                scheme="https",
-                auth="user:pass",
-                host="xdavidhu.me",
-                path="/%5Ctest.corp.google.com:8080/path/to/something",
-                query="param=value",
-                fragment="hash",
-            ),
+            False,
         ),
         # Tons of '@' causing backtracking
         pytest.param(

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -234,6 +234,16 @@ class TestUtil:
             fragment="fragment" + percent_char,
         )
 
+    def test_backslash_in_userinfo_is_percent_encoded(self) -> None:
+        parsed_url = parse_url("http://domain\\user:password@proxy.example:8080")
+        assert parsed_url == Url(
+            scheme="http",
+            auth="domain%5Cuser:password",
+            host="proxy.example",
+            port=8080,
+        )
+        assert parsed_url.auth_decoded == ("domain\\user", "password")
+
     @pytest.mark.parametrize(
         "url_template",
         [


### PR DESCRIPTION
This is a follow-up to #5095 that addresses an additional URL-parsing issue identified during that work and previously preserved by a unit test.

This change effectively reverts the parsing behavior introduced in #1845. A backslash is no longer treated as an authority terminator. Instead, urllib3 follows [RFC 3986 §3.2.2](https://datatracker.ietf.org/doc/html/rfc3986#section-3.2.2) more closely and rejects the malformed hostname covered by #1845.

URLs containing a backslash before `@` are now parsed differently. For example, `https://one.com\@two.com/path`:
- before: `Url(scheme='https', auth=None, host='one.com', port=None, path='/%5C@two.com/path', query=None, fragment=None)`
- after: `Url(scheme='https', auth='one.com%5C', host='two.com', port=None, path='/path', query=None, fragment=None)`

The new result matches trurl and Python’s `urllib.parse.urlparse`, although it differs from the recovery behavior defined by the WHATWG URL Standard and used by browsers.

This is an intentional compatibility change. It may affect users who rely on urllib3's previous interpretation of malformed URLs containing raw backslashes, but the impact is expected to be limited. The new behavior is preferable because it:
- removes urllib3's non-standard treatment of `\` as an authority delimiter
- aligns urllib3 with RFC 3986 component boundaries and other commonly used Python and command-line URL parsers
- supports backslashes in user information by percent-encoding them instead of misclassifying the preceding text as the hostname
- reduces parser inconsistencies that could otherwise lead applications to disagree about a URL's hostname

This also fixes #1963, allowing Windows-style domain credentials in proxy URLs to be parsed as user information rather than as part of the hostname.

The closer alignment with `urllib.parse.urlparse` provides a defense-in-depth benefit for applications that compare parser results or perform hostname-based checks. However, `parse_url()` is not intended to be a URL-security-validation API. This change is therefore treated as a parsing correctness and compatibility fix rather than a standalone security issue.