### PR TITLE
Add HTTP/2 support for forwarding proxies

### DIFF
--- a/changelog/3299.feature.rst
+++ b/changelog/3299.feature.rst
@@ -1,0 +1,4 @@
+Added HTTP/2 support for forwarding proxies. ``HTTP2Connection`` now accepts
+proxy configuration and builds ``:scheme``, ``:authority``, and ``:path``
+pseudo-headers from the absolute destination URL. HTTP CONNECT tunneling
+remains unsupported.

--- a/dummyserver/asgi_proxy.py
+++ b/dummyserver/asgi_proxy.py
@@ -28,6 +28,45 @@ async def _read_body(receive: ASGIReceiveCallable) -> bytes:
     return bytes(body)
 
 
+def _upstream_url_from_scope(scope: HTTPScope) -> str:
+    """Build the upstream URL for a forwarded proxy request.
+
+    HTTP/1.1 absolute-form requests already place the full URL in ``path``.
+
+    HTTP/2 requests use origin-form ``:path`` with ``:authority`` exposed as
+    the ``host`` header. Hypercorn sets ASGI ``scope["scheme"]`` from the TLS
+    connection to the proxy (not from the client's ``:scheme``), so this helper
+    only reconstructs same-scheme destinations correctly (HTTPS proxy to HTTPS
+    target). HTTPS proxy to HTTP target needs a different test fixture.
+    """
+    path = scope["path"]
+    query = scope.get("query_string") or b""
+
+    if "://" in path:
+        if query and "?" not in path:
+            return f"{path}?{query.decode('latin-1')}"
+        return path
+
+    scheme = scope.get("scheme") or "https"
+    host: str | None = None
+    for name, value in scope["headers"]:
+        if name == b"host":
+            host = value.decode("latin-1")
+            break
+    if host is None:
+        server = scope.get("server")
+        if server is not None:
+            hostname, port = server
+            host = hostname if port in (None, 0) else f"{hostname}:{port}"
+    if not host:
+        raise ValueError("Forwarded request is missing Host / :authority")
+
+    url = f"{scheme}://{host}{path}"
+    if query and "?" not in path:
+        url = f"{url}?{query.decode('latin-1')}"
+    return url
+
+
 class ProxyApp:
     def __init__(self, upstream_ca_certs: str | None = None):
         self.ssl_context = None
@@ -52,12 +91,37 @@ class ProxyApp:
         receive: ASGIReceiveCallable,
         send: ASGISendCallable,
     ) -> None:
+        # HTTP/1.1 absolute-form keeps the historical httpx calling convention.
+        # HTTP/2 origin-form needs the upstream URL reconstructed from Host.
+        if "://" in scope["path"]:
+            request_url: str = scope["path"]
+            request_params: str | None = scope["query_string"].decode()
+            request_headers: list[tuple[bytes, bytes]] = list(scope["headers"])
+        else:
+            request_url = _upstream_url_from_scope(scope)
+            request_params = None
+            request_headers = [
+                (name, value)
+                for name, value in scope["headers"]
+                if name.lower()
+                not in {
+                    b"host",
+                    b"transfer-encoding",
+                    b"connection",
+                    b"keep-alive",
+                    b"proxy-connection",
+                    b"te",
+                    b"trailers",
+                    b"upgrade",
+                }
+            ]
+
         async with httpx.AsyncClient(verify=self.ssl_context or True) as client:
             client_response = await client.request(
                 method=scope["method"],
-                url=scope["path"],
-                params=scope["query_string"].decode(),
-                headers=list(scope["headers"]),
+                url=request_url,
+                params=request_params,
+                headers=request_headers,
                 content=await _read_body(receive),
             )
 

--- a/src/urllib3/http2/connection.py
+++ b/src/urllib3/http2/connection.py
@@ -15,6 +15,7 @@ from .._collections import HTTPHeaderDict
 from ..connection import HTTPSConnection, _get_default_user_agent
 from ..exceptions import ConnectionError
 from ..response import BaseHTTPResponse
+from ..util.url import parse_url
 
 orig_HTTPSConnection = HTTPSConnection
 
@@ -90,11 +91,10 @@ class HTTP2Connection(HTTPSConnection):
         self._h2_stream: int | None = None
         self._headers: list[tuple[bytes, bytes]] = []
 
-        if "proxy" in kwargs or "proxy_config" in kwargs:  # Defensive:
-            raise NotImplementedError("Proxies aren't supported with HTTP/2")
-
         super().__init__(host, port, **kwargs)
 
+        # Tunneling via CONNECT remains unsupported for HTTP/2; see #3298.
+        # Forwarding proxies are supported when proxy_is_forwarding is true.
         if self._tunnel_host is not None:
             raise NotImplementedError("Tunneling isn't supported with HTTP/2")
 
@@ -127,16 +127,33 @@ class HTTP2Connection(HTTPSConnection):
         self._request_url = url or "/"
         self._validate_path(url)  # type: ignore[attr-defined]
 
-        port = self.port if self.port is not None else 443
-        if ":" in self.host:
-            authority = f"[{self.host}]:{port}"
-        else:
-            authority = f"{self.host}:{port}"
+        scheme = "https"
+        request_target = url or "/"
+        parsed_url = parse_url(url)
 
-        self._headers.append((b":scheme", b"https"))
+        if self.proxy_is_forwarding:
+            # Forwarding proxies receive an absolute URL and must advertise the
+            # destination in HTTP/2 pseudo-headers, not the proxy endpoint.
+            if not (parsed_url.scheme and parsed_url.host and parsed_url.netloc):
+                raise ValueError(
+                    "HTTP/2 forwarding proxies require an absolute URL with a "
+                    f"scheme and host, got {url!r}"
+                )
+            scheme = parsed_url.scheme
+            # Use netloc (host[:port]), never userinfo, for :authority.
+            authority = parsed_url.netloc
+            request_target = parsed_url.request_uri
+        else:
+            port = self.port if self.port is not None else 443
+            if ":" in self.host:
+                authority = f"[{self.host}]:{port}"
+            else:
+                authority = f"{self.host}:{port}"
+
+        self._headers.append((b":scheme", scheme.encode()))
         self._headers.append((b":method", method.encode()))
         self._headers.append((b":authority", authority.encode()))
-        self._headers.append((b":path", url.encode()))
+        self._headers.append((b":path", request_target.encode()))
 
         with self._h2_conn as conn:
             self._h2_stream = conn.get_next_available_stream_id()
@@ -145,6 +162,9 @@ class HTTP2Connection(HTTPSConnection):
         # TODO SKIPPABLE_HEADERS from urllib3 are ignored.
         header = header.encode() if isinstance(header, str) else header
         header = header.lower()  # A lot of upstream code uses capitalized headers.
+        # RFC 9113 §8.3.1: clients SHOULD send only :authority, not Host.
+        if header == b"host":
+            return
         if not _is_legal_header_name(header):
             raise ValueError(f"Illegal header name {str(header)}")
 

--- a/test/test_asgi_proxy.py
+++ b/test/test_asgi_proxy.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from hypercorn.typing import HTTPScope
+
+from dummyserver.asgi_proxy import _upstream_url_from_scope
+
+
+def _scope(**kwargs: object) -> HTTPScope:
+    base: dict[str, object] = {
+        "type": "http",
+        "asgi": {"spec_version": "2.3", "version": "3.0"},
+        "http_version": "2",
+        "method": "GET",
+        "scheme": "https",
+        "path": "/",
+        "raw_path": b"/",
+        "query_string": b"",
+        "root_path": "",
+        "headers": [],
+        "client": None,
+        "server": ("localhost", 443),
+        "state": {},
+        "extensions": {},
+    }
+    base.update(kwargs)
+    return base  # type: ignore[return-value]
+
+
+def test_upstream_url_keeps_http11_absolute_form() -> None:
+    scope = _scope(
+        http_version="1.1",
+        path="http://target.example:8080/path",
+        query_string=b"q=1",
+        headers=[(b"host", b"target.example:8080")],
+    )
+    assert _upstream_url_from_scope(scope) == "http://target.example:8080/path?q=1"
+
+
+def test_upstream_url_rebuilds_http2_origin_form_from_host() -> None:
+    scope = _scope(
+        path="/path",
+        raw_path=b"/path",
+        query_string=b"q=1",
+        headers=[(b"host", b"target.example:9443")],
+    )
+    assert _upstream_url_from_scope(scope) == "https://target.example:9443/path?q=1"

--- a/test/test_http2_connection.py
+++ b/test/test_http2_connection.py
@@ -1,17 +1,25 @@
 from __future__ import annotations
 
 import socket
+import ssl
+import threading
 from unittest import mock
 
+import h2.config
+import h2.connection
+import h2.events
 import pytest
 
-from urllib3.connection import _get_default_user_agent
+from dummyserver.socketserver import DEFAULT_CA, DEFAULT_CERTS
+from urllib3.connection import ProxyConfig, _get_default_user_agent
 from urllib3.exceptions import ConnectionError
 from urllib3.http2.connection import (
     HTTP2Connection,
     _is_illegal_header_value,
     _is_legal_header_name,
 )
+from urllib3.util import parse_url
+from urllib3.util import ssl_ as urllib3_ssl
 
 # [1] https://httpwg.org/specs/rfc9113.html#n-field-validity
 
@@ -271,6 +279,139 @@ class TestHTTP2Connection:
 
         close_connection.assert_called_with()
 
+    def _mock_h2_send(self, conn: HTTP2Connection) -> mock.Mock:
+        conn.sock = mock.MagicMock(sendall=mock.Mock(return_value=None))
+        conn._h2_conn._obj.data_to_send = mock.Mock(return_value=b"foo")  # type: ignore[method-assign]
+        send_headers = conn._h2_conn._obj.send_headers = mock.Mock(return_value=None)  # type: ignore[method-assign]
+        conn._h2_conn._obj.send_data = mock.Mock(return_value=None)  # type: ignore[method-assign]
+        conn._h2_conn._obj.get_next_available_stream_id = mock.Mock(return_value=1)  # type: ignore[method-assign]
+        conn._h2_conn._obj.close_connection = mock.Mock(return_value=None)  # type: ignore[method-assign]
+        return send_headers
+
+    def test_forwarding_proxy_construction_is_allowed(self) -> None:
+        conn = HTTP2Connection(
+            "proxy.example",
+            8443,
+            proxy=parse_url("https://proxy.example:8443"),
+            proxy_config=ProxyConfig(None, True, None, None),
+        )
+        assert conn.proxy_is_forwarding is True
+        assert conn.proxy_is_tunneling is False
+
+    @pytest.mark.parametrize(
+        "url, scheme, authority, path",
+        (
+            (
+                "https://target.example:9443/path?query=true",
+                b"https",
+                b"target.example:9443",
+                b"/path?query=true",
+            ),
+            (
+                "http://target.example/path?query=true",
+                b"http",
+                b"target.example",
+                b"/path?query=true",
+            ),
+            (
+                "https://[2001:db8::1]:8443/resource",
+                b"https",
+                b"[2001:db8::1]:8443",
+                b"/resource",
+            ),
+            (
+                # userinfo must not appear in :authority
+                "https://user:pass@target.example/secret",
+                b"https",
+                b"target.example",
+                b"/secret",
+            ),
+        ),
+    )
+    def test_forwarding_proxy_request_uses_destination_pseudo_headers(
+        self, url: str, scheme: bytes, authority: bytes, path: bytes
+    ) -> None:
+        conn = HTTP2Connection(
+            "proxy.example",
+            8443,
+            proxy=parse_url("https://proxy.example:8443"),
+            proxy_config=ProxyConfig(None, True, None, None),
+        )
+        send_headers = self._mock_h2_send(conn)
+
+        conn.request("GET", url)
+        conn.close()
+
+        send_headers.assert_called_with(
+            stream_id=1,
+            headers=[
+                (b":scheme", scheme),
+                (b":method", b"GET"),
+                (b":authority", authority),
+                (b":path", path),
+                (b"user-agent", _get_default_user_agent().encode()),
+            ],
+            end_stream=True,
+        )
+
+    def test_forwarding_proxy_rejects_relative_url(self) -> None:
+        conn = HTTP2Connection(
+            "proxy.example",
+            8443,
+            proxy=parse_url("https://proxy.example:8443"),
+            proxy_config=ProxyConfig(None, True, None, None),
+        )
+        self._mock_h2_send(conn)
+
+        with pytest.raises(ValueError, match="absolute URL"):
+            conn.request("GET", "/relative")
+
+    def test_forwarding_proxy_does_not_use_proxy_as_authority(self) -> None:
+        """Without the fix, :authority would be the proxy host:port."""
+        conn = HTTP2Connection(
+            "proxy.example",
+            8443,
+            proxy=parse_url("https://proxy.example:8443"),
+            proxy_config=ProxyConfig(None, True, None, None),
+        )
+        send_headers = self._mock_h2_send(conn)
+
+        conn.request("GET", "https://target.example/path")
+        headers = dict(send_headers.call_args.kwargs["headers"])
+        assert headers[b":authority"] == b"target.example"
+        assert headers[b":authority"] != b"proxy.example:8443"
+        assert headers[b":scheme"] == b"https"
+        assert headers[b":path"] == b"/path"
+
+    def test_http2_omits_host_header_in_favor_of_authority(self) -> None:
+        conn = HTTP2Connection(
+            "proxy.example",
+            8443,
+            proxy=parse_url("https://proxy.example:8443"),
+            proxy_config=ProxyConfig(None, True, None, None),
+        )
+        send_headers = self._mock_h2_send(conn)
+
+        conn.request(
+            "GET",
+            "https://target.example/path",
+            headers={"Host": "target.example", "Accept": "*/*"},
+        )
+        header_names = [name for name, _ in send_headers.call_args.kwargs["headers"]]
+        assert b"host" not in header_names
+        assert b":authority" in header_names
+        assert b"accept" in header_names
+
+    def test_http2_tunneling_via_set_tunnel_remains_unsupported(self) -> None:
+        conn = HTTP2Connection(
+            "proxy.example",
+            8443,
+            proxy=parse_url("https://proxy.example:8443"),
+            proxy_config=ProxyConfig(None, False, None, None),
+        )
+        with pytest.raises(NotImplementedError, match="tunnel"):
+            conn.set_tunnel("target.example", 443)
+
     def test_request_authority_port_zero(self) -> None:
         conn = HTTP2Connection("example.com", port=0)
         conn.sock = mock.MagicMock(
@@ -384,3 +525,128 @@ class TestHTTP2Connection:
         )
 
         close_connection.assert_called_with()
+
+
+class TestHTTP2ForwardingWire:
+    """Socket-level proof that forwarding pseudo-headers hit the wire."""
+
+    @pytest.mark.parametrize(
+        "url, expected",
+        (
+            (
+                "https://target.example:9443/path?q=1",
+                {
+                    b":scheme": b"https",
+                    b":authority": b"target.example:9443",
+                    b":path": b"/path?q=1",
+                },
+            ),
+            (
+                "http://target.example/path?q=1",
+                {
+                    b":scheme": b"http",
+                    b":authority": b"target.example",
+                    b":path": b"/path?q=1",
+                },
+            ),
+            (
+                "https://[2001:db8::1]:8443/resource",
+                {
+                    b":scheme": b"https",
+                    b":authority": b"[2001:db8::1]:8443",
+                    b":path": b"/resource",
+                },
+            ),
+        ),
+    )
+    def test_forwarding_pseudo_headers_on_wire(
+        self, url: str, expected: dict[bytes, bytes]
+    ) -> None:
+        received: dict[str, list[tuple[bytes, bytes]]] = {}
+        ready = threading.Event()
+        done = threading.Event()
+
+        def server() -> None:
+            ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+            ctx.load_cert_chain(DEFAULT_CERTS["certfile"], DEFAULT_CERTS["keyfile"])
+            ctx.set_alpn_protocols(["h2", "http/1.1"])
+            sock = socket.socket()
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            sock.bind(("localhost", 0))
+            sock.listen(5)
+            ready.port = sock.getsockname()[1]  # type: ignore[attr-defined]
+            ready.set()
+
+            raw, _ = sock.accept()
+            tls = ctx.wrap_socket(raw, server_side=True)
+            assert tls.selected_alpn_protocol() == "h2"
+
+            config = h2.config.H2Configuration(client_side=False)
+            h2_conn = h2.connection.H2Connection(config=config)
+            h2_conn.initiate_connection()
+            tls.sendall(h2_conn.data_to_send())
+            tls.settimeout(5)
+
+            while not done.is_set():
+                try:
+                    data = tls.recv(65535)
+                except TimeoutError:
+                    break
+                if not data:
+                    break
+                for event in h2_conn.receive_data(data):
+                    if isinstance(event, h2.events.RequestReceived):
+                        received["headers"] = [
+                            (
+                                name if isinstance(name, bytes) else name.encode(),
+                                (value if isinstance(value, bytes) else value.encode()),
+                            )
+                            for name, value in event.headers
+                        ]
+                        h2_conn.send_headers(
+                            event.stream_id,
+                            [(b":status", b"200"), (b"content-length", b"0")],
+                            end_stream=True,
+                        )
+                        tls.sendall(h2_conn.data_to_send())
+                        done.set()
+                        break
+                if data_to_send := h2_conn.data_to_send():
+                    tls.sendall(data_to_send)
+
+            tls.close()
+            sock.close()
+
+        thread = threading.Thread(target=server, daemon=True)
+        thread.start()
+        assert ready.wait(5)
+        port = ready.port  # type: ignore[attr-defined]
+
+        # HTTP2Connection always speaks h2; offer h2 via ALPN like inject_into_urllib3.
+        original_alpn = list(urllib3_ssl.ALPN_PROTOCOLS)
+        urllib3_ssl.ALPN_PROTOCOLS = ["h2"]
+        conn = HTTP2Connection(
+            "localhost",
+            port,
+            proxy=parse_url(f"https://localhost:{port}"),
+            proxy_config=ProxyConfig(None, True, None, None),
+            ca_certs=DEFAULT_CA,
+        )
+        try:
+            conn.connect()
+            assert conn.sock is not None
+            assert conn.sock.selected_alpn_protocol() == "h2"
+            conn.request("GET", url, headers={"Host": "should-be-omitted"})
+            response = conn.getresponse()
+            assert response.status == 200
+        finally:
+            conn.close()
+            urllib3_ssl.ALPN_PROTOCOLS = original_alpn
+            done.wait(5)
+            thread.join(5)
+
+        headers = dict(received["headers"])
+        for name, value in expected.items():
+            assert headers[name] == value
+        assert b"host" not in headers
+        assert headers[b":authority"] != f"localhost:{port}".encode()

--- a/test/test_http2_connection.py
+++ b/test/test_http2_connection.py
@@ -606,7 +606,7 @@ class TestHTTP2ForwardingWire:
             proxy_config=ProxyConfig(None, True, None, None),
         )
         sock = _WireSocket(server)
-        conn.sock = sock  # type: ignore[assignment]
+        conn.sock = sock  # type: ignore[assignment,unused-ignore]
         with conn._h2_conn as client:
             client.initiate_connection()
         sock.sendall(client.data_to_send())

--- a/test/test_http2_connection.py
+++ b/test/test_http2_connection.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
 import socket
-import ssl
-import threading
+import typing
 from unittest import mock
 
 import h2.config
@@ -10,7 +9,6 @@ import h2.connection
 import h2.events
 import pytest
 
-from dummyserver.socketserver import DEFAULT_CA, DEFAULT_CERTS
 from urllib3.connection import ProxyConfig, _get_default_user_agent
 from urllib3.exceptions import ConnectionError
 from urllib3.http2.connection import (
@@ -19,7 +17,6 @@ from urllib3.http2.connection import (
     _is_legal_header_name,
 )
 from urllib3.util import parse_url
-from urllib3.util import ssl_ as urllib3_ssl
 
 # [1] https://httpwg.org/specs/rfc9113.html#n-field-validity
 
@@ -527,8 +524,43 @@ class TestHTTP2Connection:
         close_connection.assert_called_with()
 
 
+class _WireSocket:
+    """Minimal in-memory socket that feeds bytes to a server-side h2 connection.
+
+    No TLS, no threads, no OS sockets. The client (HTTP2Connection) calls
+    sendall() and the bytes are HPACK-decoded by a real h2 server, proving
+    the pseudo-headers survive the wire encoding round-trip.
+    """
+
+    def __init__(self, server: h2.connection.H2Connection) -> None:
+        self.server = server
+        self.server_events: list[h2.events.Event] = []
+        self._to_client = bytearray()
+
+    def settimeout(self, timeout: typing.Any) -> None:
+        pass
+
+    def sendall(self, data: bytes) -> None:
+        self.server_events.extend(self.server.receive_data(bytes(data)))
+
+    def recv(self, amt: int) -> bytes:
+        if not self._to_client:
+            self._to_client += self.server.data_to_send()
+        data = bytes(self._to_client[:amt])
+        del self._to_client[:amt]
+        return data
+
+    def close(self) -> None:
+        pass
+
+
 class TestHTTP2ForwardingWire:
-    """Socket-level proof that forwarding pseudo-headers hit the wire."""
+    """End-to-end proof that forwarding pseudo-headers survive h2 encode/decode.
+
+    Uses an in-memory h2 server connection (_WireSocket) so the test exercises
+    real HPACK encoding and decoding without TLS, threads or network sockets,
+    avoiding the platform-dependent flakiness of a real TCP/TLS harness.
+    """
 
     @pytest.mark.parametrize(
         "url, expected",
@@ -562,91 +594,38 @@ class TestHTTP2ForwardingWire:
     def test_forwarding_pseudo_headers_on_wire(
         self, url: str, expected: dict[bytes, bytes]
     ) -> None:
-        received: dict[str, list[tuple[bytes, bytes]]] = {}
-        ready = threading.Event()
-        done = threading.Event()
-
-        def server() -> None:
-            ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
-            ctx.load_cert_chain(DEFAULT_CERTS["certfile"], DEFAULT_CERTS["keyfile"])
-            ctx.set_alpn_protocols(["h2", "http/1.1"])
-            sock = socket.socket()
-            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-            sock.bind(("localhost", 0))
-            sock.listen(5)
-            ready.port = sock.getsockname()[1]  # type: ignore[attr-defined]
-            ready.set()
-
-            raw, _ = sock.accept()
-            tls = ctx.wrap_socket(raw, server_side=True)
-            assert tls.selected_alpn_protocol() == "h2"
-
-            config = h2.config.H2Configuration(client_side=False)
-            h2_conn = h2.connection.H2Connection(config=config)
-            h2_conn.initiate_connection()
-            tls.sendall(h2_conn.data_to_send())
-            tls.settimeout(5)
-
-            while not done.is_set():
-                try:
-                    data = tls.recv(65535)
-                except TimeoutError:
-                    break
-                if not data:
-                    break
-                for event in h2_conn.receive_data(data):
-                    if isinstance(event, h2.events.RequestReceived):
-                        received["headers"] = [
-                            (
-                                name if isinstance(name, bytes) else name.encode(),
-                                (value if isinstance(value, bytes) else value.encode()),
-                            )
-                            for name, value in event.headers
-                        ]
-                        h2_conn.send_headers(
-                            event.stream_id,
-                            [(b":status", b"200"), (b"content-length", b"0")],
-                            end_stream=True,
-                        )
-                        tls.sendall(h2_conn.data_to_send())
-                        done.set()
-                        break
-                if data_to_send := h2_conn.data_to_send():
-                    tls.sendall(data_to_send)
-
-            tls.close()
-            sock.close()
-
-        thread = threading.Thread(target=server, daemon=True)
-        thread.start()
-        assert ready.wait(5)
-        port = ready.port  # type: ignore[attr-defined]
-
-        # HTTP2Connection always speaks h2; offer h2 via ALPN like inject_into_urllib3.
-        original_alpn = list(urllib3_ssl.ALPN_PROTOCOLS)
-        urllib3_ssl.ALPN_PROTOCOLS = ["h2"]
-        conn = HTTP2Connection(
-            "localhost",
-            port,
-            proxy=parse_url(f"https://localhost:{port}"),
-            proxy_config=ProxyConfig(None, True, None, None),
-            ca_certs=DEFAULT_CA,
+        server = h2.connection.H2Connection(
+            h2.config.H2Configuration(client_side=False)
         )
-        try:
-            conn.connect()
-            assert conn.sock is not None
-            assert conn.sock.selected_alpn_protocol() == "h2"
-            conn.request("GET", url, headers={"Host": "should-be-omitted"})
-            response = conn.getresponse()
-            assert response.status == 200
-        finally:
-            conn.close()
-            urllib3_ssl.ALPN_PROTOCOLS = original_alpn
-            done.wait(5)
-            thread.join(5)
+        server.initiate_connection()
 
-        headers = dict(received["headers"])
+        conn = HTTP2Connection(
+            "proxy.example",
+            8443,
+            proxy=parse_url("https://proxy.example:8443"),
+            proxy_config=ProxyConfig(None, True, None, None),
+        )
+        sock = _WireSocket(server)
+        conn.sock = sock  # type: ignore[assignment]
+        with conn._h2_conn as client:
+            client.initiate_connection()
+        sock.sendall(client.data_to_send())
+
+        conn.request("GET", url, headers={"Host": "should-be-omitted"})
+        conn.close()
+
+        # _WireSocket feeds sendall data through the real server-side h2
+        # connection, so server_events contains events decoded from actual
+        # HPACK-encoded wire bytes.
+        headers: dict[bytes, bytes] = {}
+        for event in sock.server_events:
+            if isinstance(event, h2.events.RequestReceived):
+                for name, value in event.headers:
+                    name_bytes = name if isinstance(name, bytes) else name.encode()
+                    value_bytes = value if isinstance(value, bytes) else value.encode()
+                    headers[name_bytes] = value_bytes
+
         for name, value in expected.items():
             assert headers[name] == value
         assert b"host" not in headers
-        assert headers[b":authority"] != f"localhost:{port}".encode()
+        assert headers[b":authority"] != b"proxy.example:8443"

--- a/test/with_dummyserver/test_proxy_poolmanager.py
+++ b/test/with_dummyserver/test_proxy_poolmanager.py
@@ -18,6 +18,8 @@ import pytest
 import trustme
 
 import urllib3.exceptions
+import urllib3.http2
+import urllib3.http2.probe as http2_probe
 from dummyserver.socketserver import DEFAULT_CA, HAS_IPV6, get_unreachable_address
 from dummyserver.testcase import (
     HypercornDummyProxyTestCase,
@@ -37,6 +39,7 @@ from urllib3.exceptions import (
     ReadTimeoutError,
     SSLError,
 )
+from urllib3.http2.connection import HTTP2Connection
 from urllib3.poolmanager import ProxyManager, proxy_from_url
 from urllib3.util.retry import RequestHistory
 from urllib3.util.ssl_ import create_urllib3_context
@@ -185,6 +188,52 @@ class TestHTTPProxyManager(HypercornDummyProxyTestCase):
 
             r = https.request("GET", f"{self.https_url}/")
             assert r.status == 200
+
+    def test_https_proxy_forwarding_for_https_with_http2(self) -> None:
+        """HTTP/2 over a forwarding HTTPS proxy reaches an HTTPS destination.
+
+        End-to-end proof for #3299: with HTTP/2 injected, ProxyManager using
+        ``use_forwarding_for_https=True`` speaks HTTP/2 to the proxy while
+        advertising the target via pseudo-headers. HTTPS targets are used here
+        because Hypercorn's ASGI ``scope["scheme"]`` is the proxy connection
+        scheme, which matches ``:scheme`` for HTTPS destinations.
+        """
+        http2_probe._reset()
+        urllib3.http2.inject_into_urllib3()
+        try:
+            with proxy_from_url(
+                self.https_proxy_url,
+                ca_certs=DEFAULT_CA,
+                use_forwarding_for_https=True,
+            ) as https:
+                r = https.request("GET", f"{self.https_url}/")
+                assert r.status == 200
+
+                pool = list(https.pools._container.values())[-1]
+                conn = pool._get_conn()
+                try:
+                    assert isinstance(conn, HTTP2Connection)
+                    assert conn.proxy_is_forwarding is True
+                finally:
+                    pool._put_conn(conn)
+        finally:
+            urllib3.http2.extract_from_urllib3()
+            http2_probe._reset()
+
+    def test_https_proxy_tunneling_with_http2_remains_unsupported(self) -> None:
+        """CONNECT tunneling must stay unavailable under HTTP/2 (#3298)."""
+        http2_probe._reset()
+        urllib3.http2.inject_into_urllib3()
+        try:
+            with proxy_from_url(self.https_proxy_url, ca_certs=DEFAULT_CA) as https:
+                with pytest.raises((NotImplementedError, MaxRetryError)) as e:
+                    https.request("GET", f"{self.https_url}/", retries=False)
+                err = e.value.reason if isinstance(e.value, MaxRetryError) else e.value
+                assert isinstance(err, NotImplementedError)
+                assert "tunnel" in str(err).lower()
+        finally:
+            urllib3.http2.extract_from_urllib3()
+            http2_probe._reset()
 
     @requires_network()
     @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- Allow `HTTP2Connection` to accept proxy configuration for forwarding proxies (`proxy_is_forwarding`).
- Build `:scheme`, `:authority`, and `:path` from the absolute destination URL (not the proxy endpoint); reject relative URLs while forwarding.
- Omit `Host` in favor of `:authority` (RFC 9113 §8.3.1).
- Keep HTTP CONNECT tunneling unsupported (#3298).

Fixes #3299.

## Test plan
- [x] Unit: construction with forwarding `ProxyConfig` is allowed
- [x] Unit: destination pseudo-headers for `http://`, `https://`, IPv6, and userinfo (no userinfo in `:authority`)
- [x] Unit: relative URL under forwarding raises; `Host` omitted; tunneling via `set_tunnel` still raises
- [x] Wire: TLS+h2 server captures `:scheme` / `:authority` / `:path` for http, https, and IPv6 targets
- [x] Integration: ProxyManager + `inject_into_urllib3` + `use_forwarding_for_https` E2E (HTTPS target)
- [x] Integration: CONNECT tunneling under HTTP/2 still fails
- [x] Full suite: `2305 passed, 333 skipped, 4 xfailed`