### PR TITLE
Move HTTP/2 response body handling into HTTP2Response

### DIFF
--- a/changelog/3294.feature.rst
+++ b/changelog/3294.feature.rst
@@ -1,0 +1,7 @@
+Moved HTTP/2 response body handling into ``HTTP2Response``, which now reads
+from the connection on demand instead of buffering the whole body eagerly.
+HTTP/2 responses support ``preload_content=False``, ``read()``, ``read1()``
+and ``stream()``, and decode compressed bodies based on the
+``content-encoding`` header. Read timeouts are now respected during body
+reads, and the connection is released back to the pool once the body is
+fully consumed.

--- a/dummyserver/app.py
+++ b/dummyserver/app.py
@@ -132,6 +132,13 @@ async def keepalive() -> ResponseReturnValue:
     return await make_response("Keeping alive", 200, headers)
 
 
+@hypercorn_app.route("/large_response")
+async def large_response() -> ResponseReturnValue:
+    "Return a body larger than the default HTTP/2 flow control window"
+    size = int(request.args.get("size", "131072"))
+    return await make_response(b"x" * size, 200)
+
+
 @hypercorn_app.route("/echo", methods=["GET", "POST", "PUT"])
 async def echo() -> ResponseReturnValue:
     "Echo back the params"
@@ -315,6 +322,7 @@ def apply_caching(response: Response) -> ResponseReturnValue:
     return response
 
 
+@hypercorn_app.route("/slow")
 @pyodide_testing_app.route("/slow")
 async def slow() -> ResponseReturnValue:
     await trio.sleep(10)

--- a/src/urllib3/http2/connection.py
+++ b/src/urllib3/http2/connection.py
@@ -1,20 +1,39 @@
 from __future__ import annotations
 
+import io
 import logging
 import re
+import socket
 import threading
 import types
 import typing
+from contextlib import contextmanager
+from http.client import HTTPException, ResponseNotReady
+from socket import timeout as SocketTimeout
 
 import h2.config
 import h2.connection
 import h2.events
+import h2.exceptions
 
-from .._base_connection import _TYPE_BODY
+from .._base_connection import _TYPE_BODY, _ResponseOptions
 from .._collections import HTTPHeaderDict
-from ..connection import HTTPSConnection, _get_default_user_agent
-from ..exceptions import ConnectionError
-from ..response import BaseHTTPResponse
+from ..connection import BaseSSLError, HTTPSConnection, _get_default_user_agent
+from ..exceptions import (
+    ConnectionError,
+    HTTPError,
+    IncompleteRead,
+    InvalidHeader,
+    ProtocolError,
+    ReadTimeoutError,
+    ResponseNotChunked,
+    SSLError,
+)
+from ..response import _READ_CHUNK_SIZE, BaseHTTPResponse, BytesQueueBuffer
+
+if typing.TYPE_CHECKING:
+    from .._base_connection import BaseHTTPConnection
+    from ..connectionpool import HTTPConnectionPool
 
 orig_HTTPSConnection = HTTPSConnection
 
@@ -82,6 +101,175 @@ class _LockedObject(typing.Generic[T]):
         self.lock.release()
 
 
+class HTTP2Stream:
+    """
+    Owns the read side of a single HTTP/2 stream.
+
+    Instances of this class receive h2 events for the shared HTTP/2
+    connection, buffer the DATA frames destined for their stream and
+    acknowledge received data to keep the connection's flow control
+    window open.
+
+    :meth:`HTTP2Connection.getresponse` uses this object to read the
+    response headers and then transfers ownership to
+    :class:`HTTP2Response`, which reads the response body through it.
+    Keeping all socket reads in one place avoids two competing h2 event
+    loops in the connection and the response.
+    """
+
+    def __init__(
+        self,
+        sock: socket.socket,
+        h2_conn: _LockedObject[h2.connection.H2Connection],
+        stream_id: int,
+    ) -> None:
+        self._sock = sock
+        self._h2_conn = h2_conn
+        self.stream_id = stream_id
+        self._data_buffer = BytesQueueBuffer()
+        self._response: tuple[int, HTTPHeaderDict] | None = None
+        self._ended = False
+
+    @property
+    def is_complete(self) -> bool:
+        """Whether the stream has ended and all buffered data was consumed."""
+        return self._ended and not len(self._data_buffer)
+
+    def read_response(self) -> tuple[int, HTTPHeaderDict]:
+        """
+        Receive events until the response headers for this stream arrive
+        and return the status code and headers.
+
+        Informational (1xx) responses are skipped. DATA frames received
+        together with the headers are buffered for later reads.
+        """
+        while self._response is None:
+            self._receive_events()
+        return self._response
+
+    def read(self, amt: int | None = None, *, read1: bool = False) -> bytes:
+        """
+        Read up to ``amt`` bytes of the response body, receiving from the
+        socket as needed.
+
+        ``amt=None`` reads until the end of the stream. ``read1=True``
+        returns as soon as any data is buffered instead of waiting for
+        ``amt`` bytes to accumulate. Returns ``b""`` only once the stream
+        has ended and all buffered data was consumed.
+        """
+        if read1 or amt is None:
+            while not len(self._data_buffer) and not self._ended:
+                self._receive_events()
+            if amt is None and not read1:
+                while not self._ended:
+                    self._receive_events()
+        else:
+            while len(self._data_buffer) < amt and not self._ended:
+                self._receive_events()
+
+        if not len(self._data_buffer):
+            return b""
+        elif amt is None:
+            return self._data_buffer.get_all()
+        else:
+            return self._data_buffer.get(amt)
+
+    def _receive_events(self) -> None:
+        """Read once from the socket and dispatch the resulting h2 events."""
+        # recv() deliberately happens outside the h2 lock: if a blocking
+        # read held the lock, close() from another thread (which needs the
+        # lock) would block until the read returned.
+        received_data = self._sock.recv(_READ_CHUNK_SIZE)
+        if not received_data:
+            if self._response is None:
+                msg = "Connection closed without sending a complete response"
+            else:
+                msg = "Connection closed before the response body was complete"
+            raise ProtocolError(msg)
+
+        with self._h2_conn as conn:
+            try:
+                events = conn.receive_data(received_data)
+            except h2.exceptions.ProtocolError as e:
+                # h2 queues a GOAWAY frame for the peer when it encounters
+                # a protocol error. Try to deliver it, but don't let a send
+                # failure mask the actual error.
+                try:
+                    if data_to_send := conn.data_to_send():
+                        self._sock.sendall(data_to_send)
+                except OSError:
+                    pass
+                raise ProtocolError(f"Invalid HTTP/2 data received: {e!r}", e) from e
+
+            for event in events:
+                if isinstance(event, h2.events.ResponseReceived):
+                    if event.stream_id == self.stream_id:
+                        self._response = self._response_from_event(event)
+                elif isinstance(event, h2.events.DataReceived):
+                    # Open up the flow control window for the peer even if
+                    # the data is not for our stream.
+                    conn.acknowledge_received_data(
+                        event.flow_controlled_length, event.stream_id
+                    )
+                    if event.stream_id == self.stream_id:
+                        self._data_buffer.put(event.data)
+                elif isinstance(event, h2.events.StreamEnded):
+                    if event.stream_id == self.stream_id:
+                        self._ended = True
+                elif isinstance(event, h2.events.StreamReset):
+                    # Minimal safety net so reads fail instead of blocking
+                    # forever. Comprehensive error event handling is
+                    # tracked in https://github.com/urllib3/urllib3/issues/3291
+                    if event.stream_id == self.stream_id and not self._ended:
+                        raise ProtocolError(
+                            "Stream was reset by the remote peer "
+                            f"(error code {event.error_code})"
+                        )
+                elif isinstance(event, h2.events.ConnectionTerminated):
+                    # Frames that complete this stream before the GOAWAY
+                    # already set _ended above. Anything else can never
+                    # complete: h2 moves the connection to the CLOSED
+                    # state on a received GOAWAY and rejects all frames
+                    # after it, so fail fast with a clear error.
+                    if not self._ended:
+                        raise ProtocolError(
+                            "Connection was terminated by the remote peer "
+                            f"(error code {event.error_code})"
+                        )
+
+            if data_to_send := conn.data_to_send():
+                try:
+                    self._sock.sendall(data_to_send)
+                except OSError:
+                    # The stream ended in this batch: failing to deliver
+                    # trailing acknowledgements doesn't invalidate the
+                    # fully received response.
+                    if not self._ended:
+                        raise
+
+    def _response_from_event(
+        self, event: h2.events.ResponseReceived
+    ) -> tuple[int, HTTPHeaderDict]:
+        status: int | None = None
+        headers = HTTPHeaderDict()
+        assert event.headers is not None
+        for header, value in event.headers:
+            if header == b":status":
+                try:
+                    status = int(value.decode())
+                except ValueError as e:
+                    raise ProtocolError(
+                        f"Invalid :status pseudo-header value {value!r}"
+                    ) from e
+            elif not header.startswith(b":"):
+                # http.client decodes HTTP/1.1 header bytes as latin-1;
+                # match that so byte-identical headers parse identically.
+                headers.add(header.decode("latin-1"), value.decode("latin-1"))
+        if status is None:  # Defensive: h2 rejects responses without :status.
+            raise ProtocolError("Received HTTP/2 response without a :status header")
+        return status, headers
+
+
 class HTTP2Connection(HTTPSConnection):
     def __init__(
         self, host: str, port: int | None = None, **kwargs: typing.Any
@@ -89,6 +277,7 @@ class HTTP2Connection(HTTPSConnection):
         self._h2_conn = self._new_h2_conn()
         self._h2_stream: int | None = None
         self._headers: list[tuple[bytes, bytes]] = []
+        self._response_options: _ResponseOptions | None = None
 
         if "proxy" in kwargs or "proxy_config" in kwargs:  # Defensive:
             raise NotImplementedError("Proxies aren't supported with HTTP/2")
@@ -227,43 +416,42 @@ class HTTP2Connection(HTTPSConnection):
     def getresponse(  # type: ignore[override]
         self,
     ) -> HTTP2Response:
-        status = None
-        data = bytearray()
-        with self._h2_conn as conn:
-            end_stream = False
-            while not end_stream:
-                # TODO: Arbitrary read value.
-                if received_data := self.sock.recv(65535):
-                    events = conn.receive_data(received_data)
-                    for event in events:
-                        if isinstance(event, h2.events.ResponseReceived):
-                            headers = HTTPHeaderDict()
-                            for header, value in event.headers:
-                                if header == b":status":
-                                    status = int(value.decode())
-                                else:
-                                    headers.add(
-                                        header.decode("ascii"), value.decode("ascii")
-                                    )
+        """
+        Read from the socket until the response headers arrive, then hand
+        the body off to :class:`HTTP2Response` via :class:`HTTP2Stream`.
 
-                        elif isinstance(event, h2.events.DataReceived):
-                            data += event.data
-                            conn.acknowledge_received_data(
-                                event.flow_controlled_length, event.stream_id
-                            )
+        Raises :class:`http.client.ResponseNotReady` if a request has not
+        been sent or a previous response was not handled.
+        """
+        # Raise the same error as http.client.HTTPConnection
+        if self._response_options is None or self._h2_stream is None:
+            raise ResponseNotReady()
 
-                        elif isinstance(event, h2.events.StreamEnded):
-                            end_stream = True
+        # Reset this attribute for being used again.
+        resp_options = self._response_options
+        self._response_options = None
 
-                if data_to_send := conn.data_to_send():
-                    self.sock.sendall(data_to_send)
+        # Since the connection's timeout value may have been updated
+        # we need to set the timeout on the socket.
+        self.sock.settimeout(self.timeout)
 
-        assert status is not None
+        # Transfer ownership of the stream's read side to the response.
+        # The response object reads the body from the stream on demand.
+        stream = HTTP2Stream(self.sock, self._h2_conn, self._h2_stream)
+        self._h2_stream = None
+
+        status, headers = stream.read_response()
+
         return HTTP2Response(
             status=status,
             headers=headers,
-            request_url=self._request_url,
-            data=bytes(data),
+            request_url=resp_options.request_url,
+            stream=stream,
+            request_method=resp_options.request_method,
+            preload_content=resp_options.preload_content,
+            decode_content=resp_options.decode_content,
+            enforce_content_length=resp_options.enforce_content_length,
+            sock_shutdown=getattr(self.sock, "shutdown", None),
         )
 
     def request(  # type: ignore[override]
@@ -286,6 +474,18 @@ class HTTP2Connection(HTTPSConnection):
 
         if self.sock is not None:
             self.sock.settimeout(self.timeout)
+
+        # Store these values to be fed into the HTTP2Response object later.
+        # We have to store these before we send the request in case we
+        # can still salvage a response off the wire even if we aren't able
+        # to completely send the request body.
+        self._response_options = _ResponseOptions(
+            request_method=method,
+            request_url=url,
+            preload_content=preload_content,
+            decode_content=decode_content,
+            enforce_content_length=enforce_content_length,
+        )
 
         self.putrequest(method, url)
 
@@ -318,19 +518,37 @@ class HTTP2Connection(HTTPSConnection):
         self._h2_conn = self._new_h2_conn()
         self._h2_stream = None
         self._headers = []
+        self._response_options = None
 
         super().close()
 
 
 class HTTP2Response(BaseHTTPResponse):
-    # TODO: This is a woefully incomplete response object, but works for non-streaming.
+    """
+    HTTP/2 response.
+
+    The response body is owned by an :class:`HTTP2Stream` handed off by
+    :meth:`HTTP2Connection.getresponse` once the response headers were
+    received. The body is read from the stream on demand, so responses
+    can be streamed with ``preload_content=False`` and decoded based on
+    the ``content-encoding`` header just like HTTP/1.1 responses.
+
+    Note that HTTP/2 always enforces that the response body matches the
+    ``content-length`` header, as required by RFC 9113 section 8.1.1.
+    """
+
     def __init__(
         self,
         status: int,
         headers: HTTPHeaderDict,
         request_url: str,
-        data: bytes,
-        decode_content: bool = False,  # TODO: support decoding
+        stream: HTTP2Stream,
+        request_method: str | None = None,
+        preload_content: bool = True,
+        decode_content: bool = True,
+        enforce_content_length: bool = True,
+        auto_close: bool = True,
+        sock_shutdown: typing.Callable[[int], None] | None = None,
     ) -> None:
         super().__init__(
             status=status,
@@ -343,15 +561,437 @@ class HTTP2Response(BaseHTTPResponse):
             decode_content=decode_content,
             request_url=request_url,
         )
-        self._data = data
-        self.length_remaining = 0
+        self._stream = stream
+        self._body: bytes | None = None
+        self._closed = False
+        self._fp_bytes_read = 0
+        self._uncached_read_occurred = False
+        self._decoded_buffer = BytesQueueBuffer()
+        self._sock_shutdown = sock_shutdown
+
+        # h2 enforces on the wire that the received body matches the
+        # content-length header. This attribute additionally gates the
+        # IncompleteRead check for responses closed before the body was
+        # fully read, mirroring HTTPResponse.
+        self.enforce_content_length = enforce_content_length
+        self.auto_close = auto_close
+
+        # Set by the connection pool after the response is constructed.
+        self._pool: HTTPConnectionPool | None = None
+        self._connection: BaseHTTPConnection | None = None
+
+        self.length_remaining = self._init_length(request_method)
+
+        # If requested, preload the body.
+        if preload_content:
+            self._body = self.read(decode_content=decode_content)
+
+    def _init_length(self, request_method: str | None) -> int | None:
+        # h2 validates the content-length header on the wire and enforces
+        # that the received body matches it, so unlike HTTP/1.1 we only
+        # need to parse the value for bookkeeping. The multiple-value
+        # handling mirrors HTTPResponse for responses constructed directly.
+        length: int | None = None
+        content_length = self.headers.get("content-length")
+        if content_length is not None:
+            try:
+                lengths = {int(val) for val in content_length.split(",")}
+                if len(lengths) > 1:
+                    raise InvalidHeader(
+                        "Content-Length contained multiple "
+                        "unmatching values (%s)" % content_length
+                    )
+                length = lengths.pop()
+            except ValueError:
+                length = None
+            else:
+                if length < 0:
+                    length = None
+
+        # Check for responses that shouldn't include a body
+        if (
+            self.status in (204, 304)
+            or 100 <= self.status < 200
+            or request_method == "HEAD"
+        ):
+            length = 0
+
+        return length
+
+    @contextmanager
+    def _error_catcher(self) -> typing.Generator[None]:
+        """
+        Catch low-level python exceptions, instead re-raising urllib3
+        variants, so that low-level exceptions are not leaked in the
+        high-level api.
+
+        On exit, release the connection back to the pool if the stream
+        was fully consumed, or close it if reading failed part-way.
+        """
+        clean_exit = False
+
+        try:
+            try:
+                yield
+
+            except SocketTimeout as e:
+                raise ReadTimeoutError(self._pool, None, "Read timed out.") from e  # type: ignore[arg-type]
+
+            except BaseSSLError as e:
+                # SSL errors related to framing/MAC get wrapped and reraised here
+                raise SSLError(e) from e
+
+            except (HTTPException, OSError) as e:
+                raise ProtocolError(f"Connection broken: {e!r}", e) from e
+
+            # If no exception is thrown, we should avoid cleaning up
+            # unnecessarily.
+            clean_exit = True
+        finally:
+            # If we didn't terminate cleanly, the connection is in an
+            # unknown state and can't be reused: close it.
+            if not clean_exit and self._connection:
+                self._connection.close()
+
+            # Once the stream is fully consumed (or reading failed) the
+            # connection is no longer blocked by this response, so we
+            # should return it back to the pool.
+            if not clean_exit or self._stream.is_complete:
+                self.release_conn()
+
+    def _raw_read(self, amt: int | None = None, *, read1: bool = False) -> bytes:
+        """
+        Reads `amt` of (still encoded) body bytes from the HTTP/2 stream.
+        """
+        with self._error_catcher():
+            if self._closed:
+                data = b""
+                if (
+                    amt is not None
+                    and amt != 0
+                    and self.enforce_content_length
+                    and self.length_remaining is not None
+                    and self.length_remaining != 0
+                ):
+                    # Mirror HTTPResponse: an amt-read on a closed response
+                    # with an unsatisfied Content-Length is an error, not
+                    # a silent truncation.
+                    raise IncompleteRead(self._fp_bytes_read, self.length_remaining)
+            else:
+                data = self._stream.read(amt, read1=read1)
+                if data:
+                    self._fp_bytes_read += len(data)
+                    if self.length_remaining is not None:
+                        self.length_remaining -= len(data)
+        return data
+
+    # read(), read1() and stream() are kept in sync with HTTPResponse; a
+    # follow-up can hoist the shared logic into BaseHTTPResponse on top of
+    # the common _raw_read() contract.
+    def read(
+        self,
+        amt: int | None = None,
+        decode_content: bool | None = None,
+        cache_content: bool = False,
+    ) -> bytes:
+        """
+        Similar to :meth:`~urllib3.response.HTTPResponse.read`, but reads
+        from the :class:`HTTP2Stream` this response owns.
+
+        :param amt:
+            How much of the content to read. If specified, caching is skipped
+            because it doesn't make sense to cache partial content as the full
+            response.
+
+        :param decode_content:
+            If True, will attempt to decode the body based on the
+            'content-encoding' header.
+
+        :param cache_content:
+            If True, will save the returned data such that the same result is
+            returned despite of the state of the underlying file object. This
+            is useful if you want the ``.data`` property to continue working
+            after having ``.read()`` the file object. (Overridden if ``amt`` is
+            set.)
+        """
+        self._init_decoder()
+        if decode_content is None:
+            decode_content = self.decode_content
+
+        if amt and amt < 0:
+            # Negative numbers and `None` should be treated the same.
+            amt = None
+        elif amt is not None:
+            cache_content = False
+
+            if (
+                self._decoder
+                and self._decoder.has_unconsumed_tail
+                and len(self._decoded_buffer) < amt
+            ):
+                decoded_data = self._decode(
+                    b"",
+                    decode_content,
+                    flush_decoder=False,
+                    max_length=amt - len(self._decoded_buffer),
+                )
+                self._decoded_buffer.put(decoded_data)
+            if len(self._decoded_buffer) >= amt:
+                return self._decoded_buffer.get(amt)
+
+        data = self._raw_read(amt)
+        if not cache_content:
+            self._uncached_read_occurred = True
+
+        flush_decoder = amt is None or (amt != 0 and not data)
+
+        if (
+            not data
+            and len(self._decoded_buffer) == 0
+            and not (self._decoder and self._decoder.has_unconsumed_tail)
+        ):
+            return data
+
+        if amt is None:
+            data = self._decode(data, decode_content, flush_decoder)
+            # It's possible that there is buffered decoded data after a
+            # partial read.
+            if decode_content and len(self._decoded_buffer) > 0:
+                self._decoded_buffer.put(data)
+                data = self._decoded_buffer.get_all()
+
+            if cache_content and not self._uncached_read_occurred:
+                self._body = data
+        else:
+            # do not waste memory on buffer when not decoding
+            if not decode_content:
+                if self._has_decoded_content:
+                    raise RuntimeError(
+                        "Calling read(decode_content=False) is not supported after "
+                        "read(decode_content=True) was called."
+                    )
+                return data
+
+            decoded_data = self._decode(
+                data,
+                decode_content,
+                flush_decoder,
+                max_length=amt - len(self._decoded_buffer),
+            )
+            self._decoded_buffer.put(decoded_data)
+
+            while len(self._decoded_buffer) < amt and data:
+                data = self._raw_read(amt)
+                decoded_data = self._decode(
+                    data,
+                    decode_content,
+                    flush_decoder,
+                    max_length=amt - len(self._decoded_buffer),
+                )
+                self._decoded_buffer.put(decoded_data)
+            data = self._decoded_buffer.get(amt)
+
+        return data
+
+    def read1(
+        self,
+        amt: int | None = None,
+        decode_content: bool | None = None,
+    ) -> bytes:
+        """
+        Similar to ``http.client.HTTPResponse.read1`` and documented
+        in :meth:`io.BufferedReader.read1`, but with an additional parameter:
+        ``decode_content``.
+
+        :param amt:
+            How much of the content to read.
+
+        :param decode_content:
+            If True, will attempt to decode the body based on the
+            'content-encoding' header.
+        """
+        if decode_content is None:
+            decode_content = self.decode_content
+        if amt and amt < 0:
+            # Negative numbers and `None` should be treated the same.
+            amt = None
+        # try and respond without going to the network
+        if self._has_decoded_content:
+            if not decode_content:
+                raise RuntimeError(
+                    "Calling read1(decode_content=False) is not supported after "
+                    "read1(decode_content=True) was called."
+                )
+            if (
+                self._decoder
+                and self._decoder.has_unconsumed_tail
+                and (amt is None or len(self._decoded_buffer) < amt)
+            ):
+                decoded_data = self._decode(
+                    b"",
+                    decode_content,
+                    flush_decoder=False,
+                    max_length=(
+                        amt - len(self._decoded_buffer) if amt is not None else None
+                    ),
+                )
+                self._decoded_buffer.put(decoded_data)
+            if len(self._decoded_buffer) > 0:
+                if amt is None:
+                    return self._decoded_buffer.get_all()
+                return self._decoded_buffer.get(amt)
+        if amt == 0:
+            return b""
+
+        data = self._raw_read(amt, read1=True)
+        self._uncached_read_occurred = True
+        if not decode_content:
+            return data
+
+        self._init_decoder()
+        while True:
+            flush_decoder = not data
+            decoded_data = self._decode(
+                data, decode_content, flush_decoder, max_length=amt
+            )
+            self._decoded_buffer.put(decoded_data)
+            if decoded_data or flush_decoder:
+                break
+            data = self._raw_read(8192, read1=True)
+
+        if amt is None:
+            return self._decoded_buffer.get_all()
+        return self._decoded_buffer.get(amt)
+
+    def stream(
+        self, amt: int | None = _READ_CHUNK_SIZE, decode_content: bool | None = None
+    ) -> typing.Generator[bytes]:
+        """
+        A generator wrapper for the read() method. A call will block until
+        ``amt`` bytes have been read from the connection or until the
+        stream has ended.
+
+        :param amt:
+            How much of the content to read. The generator will return up to
+            much data per iteration, but may return less. This is particularly
+            likely when using compressed data. However, the empty string will
+            never be returned.
+
+        :param decode_content:
+            If True, will attempt to decode the body based on the
+            'content-encoding' header.
+        """
+        if amt == 0:
+            return
+
+        while (
+            (not self._closed and not self._stream.is_complete)
+            or len(self._decoded_buffer) > 0
+            or (self._decoder and self._decoder.has_unconsumed_tail)
+        ):
+            data = self.read(amt=amt, decode_content=decode_content)
+
+            if data:
+                yield data
 
     @property
     def data(self) -> bytes:
-        return self._data
+        if self._body is not None:
+            return self._body
+        return self.read(cache_content=True)
+
+    @property
+    def url(self) -> str | None:
+        """
+        Returns the URL that was the source of this response.
+        """
+        return self._request_url
+
+    @url.setter
+    def url(self, url: str | None) -> None:
+        self._request_url = url
+
+    @property
+    def connection(self) -> BaseHTTPConnection | None:
+        return self._connection
+
+    def tell(self) -> int:
+        """
+        Obtain the number of bytes pulled over the wire so far. May differ
+        from the amount of content returned by :meth:`HTTP2Response.read`
+        if bytes are encoded on the wire (e.g, compressed).
+        """
+        return self._fp_bytes_read
 
     def get_redirect_location(self) -> None:
         return None
 
+    def release_conn(self) -> None:
+        if not self._pool or not self._connection:
+            return None
+
+        self._pool._put_conn(self._connection)
+        self._connection = None
+
+    def drain_conn(self) -> None:
+        """
+        Read and discard any remaining HTTP response data in the response
+        stream.
+
+        Unread data in the HTTP2Response stream blocks the connection from
+        being released back to the pool.
+        """
+        try:
+            while self._raw_read(_READ_CHUNK_SIZE):
+                pass
+        except (HTTPError, OSError, BaseSSLError, HTTPException):
+            pass
+        if self._has_decoded_content:
+            # `_raw_read` skips decompression, so we should clean up the
+            # decoder to avoid keeping unnecessary data in memory.
+            self._decoded_buffer = BytesQueueBuffer()
+            self._decoder = None
+
+    def read_chunked(
+        self,
+        amt: int | None = None,
+        decode_content: bool | None = None,
+    ) -> typing.Iterator[bytes]:
+        raise ResponseNotChunked(
+            "Response is not chunked. "
+            "HTTP/2 does not support chunked transfer encoding."
+        )
+
+    def readable(self) -> bool:
+        return True
+
+    def shutdown(self) -> None:
+        if not self._sock_shutdown:
+            raise ValueError("Cannot shutdown socket as self._sock_shutdown is not set")
+        if self._connection is None:
+            raise RuntimeError(
+                "Cannot shutdown as connection has already been released to the pool"
+            )
+        self._sock_shutdown(socket.SHUT_RD)
+
     def close(self) -> None:
-        pass
+        self._sock_shutdown = None
+        self._closed = True
+
+        # Closing the socket does not reliably interrupt a thread that is
+        # already blocked in recv(); use shutdown() to unblock a pending
+        # read instead.
+        if self._connection:
+            self._connection.close()
+
+        if not self.auto_close:
+            io.IOBase.close(self)
+
+    @property
+    def closed(self) -> bool:
+        if not self.auto_close:
+            return io.IOBase.closed.__get__(self)  # type: ignore[no-any-return]
+        return self._closed or self._stream.is_complete
+
+    def isclosed(self) -> bool:
+        return self._closed or self._stream.is_complete

--- a/test/test_http2_connection.py
+++ b/test/test_http2_connection.py
@@ -1,17 +1,34 @@
 from __future__ import annotations
 
+import gzip
 import socket
+import sys
+import threading
+import time
+import typing
+import zlib
+from http.client import ResponseNotReady
+from test import onlyBrotli, onlyZstd
 from unittest import mock
 
+import h2.config
+import h2.connection
+import h2.events
 import pytest
 
 from urllib3.connection import _get_default_user_agent
-from urllib3.exceptions import ConnectionError
+from urllib3.exceptions import (
+    ConnectionError,
+    DecodeError,
+    ProtocolError,
+    ReadTimeoutError,
+)
 from urllib3.http2.connection import (
     HTTP2Connection,
     _is_illegal_header_value,
     _is_legal_header_name,
 )
+from urllib3.util.retry import RequestHistory, Retry
 
 # [1] https://httpwg.org/specs/rfc9113.html#n-field-validity
 
@@ -384,3 +401,1076 @@ class TestHTTP2Connection:
         )
 
         close_connection.assert_called_with()
+
+
+class FakeSocket:
+    """
+    An in-memory socket wired directly to a server-side h2 connection.
+
+    Bytes sent by the client are processed by the server connection
+    immediately, so the tests exercise real HTTP/2 wire data in both
+    directions. ``recv()`` delivers whatever the server connection has
+    pending; when it has nothing, an optional ``pump`` callback gets a
+    chance to produce more (used to model responses limited by flow
+    control). A ``recv()`` that would block forever raises instead, so
+    tests fail loudly if the client reads more than the server sent.
+    """
+
+    def __init__(
+        self,
+        server: h2.connection.H2Connection,
+        pump: typing.Callable[[], None] | None = None,
+    ) -> None:
+        self.server = server
+        self.pump = pump
+        self.server_events: list[h2.events.Event] = []
+        self.server_closed = False
+        self.raise_timeout = False
+        self.fail_sendall = False
+        self.timeout: typing.Any = None
+        self._to_client = bytearray()
+
+    def settimeout(self, timeout: typing.Any) -> None:
+        self.timeout = timeout
+
+    def sendall(self, data: bytes) -> None:
+        if self.fail_sendall:
+            raise OSError("Connection reset by peer")
+        self.server_events.extend(self.server.receive_data(bytes(data)))
+
+    def recv(self, amt: int) -> bytes:
+        if self.raise_timeout:
+            raise TimeoutError("Read timed out")
+        if not self._to_client:
+            self._to_client += self.server.data_to_send()
+        if not self._to_client and self.pump is not None:
+            self.pump()
+            self._to_client += self.server.data_to_send()
+        if not self._to_client:
+            if self.server_closed:
+                return b""
+            raise AssertionError(
+                "recv() would block forever: the server has no data to send"
+            )
+        data = bytes(self._to_client[:amt])
+        del self._to_client[:amt]
+        return data
+
+    def close(self) -> None:
+        pass
+
+
+def _connected_http2_pair(
+    pump: typing.Callable[[], None] | None = None,
+) -> tuple[HTTP2Connection, h2.connection.H2Connection, FakeSocket]:
+    """Create an HTTP2Connection talking to a real server-side h2 connection."""
+    server = h2.connection.H2Connection(h2.config.H2Configuration(client_side=False))
+    server.initiate_connection()
+
+    conn = HTTP2Connection("example.com")
+    sock = FakeSocket(server, pump=pump)
+    conn.sock = sock
+    with conn._h2_conn as client:
+        client.initiate_connection()
+        data_to_send = client.data_to_send()
+    sock.sendall(data_to_send)
+    return conn, server, sock
+
+
+def _request_stream_id(
+    conn: HTTP2Connection, sock: FakeSocket, method: str = "GET", **kwargs: typing.Any
+) -> int:
+    """Send a request and return the stream id the server saw."""
+    conn.request(method, "/", **kwargs)
+    stream_id = [
+        event.stream_id
+        for event in sock.server_events
+        if isinstance(event, h2.events.RequestReceived)
+    ][-1]
+    assert stream_id is not None
+    return stream_id
+
+
+class TestHTTP2ResponseBody:
+    """The response body is owned and read on demand by HTTP2Response."""
+
+    def test_getresponse_returns_before_body_is_received(self) -> None:
+        conn, server, sock = _connected_http2_pair()
+        stream_id = _request_stream_id(conn, sock, preload_content=False)
+
+        # Only the response headers are sent. If getresponse() tried to
+        # read the body, FakeSocket.recv() would raise.
+        server.send_headers(stream_id, [(b":status", b"200")])
+        response = conn.getresponse()
+
+        assert response.status == 200
+        assert not response._stream.is_complete
+
+        server.send_data(stream_id, b"hello world", end_stream=True)
+        assert response.read() == b"hello world"
+        assert response._stream.is_complete
+
+    def test_read_amt_across_data_frames(self) -> None:
+        conn, server, sock = _connected_http2_pair()
+        stream_id = _request_stream_id(conn, sock, preload_content=False)
+
+        server.send_headers(stream_id, [(b":status", b"200")])
+        server.send_data(stream_id, b"foo")
+        server.send_data(stream_id, b"bar")
+        server.send_data(stream_id, b"baz", end_stream=True)
+
+        response = conn.getresponse()
+        assert response.read(4) == b"foob"
+        assert response.read(4) == b"arba"
+        assert response.read(4) == b"z"
+        assert response.read(4) == b""
+        assert response.read() == b""
+
+    def test_read_all_after_headers_only_batch(self) -> None:
+        conn, server, sock = _connected_http2_pair()
+        stream_id = _request_stream_id(conn, sock, preload_content=False)
+
+        server.send_headers(stream_id, [(b":status", b"200")])
+        response = conn.getresponse()
+
+        server.send_data(stream_id, b"first")
+        server.send_data(stream_id, b"second", end_stream=True)
+        assert response.read() == b"firstsecond"
+
+    def test_preload_content_reads_everything_eagerly(self) -> None:
+        conn, server, sock = _connected_http2_pair()
+        stream_id = _request_stream_id(conn, sock)
+
+        server.send_headers(
+            stream_id, [(b":status", b"200"), (b"content-length", b"3")]
+        )
+        server.send_data(stream_id, b"foo", end_stream=True)
+
+        response = conn.getresponse()
+        assert response._stream.is_complete
+        assert response.data == b"foo"
+        assert response.length_remaining == 0
+
+    def test_stream_yields_data_frames(self) -> None:
+        conn, server, sock = _connected_http2_pair()
+        stream_id = _request_stream_id(conn, sock, preload_content=False)
+
+        server.send_headers(stream_id, [(b":status", b"200")])
+        server.send_data(stream_id, b"aaaa")
+        server.send_data(stream_id, b"bbbb")
+        server.send_data(stream_id, b"cc", end_stream=True)
+
+        response = conn.getresponse()
+        assert list(response.stream(4)) == [b"aaaa", b"bbbb", b"cc"]
+
+    def test_read1_returns_available_data_without_waiting(self) -> None:
+        conn, server, sock = _connected_http2_pair()
+        stream_id = _request_stream_id(conn, sock, preload_content=False)
+
+        server.send_headers(stream_id, [(b":status", b"200")])
+        server.send_data(stream_id, b"first")
+        response = conn.getresponse()
+
+        # read1 must return the buffered frame instead of blocking until
+        # 100 bytes have accumulated. A blocking read would raise in recv().
+        assert response.read1(100) == b"first"
+
+        server.send_data(stream_id, b"second", end_stream=True)
+        assert response.read1(100) == b"second"
+        assert response.read1(100) == b""
+
+    def test_data_and_headers_in_a_single_recv_batch(self) -> None:
+        conn, server, sock = _connected_http2_pair()
+        stream_id = _request_stream_id(conn, sock, preload_content=False)
+
+        # Everything arrives in one TCP segment: DATA frames received
+        # while waiting for headers must be buffered for later reads.
+        server.send_headers(stream_id, [(b":status", b"200")])
+        server.send_data(stream_id, b"inline body", end_stream=True)
+
+        response = conn.getresponse()
+        assert response.read() == b"inline body"
+
+    def test_flow_control_window_is_acknowledged(self) -> None:
+        body = b"x" * 200_000
+        state = {"sent": 0, "ended": False}
+        stream_id = 0
+
+        def pump() -> None:
+            while state["sent"] < len(body):
+                window = min(
+                    server.local_flow_control_window(stream_id),
+                    server.max_outbound_frame_size,
+                )
+                if window == 0:
+                    return
+                chunk = body[state["sent"] : state["sent"] + window]
+                server.send_data(stream_id, chunk)
+                state["sent"] += len(chunk)
+            if not state["ended"]:
+                server.end_stream(stream_id)
+                state["ended"] = True
+
+        conn, server, sock = _connected_http2_pair(pump=pump)
+        stream_id = _request_stream_id(conn, sock, preload_content=False)
+
+        server.send_headers(stream_id, [(b":status", b"200")])
+        response = conn.getresponse()
+
+        # The default flow control window is 65,535 bytes: receiving 200kB
+        # only works if the client acknowledges received data. Without
+        # acknowledgements the pump stalls and recv() raises.
+        assert response.read() == body
+
+    def test_gzip_decoding_preloaded(self) -> None:
+        conn, server, sock = _connected_http2_pair()
+        stream_id = _request_stream_id(conn, sock)
+
+        server.send_headers(
+            stream_id, [(b":status", b"200"), (b"content-encoding", b"gzip")]
+        )
+        server.send_data(stream_id, gzip.compress(b"hello, world!"), end_stream=True)
+
+        response = conn.getresponse()
+        assert response.data == b"hello, world!"
+
+    def test_gzip_decoding_streamed(self) -> None:
+        conn, server, sock = _connected_http2_pair()
+        stream_id = _request_stream_id(conn, sock, preload_content=False)
+
+        compressed = gzip.compress(b"hello, world!" * 100)
+        server.send_headers(
+            stream_id, [(b":status", b"200"), (b"content-encoding", b"gzip")]
+        )
+        # Deliver the compressed body across multiple DATA frames.
+        third = len(compressed) // 3
+        server.send_data(stream_id, compressed[:third])
+        server.send_data(stream_id, compressed[third : 2 * third])
+        server.send_data(stream_id, compressed[2 * third :], end_stream=True)
+
+        response = conn.getresponse()
+        assert b"".join(response.stream(64)) == b"hello, world!" * 100
+
+    def test_deflate_decoding_partial_reads(self) -> None:
+        conn, server, sock = _connected_http2_pair()
+        stream_id = _request_stream_id(conn, sock, preload_content=False)
+
+        server.send_headers(
+            stream_id, [(b":status", b"200"), (b"content-encoding", b"deflate")]
+        )
+        server.send_data(stream_id, zlib.compress(b"foobarbaz"), end_stream=True)
+
+        response = conn.getresponse()
+        assert response.read(3) == b"foo"
+        assert response.read(3) == b"bar"
+        assert response.read(3) == b"baz"
+        assert response.read(3) == b""
+
+    def test_decode_content_false_returns_raw_bytes(self) -> None:
+        conn, server, sock = _connected_http2_pair()
+        stream_id = _request_stream_id(conn, sock, preload_content=False)
+
+        compressed = gzip.compress(b"hello, world!")
+        server.send_headers(
+            stream_id, [(b":status", b"200"), (b"content-encoding", b"gzip")]
+        )
+        server.send_data(stream_id, compressed, end_stream=True)
+
+        response = conn.getresponse()
+        assert response.read(decode_content=False) == compressed
+
+    def test_read_decode_content_false_after_true_raises(self) -> None:
+        conn, server, sock = _connected_http2_pair()
+        stream_id = _request_stream_id(conn, sock, preload_content=False)
+
+        compressed = gzip.compress(b"hello, world!" * 100)
+        server.send_headers(
+            stream_id, [(b":status", b"200"), (b"content-encoding", b"gzip")]
+        )
+        server.send_data(stream_id, compressed, end_stream=True)
+
+        response = conn.getresponse()
+        assert response.read(5, decode_content=True) == b"hello"
+        with pytest.raises(RuntimeError, match="read\\(decode_content=False\\)"):
+            response.read(5, decode_content=False)
+
+    def test_invalid_compressed_data_raises_decode_error(self) -> None:
+        conn, server, sock = _connected_http2_pair()
+        stream_id = _request_stream_id(conn, sock, preload_content=False)
+
+        server.send_headers(
+            stream_id, [(b":status", b"200"), (b"content-encoding", b"gzip")]
+        )
+        server.send_data(stream_id, b"garbage", end_stream=True)
+
+        response = conn.getresponse()
+        with pytest.raises(DecodeError):
+            response.read()
+
+    def test_read_amt_accumulates_across_socket_reads(self) -> None:
+        chunks = [b"bbbb", b"cccc"]
+        state = {"i": 0}
+        stream_id = 0
+
+        def pump() -> None:
+            if state["i"] < len(chunks):
+                server.send_data(
+                    stream_id,
+                    chunks[state["i"]],
+                    end_stream=state["i"] == len(chunks) - 1,
+                )
+                state["i"] += 1
+
+        conn, server, sock = _connected_http2_pair(pump=pump)
+        stream_id = _request_stream_id(conn, sock, preload_content=False)
+        server.send_headers(stream_id, [(b":status", b"200")])
+        server.send_data(stream_id, b"aaaa")
+        response = conn.getresponse()
+
+        # read(amt) must keep receiving until amt bytes accumulated, not
+        # return a short read after the first frame.
+        assert response.read(12, decode_content=False) == b"aaaabbbbcccc"
+
+    def test_frames_for_other_streams_are_ignored(self) -> None:
+        conn, server, sock = _connected_http2_pair()
+        first_stream_id = _request_stream_id(conn, sock, preload_content=False)
+        server.send_headers(first_stream_id, [(b":status", b"200")])
+        first_response = conn.getresponse()
+        assert first_response.status == 200
+
+        # A second request on the same connection while the first body is
+        # unread: late frames for the old stream must not corrupt the new
+        # response's body.
+        second_stream_id = _request_stream_id(conn, sock, preload_content=False)
+        assert second_stream_id != first_stream_id
+
+        server.send_data(first_stream_id, b"stale-data", end_stream=True)
+        server.send_headers(second_stream_id, [(b":status", b"200")])
+        second_response = conn.getresponse()
+
+        server.send_data(second_stream_id, b"fresh", end_stream=True)
+        assert second_response.read() == b"fresh"
+
+    def test_full_read_merges_buffered_decoded_data(self) -> None:
+        conn, server, sock = _connected_http2_pair()
+        stream_id = _request_stream_id(conn, sock, preload_content=False)
+        server.send_headers(
+            stream_id, [(b":status", b"200"), (b"content-encoding", b"deflate")]
+        )
+        server.send_data(stream_id, zlib.compress(b"foobarbaz"), end_stream=True)
+
+        response = conn.getresponse()
+        assert response.read(3) == b"foo"
+        # Simulate a decoder that does not respect max_length: decoded
+        # data ends up buffered before a full read.
+        middle_part = response._decode(
+            response._raw_read(),
+            decode_content=True,
+            flush_decoder=False,
+            max_length=3,
+        )
+        assert middle_part == b"bar"
+        response._decoded_buffer.put(middle_part)
+        assert response.read() == b"barbaz"
+
+    def test_read1_does_not_fake_eof_when_first_chunk_decodes_to_nothing(
+        self,
+    ) -> None:
+        compressed = gzip.compress(b"data" * 100)
+        conn, server, sock = _connected_http2_pair()
+        stream_id = _request_stream_id(conn, sock, preload_content=False)
+        server.send_headers(
+            stream_id, [(b":status", b"200"), (b"content-encoding", b"gzip")]
+        )
+        # The first frame contains only the gzip header, which decodes to
+        # zero bytes: read1 must keep reading instead of returning b"".
+        server.send_data(stream_id, compressed[:10])
+        response = conn.getresponse()
+        server.send_data(stream_id, compressed[10:], end_stream=True)
+
+        body = bytearray(response.read1())
+        assert body != b""
+        while chunk := response.read1():
+            body += chunk
+        assert bytes(body) == b"data" * 100
+
+    @onlyZstd()
+    def test_truncated_zstd_raises_decode_error(self) -> None:
+        if sys.version_info >= (3, 14):
+            from compression import zstd
+        else:
+            from backports import zstd
+
+        compressed = zstd.compress(b"hello, world!" * 64)
+        conn, server, sock = _connected_http2_pair()
+        stream_id = _request_stream_id(conn, sock, preload_content=False)
+        server.send_headers(
+            stream_id, [(b":status", b"200"), (b"content-encoding", b"zstd")]
+        )
+        server.send_data(stream_id, compressed[:-10], end_stream=True)
+
+        response = conn.getresponse()
+        # Truncation is only detectable when the decoder is flushed.
+        with pytest.raises(DecodeError):
+            response.read()
+
+    @onlyBrotli()
+    def test_brotli_decoding_streamed(self) -> None:
+        from urllib3.response import brotli  # type: ignore[attr-defined]
+
+        compressed = brotli.compress(b"hello, world!" * 50)
+        conn, server, sock = _connected_http2_pair()
+        stream_id = _request_stream_id(conn, sock, preload_content=False)
+        server.send_headers(
+            stream_id, [(b":status", b"200"), (b"content-encoding", b"br")]
+        )
+        half = len(compressed) // 2
+        server.send_data(stream_id, compressed[:half])
+        server.send_data(stream_id, compressed[half:], end_stream=True)
+
+        response = conn.getresponse()
+        assert b"".join(response.stream(64)) == b"hello, world!" * 50
+
+    def test_tell_counts_wire_bytes(self) -> None:
+        conn, server, sock = _connected_http2_pair()
+        stream_id = _request_stream_id(conn, sock, preload_content=False)
+        server.send_headers(stream_id, [(b":status", b"200")])
+        server.send_data(stream_id, b"0123456789", end_stream=True)
+
+        response = conn.getresponse()
+        assert response.tell() == 0
+        assert response.read(4) == b"0123"
+        assert response.tell() == 4
+        response.read()
+        assert response.tell() == 10
+
+    def test_negative_amt_reads_all(self) -> None:
+        conn, server, sock = _connected_http2_pair()
+        stream_id = _request_stream_id(conn, sock, preload_content=False)
+        server.send_headers(stream_id, [(b":status", b"200")])
+        server.send_data(stream_id, b"whole body", end_stream=True)
+
+        response = conn.getresponse()
+        assert response.read(-1) == b"whole body"
+
+    def test_data_property_not_cached_after_partial_read(self) -> None:
+        conn, server, sock = _connected_http2_pair()
+        stream_id = _request_stream_id(conn, sock, preload_content=False)
+        server.send_headers(stream_id, [(b":status", b"200")])
+        server.send_data(stream_id, b"0123456789", end_stream=True)
+
+        response = conn.getresponse()
+        assert response.read(4) == b"0123"
+        # After an uncached partial read the remainder must not be
+        # presented as the full cached body.
+        assert response.data == b"456789"
+        assert response.data == b""
+
+    def test_read_zero_is_noop(self) -> None:
+        conn, server, sock = _connected_http2_pair()
+        stream_id = _request_stream_id(conn, sock, preload_content=False)
+        server.send_headers(stream_id, [(b":status", b"200")])
+        server.send_data(stream_id, b"body", end_stream=True)
+
+        response = conn.getresponse()
+        assert response.read(0) == b""
+        assert response.read() == b"body"
+
+    def test_zero_length_data_frame_with_end_stream(self) -> None:
+        conn, server, sock = _connected_http2_pair()
+        stream_id = _request_stream_id(conn, sock, preload_content=False)
+        server.send_headers(stream_id, [(b":status", b"200")])
+        server.send_data(stream_id, b"payload")
+        response = conn.getresponse()
+
+        server.send_data(stream_id, b"", end_stream=True)
+        assert response.read() == b"payload"
+        assert response._stream.is_complete
+
+    def test_empty_body_with_content_encoding(self) -> None:
+        conn, server, sock = _connected_http2_pair()
+        stream_id = _request_stream_id(conn, sock, preload_content=False)
+        server.send_headers(
+            stream_id,
+            [(b":status", b"200"), (b"content-encoding", b"gzip")],
+            end_stream=True,
+        )
+
+        response = conn.getresponse()
+        assert response.read() == b""
+
+    def test_stream_amt_none_reads_everything(self) -> None:
+        conn, server, sock = _connected_http2_pair()
+        stream_id = _request_stream_id(conn, sock, preload_content=False)
+        server.send_headers(stream_id, [(b":status", b"200")])
+        server.send_data(stream_id, b"foo")
+        server.send_data(stream_id, b"bar", end_stream=True)
+
+        response = conn.getresponse()
+        assert list(response.stream(None)) == [b"foobar"]
+
+    def test_latin1_header_values_preserved(self) -> None:
+        conn, server, sock = _connected_http2_pair()
+        stream_id = _request_stream_id(conn, sock, preload_content=False)
+
+        server.config.validate_outbound_headers = False
+        server.send_headers(
+            stream_id,
+            [(b":status", b"200"), (b"x-filename", "café".encode("latin-1"))],
+            end_stream=True,
+        )
+
+        # http.client decodes HTTP/1.1 header bytes as latin-1; HTTP/2
+        # responses must parse byte-identical headers identically.
+        response = conn.getresponse()
+        assert response.headers["x-filename"] == "café"
+
+    def test_invalid_status_value_raises_protocol_error(self) -> None:
+        conn, server, sock = _connected_http2_pair()
+        stream_id = _request_stream_id(conn, sock, preload_content=False)
+
+        server.config.validate_outbound_headers = False
+        server.send_headers(stream_id, [(b":status", b"abc")], end_stream=True)
+
+        with pytest.raises(ProtocolError, match=":status"):
+            conn.getresponse()
+
+
+class TestHTTP2ResponseLifecycle:
+    """Error handling, timeouts and connection lifecycle."""
+
+    def test_getresponse_without_request_raises_response_not_ready(self) -> None:
+        conn, server, sock = _connected_http2_pair()
+        with pytest.raises(ResponseNotReady):
+            conn.getresponse()
+
+    def test_socket_timeout_during_read_raises_read_timeout_error(self) -> None:
+        conn, server, sock = _connected_http2_pair()
+        stream_id = _request_stream_id(conn, sock, preload_content=False)
+
+        server.send_headers(stream_id, [(b":status", b"200")])
+        response = conn.getresponse()
+
+        sock.raise_timeout = True
+        with pytest.raises(ReadTimeoutError):
+            response.read()
+
+    def test_connection_closed_before_headers_raises_protocol_error(self) -> None:
+        conn, server, sock = _connected_http2_pair()
+        _request_stream_id(conn, sock, preload_content=False)
+
+        sock.server_closed = True
+        with pytest.raises(ProtocolError, match="without sending a complete response"):
+            conn.getresponse()
+
+    def test_connection_closed_mid_body_raises_protocol_error(self) -> None:
+        conn, server, sock = _connected_http2_pair()
+        stream_id = _request_stream_id(conn, sock, preload_content=False)
+
+        server.send_headers(stream_id, [(b":status", b"200")])
+        server.send_data(stream_id, b"partial")
+        response = conn.getresponse()
+
+        sock.server_closed = True
+        with pytest.raises(ProtocolError, match="before the response body"):
+            response.read()
+
+    def test_content_length_mismatch_raises_protocol_error(self) -> None:
+        conn, server, sock = _connected_http2_pair()
+        stream_id = _request_stream_id(conn, sock, preload_content=False)
+
+        server.config.validate_outbound_headers = False
+        server.send_headers(
+            stream_id, [(b":status", b"200"), (b"content-length", b"100")]
+        )
+        response = conn.getresponse()
+
+        server.send_data(stream_id, b"short", end_stream=True)
+        with pytest.raises(ProtocolError, match="Invalid HTTP/2 data"):
+            response.read()
+
+    def test_trailers_are_ignored(self) -> None:
+        conn, server, sock = _connected_http2_pair()
+        stream_id = _request_stream_id(conn, sock, preload_content=False)
+
+        server.send_headers(stream_id, [(b":status", b"200")])
+        server.send_data(stream_id, b"body")
+        server.send_headers(stream_id, [(b"x-trailer", b"value")], end_stream=True)
+
+        response = conn.getresponse()
+        assert response.read() == b"body"
+        assert "x-trailer" not in response.headers
+
+    def test_informational_responses_are_skipped(self) -> None:
+        conn, server, sock = _connected_http2_pair()
+        stream_id = _request_stream_id(conn, sock, preload_content=False)
+
+        server.send_headers(stream_id, [(b":status", b"103")])
+        server.send_headers(stream_id, [(b":status", b"200")])
+        server.send_data(stream_id, b"final", end_stream=True)
+
+        response = conn.getresponse()
+        assert response.status == 200
+        assert response.read() == b"final"
+
+    def test_connection_released_to_pool_when_stream_consumed(self) -> None:
+        conn, server, sock = _connected_http2_pair()
+        stream_id = _request_stream_id(conn, sock, preload_content=False)
+
+        server.send_headers(stream_id, [(b":status", b"200")])
+        server.send_data(stream_id, b"body", end_stream=True)
+
+        response = conn.getresponse()
+        pool = mock.MagicMock()
+        response._pool = pool
+        response._connection = conn
+
+        assert response.read() == b"body"
+        pool._put_conn.assert_called_once_with(conn)
+        assert response.connection is None
+
+    def test_connection_closed_and_released_on_read_error(self) -> None:
+        conn, server, sock = _connected_http2_pair()
+        stream_id = _request_stream_id(conn, sock, preload_content=False)
+
+        server.send_headers(stream_id, [(b":status", b"200")])
+        response = conn.getresponse()
+
+        pool = mock.MagicMock()
+        connection = mock.MagicMock()
+        response._pool = pool
+        response._connection = connection
+
+        sock.server_closed = True
+        with pytest.raises(ProtocolError):
+            response.read()
+
+        connection.close.assert_called_once_with()
+        pool._put_conn.assert_called_once_with(connection)
+
+    def test_drain_conn_consumes_stream(self) -> None:
+        conn, server, sock = _connected_http2_pair()
+        stream_id = _request_stream_id(conn, sock, preload_content=False)
+
+        server.send_headers(stream_id, [(b":status", b"200")])
+        server.send_data(stream_id, b"x" * 1000, end_stream=True)
+
+        response = conn.getresponse()
+        assert not response._stream.is_complete
+        response.drain_conn()
+        assert response._stream.is_complete
+
+    def test_close_unconsumed_response_closes_connection(self) -> None:
+        conn, server, sock = _connected_http2_pair()
+        stream_id = _request_stream_id(conn, sock, preload_content=False)
+
+        server.send_headers(stream_id, [(b":status", b"200")])
+        response = conn.getresponse()
+
+        connection = mock.MagicMock()
+        response._connection = connection
+
+        assert not response.closed
+        response.close()
+        connection.close.assert_called_once_with()
+        assert response.closed
+
+    def test_head_response_has_no_body(self) -> None:
+        conn, server, sock = _connected_http2_pair()
+        stream_id = _request_stream_id(conn, sock, method="HEAD")
+
+        server.send_headers(
+            stream_id,
+            [(b":status", b"200"), (b"content-length", b"1000")],
+            end_stream=True,
+        )
+
+        response = conn.getresponse()
+        assert response.length_remaining == 0
+        assert response.data == b""
+
+    def test_setting_retries_with_history_does_not_crash(self) -> None:
+        conn, server, sock = _connected_http2_pair()
+        stream_id = _request_stream_id(conn, sock, preload_content=False)
+
+        server.send_headers(stream_id, [(b":status", b"200")])
+        response = conn.getresponse()
+
+        # The connection pool assigns retries to every response. With a
+        # non-empty history the setter assigns the redirect location to
+        # response.url, which previously raised NotImplementedError.
+        retries = Retry(history=(RequestHistory("GET", "/", None, None, None),))
+        response.retries = retries
+        assert response.url is None
+
+        response.url = "https://example.com/"
+        assert response.url == "https://example.com/"
+
+    def test_json(self) -> None:
+        conn, server, sock = _connected_http2_pair()
+        stream_id = _request_stream_id(conn, sock)
+
+        server.send_headers(
+            stream_id, [(b":status", b"200"), (b"content-type", b"application/json")]
+        )
+        server.send_data(stream_id, b'{"hello": "world"}', end_stream=True)
+
+        response = conn.getresponse()
+        assert response.json() == {"hello": "world"}
+
+    def test_readinto(self) -> None:
+        conn, server, sock = _connected_http2_pair()
+        stream_id = _request_stream_id(conn, sock, preload_content=False)
+
+        server.send_headers(stream_id, [(b":status", b"200")])
+        server.send_data(stream_id, b"some data", end_stream=True)
+
+        response = conn.getresponse()
+        buffer = bytearray(4)
+        assert response.readinto(buffer) == 4
+        assert bytes(buffer) == b"some"
+
+    def test_stream_reset_raises_protocol_error(self) -> None:
+        conn, server, sock = _connected_http2_pair()
+        stream_id = _request_stream_id(conn, sock, preload_content=False)
+
+        server.send_headers(stream_id, [(b":status", b"200")])
+        server.send_data(stream_id, b"partial")
+        response = conn.getresponse()
+
+        server.reset_stream(stream_id, error_code=8)
+        with pytest.raises(ProtocolError, match="reset by the remote peer"):
+            response.read()
+
+    def test_goaway_raises_protocol_error(self) -> None:
+        conn, server, sock = _connected_http2_pair()
+        stream_id = _request_stream_id(conn, sock, preload_content=False)
+
+        server.send_headers(stream_id, [(b":status", b"200")])
+        response = conn.getresponse()
+
+        server.close_connection(error_code=2)
+        with pytest.raises(ProtocolError, match="terminated by the remote peer"):
+            response.read()
+
+    def test_goaway_after_stream_end_is_ignored(self) -> None:
+        # A graceful shutdown: the server finishes the stream and sends
+        # GOAWAY afterwards. The completed response must not error.
+        conn, server, sock = _connected_http2_pair()
+        stream_id = _request_stream_id(conn, sock, preload_content=False)
+
+        server.send_headers(stream_id, [(b":status", b"200")])
+        response = conn.getresponse()
+
+        server.send_data(stream_id, b"graceful", end_stream=True)
+        server.close_connection(error_code=0)
+        assert response.read() == b"graceful"
+
+    def test_close_then_release_returns_connection_to_pool(self) -> None:
+        # requests calls response.close() and then release_conn() when a
+        # streamed response is closed before being consumed. The pool slot
+        # must be returned in that case.
+        conn, server, sock = _connected_http2_pair()
+        stream_id = _request_stream_id(conn, sock, preload_content=False)
+
+        server.send_headers(stream_id, [(b":status", b"200")])
+        response = conn.getresponse()
+
+        pool = mock.MagicMock()
+        connection = mock.MagicMock()
+        response._pool = pool
+        response._connection = connection
+
+        response.close()
+        response.release_conn()
+
+        connection.close.assert_called_once_with()
+        pool._put_conn.assert_called_once_with(connection)
+
+    def test_read_and_stream_after_close_return_no_data(self) -> None:
+        conn, server, sock = _connected_http2_pair()
+        stream_id = _request_stream_id(conn, sock, preload_content=False)
+
+        server.send_headers(stream_id, [(b":status", b"200")])
+        server.send_data(stream_id, b"data")
+        response = conn.getresponse()
+        assert response.read(2) == b"da"
+
+        response.close()
+        assert response.read() == b""
+        assert list(response.stream(2)) == []
+
+    def test_auto_close_false_supports_io_wrapper(self) -> None:
+        import io
+
+        conn, server, sock = _connected_http2_pair()
+        stream_id = _request_stream_id(conn, sock, preload_content=False)
+
+        server.send_headers(stream_id, [(b":status", b"200")])
+        server.send_data(stream_id, b"hello world", end_stream=True)
+
+        response = conn.getresponse()
+        response.auto_close = False
+        reader = io.TextIOWrapper(response)  # type: ignore[type-var]
+        assert reader.read() == "hello world"
+        assert not response.closed
+        assert response.isclosed()
+
+        reader.close()
+        assert response.closed
+
+    def test_multiple_content_length_values(self) -> None:
+        from urllib3._collections import HTTPHeaderDict
+        from urllib3.exceptions import InvalidHeader
+        from urllib3.http2.connection import HTTP2Response, HTTP2Stream
+
+        conn, server, sock = _connected_http2_pair()
+
+        def response_with_content_length(value1: str, value2: str) -> HTTP2Response:
+            return HTTP2Response(
+                status=200,
+                headers=HTTPHeaderDict(
+                    [("content-length", value1), ("content-length", value2)]
+                ),
+                request_url="/",
+                stream=HTTP2Stream(sock, conn._h2_conn, 1),  # type: ignore[arg-type]
+                preload_content=False,
+            )
+
+        assert response_with_content_length("42", "42").length_remaining == 42
+        with pytest.raises(InvalidHeader):
+            response_with_content_length("42", "43")
+
+    def test_read_chunked_raises_response_not_chunked(self) -> None:
+        from urllib3.exceptions import ResponseNotChunked
+
+        conn, server, sock = _connected_http2_pair()
+        stream_id = _request_stream_id(conn, sock, preload_content=False)
+
+        server.send_headers(stream_id, [(b":status", b"200")])
+        response = conn.getresponse()
+
+        with pytest.raises(ResponseNotChunked):
+            response.read_chunked()
+
+    def test_304_reports_zero_length(self) -> None:
+        conn, server, sock = _connected_http2_pair()
+        stream_id = _request_stream_id(conn, sock, preload_content=False)
+
+        # A 304 may carry the entity's content-length without a body.
+        server.send_headers(
+            stream_id,
+            [(b":status", b"304"), (b"content-length", b"1000")],
+            end_stream=True,
+        )
+
+        response = conn.getresponse()
+        assert response.length_remaining == 0
+        assert response.read() == b""
+
+    def test_shutdown_calls_sock_shutdown(self) -> None:
+        calls: list[int] = []
+
+        conn, server, sock = _connected_http2_pair()
+        sock.shutdown = calls.append  # type: ignore[attr-defined]
+        stream_id = _request_stream_id(conn, sock, preload_content=False)
+        server.send_headers(stream_id, [(b":status", b"200")])
+
+        response = conn.getresponse()
+        response._connection = mock.MagicMock()
+        response.shutdown()
+        assert calls == [socket.SHUT_RD]
+
+    def test_shutdown_after_release_raises(self) -> None:
+        conn, server, sock = _connected_http2_pair()
+        sock.shutdown = lambda how: None  # type: ignore[attr-defined]
+        stream_id = _request_stream_id(conn, sock, preload_content=False)
+        server.send_headers(stream_id, [(b":status", b"200")])
+
+        response = conn.getresponse()
+        with pytest.raises(RuntimeError, match="released"):
+            response.shutdown()
+
+    def test_shutdown_after_close_raises(self) -> None:
+        conn, server, sock = _connected_http2_pair()
+        sock.shutdown = lambda how: None  # type: ignore[attr-defined]
+        stream_id = _request_stream_id(conn, sock, preload_content=False)
+        server.send_headers(stream_id, [(b":status", b"200")])
+
+        response = conn.getresponse()
+        response.close()
+        with pytest.raises(ValueError):
+            response.shutdown()
+
+    def test_closed_after_stream_consumed(self) -> None:
+        conn, server, sock = _connected_http2_pair()
+        stream_id = _request_stream_id(conn, sock, preload_content=False)
+        server.send_headers(stream_id, [(b":status", b"200")])
+        server.send_data(stream_id, b"body", end_stream=True)
+
+        response = conn.getresponse()
+        assert not response.closed
+        assert response.read() == b"body"
+        assert response.closed
+        assert response.isclosed()
+
+    def test_getresponse_applies_updated_timeout(self) -> None:
+        conn, server, sock = _connected_http2_pair()
+        stream_id = _request_stream_id(conn, sock, preload_content=False)
+
+        # The pool updates conn.timeout to the read timeout after sending
+        # the request and before calling getresponse().
+        conn.timeout = 0.25
+        server.send_headers(stream_id, [(b":status", b"200")])
+        conn.getresponse()
+        assert sock.timeout == 0.25
+
+    def test_send_failure_after_stream_end_is_ignored(self) -> None:
+        conn, server, sock = _connected_http2_pair()
+        stream_id = _request_stream_id(conn, sock, preload_content=False)
+        server.send_headers(stream_id, [(b":status", b"200")])
+        response = conn.getresponse()
+
+        # The PING arrives in the same batch as END_STREAM: failing to
+        # send the queued PING ack must not invalidate the received body.
+        server.send_data(stream_id, b"done", end_stream=True)
+        server.ping(b"12345678")
+        sock.fail_sendall = True
+        assert response.read() == b"done"
+
+    def test_send_failure_mid_stream_raises(self) -> None:
+        body = b"x" * 200_000
+        state = {"sent": 0, "ended": False}
+        stream_id = 0
+
+        def pump() -> None:
+            while state["sent"] < len(body):
+                window = min(
+                    server.local_flow_control_window(stream_id),
+                    server.max_outbound_frame_size,
+                )
+                if window == 0:
+                    return
+                chunk = body[state["sent"] : state["sent"] + window]
+                server.send_data(stream_id, chunk)
+                state["sent"] += len(chunk)
+            if not state["ended"]:
+                server.end_stream(stream_id)
+                state["ended"] = True
+
+        conn, server, sock = _connected_http2_pair(pump=pump)
+        stream_id = _request_stream_id(conn, sock, preload_content=False)
+
+        server.send_headers(stream_id, [(b":status", b"200")])
+        response = conn.getresponse()
+
+        # Failing to send flow control acknowledgements while the body is
+        # still incomplete leaves the connection unusable and must raise.
+        sock.fail_sendall = True
+        with pytest.raises(ProtocolError):
+            response.read()
+
+    def test_read_after_close_with_unread_content_length_raises(self) -> None:
+        conn, server, sock = _connected_http2_pair()
+        stream_id = _request_stream_id(conn, sock, preload_content=False)
+
+        server.send_headers(
+            stream_id, [(b":status", b"200"), (b"content-length", b"10")]
+        )
+        server.send_data(stream_id, b"ab")
+        response = conn.getresponse()
+        assert response.read(2) == b"ab"
+
+        response.close()
+        with pytest.raises(ProtocolError):
+            response.read(2)
+
+    def _blocked_reader_setup(
+        self,
+    ) -> tuple[
+        HTTP2Connection,
+        typing.Any,
+        socket.socket,
+        socket.socket,
+        list[BaseException],
+        threading.Thread,
+    ]:
+        """Start a request over a real socketpair and a daemon thread
+        blocked in response.read()."""
+        client_sock, server_sock = socket.socketpair()
+
+        server = h2.connection.H2Connection(
+            h2.config.H2Configuration(client_side=False)
+        )
+        server.initiate_connection()
+
+        conn = HTTP2Connection("example.com")
+        conn.sock = client_sock
+        with conn._h2_conn as client:
+            client.initiate_connection()
+            client_sock.sendall(client.data_to_send())
+
+        conn.request("GET", "/", preload_content=False)
+
+        stream_id = None
+        while stream_id is None:
+            events = server.receive_data(server_sock.recv(65536))
+            for event in events:
+                if isinstance(event, h2.events.RequestReceived):
+                    stream_id = event.stream_id
+        server.send_headers(stream_id, [(b":status", b"200")])
+        server_sock.sendall(server.data_to_send())
+
+        response = conn.getresponse()
+        response._connection = conn
+
+        errors: list[BaseException] = []
+
+        def read_body() -> None:
+            try:
+                response.read()
+            except BaseException as e:  # noqa: BLE001
+                errors.append(e)
+
+        reader = threading.Thread(target=read_body, daemon=True)
+        reader.start()
+        time.sleep(0.2)  # Let the reader block in recv().
+        return conn, response, client_sock, server_sock, errors, reader
+
+    @pytest.mark.timeout(10)
+    def test_shutdown_unblocks_concurrent_read(self) -> None:
+        conn, response, client_sock, server_sock, errors, reader = (
+            self._blocked_reader_setup()
+        )
+        try:
+            # shutdown() is the cross-platform way to interrupt a thread
+            # blocked in recv(): SHUT_RD makes the pending recv return b"".
+            response.shutdown()
+            reader.join(timeout=5)
+
+            assert not reader.is_alive()
+            assert len(errors) == 1
+            assert isinstance(errors[0], ProtocolError)
+        finally:
+            conn.close()
+            server_sock.close()
+            client_sock.close()
+
+    @pytest.mark.timeout(10)
+    def test_close_does_not_deadlock_with_concurrent_read(self) -> None:
+        conn, response, client_sock, server_sock, errors, reader = (
+            self._blocked_reader_setup()
+        )
+        try:
+            # Receiving must not hold the h2 lock during the blocking
+            # recv(), otherwise this close() would wait for the reader
+            # (which never returns) instead of completing promptly. The
+            # reader itself is a daemon thread: whether a close() wakes a
+            # blocked recv() is platform-dependent, so its outcome is not
+            # asserted here (see test_shutdown_unblocks_concurrent_read).
+            start = time.monotonic()
+            conn.close()
+            assert time.monotonic() - start < 2
+        finally:
+            server_sock.close()
+            client_sock.close()

--- a/test/test_http2_connection.py
+++ b/test/test_http2_connection.py
@@ -2,13 +2,14 @@ from __future__ import annotations
 
 import gzip
 import socket
+import ssl
 import sys
 import threading
 import time
 import typing
 import zlib
 from http.client import ResponseNotReady
-from test import onlyBrotli, onlyZstd
+from test import notWindows, onlyBrotli, onlyZstd
 from unittest import mock
 
 import h2.config
@@ -935,6 +936,103 @@ class TestHTTP2ResponseBody:
         with pytest.raises(ProtocolError, match=":status"):
             conn.getresponse()
 
+    def test_read_cache_content_stores_body(self) -> None:
+        conn, server, sock = _connected_http2_pair()
+        stream_id = _request_stream_id(conn, sock, preload_content=False)
+
+        server.send_headers(stream_id, [(b":status", b"200")])
+        server.send_data(stream_id, b"cached body", end_stream=True)
+
+        response = conn.getresponse()
+        assert response.read(cache_content=True) == b"cached body"
+        # The cached body keeps serving after the stream is consumed.
+        assert response.data == b"cached body"
+
+    def test_read_amt_decode_content_false_after_true_raises(self) -> None:
+        conn, server, sock = _connected_http2_pair()
+        stream_id = _request_stream_id(conn, sock, preload_content=False)
+
+        server.send_headers(
+            stream_id, [(b":status", b"200"), (b"content-encoding", b"gzip")]
+        )
+        server.send_data(stream_id, gzip.compress(b"hello, world!"), end_stream=True)
+
+        response = conn.getresponse()
+        assert response.read(4) == b"hell"
+        with pytest.raises(RuntimeError, match="not supported"):
+            response.read(4, decode_content=False)
+
+    def test_read1_negative_amt_reads_all(self) -> None:
+        conn, server, sock = _connected_http2_pair()
+        stream_id = _request_stream_id(conn, sock, preload_content=False)
+
+        server.send_headers(stream_id, [(b":status", b"200")])
+        server.send_data(stream_id, b"everything", end_stream=True)
+
+        response = conn.getresponse()
+        assert response.read1(-3) == b"everything"
+
+    def test_read1_decode_content_false_after_true_raises(self) -> None:
+        conn, server, sock = _connected_http2_pair()
+        stream_id = _request_stream_id(conn, sock, preload_content=False)
+
+        server.send_headers(
+            stream_id, [(b":status", b"200"), (b"content-encoding", b"gzip")]
+        )
+        server.send_data(stream_id, gzip.compress(b"hello, world!"), end_stream=True)
+
+        response = conn.getresponse()
+        assert response.read1(1) == b"h"
+        with pytest.raises(RuntimeError, match="not supported"):
+            response.read1(1, decode_content=False)
+
+    def test_read1_serves_decoder_tail_before_reading_network(self) -> None:
+        conn, server, sock = _connected_http2_pair()
+        stream_id = _request_stream_id(conn, sock, preload_content=False)
+
+        server.send_headers(
+            stream_id, [(b":status", b"200"), (b"content-encoding", b"gzip")]
+        )
+        server.send_data(stream_id, gzip.compress(b"hello, world!"), end_stream=True)
+
+        response = conn.getresponse()
+        # The whole compressed frame is consumed by the first read1; the
+        # remaining decoded bytes must come from the decoder's unconsumed
+        # tail without touching the network again.
+        assert response.read1(1) == b"h"
+        assert response.read1(1) == b"e"
+        assert response.read1() == b"llo, world!"
+
+    def test_read1_zero_amt_returns_empty(self) -> None:
+        conn, server, sock = _connected_http2_pair()
+        stream_id = _request_stream_id(conn, sock, preload_content=False)
+
+        server.send_headers(stream_id, [(b":status", b"200")])
+        server.send_data(stream_id, b"data", end_stream=True)
+
+        response = conn.getresponse()
+        assert response.read1(0) == b""
+
+    def test_read1_decode_content_false_returns_raw_bytes(self) -> None:
+        conn, server, sock = _connected_http2_pair()
+        stream_id = _request_stream_id(conn, sock, preload_content=False)
+
+        server.send_headers(stream_id, [(b":status", b"200")])
+        server.send_data(stream_id, b"raw bytes", end_stream=True)
+
+        response = conn.getresponse()
+        assert response.read1(decode_content=False) == b"raw bytes"
+
+    def test_stream_zero_amt_yields_nothing(self) -> None:
+        conn, server, sock = _connected_http2_pair()
+        stream_id = _request_stream_id(conn, sock, preload_content=False)
+
+        server.send_headers(stream_id, [(b":status", b"200")])
+        server.send_data(stream_id, b"data", end_stream=True)
+
+        response = conn.getresponse()
+        assert list(response.stream(0)) == []
+
 
 class TestHTTP2ResponseLifecycle:
     """Error handling, timeouts and connection lifecycle."""
@@ -1385,6 +1483,82 @@ class TestHTTP2ResponseLifecycle:
         with pytest.raises(ProtocolError):
             response.read(2)
 
+    def test_ssl_error_during_read_raises_urllib3_ssl_error(self) -> None:
+        from urllib3.exceptions import SSLError
+
+        conn, server, sock = _connected_http2_pair()
+        stream_id = _request_stream_id(conn, sock, preload_content=False)
+
+        server.send_headers(stream_id, [(b":status", b"200")])
+        response = conn.getresponse()
+
+        def raise_ssl_error(amt: int) -> bytes:
+            raise ssl.SSLError("decryption failed or bad record mac")
+
+        sock.recv = raise_ssl_error  # type: ignore[method-assign]
+        with pytest.raises(SSLError, match="bad record mac"):
+            response.read()
+
+    def test_goaway_send_failure_after_protocol_error_is_ignored(self) -> None:
+        conn, server, sock = _connected_http2_pair()
+        stream_id = _request_stream_id(conn, sock, preload_content=False)
+
+        server.send_headers(stream_id, [(b":status", b"200")])
+        response = conn.getresponse()
+
+        # Deliver garbage so h2 raises and queues a GOAWAY for the peer.
+        # Sending that GOAWAY fails: the original error must still win.
+        sock._to_client += b"\x00" * 24
+        sock.fail_sendall = True
+        with pytest.raises(ProtocolError, match="Invalid HTTP/2 data"):
+            response.read()
+
+    def test_unparseable_content_length_reports_none(self) -> None:
+        from urllib3._collections import HTTPHeaderDict
+        from urllib3.http2.connection import HTTP2Response, HTTP2Stream
+
+        conn, server, sock = _connected_http2_pair()
+
+        def response_with_content_length(value: str) -> HTTP2Response:
+            return HTTP2Response(
+                status=200,
+                headers=HTTPHeaderDict([("content-length", value)]),
+                request_url="/",
+                stream=HTTP2Stream(sock, conn._h2_conn, 1),  # type: ignore[arg-type]
+                preload_content=False,
+            )
+
+        assert response_with_content_length("abc").length_remaining is None
+        assert response_with_content_length("-5").length_remaining is None
+
+    def test_drain_conn_swallows_read_errors(self) -> None:
+        conn, server, sock = _connected_http2_pair()
+        stream_id = _request_stream_id(conn, sock, preload_content=False)
+
+        server.send_headers(stream_id, [(b":status", b"200")])
+        response = conn.getresponse()
+
+        sock.raise_timeout = True
+        # drain_conn is used on a best-effort basis by Retry: read errors
+        # while discarding the body must not propagate.
+        response.drain_conn()
+
+    def test_drain_conn_resets_decoder_state(self) -> None:
+        conn, server, sock = _connected_http2_pair()
+        stream_id = _request_stream_id(conn, sock, preload_content=False)
+
+        server.send_headers(
+            stream_id, [(b":status", b"200"), (b"content-encoding", b"gzip")]
+        )
+        server.send_data(stream_id, gzip.compress(b"hello, world!"), end_stream=True)
+
+        response = conn.getresponse()
+        assert response.read1(1) == b"h"
+
+        response.drain_conn()
+        assert response._decoder is None
+        assert len(response._decoded_buffer) == 0
+
     def _blocked_reader_setup(
         self,
     ) -> tuple[
@@ -1437,14 +1611,17 @@ class TestHTTP2ResponseLifecycle:
         time.sleep(0.2)  # Let the reader block in recv().
         return conn, response, client_sock, server_sock, errors, reader
 
+    @notWindows()
     @pytest.mark.timeout(10)
     def test_shutdown_unblocks_concurrent_read(self) -> None:
+        # On POSIX, shutdown(SHUT_RD) makes a recv() blocked in another
+        # thread return b"" immediately. Windows does not interrupt an
+        # in-progress recv() for SD_RECEIVE, so this test is POSIX-only,
+        # matching the documented HTTPResponse.shutdown() semantics.
         conn, response, client_sock, server_sock, errors, reader = (
             self._blocked_reader_setup()
         )
         try:
-            # shutdown() is the cross-platform way to interrupt a thread
-            # blocked in recv(): SHUT_RD makes the pending recv return b"".
             response.shutdown()
             reader.join(timeout=5)
 

--- a/test/with_dummyserver/test_http2.py
+++ b/test/with_dummyserver/test_http2.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import typing
+
+import pytest
+
+import urllib3.http2
+from dummyserver.socketserver import DEFAULT_CA
+from dummyserver.testcase import HTTPSHypercornDummyServerTestCase
+from urllib3 import HTTPSConnectionPool
+from urllib3.exceptions import DecodeError, ReadTimeoutError
+from urllib3.http2.connection import HTTP2Response
+from urllib3.util.timeout import Timeout
+
+
+@pytest.fixture(autouse=True)
+def inject_http2() -> typing.Generator[None]:
+    urllib3.http2.inject_into_urllib3()
+    try:
+        yield
+    finally:
+        urllib3.http2.extract_from_urllib3()
+
+
+class TestHTTP2ResponseBody(HTTPSHypercornDummyServerTestCase):
+    def _pool(self, **kwargs: typing.Any) -> HTTPSConnectionPool:
+        return HTTPSConnectionPool(self.host, self.port, ca_certs=DEFAULT_CA, **kwargs)
+
+    def test_preloaded_response(self) -> None:
+        with self._pool() as pool:
+            r = pool.request("GET", "/")
+
+        assert isinstance(r, HTTP2Response)
+        assert r.status == 200
+        assert r.version == 20
+        assert r.version_string == "HTTP/2"
+        assert r.headers["server"] == "hypercorn-h2"
+        assert r.data == b"Dummy server!"
+
+    def test_streamed_response(self) -> None:
+        with self._pool() as pool:
+            r = pool.request("GET", "/chunked", preload_content=False)
+            assert isinstance(r, HTTP2Response)
+            assert list(r.stream(4)) == [b"1231", b"2312", b"3123"]
+
+    def test_partial_reads(self) -> None:
+        with self._pool() as pool:
+            r = pool.request("GET", "/", preload_content=False)
+            assert r.read(5) == b"Dummy"
+            assert r.read(1) == b" "
+            assert r.read() == b"server!"
+            assert r.read() == b""
+
+    @pytest.mark.parametrize("encoding", ["gzip", "deflate"])
+    def test_decodes_compressed_response(self, encoding: str) -> None:
+        with self._pool() as pool:
+            r = pool.request(
+                "GET", "/encodingrequest", headers={"Accept-Encoding": encoding}
+            )
+            assert r.headers["content-encoding"] == encoding
+            assert r.data == b"hello, world!"
+
+    def test_decodes_compressed_response_streamed(self) -> None:
+        with self._pool() as pool:
+            r = pool.request(
+                "GET",
+                "/encodingrequest",
+                headers={"Accept-Encoding": "gzip"},
+                preload_content=False,
+            )
+            assert b"".join(r.stream(3)) == b"hello, world!"
+
+    def test_decode_content_false_returns_compressed_bytes(self) -> None:
+        with self._pool() as pool:
+            r = pool.request(
+                "GET",
+                "/encodingrequest",
+                headers={"Accept-Encoding": "gzip"},
+                decode_content=False,
+            )
+            # gzip magic number proves the body was left compressed.
+            assert r.data[:2] == b"\x1f\x8b"
+
+    def test_invalid_compressed_body_raises_decode_error(self) -> None:
+        with self._pool() as pool:
+            with pytest.raises(DecodeError):
+                pool.request(
+                    "GET",
+                    "/encodingrequest",
+                    headers={"Accept-Encoding": "garbage-gzip"},
+                    retries=False,
+                )
+
+    def test_response_larger_than_flow_control_window(self) -> None:
+        # 300kB is several times the default 64kB flow control window, so
+        # this only completes if HTTP2Response acknowledges received data
+        # while streaming.
+        with self._pool() as pool:
+            r = pool.request(
+                "GET",
+                "/large_response?size=300000",
+                preload_content=False,
+                retries=False,
+            )
+            received = sum(len(chunk) for chunk in r.stream(16384))
+            assert received == 300000
+
+    def test_connection_released_to_pool_after_body_consumed(self) -> None:
+        # Connection reuse across sequential requests is not new behavior;
+        # this proves the release path: with preload_content=False the
+        # connection must return to the pool once the body is consumed.
+        with self._pool() as pool:
+            r1 = pool.request("GET", "/", preload_content=False)
+            assert r1.read() == b"Dummy server!"
+            r2 = pool.request("GET", "/")
+            assert r2.data == b"Dummy server!"
+            assert pool.num_connections == 1
+
+    def test_read_timeout_is_respected(self) -> None:
+        with self._pool(retries=False) as pool:
+            with pytest.raises(ReadTimeoutError):
+                pool.request(
+                    "GET",
+                    "/slow",
+                    timeout=Timeout(connect=5, read=0.25),
+                )
+
+    def test_json(self) -> None:
+        with self._pool() as pool:
+            r = pool.request(
+                "POST",
+                "/echo_json",
+                body=b'{"hello": "world"}',
+                headers={"Content-Type": "application/json"},
+            )
+            assert r.json() == {"hello": "world"}
+
+    def test_head_response_has_no_body(self) -> None:
+        with self._pool() as pool:
+            r = pool.request("HEAD", "/", preload_content=False)
+            assert r.status == 200
+            assert r.read() == b""


### PR DESCRIPTION
Closes #3294

## What this does

Moves HTTP/2 response body handling out of `HTTP2Connection.getresponse()` and into `HTTP2Response`, following the design @pquentin sketched in the issue discussion:

* A new `HTTP2Stream` object owns the read side of a stream: the socket, the shared (locked) `h2.connection.H2Connection`, the stream id, the DATA buffer, and the single h2 event loop. It acknowledges received data so the flow control window stays open.
* `HTTP2Connection.getresponse()` now only reads until the final (non-informational) `ResponseReceived` event, builds the response from `:status` and the headers, and transfers ownership of the `HTTP2Stream` to `HTTP2Response`. DATA frames that arrive in the same batch as the headers are buffered, not lost.
* `HTTP2Response` reads the body from the stream on demand and now supports the same body API as `HTTPResponse`: `preload_content=False`, `read()`, `read1()`, `stream()`, `readinto()`, `json()`, `drain_conn()`, `release_conn()`, `close()`, `shutdown()`, and decoding of compressed bodies (`gzip`, `deflate`, plus `br`/`zstd` when installed) driven by `decode_content`. The read/decode semantics deliberately mirror `HTTPResponse.read()`/`read1()` so behavior is identical across HTTP versions.
* `HTTP2Connection.request()` records `_ResponseOptions` exactly like the HTTP/1.1 `HTTPConnection.request()` does, so `preload_content`/`decode_content` flow into the response and `getresponse()` without a prior `request()` raises `ResponseNotReady` consistently with HTTP/1.1.
* Read timeouts now apply to on-demand body reads and surface as `ReadTimeoutError` from `read()`/`stream()` (previously the whole body was read eagerly inside `getresponse()`), and `getresponse()` refreshes the socket timeout like HTTP/1.1 does in case it changed after `request()`.
* The connection is released back to the pool once the stream is fully consumed, and closed if reading fails part-way, mirroring the `HTTPResponse` lifecycle. This keeps sequential connection reuse working with `preload_content=False`.

Fixed along the way:

* The old receive loop busy-looped forever if the peer closed the TCP connection mid-response (`sock.recv()` returning `b""` was silently ignored). This now raises `ProtocolError`.
* Setting `response.retries` with a non-empty retry history crashed with `NotImplementedError` because `HTTP2Response` had no `url` setter.
* h2 protocol errors (e.g. `InvalidBodyLengthError` for a body that does not match `content-length`) are wrapped in urllib3's `ProtocolError` instead of leaking h2 exceptions.
* As a minimal safety net, `StreamReset` and `ConnectionTerminated` events for the active stream now raise `ProtocolError` instead of leaving `read()` blocked forever. Comprehensive error event handling (e.g. retry semantics for `REFUSED_STREAM`) remains #3291's scope.
* `auto_close = False` is supported like on `HTTPResponse`, so the documented `io.TextIOWrapper` pattern works. `read()` after `close()` matches HTTP/1.1: it returns `b""`, except that an `amt`-read with an unsatisfied `content-length` raises `ProtocolError` (`IncompleteRead`). `close()` followed by `release_conn()` (the pattern requests uses for unconsumed streamed responses) returns the pool slot.

Not in scope (left for their own issues): concurrent/multiplexed streams and connection reuse robustness such as GOAWAY handling and stream limits (#3301), redirects for HTTP/2 (`get_redirect_location()` still returns `None`, unchanged). Known pre-existing limitation: `HTTP2Response` has no `_original_response`, so requests' cookie extraction is skipped for HTTP/2 responses, as before this change.

## Notes for reviewers

* `HTTP2Response.read()`/`read1()`/`stream()` intentionally duplicate the decode/buffer logic of `HTTPResponse` rather than refactoring the HTTP/1.1 hot path in the same PR. `HTTP2Response._raw_read` deliberately matches `HTTPResponse._raw_read`'s signature (`amt, *, read1`) so those methods can later be hoisted verbatim into `BaseHTTPResponse` over a shared `_raw_read()` contract. I kept that refactor out of this PR because it touches the HTTP/1.1 hot path and `auto_close`/`_fp` semantics; happy to do it here if preferred, or as an immediate follow-up.
* Scope boundaries: the overlap with #3300 (streaming) is inherent to the design described in #3294 ("transfer the ownership of the state ... so that it can implement read() and stream()"). The `release_conn`/`_pool` machinery is not #3301 scope creep: without it, every `preload_content=False` response would permanently leak its connection from the pool. `StreamReset`/`ConnectionTerminated` get only a minimal safety net here (raise `ProtocolError` instead of blocking forever); comprehensive error event handling, e.g. retry semantics for `REFUSED_STREAM`, remains #3291's scope.
* h2 always enforces on the wire that the body matches `content-length` (RFC 9113 section 8.1.1). The `enforce_content_length` attribute additionally gates the `IncompleteRead` check for responses closed before the body was fully read, mirroring `HTTPResponse`.
* `dummyserver/app.py` gains a `/large_response` endpoint (needed to exercise responses larger than the 64 KiB flow control window) and registers the existing `/slow` endpoint on the hypercorn app (needed to test read timeouts).

## How this is tested

Unit tests (`test/test_http2_connection.py`) run the real h2 stack on both sides: a `FakeSocket` pipes wire bytes between the `HTTP2Connection` under test and a genuine server-side `h2.connection.H2Connection`, so no urllib3 or h2 code is mocked. `recv()` on the fake socket raises if the client would block forever, which makes laziness and flow-control regressions fail loudly:

* `getresponse()` returns after headers without touching the body; body readable afterwards
* partial reads across DATA frame boundaries, `read1` returning buffered data immediately, `stream()` chunking, `readinto()`, `json()`
* headers + body + END_STREAM arriving in a single `recv()` batch
* a 200 kB body behind the default 65,535-byte flow control window (fails if `acknowledge_received_data` is removed)
* gzip/deflate decoding: preloaded, streamed, partial reads, `decode_content=False`, mixing decoded and raw reads raises `RuntimeError`, garbage bodies raise `DecodeError`
* lifecycle: socket timeout -> `ReadTimeoutError`; peer close before headers and mid-body -> `ProtocolError`; `content-length` mismatch -> `ProtocolError`; trailers ignored; 1xx responses skipped; pool release on consumption; close-on-error; `drain_conn()`; HEAD; `ResponseNotReady`; the `retries`/`url` crash above

Integration tests (`test/with_dummyserver/test_http2.py`) exercise the same behaviors end to end against the hypercorn HTTP/2 server, including a 300 kB streamed download, connection reuse across requests, and read timeout enforcement.

Downstream: verified Requests works over the injected HTTP/2 path (plain GET, `stream=True` + `iter_content`, transparent gzip, 300 kB streamed download, `resp.raw.read()`, session connection reuse).

Full local run: 2,061 passed; the only failures are environment issues present on `main` as well (hypercorn `tls` extension and local proxy cert setup, identical failure list with and without this change).
