### PR TITLE
Late-bind ConnectionPool.QueueCls for queue monkey-patching

### DIFF
--- a/changelog/3289.bugfix.rst
+++ b/changelog/3289.bugfix.rst
@@ -1,0 +1,8 @@
+Fixed default connection pools to resolve ``queue.LifoQueue`` at pool creation
+time instead of caching the class at import time.
+
+``ConnectionPool.QueueCls`` now defaults to ``None``, which means "use the current
+``queue.LifoQueue`` when the pool is created". Set ``QueueCls`` to a concrete
+class to force a specific queue implementation. This allows post-import
+monkey-patching of the ``queue`` module (for example by gevent) to take effect
+for default pools.

--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -76,7 +76,13 @@ class ConnectionPool:
     """
 
     scheme: str | None = None
-    QueueCls = queue.LifoQueue
+    #: Queue class used for the connection pool. The default ``None`` means
+    #: resolve ``queue.LifoQueue`` at pool creation time so monkey-patching of
+    #: the ``queue`` module (for example by gevent) is honored. This is a
+    #: deliberate API change from earlier versions that cached
+    #: ``queue.LifoQueue`` on the class at import time. Override with a concrete
+    #: class to force a specific queue implementation.
+    QueueCls: type[queue.LifoQueue[typing.Any]] | None = None
 
     def __init__(self, host: str, port: int | None = None) -> None:
         if not host:
@@ -111,6 +117,18 @@ class ConnectionPool:
         """
         Close all pooled connections and disable the pool.
         """
+
+    def _make_queue(
+        self, *args: typing.Any, **kwargs: typing.Any
+    ) -> queue.LifoQueue[typing.Any]:
+        """Create the pool queue, late-binding the default class.
+
+        When :attr:`QueueCls` is ``None``, look up ``queue.LifoQueue`` at call
+        time so a monkey-patched queue module is used. Explicit ``QueueCls``
+        overrides are always respected.
+        """
+        queue_cls = self.QueueCls if self.QueueCls is not None else queue.LifoQueue
+        return queue_cls(*args, **kwargs)
 
 
 # This is taken from http://hg.python.org/cpython/file/7aaba721ebc0/Lib/socket.py#l252
@@ -198,7 +216,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         self.timeout = timeout
         self.retries = retries
 
-        self.pool: queue.LifoQueue[typing.Any] | None = self.QueueCls(maxsize)
+        self.pool: queue.LifoQueue[typing.Any] | None = self._make_queue(maxsize)
         self.block = block
 
         self.proxy = _proxy

--- a/test/test_connectionpool.py
+++ b/test/test_connectionpool.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 import http.client as httplib
+import queue
 import ssl
+import subprocess
+import sys
 import typing
 from http.client import HTTPException
 from queue import Empty
@@ -16,6 +19,7 @@ from dummyserver.socketserver import DEFAULT_CA
 from urllib3 import Retry
 from urllib3.connection import HTTPConnection
 from urllib3.connectionpool import (
+    ConnectionPool,
     HTTPConnectionPool,
     HTTPSConnectionPool,
     _url_from_pool,
@@ -740,3 +744,155 @@ class TestConnectionPool:
 
         assert response.status == 200
         assert requested_urls == ["/", "http://localhost/next?x=1"]
+
+    def test_default_pool_uses_stdlib_lifoqueue_without_monkeypatch(self) -> None:
+        assert ConnectionPool.QueueCls is None
+
+        with HTTPConnectionPool(host="localhost", maxsize=1) as pool:
+            assert pool.pool is not None
+            assert type(pool.pool) is queue.LifoQueue
+            assert type(pool.pool).__module__ == "queue"
+
+        with HTTPSConnectionPool(host="localhost", maxsize=1) as https_pool:
+            assert https_pool.pool is not None
+            assert type(https_pool.pool) is queue.LifoQueue
+            assert type(https_pool.pool).__module__ == "queue"
+
+    def test_default_queue_resolves_lifoqueue_at_pool_creation(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Default pools must pick up a LifoQueue replaced after urllib3 import."""
+
+        class PatchedLifoQueue(queue.LifoQueue[typing.Any]):
+            pass
+
+        assert ConnectionPool.QueueCls is None
+        monkeypatch.setattr(queue, "LifoQueue", PatchedLifoQueue)
+
+        with HTTPConnectionPool(host="localhost", maxsize=1) as pool:
+            assert pool.pool is not None
+            assert type(pool.pool) is PatchedLifoQueue
+            # Pool was pre-filled with None sentinels and remains usable.
+            assert pool.pool.qsize() == 1
+            assert pool.pool.get(block=False) is None
+            pool.pool.put(None)
+
+        with HTTPSConnectionPool(host="localhost", maxsize=2) as https_pool:
+            assert https_pool.pool is not None
+            assert type(https_pool.pool) is PatchedLifoQueue
+            assert https_pool.pool.qsize() == 2
+
+    def test_late_bound_default_queue_receives_maxsize(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        created: list[tuple[tuple[typing.Any, ...], dict[str, typing.Any]]] = []
+
+        class RecordingQueue(queue.LifoQueue[typing.Any]):
+            def __init__(self, *args: typing.Any, **kwargs: typing.Any) -> None:
+                created.append((args, kwargs))
+                super().__init__(*args, **kwargs)
+
+        monkeypatch.setattr(queue, "LifoQueue", RecordingQueue)
+
+        with HTTPConnectionPool(host="localhost", maxsize=3) as pool:
+            assert pool.pool is not None
+            assert type(pool.pool) is RecordingQueue
+
+        assert created == [((3,), {})]
+
+    def test_custom_queue_class_override_is_respected(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        class CustomLifoQueue(queue.LifoQueue[typing.Any]):
+            pass
+
+        class PatchedLifoQueue(queue.LifoQueue[typing.Any]):
+            pass
+
+        class CustomQueueHTTPConnectionPool(HTTPConnectionPool):
+            QueueCls = CustomLifoQueue
+
+        monkeypatch.setattr(queue, "LifoQueue", PatchedLifoQueue)
+
+        with CustomQueueHTTPConnectionPool(host="localhost", maxsize=1) as pool:
+            assert pool.pool is not None
+            assert type(pool.pool) is CustomLifoQueue
+
+    def test_runtime_queuecls_assignment_and_reset(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        class RuntimeCustomQueue(queue.LifoQueue[typing.Any]):
+            pass
+
+        class PatchedLifoQueue(queue.LifoQueue[typing.Any]):
+            pass
+
+        original_queue_cls = HTTPConnectionPool.QueueCls
+        try:
+            HTTPConnectionPool.QueueCls = RuntimeCustomQueue
+            with HTTPConnectionPool(host="localhost", maxsize=1) as pool:
+                assert pool.pool is not None
+                assert type(pool.pool) is RuntimeCustomQueue
+
+            # Resetting to None restores late binding to queue.LifoQueue.
+            HTTPConnectionPool.QueueCls = None
+            monkeypatch.setattr(queue, "LifoQueue", PatchedLifoQueue)
+            with HTTPConnectionPool(host="localhost", maxsize=1) as pool:
+                assert pool.pool is not None
+                assert type(pool.pool) is PatchedLifoQueue
+        finally:
+            if original_queue_cls is None:
+                if "QueueCls" in HTTPConnectionPool.__dict__:
+                    delattr(HTTPConnectionPool, "QueueCls")
+            else:
+                HTTPConnectionPool.QueueCls = original_queue_cls
+
+    def test_gevent_patch_after_import_uses_gevent_lifoqueue(self) -> None:
+        """Exact #3289 scenario: import urllib3, then gevent patches queue.
+
+        Runs in a subprocess so gevent monkey-patching cannot contaminate the
+        rest of the suite. Skips when gevent is not installed.
+        """
+        pytest.importorskip("gevent")
+
+        script = """
+import queue
+import urllib3.connectionpool  # noqa: F401  -- import before patching
+from urllib3.connectionpool import HTTPConnectionPool, HTTPSConnectionPool
+
+stdlib_lifo_queue = queue.LifoQueue
+
+from gevent import monkey
+
+monkey.patch_queue()
+
+assert "gevent" in queue.LifoQueue.__module__, queue.LifoQueue
+
+class StaleQueuePool(HTTPConnectionPool):
+    # Pre-fix behavior: import-time capture misses the gevent queue.
+    QueueCls = stdlib_lifo_queue
+
+with StaleQueuePool(host="localhost", maxsize=1) as stale_pool:
+    assert stale_pool.pool is not None
+    assert type(stale_pool.pool) is stdlib_lifo_queue
+    assert "gevent" not in type(stale_pool.pool).__module__
+
+with HTTPConnectionPool(host="localhost", maxsize=1) as pool:
+    assert pool.pool is not None
+    assert type(pool.pool) is queue.LifoQueue
+    assert "gevent" in type(pool.pool).__module__
+    assert pool.pool.qsize() == 1
+    assert pool.pool.get(block=False) is None
+    pool.pool.put(None)
+
+with HTTPSConnectionPool(host="localhost", maxsize=1) as https_pool:
+    assert https_pool.pool is not None
+    assert "gevent" in type(https_pool.pool).__module__
+"""
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 0, result.stdout + result.stderr


### PR DESCRIPTION
## Summary
- Default `ConnectionPool.QueueCls` is now `None`, and pools resolve `queue.LifoQueue` at creation time via `_make_queue()` so post-import monkey-patching of the `queue` module is honored.
- Explicit `QueueCls` overrides still win over a patched default.
- This follows the maintainer-suggested design from #3289 and targets the late-bound queue class issue (not general gevent lock/deadlock cases around `_close_pool_connections`).

Fixes #3289.

## Test plan
- [x] Unit: default pools use stdlib `queue.LifoQueue` with no monkeypatch
- [x] Unit: default pools pick up a `queue.LifoQueue` replaced after urllib3 import
- [x] Unit: late-bound default forwards `maxsize` to the queue constructor
- [x] Unit: custom `QueueCls` override is respected under monkeypatch
- [x] Unit: runtime `QueueCls` assignment and reset to `None`
- [x] Integration: subprocess + gevent `patch_queue()` after importing urllib3 uses gevent's `LifoQueue` (skips if gevent is absent); stale import-time `QueueCls` contrast included
- [x] Full suite: `2295 passed, 333 skipped, 4 xfailed`
- [x] Lint: black / isort / flake8 / mypy on touched files
