### PR TITLE
Support bytes field names and values in HTTPHeaderDict

### DIFF
--- a/changelog/3072.bugfix.rst
+++ b/changelog/3072.bugfix.rst
@@ -1,0 +1,5 @@
+Fixed ``HTTPHeaderDict`` raising ``TypeError`` when reading a header whose
+value was set as ``bytes``. Field names and values given as ``bytes`` are now
+decoded as latin-1 across all ``HTTPHeaderDict`` methods and stored as ``str``,
+so a ``bytes`` value compares equal to the equivalent ``str`` and is sent
+byte-for-byte over HTTP/1.1.

--- a/src/urllib3/_collections.py
+++ b/src/urllib3/_collections.py
@@ -30,8 +30,9 @@ _DT = typing.TypeVar("_DT")
 
 ValidHTTPHeaderSource = typing.Union[
     "HTTPHeaderDict",
-    typing.Mapping[str, str],
-    typing.Iterable[tuple[str, str]],
+    typing.Mapping[str, typing.Union[str, bytes]],
+    typing.Mapping[bytes, typing.Union[str, bytes]],
+    typing.Iterable[tuple[typing.Union[str, bytes], typing.Union[str, bytes]]],
     "HasGettableStringKeys",
 ]
 
@@ -48,12 +49,14 @@ def ensure_can_construct_http_header_dict(
     elif isinstance(potential, typing.Mapping):
         # Full runtime checking of the contents of a Mapping is expensive, so for the
         # purposes of typechecking, we assume that any Mapping is the right shape.
-        return typing.cast(typing.Mapping[str, str], potential)
+        return typing.cast("typing.Mapping[str, str | bytes]", potential)
     elif isinstance(potential, typing.Iterable):
         # Similarly to Mapping, full runtime checking of the contents of an Iterable is
         # expensive, so for the purposes of typechecking, we assume that any Iterable
         # is the right shape.
-        return typing.cast(typing.Iterable[tuple[str, str]], potential)
+        return typing.cast(
+            "typing.Iterable[tuple[str | bytes, str | bytes]]", potential
+        )
     elif hasattr(potential, "keys") and hasattr(potential, "__getitem__"):
         return typing.cast("HasGettableStringKeys", potential)
     else:
@@ -196,7 +199,9 @@ class HTTPHeaderDictItemView(set[tuple[str, str]]):
     def __contains__(self, item: object) -> bool:
         if isinstance(item, tuple) and len(item) == 2:
             passed_key, passed_val = item
-            if isinstance(passed_key, str) and isinstance(passed_val, str):
+            if isinstance(passed_key, (str, bytes)) and isinstance(
+                passed_val, (str, bytes)
+            ):
                 return self._headers._has_value_for_header(passed_key, passed_val)
         return False
 
@@ -225,6 +230,11 @@ class HTTPHeaderDict(typing.MutableMapping[str, str]):
     constructor or ``.update``, the behavior is undefined and some will be
     lost.
 
+    Field names and values given as ``bytes`` are decoded as latin-1, the
+    encoding ``http.client`` uses for HTTP/1.1 header fields, and stored as
+    ``str``. A ``bytes`` value therefore compares equal to the equivalent
+    ``str`` and is sent byte-for-byte over HTTP/1.1.
+
     >>> headers = HTTPHeaderDict()
     >>> headers.add('Set-Cookie', 'foo=bar')
     >>> headers.add('set-cookie', 'baz=quxx')
@@ -237,7 +247,9 @@ class HTTPHeaderDict(typing.MutableMapping[str, str]):
 
     _container: typing.MutableMapping[str, list[str]]
 
-    def __init__(self, headers: ValidHTTPHeaderSource | None = None, **kwargs: str):
+    def __init__(
+        self, headers: ValidHTTPHeaderSource | None = None, **kwargs: str | bytes
+    ):
         super().__init__()
         self._container = {}  # 'dict' is insert-ordered
         if headers is not None:
@@ -248,19 +260,23 @@ class HTTPHeaderDict(typing.MutableMapping[str, str]):
         if kwargs:
             self.extend(kwargs)
 
-    def __setitem__(self, key: str, val: str) -> None:
+    def __setitem__(self, key: str | bytes, val: str | bytes) -> None:
         # avoid a bytes/str comparison by decoding before httplib
         if isinstance(key, bytes):
             key = key.decode("latin-1")
+        # Decoding as latin-1 mirrors how field values are encoded on the
+        # wire, so a bytes value round-trips byte-for-byte.
+        if isinstance(val, bytes):
+            val = val.decode("latin-1")
         self._container[key.lower()] = [key, val]
 
-    def __getitem__(self, key: str) -> str:
+    def __getitem__(self, key: str | bytes) -> str:
         if isinstance(key, bytes):
             key = key.decode("latin-1")
         val = self._container[key.lower()]
         return ", ".join(val[1:])
 
-    def __delitem__(self, key: str) -> None:
+    def __delitem__(self, key: str | bytes) -> None:
         if isinstance(key, bytes):
             key = key.decode("latin-1")
         del self._container[key.lower()]
@@ -272,7 +288,13 @@ class HTTPHeaderDict(typing.MutableMapping[str, str]):
             return key.lower() in self._container
         return False
 
-    def setdefault(self, key: str, default: str = "") -> str:
+    def setdefault(self, key: str | bytes, default: str | bytes = "") -> str:
+        # Decode ahead of the inherited implementation so that a bytes
+        # default is returned as the str that would be stored.
+        if isinstance(key, bytes):
+            key = key.decode("latin-1")
+        if isinstance(default, bytes):
+            default = default.decode("latin-1")
         return super().setdefault(key, default)
 
     def __eq__(self, other: object) -> bool:
@@ -297,13 +319,13 @@ class HTTPHeaderDict(typing.MutableMapping[str, str]):
         for vals in self._container.values():
             yield vals[0]
 
-    def discard(self, key: str) -> None:
+    def discard(self, key: str | bytes) -> None:
         try:
             del self[key]
         except KeyError:
             pass
 
-    def add(self, key: str, val: str, *, combine: bool = False) -> None:
+    def add(self, key: str | bytes, val: str | bytes, *, combine: bool = False) -> None:
         """Adds a (name, value) pair, doesn't overwrite the value if it already
         exists.
 
@@ -325,6 +347,8 @@ class HTTPHeaderDict(typing.MutableMapping[str, str]):
         # avoid a bytes/str comparison by decoding before httplib
         if isinstance(key, bytes):
             key = key.decode("latin-1")
+        if isinstance(val, bytes):
+            val = val.decode("latin-1")
         key_lower = key.lower()
         new_vals = [key, val]
         # Keep the common case aka no item present as fast as possible
@@ -338,7 +362,7 @@ class HTTPHeaderDict(typing.MutableMapping[str, str]):
             else:
                 vals.append(val)
 
-    def extend(self, *args: ValidHTTPHeaderSource, **kwargs: str) -> None:
+    def extend(self, *args: ValidHTTPHeaderSource, **kwargs: str | bytes) -> None:
         """Generic import function for any type of header-like object.
         Adapted version of MutableMapping.update in order to insert items
         with self.add instead of self.__setitem__
@@ -353,11 +377,11 @@ class HTTPHeaderDict(typing.MutableMapping[str, str]):
             for key, val in other.iteritems():
                 self.add(key, val)
         elif isinstance(other, typing.Mapping):
-            for key, val in other.items():
-                self.add(key, val)
+            for mapping_key, mapping_val in other.items():
+                self.add(mapping_key, mapping_val)
         elif isinstance(other, typing.Iterable):
-            for key, value in other:
-                self.add(key, value)
+            for iterable_key, iterable_val in other:
+                self.add(iterable_key, iterable_val)
         elif hasattr(other, "keys") and hasattr(other, "__getitem__"):
             # THIS IS NOT A TYPESAFE BRANCH
             # In this branch, the object has a `keys` attr but is not a Mapping or any of
@@ -371,13 +395,13 @@ class HTTPHeaderDict(typing.MutableMapping[str, str]):
             self.add(key, value)
 
     @typing.overload
-    def getlist(self, key: str) -> list[str]: ...
+    def getlist(self, key: str | bytes) -> list[str]: ...
 
     @typing.overload
-    def getlist(self, key: str, default: _DT) -> list[str] | _DT: ...
+    def getlist(self, key: str | bytes, default: _DT) -> list[str] | _DT: ...
 
     def getlist(
-        self, key: str, default: _Sentinel | _DT = _Sentinel.not_passed
+        self, key: str | bytes, default: _Sentinel | _DT = _Sentinel.not_passed
     ) -> list[str] | _DT:
         """Returns a list of all the values for the named field. Returns an
         empty list if the key doesn't exist."""
@@ -451,7 +475,13 @@ class HTTPHeaderDict(typing.MutableMapping[str, str]):
     def items(self) -> HTTPHeaderDictItemView:  # type: ignore[override]
         return HTTPHeaderDictItemView(self)
 
-    def _has_value_for_header(self, header_name: str, potential_value: str) -> bool:
+    def _has_value_for_header(
+        self, header_name: str | bytes, potential_value: str | bytes
+    ) -> bool:
+        if isinstance(header_name, bytes):
+            header_name = header_name.decode("latin-1")
+        if isinstance(potential_value, bytes):
+            potential_value = potential_value.decode("latin-1")
         if header_name in self:
             return potential_value in self._container[header_name.lower()][1:]
         return False

--- a/src/urllib3/response.py
+++ b/src/urllib3/response.py
@@ -481,7 +481,7 @@ class BaseHTTPResponse(io.IOBase):
         if isinstance(headers, HTTPHeaderDict):
             self.headers = headers
         else:
-            self.headers = HTTPHeaderDict(headers)  # type: ignore[arg-type]
+            self.headers = HTTPHeaderDict(headers)
         self.status = status
         self.version = version
         self.version_string = version_string

--- a/test/test_collections.py
+++ b/test/test_collections.py
@@ -212,9 +212,8 @@ class TestHTTPHeaderDict:
 
     def test_setitem(self, d: HTTPHeaderDict) -> None:
         d["Cookie"] = "foo"
-        # The bytes value gets converted to str. The API is typed for str only,
-        # but the implementation continues supports bytes.
-        d[b"Cookie"] = "bar"  # type: ignore[index]
+        # Bytes keys and values are decoded as latin-1.
+        d[b"Cookie"] = "bar"
         assert d["cookie"] == "bar"
         d["cookie"] = "with, comma"
         assert d.getlist("cookie") == ["with, comma"]
@@ -231,7 +230,7 @@ class TestHTTPHeaderDict:
         assert "COOKIE" not in d
 
     def test_delitem_with_bytes_key(self, d: HTTPHeaderDict) -> None:
-        del d[b"cookie"]  # type: ignore[arg-type]
+        del d[b"cookie"]
         assert "cookie" not in d
 
     def test_add_well_known_multiheader(self, d: HTTPHeaderDict) -> None:
@@ -241,9 +240,8 @@ class TestHTTPHeaderDict:
 
     def test_add_comma_separated_multiheader(self, d: HTTPHeaderDict) -> None:
         d.add("bar", "foo")
-        # The bytes value gets converted to str. The API is typed for str only,
-        # but the implementation continues supports bytes.
-        d.add(b"BAR", "bar")  # type: ignore[arg-type]
+        # Bytes keys and values are decoded as latin-1.
+        d.add(b"BAR", "bar")
         d.add("Bar", "asdf")
         assert d.getlist("bar") == ["foo", "bar", "asdf"]
         assert d["bar"] == "foo, bar, asdf"
@@ -323,18 +321,133 @@ class TestHTTPHeaderDict:
         assert d.getlist("b") == ["asdf"]
 
     def test_getlist_with_bytes_key(self, d: HTTPHeaderDict) -> None:
-        assert d.getlist(b"cookie") == ["foo", "bar"]  # type: ignore[call-overload]
+        assert d.getlist(b"cookie") == ["foo", "bar"]
 
     def test_getitem_with_bytes(self, d: HTTPHeaderDict) -> None:
         d["Content-Type"] = "application/json"
         d.add("Content-Type", "charset=utf-8")
-        result = d[b"Content-Type"]  # type: ignore[index]
+        result = d[b"Content-Type"]
         assert result == "application/json, charset=utf-8"
 
     def test_contains_with_bytes(self, d: HTTPHeaderDict) -> None:
         d["Content-Type"] = "application/json"
         assert b"Content-Type" in d  # type: ignore[comparison-overlap]
         assert b"X-Not-There" not in d  # type: ignore[comparison-overlap]
+
+    def test_setitem_with_bytes_value(self, d: HTTPHeaderDict) -> None:
+        # The exact scenario from issue #3072.
+        encoded_data = "Schönefeld/1.18.0".encode("latin-1")
+        d["user-agent"] = encoded_data
+        assert d["user-agent"] == "Schönefeld/1.18.0"
+
+    def test_bytes_value_round_trips_every_field_octet(self, d: HTTPHeaderDict) -> None:
+        # latin-1 maps every byte to the code point of the same number, so
+        # any value a server or user can produce survives byte-for-byte.
+        raw = b"\t" + bytes(range(0x20, 0x7F)) + bytes(range(0x80, 0x100))
+        d[b"x-raw"] = raw
+        assert d["x-raw"].encode("latin-1") == raw
+
+    def test_utf8_bytes_are_preserved_verbatim(self, d: HTTPHeaderDict) -> None:
+        # UTF-8 encoded bytes are stored as their latin-1 decoding: the str
+        # form looks like mojibake but encodes back to the identical octets
+        # that http.client puts on the wire.
+        utf8_value = "Schönefeld".encode()
+        d["x-name"] = utf8_value
+        assert d["x-name"] == "SchÃ¶nefeld"
+        assert d["x-name"].encode("latin-1") == utf8_value
+
+    def test_bytes_field_name_uses_latin1(self, d: HTTPHeaderDict) -> None:
+        # Field names given as bytes decode as latin-1, like values. latin-1
+        # never raises (unlike utf-8 on a lone high byte) and folds case the
+        # latin-1 way, so a high-byte name round-trips across every method.
+        high_byte_item = (b"x-caf\xe9", b"two")
+        d[b"x-caf\xe9"] = "one"
+        assert d["x-caf\xe9"] == "one"
+        assert d[b"X-CAF\xc9"] == "one"
+        assert b"x-caf\xe9" in d  # type: ignore[comparison-overlap]
+        d.add(b"X-Caf\xe9", b"two")
+        assert d.getlist(b"x-caf\xe9") == ["one", "two"]
+        assert high_byte_item in d.items()  # type: ignore[comparison-overlap]
+        del d[b"x-caf\xe9"]
+        assert "x-caf\xe9" not in d
+
+    def test_add_with_bytes_values(self, d: HTTPHeaderDict) -> None:
+        d.add(b"x-token", b"one")
+        d.add("X-Token", b"two")
+        d.add(b"X-TOKEN", "three", combine=True)
+        assert d["x-token"] == "one, two, three"
+        assert d.getlist("x-token") == ["one", "two, three"]
+
+    def test_setdefault_with_bytes(self, d: HTTPHeaderDict) -> None:
+        # The str form of the default must be returned, not the raw bytes.
+        default = d.setdefault(b"x-default", b"v\xe9")
+        assert default == "v\xe9"
+        assert isinstance(default, str)
+        assert d["x-default"] == "v\xe9"
+        # An existing value wins over the default, whatever the key type.
+        assert d.setdefault(b"cookie", b"nope") == "foo, bar"
+
+    def test_create_from_bytes_sources(self) -> None:
+        from_mapping = HTTPHeaderDict({b"key": b"value"})
+        from_iterable = HTTPHeaderDict([(b"key", b"value")])
+        from_kwargs = HTTPHeaderDict(key=b"value")
+        assert (
+            from_mapping["key"] == from_iterable["key"] == from_kwargs["key"] == "value"
+        )
+
+    def test_extend_with_bytes_sources(self, d: HTTPHeaderDict) -> None:
+        d.extend({b"a": b"1"})
+        d.extend([(b"b", b"2")])
+        d.extend(c=b"3")
+        assert (d["a"], d["b"], d["c"]) == ("1", "2", "3")
+
+    def test_extend_kwargs_appends_to_existing(self) -> None:
+        # extend() adds rather than overwrites, including for kwargs.
+        d = HTTPHeaderDict()
+        d.add("a", "1")
+        d.extend(a="2")
+        assert d.getlist("a") == ["1", "2"]
+
+    def test_or_operators_with_bytes_mapping(self, d: HTTPHeaderDict) -> None:
+        merged = d | {b"x-new": b"value"}
+        assert merged["x-new"] == "value"
+        # Reflected __or__: a plain dict on the left dispatches to __ror__.
+        reflected = {b"x-new": b"value"} | d
+        assert reflected["x-new"] == "value"
+        d |= {b"x-new": b"value"}
+        assert d["x-new"] == "value"
+
+    def test_equality_between_bytes_and_str_constructions(self) -> None:
+        assert HTTPHeaderDict({b"key": b"v\xe9"}) == HTTPHeaderDict({"key": "v\xe9"})
+        assert HTTPHeaderDict({"key": "value"}) == {b"key": b"value"}
+        assert HTTPHeaderDict({"key": "value"}) != {b"key": b"other"}
+
+    def test_items_containment_with_bytes(self, d: HTTPHeaderDict) -> None:
+        d.add("x-name", "v\xe9")
+        items = d.items()
+        bytes_key_and_value = (b"cookie", b"foo")
+        bytes_key = (b"cookie", "foo")
+        bytes_value = ("cookie", b"foo")
+        non_ascii_value = (b"x-name", b"v\xe9")
+        missing = (b"cookie", b"nope")
+        assert bytes_key_and_value in items  # type: ignore[comparison-overlap]
+        assert bytes_key in items  # type: ignore[comparison-overlap]
+        assert bytes_value in items  # type: ignore[comparison-overlap]
+        assert non_ascii_value in items  # type: ignore[comparison-overlap]
+        assert missing not in items  # type: ignore[comparison-overlap]
+
+    def test_getlist_with_mixed_bytes_and_str_additions(self) -> None:
+        d = HTTPHeaderDict()
+        d.add("set-cookie", b"a=1")
+        d.add(b"Set-Cookie", "b=2")
+        assert d.getlist(b"SET-COOKIE") == ["a=1", "b=2"]
+
+    def test_copy_preserves_bytes_derived_values(self) -> None:
+        d = HTTPHeaderDict()
+        d[b"x-raw"] = b"\x80\xff"
+        copied = d.copy()
+        assert copied["x-raw"] == d["x-raw"]
+        assert copied["x-raw"].encode("latin-1") == b"\x80\xff"
 
     def test_getlist_after_copy(self, d: HTTPHeaderDict) -> None:
         assert d.getlist("cookie") == HTTPHeaderDict(d).getlist("cookie")

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -146,6 +146,41 @@ class TestCookies(SocketDummyServerTestCase):
             assert r._original_response.msg["fold-mixed-repeated"] == "one two three"
 
 
+class TestBytesHeaderValues(SocketDummyServerTestCase):
+    def test_bytes_header_value_is_sent_byte_for_byte(self) -> None:
+        # This guards the decode-to-str then latin-1-re-encode round trip
+        # introduced by normalizing bytes at ingestion: the octets on the
+        # HTTP/1.1 wire must be identical to what a raw bytes value produced
+        # before. Echo the raw request bytes in the response body so the
+        # assertion sees the exact octets urllib3 put on the wire, without
+        # any header decoding by http.client on the response side.
+        def echo_request_handler(listener: socket.socket) -> None:
+            with listener.accept()[0] as sock:
+                buf = b""
+                while not buf.endswith(b"\r\n\r\n"):
+                    buf += sock.recv(65536)
+
+                sock.sendall(
+                    b"HTTP/1.1 200 OK\r\n"
+                    b"Content-Length: " + str(len(buf)).encode() + b"\r\n"
+                    b"\r\n" + buf
+                )
+
+        self._start_server(echo_request_handler)
+
+        utf8_value = "Schönefeld/1.18.0".encode()
+        obs_text_value = b"\x80\xfe\xff"
+        headers = HTTPHeaderDict()
+        headers[b"x-utf8"] = utf8_value
+        headers["x-raw"] = obs_text_value
+
+        with HTTPConnectionPool(self.host, self.port) as pool:
+            r = pool.request("GET", "/", headers=headers, retries=False)
+
+        assert b"x-utf8: " + utf8_value + b"\r\n" in r.data
+        assert b"x-raw: " + obs_text_value + b"\r\n" in r.data
+
+
 class TestSNI(SocketDummyServerTestCase):
     def test_hostname_in_first_request_packet(self) -> None:
         done_receiving = Event()


### PR DESCRIPTION
Closes #3072

## What this does

`HTTPHeaderDict` now supports ``bytes`` field names and values in every method. The reporter's exact scenario works:

```python
headers = urllib3.HTTPHeaderDict()
headers["user-agent"] = "Schönefeld/1.18.0".encode("latin-1")
headers["user-agent"]  # 'Schönefeld/1.18.0' (previously raised TypeError)
```

## How it works internally

Answering the "how would this work internally" question from the issue: ``bytes`` input is decoded as **latin-1** at every ingestion point and stored as ``str``. latin-1 is the natural codec here for two reasons:

* It is the encoding ``http.client`` applies to ``str`` header values on the wire, and the encoding used to decode response headers. Since latin-1 maps every byte 0x00-0xFF to the code point of the same number, ``bytes in -> bytes on the wire`` is the identity: a UTF-8 (or any other) byte sequence is sent byte-for-byte.
* `HTTPHeaderDict` already used exactly this convention for ``bytes`` keys; this change extends the same rule to values and to the methods that were missed.

Measurements posted in the issue discussion confirm the round-trip property; the HTTP/2 encode-side alignment is tracked separately in #5138 and is independent of this change.

Concretely:

* ``__setitem__`` and ``add()`` decode ``bytes`` values (keys were already handled), which also covers ``extend()``, ``update()``, the constructor, ``**kwargs`` and the ``|``/``|=`` operators since they all funnel through these two methods.
* ``setdefault()`` decodes the key and the default before delegating, fixing a latent bug: previously a ``bytes`` default was returned as raw ``bytes`` while nothing (or the decoded form) was stored.
* ``_has_value_for_header()`` and ``HTTPHeaderDictItemView.__contains__`` accept ``bytes``, so ``(b"name", b"value") in headers.items()`` works.
* Type annotations updated accordingly: ``ValidHTTPHeaderSource`` accepts mappings and iterables with ``bytes`` names/values, and ``__setitem__``/``add``/``getlist``/``setdefault``/``discard``/``__getitem__``/``__delitem__`` accept ``str | bytes``. One previously-needed ``type: ignore`` in ``response.py`` becomes unnecessary and is removed; no new ignores are added outside of two test-side ``comparison-overlap`` silences that follow the file's existing pattern.

## How this is tested

* The issue reporter's exact repro.
* A round-trip test over every octet legal in a field value (``0x09``, ``0x20``-``0x7E``, ``0x80``-``0xFF``): the stored ``str`` re-encodes to the identical ``bytes``.
* A UTF-8 test documenting the intended semantics: the ``str`` form is the latin-1 decoding, and it re-encodes to the identical UTF-8 octets.
* Every ingestion path with ``bytes``: constructor from mapping/iterable/kwargs, ``add`` (including ``combine=True``), ``extend`` with each source shape, ``setdefault`` (returns ``str``, existing values win), ``getlist`` with mixed additions, ``|`` and ``|=``, ``copy()``, equality between ``bytes``- and ``str``-built dicts, and ``items()`` containment.
* A socket-level test that echoes the raw request bytes in the response body (the technique suggested in review of an earlier attempt), proving a ``bytes`` value passed to ``urlopen(headers=...)`` reaches the wire byte-for-byte over HTTP/1.1 -- for both UTF-8 octets and raw obs-text bytes.
* Verified downstream: a ``bytes``-valued ``HTTPHeaderDict`` sent through a ``requests.Session`` arrives byte-identical on the wire, and response header handling is unchanged.
* Full local suite run with no new failures relative to ``main``; mypy clean on all changed files.

## HTTP/2 note

Byte-for-byte transmission is guaranteed for HTTP/1.1, whose ``http.client`` backend encodes header fields as latin-1. HTTP/2 is a separate matter: ``HTTP2Connection.putheader`` currently encodes header values as UTF-8, so a non-ASCII value (whether a ``str`` or a ``bytes`` value decoded by this change) is encoded differently there than on HTTP/1.1. That HTTP/2 encoding alignment is a pre-existing inconsistency tracked in #5138; this PR deliberately does not touch ``http2/connection.py`` so as not to duplicate that work. Once #5138 lands, ``bytes`` values are byte-for-byte on HTTP/2 as well, since this change stores them as the latin-1 ``str`` that #5138 then encodes as latin-1. For ASCII values (the overwhelming majority of real headers) the two protocols already agree.

## Scope note

``bytes`` arguments are accepted (and typed) by the ``HTTPHeaderDict``-specific methods. The inherited ``MutableMapping`` helpers (``get``, ``pop``, ``update``) accept ``bytes`` at runtime because they funnel through the overridden dunder methods, but they remain typed ``str``-only; widening them purely for typing would add signature overrides without changing behavior, so it is intentionally left out.

## Relation to the other open PRs for #3072

This PR covers the full method surface (notably ``setdefault``'s raw-``bytes`` return, ``items()`` containment, and ``bytes`` keys in constructor sources), updates the type annotations to match the runtime behavior with no new ``type: ignore`` in library code, and adds the wire-octet regression test plus a changelog fragment.
