### PR TITLE
Keep idle HTTP/2 connections reusable

### DIFF
--- a/changelog/3301.bugfix.rst
+++ b/changelog/3301.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed HTTP/2 connections being discarded instead of reused when control frames arrive while idle.

--- a/src/urllib3/contrib/pyopenssl.py
+++ b/src/urllib3/contrib/pyopenssl.py
@@ -355,8 +355,11 @@ class WrappedSocket:
         except OpenSSL.SSL.Error as e:
             raise ssl.SSLError(f"read error: {e!r}") from e
 
-    def settimeout(self, timeout: float) -> None:
+    def settimeout(self, timeout: float | None) -> None:
         return self.socket.settimeout(timeout)
+
+    def gettimeout(self) -> float | None:
+        return self.socket.gettimeout()
 
     def _send_until_done(self, data: bytes) -> int:
         while True:

--- a/src/urllib3/http2/connection.py
+++ b/src/urllib3/http2/connection.py
@@ -2,18 +2,21 @@ from __future__ import annotations
 
 import logging
 import re
+import ssl
 import threading
 import types
 import typing
+from http.client import CannotSendRequest
 
 import h2.config
 import h2.connection
 import h2.events
+import h2.exceptions
 
 from .._base_connection import _TYPE_BODY
 from .._collections import HTTPHeaderDict
 from ..connection import HTTPSConnection, _get_default_user_agent
-from ..exceptions import ConnectionError
+from ..exceptions import ProtocolError
 from ..response import BaseHTTPResponse
 
 orig_HTTPSConnection = HTTPSConnection
@@ -21,6 +24,9 @@ orig_HTTPSConnection = HTTPSConnection
 T = typing.TypeVar("T")
 
 log = logging.getLogger(__name__)
+
+_IDLE_READ_SIZE = 65535
+_MAX_IDLE_READS = 16
 
 RE_IS_LEGAL_HEADER_NAME = re.compile(rb"^[!#$%&'*+\-.^_`|~0-9a-z]+$")
 RE_IS_ILLEGAL_HEADER_VALUE = re.compile(rb"[\0\x00\x0a\x0d\r\n]|^[ \r\n\t]|[ \r\n\t]$")
@@ -88,7 +94,10 @@ class HTTP2Connection(HTTPSConnection):
     ) -> None:
         self._h2_conn = self._new_h2_conn()
         self._h2_stream: int | None = None
+        self._stream_owner: object | None = None
         self._headers: list[tuple[bytes, bytes]] = []
+        self._connection_terminated = False
+        self._has_completed_response = False
 
         if "proxy" in kwargs or "proxy_config" in kwargs:  # Defensive:
             raise NotImplementedError("Proxies aren't supported with HTTP/2")
@@ -104,10 +113,129 @@ class HTTP2Connection(HTTPSConnection):
 
     def connect(self) -> None:
         super().connect()
+        self._connection_terminated = False
         with self._h2_conn as conn:
             conn.initiate_connection()
             if data_to_send := conn.data_to_send():
                 self.sock.sendall(data_to_send)
+
+    def _assert_stream_owner(self, stream_owner: object | None) -> None:
+        if self._stream_owner is not stream_owner:
+            raise RuntimeError("HTTP/2 stream events have a different owner")
+
+    def _transfer_stream_owner(self, current_owner: object, new_owner: object) -> None:
+        """Transfer the right to receive events for the active stream."""
+        if self._stream_owner is not current_owner:
+            raise RuntimeError("HTTP/2 stream events have a different owner")
+        self._stream_owner = new_owner
+
+    def _release_stream_owner(self, stream_owner: object) -> None:
+        """Release an active stream after its response has completed."""
+        self._assert_stream_owner(stream_owner)
+        self._stream_owner = None
+        self._h2_stream = None
+
+    def _process_received_data(
+        self, received_data: bytes, *, stream_owner: object | None
+    ) -> list[h2.events.Event]:
+        """Process HTTP/2 bytes and flush protocol-generated output."""
+        self._assert_stream_owner(stream_owner)
+        with self._h2_conn as conn:
+            events = conn.receive_data(received_data)
+            for event in events:
+                if isinstance(event, h2.events.DataReceived):
+                    conn.acknowledge_received_data(
+                        event.flow_controlled_length, event.stream_id
+                    )
+                elif isinstance(event, h2.events.ConnectionTerminated):
+                    self._connection_terminated = True
+
+            if data_to_send := conn.data_to_send():
+                self.sock.sendall(data_to_send)
+
+        return events
+
+    def _receive_events(
+        self, *, stream_owner: object | None
+    ) -> list[h2.events.Event] | None:
+        """Receive and process one batch of HTTP/2 events.
+
+        ``None`` means the peer reached EOF. Flow-controlled data is always
+        acknowledged and protocol-generated output (for example PING and
+        SETTINGS acknowledgements) is flushed before returning.
+        """
+        self._assert_stream_owner(stream_owner)
+        assert self.sock is not None
+        received_data = self.sock.recv(65535)
+        if not received_data:
+            self._connection_terminated = True
+            return None
+        return self._process_received_data(received_data, stream_owner=stream_owner)
+
+    def _probe_idle_connection(self) -> bool:
+        """Process pending control frames and determine idle connection health."""
+        sock = self.sock
+        if sock is None or self._connection_terminated:
+            return False
+
+        # Never consume response events behind the response reader's back.
+        if self._stream_owner is not None:
+            return True
+
+        try:
+            previous_timeout = sock.gettimeout()
+        except OSError:
+            self._connection_terminated = True
+            return False
+
+        for _ in range(_MAX_IDLE_READS):
+            received_data: bytes | None = None
+            receive_failed = False
+            try:
+                sock.settimeout(0.0)
+                try:
+                    received_data = sock.recv(_IDLE_READ_SIZE)
+                except (BlockingIOError, TimeoutError, ssl.SSLWantReadError):
+                    pass
+                except OSError:
+                    receive_failed = True
+            except OSError:
+                receive_failed = True
+            finally:
+                # Only recv() is non-blocking. Restore the caller's timeout
+                # before parsing because hyper-h2 can generate output which
+                # must be delivered with sendall().
+                if self.sock is sock:
+                    try:
+                        sock.settimeout(previous_timeout)
+                    except OSError:
+                        receive_failed = True
+
+            if receive_failed or received_data == b"":
+                self._connection_terminated = True
+                return False
+            if received_data is None:
+                return True
+
+            try:
+                self._process_received_data(received_data, stream_owner=None)
+            except (OSError, h2.exceptions.ProtocolError):
+                # If generated protocol output can't be sent then this
+                # connection is no longer safe to reuse. The pool will close
+                # it instead of losing bytes and continuing the session.
+                self._connection_terminated = True
+                return False
+            if self._connection_terminated:
+                return False
+
+        # A peer that can keep the socket continuously readable can otherwise
+        # starve the pool indefinitely. Conservatively discard the connection.
+        self._connection_terminated = True
+        return False
+
+    @property
+    def is_connected(self) -> bool:
+        return self._probe_idle_connection()
 
     def putrequest(  # type: ignore[override]
         self,
@@ -124,6 +252,19 @@ class HTTP2Connection(HTTPSConnection):
         if "skip_accept_encoding" in kwargs:
             raise NotImplementedError("`skip_accept_encoding` isn't supported")
 
+        if self._stream_owner is not None:
+            raise CannotSendRequest(
+                "Cannot send a new HTTP/2 request while a response stream is active"
+            )
+
+        if self._has_completed_response and not self._probe_idle_connection():
+            raise ProtocolError("HTTP/2 connection is no longer reusable")
+
+        with self._h2_conn as conn:
+            if conn.remote_settings.max_concurrent_streams == 0:
+                raise ProtocolError("HTTP/2 peer does not currently allow new streams")
+            stream_id = conn.get_next_available_stream_id()
+
         self._request_url = url or "/"
         self._validate_path(url)  # type: ignore[attr-defined]
 
@@ -138,8 +279,8 @@ class HTTP2Connection(HTTPSConnection):
         self._headers.append((b":authority", authority.encode()))
         self._headers.append((b":path", url.encode()))
 
-        with self._h2_conn as conn:
-            self._h2_stream = conn.get_next_available_stream_id()
+        self._h2_stream = stream_id
+        self._stream_owner = self
 
     def putheader(self, header: str | bytes, *values: str | bytes) -> None:  # type: ignore[override]
         # TODO SKIPPABLE_HEADERS from urllib3 are ignored.
@@ -156,14 +297,21 @@ class HTTP2Connection(HTTPSConnection):
 
     def endheaders(self, message_body: typing.Any = None) -> None:  # type: ignore[override]
         if self._h2_stream is None:
-            raise ConnectionError("Must call `putrequest` first.")
+            raise ProtocolError("Must call `putrequest` first.")
 
         with self._h2_conn as conn:
-            conn.send_headers(
-                stream_id=self._h2_stream,
-                headers=self._headers,
-                end_stream=(message_body is None),
-            )
+            try:
+                conn.send_headers(
+                    stream_id=self._h2_stream,
+                    headers=self._headers,
+                    end_stream=(message_body is None),
+                )
+            except h2.exceptions.TooManyStreamsError as e:
+                self._headers = []
+                self._release_stream_owner(self)
+                raise ProtocolError(
+                    "HTTP/2 peer does not currently allow new streams"
+                ) from e
             if data_to_send := conn.data_to_send():
                 self.sock.sendall(data_to_send)
         self._headers = []  # Reset headers for the next request.
@@ -174,7 +322,7 @@ class HTTP2Connection(HTTPSConnection):
         that support a .read() method.
         """
         if self._h2_stream is None:
-            raise ConnectionError("Must call `putrequest` first.")
+            raise ProtocolError("Must call `putrequest` first.")
 
         with self._h2_conn as conn:
             if data_to_send := conn.data_to_send():
@@ -228,37 +376,60 @@ class HTTP2Connection(HTTPSConnection):
         self,
     ) -> HTTP2Response:
         status = None
+        headers = HTTPHeaderDict()
         data = bytearray()
-        with self._h2_conn as conn:
-            end_stream = False
-            while not end_stream:
-                # TODO: Arbitrary read value.
-                if received_data := self.sock.recv(65535):
-                    events = conn.receive_data(received_data)
-                    for event in events:
-                        if isinstance(event, h2.events.ResponseReceived):
-                            headers = HTTPHeaderDict()
-                            for header, value in event.headers:
-                                if header == b":status":
-                                    status = int(value.decode())
-                                else:
-                                    headers.add(
-                                        header.decode("ascii"), value.decode("ascii")
-                                    )
+        stream_id = self._h2_stream
+        end_stream = False
+        while not end_stream:
+            events = self._receive_events(stream_owner=self)
+            if events is None:
+                raise ProtocolError(
+                    "HTTP/2 connection closed before the response completed"
+                )
 
-                        elif isinstance(event, h2.events.DataReceived):
-                            data += event.data
-                            conn.acknowledge_received_data(
-                                event.flow_controlled_length, event.stream_id
-                            )
+            for event in events:
+                if (
+                    isinstance(event, h2.events.ResponseReceived)
+                    and event.stream_id == stream_id
+                ):
+                    headers = HTTPHeaderDict()
+                    for header, value in event.headers:
+                        if header == b":status":
+                            status = int(value.decode())
+                        else:
+                            headers.add(header.decode("ascii"), value.decode("ascii"))
 
-                        elif isinstance(event, h2.events.StreamEnded):
-                            end_stream = True
+                elif (
+                    isinstance(event, h2.events.DataReceived)
+                    and event.stream_id == stream_id
+                ):
+                    data += event.data
 
-                if data_to_send := conn.data_to_send():
-                    self.sock.sendall(data_to_send)
+                elif (
+                    isinstance(event, h2.events.StreamEnded)
+                    and event.stream_id == stream_id
+                ):
+                    end_stream = True
+
+                elif (
+                    isinstance(event, h2.events.StreamReset)
+                    and event.stream_id == stream_id
+                ):
+                    raise ProtocolError(
+                        "HTTP/2 stream was reset by the peer "
+                        f"(error code {event.error_code})"
+                    )
+
+                elif isinstance(event, h2.events.ConnectionTerminated):
+                    if not end_stream:
+                        raise ProtocolError(
+                            "HTTP/2 connection was terminated by the peer "
+                            f"(error code {event.error_code})"
+                        )
 
         assert status is not None
+        self._release_stream_owner(self)
+        self._has_completed_response = True
         return HTTP2Response(
             status=status,
             headers=headers,
@@ -317,7 +488,10 @@ class HTTP2Connection(HTTPSConnection):
         # Reset all our HTTP/2 connection state.
         self._h2_conn = self._new_h2_conn()
         self._h2_stream = None
+        self._stream_owner = None
         self._headers = []
+        self._connection_terminated = False
+        self._has_completed_response = False
 
         super().close()
 
@@ -349,6 +523,14 @@ class HTTP2Response(BaseHTTPResponse):
     @property
     def data(self) -> bytes:
         return self._data
+
+    @property
+    def url(self) -> str | None:
+        return self._request_url
+
+    @url.setter
+    def url(self, url: str | None) -> None:
+        self._request_url = url
 
     def get_redirect_location(self) -> None:
         return None

--- a/test/contrib/test_pyopenssl.py
+++ b/test/contrib/test_pyopenssl.py
@@ -9,7 +9,11 @@ try:
     from cryptography import x509
     from OpenSSL.crypto import FILETYPE_PEM, load_certificate
 
-    from urllib3.contrib.pyopenssl import _dnsname_to_stdlib, get_subj_alt_name
+    from urllib3.contrib.pyopenssl import (
+        WrappedSocket,
+        _dnsname_to_stdlib,
+        get_subj_alt_name,
+    )
 except ImportError:
     pass
 
@@ -56,6 +60,14 @@ class TestPyOpenSSLHelpers:
     """
     Tests for PyOpenSSL helper functions.
     """
+
+    def test_wrapped_socket_gettimeout(self) -> None:
+        socket = mock.Mock()
+        socket.gettimeout.return_value = 12.5
+        wrapped_socket = WrappedSocket(mock.Mock(), socket)
+
+        assert wrapped_socket.gettimeout() == 12.5
+        socket.gettimeout.assert_called_once_with()
 
     def test_dnsname_to_stdlib_simple(self) -> None:
         """

--- a/test/test_http2_connection.py
+++ b/test/test_http2_connection.py
@@ -1,14 +1,23 @@
 from __future__ import annotations
 
 import socket
+import threading
+from http.client import CannotSendRequest
 from unittest import mock
 
+import h2.config
+import h2.connection
+import h2.events
+import h2.settings
 import pytest
 
+from urllib3 import HTTPSConnectionPool
+from urllib3._collections import HTTPHeaderDict
 from urllib3.connection import _get_default_user_agent
 from urllib3.exceptions import ConnectionError
 from urllib3.http2.connection import (
     HTTP2Connection,
+    HTTP2Response,
     _is_illegal_header_value,
     _is_legal_header_name,
 )
@@ -17,6 +26,50 @@ from urllib3.http2.connection import (
 
 
 class TestHTTP2Connection:
+    @staticmethod
+    def _connected_h2_pair(
+        connection_class: type[HTTP2Connection] = HTTP2Connection,
+    ) -> tuple[HTTP2Connection, socket.socket, h2.connection.H2Connection]:
+        client_sock, server_sock = socket.socketpair()
+        server_h2 = h2.connection.H2Connection(
+            config=h2.config.H2Configuration(client_side=False)
+        )
+        conn = connection_class("example.com")
+        conn.sock = client_sock
+
+        with conn._h2_conn as client_h2:
+            client_h2.initiate_connection()
+            client_sock.sendall(client_h2.data_to_send())
+
+        server_h2.initiate_connection()
+        server_h2.receive_data(server_sock.recv(65535))
+        server_sock.sendall(server_h2.data_to_send())
+        return conn, server_sock, server_h2
+
+    @staticmethod
+    def _send_response(
+        conn: HTTP2Connection,
+        server_sock: socket.socket,
+        server_h2: h2.connection.H2Connection,
+        path: str,
+        body: bytes,
+    ) -> int:
+        conn.request("GET", path)
+        events = server_h2.receive_data(server_sock.recv(65535))
+        stream_id = next(
+            event.stream_id
+            for event in events
+            if isinstance(event, h2.events.RequestReceived)
+        )
+        server_h2.send_headers(
+            stream_id,
+            [(":status", "200"), ("content-length", str(len(body)))],
+        )
+        server_h2.send_data(stream_id, body, end_stream=True)
+        server_sock.sendall(server_h2.data_to_send())
+        assert conn.getresponse().data == body
+        return stream_id
+
     def test__is_legal_header_name(self) -> None:
         assert _is_legal_header_name(b"foo"), "foo"
         assert _is_legal_header_name(b"foo-bar"), "foo-bar"
@@ -79,6 +132,522 @@ class TestHTTP2Connection:
         conn = HTTP2Connection("example.com")
         assert conn.socket_options == [(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)]
         assert conn.port == 443
+
+    def test_response_url_can_be_updated_for_retry_history(self) -> None:
+        response = HTTP2Response(200, HTTPHeaderDict(), "/original", b"")
+
+        assert response.url == "/original"
+        response.url = "/retried"
+        assert response.url == "/retried"
+
+    def test_pool_reuses_connection_after_processing_idle_ping(self) -> None:
+        conn, server_sock, server_h2 = self._connected_h2_pair()
+        pool = HTTPSConnectionPool("example.com", maxsize=1)
+
+        class RecordingSocket:
+            def __init__(self, wrapped: socket.socket) -> None:
+                self.wrapped = wrapped
+                self.send_timeouts: list[float | None] = []
+
+            def __getattr__(self, name: str) -> object:
+                return getattr(self.wrapped, name)
+
+            def sendall(self, data: bytes) -> None:
+                self.send_timeouts.append(self.wrapped.gettimeout())
+                self.wrapped.sendall(data)
+
+        try:
+            first_stream_id = self._send_response(
+                conn, server_sock, server_h2, "/", b"first"
+            )
+
+            server_h2.ping(b"12345678")
+            server_sock.sendall(server_h2.data_to_send())
+
+            original_timeout = 12.5
+            assert conn.sock is not None
+            recording_sock = RecordingSocket(conn.sock)
+            conn.sock = recording_sock
+            recording_sock.wrapped.settimeout(original_timeout)
+            assert conn.is_connected
+            assert recording_sock.wrapped.gettimeout() == original_timeout
+            assert recording_sock.send_timeouts == [original_timeout]
+
+            events = server_h2.receive_data(server_sock.recv(65535))
+            assert any(isinstance(event, h2.events.PingAckReceived) for event in events)
+
+            assert pool.pool is not None
+            pool.pool.get(block=False)
+            pool._put_conn(conn)
+            reused = pool._get_conn()
+            assert reused is conn
+            assert reused.sock is not None
+
+            second_stream_id = self._send_response(
+                reused, server_sock, server_h2, "/again", b"second"
+            )
+            assert second_stream_id > first_stream_id
+        finally:
+            conn.close()
+            pool.close()
+            server_sock.close()
+
+    def test_idle_eof_is_not_reusable(self) -> None:
+        conn, server_sock, _ = self._connected_h2_pair()
+        try:
+            server_sock.close()
+            assert not conn.is_connected
+        finally:
+            conn.close()
+
+    def test_idle_goaway_is_not_reusable(self) -> None:
+        conn, server_sock, server_h2 = self._connected_h2_pair()
+        try:
+            stream_id = self._send_response(
+                conn, server_sock, server_h2, "/", b"complete"
+            )
+            server_h2.close_connection(error_code=0, last_stream_id=stream_id)
+            server_sock.sendall(server_h2.data_to_send())
+
+            assert not conn.is_connected
+        finally:
+            conn.close()
+            server_sock.close()
+
+    def test_request_rechecks_for_goaway_after_pool_probe(self) -> None:
+        conn, server_sock, server_h2 = self._connected_h2_pair()
+        try:
+            stream_id = self._send_response(
+                conn, server_sock, server_h2, "/", b"complete"
+            )
+            assert conn.is_connected
+
+            server_h2.close_connection(error_code=0, last_stream_id=stream_id)
+            server_sock.sendall(server_h2.data_to_send())
+
+            with pytest.raises(ConnectionError, match="no longer reusable"):
+                conn.request("GET", "/must-not-be-sent")
+        finally:
+            conn.close()
+            server_sock.close()
+
+    def test_pool_retries_on_goaway_between_health_check_and_request(self) -> None:
+        class GoawayAfterProbeConnection(HTTP2Connection):
+            server_sock: socket.socket
+            server_h2: h2.connection.H2Connection
+            sent_goaway = False
+
+            def _probe_idle_connection(self) -> bool:
+                reusable = super()._probe_idle_connection()
+                if self._has_completed_response and reusable and not self.sent_goaway:
+                    self.server_h2.close_connection(
+                        error_code=0,
+                        last_stream_id=self.server_h2.highest_inbound_stream_id,
+                    )
+                    self.server_sock.sendall(self.server_h2.data_to_send())
+                    self.sent_goaway = True
+                return reusable
+
+        first_conn, first_server_sock, first_server_h2 = self._connected_h2_pair(
+            GoawayAfterProbeConnection
+        )
+        assert isinstance(first_conn, GoawayAfterProbeConnection)
+        first_conn.server_sock = first_server_sock
+        first_conn.server_h2 = first_server_h2
+        first_conn.is_verified = True
+        second_conn, second_server_sock, second_server_h2 = self._connected_h2_pair()
+        second_conn.is_verified = True
+
+        class TwoConnectionPool(HTTPSConnectionPool):
+            def __init__(self) -> None:
+                super().__init__("example.com", maxsize=1)
+                self.available_connections = [first_conn, second_conn]
+
+            def _new_conn(self) -> HTTP2Connection:
+                self.num_connections += 1
+                return self.available_connections.pop(0)
+
+        def serve_one_response(
+            server_sock: socket.socket,
+            server_h2: h2.connection.H2Connection,
+            body: bytes,
+        ) -> None:
+            events = server_h2.receive_data(server_sock.recv(65535))
+            stream_id = next(
+                event.stream_id
+                for event in events
+                if isinstance(event, h2.events.RequestReceived)
+            )
+            server_h2.send_headers(
+                stream_id,
+                [(":status", "200"), ("content-length", str(len(body)))],
+            )
+            server_h2.send_data(stream_id, body, end_stream=True)
+            server_sock.sendall(server_h2.data_to_send())
+
+        pool = TwoConnectionPool()
+        first_server = threading.Thread(
+            target=serve_one_response,
+            args=(first_server_sock, first_server_h2, b"first"),
+        )
+        first_server.start()
+        try:
+            first_response = pool.request("GET", "/first", retries=1)
+            first_server.join(timeout=1)
+            assert not first_server.is_alive()
+            assert first_response.data == b"first"
+
+            second_server = threading.Thread(
+                target=serve_one_response,
+                args=(second_server_sock, second_server_h2, b"second"),
+            )
+            second_server.start()
+            second_response = pool.request("GET", "/second", retries=1)
+            second_server.join(timeout=1)
+            assert not second_server.is_alive()
+
+            assert second_response.data == b"second"
+            assert first_conn.sent_goaway
+            assert first_conn.sock is None
+            assert pool.num_connections == 2
+        finally:
+            pool.close()
+            first_conn.close()
+            second_conn.close()
+            first_server_sock.close()
+            second_server_sock.close()
+
+    def test_pool_retries_when_peer_disables_new_streams(self) -> None:
+        first_conn, first_server_sock, first_server_h2 = self._connected_h2_pair()
+        second_conn, second_server_sock, second_server_h2 = self._connected_h2_pair()
+        first_conn.is_verified = True
+        second_conn.is_verified = True
+
+        class TwoConnectionPool(HTTPSConnectionPool):
+            def __init__(self) -> None:
+                super().__init__("example.com", maxsize=1)
+                self.available_connections = [first_conn, second_conn]
+
+            def _new_conn(self) -> HTTP2Connection:
+                self.num_connections += 1
+                return self.available_connections.pop(0)
+
+        def serve_one_response(
+            server_sock: socket.socket,
+            server_h2: h2.connection.H2Connection,
+            body: bytes,
+        ) -> None:
+            events = server_h2.receive_data(server_sock.recv(65535))
+            stream_id = next(
+                event.stream_id
+                for event in events
+                if isinstance(event, h2.events.RequestReceived)
+            )
+            server_h2.send_headers(
+                stream_id,
+                [(":status", "200"), ("content-length", str(len(body)))],
+            )
+            server_h2.send_data(stream_id, body, end_stream=True)
+            server_sock.sendall(server_h2.data_to_send())
+
+        pool = TwoConnectionPool()
+        first_server = threading.Thread(
+            target=serve_one_response,
+            args=(first_server_sock, first_server_h2, b"first"),
+        )
+        first_server.start()
+        try:
+            first_response = pool.request("GET", "/first", retries=1)
+            first_server.join(timeout=1)
+            assert not first_server.is_alive()
+            assert first_response.data == b"first"
+
+            first_server_h2.update_settings(
+                {h2.settings.SettingCodes.MAX_CONCURRENT_STREAMS: 0}
+            )
+            first_server_sock.sendall(first_server_h2.data_to_send())
+
+            second_server = threading.Thread(
+                target=serve_one_response,
+                args=(second_server_sock, second_server_h2, b"second"),
+            )
+            second_server.start()
+            second_response = pool.request("GET", "/second", retries=1)
+            second_server.join(timeout=1)
+            assert not second_server.is_alive()
+
+            assert second_response.data == b"second"
+            assert first_conn.sock is None
+            assert pool.num_connections == 2
+        finally:
+            pool.close()
+            first_conn.close()
+            second_conn.close()
+            first_server_sock.close()
+            second_server_sock.close()
+
+    def test_idle_settings_are_processed_and_acknowledged(self) -> None:
+        conn, server_sock, server_h2 = self._connected_h2_pair()
+        try:
+            self._send_response(conn, server_sock, server_h2, "/", b"complete")
+            server_h2.update_settings(
+                {h2.settings.SettingCodes.MAX_CONCURRENT_STREAMS: 1}
+            )
+            server_sock.sendall(server_h2.data_to_send())
+
+            assert conn.is_connected
+            events = server_h2.receive_data(server_sock.recv(65535))
+            assert any(
+                isinstance(event, h2.events.SettingsAcknowledged) for event in events
+            )
+        finally:
+            conn.close()
+            server_sock.close()
+
+    def test_zero_max_concurrent_streams_is_explicit_and_can_be_restored(
+        self,
+    ) -> None:
+        conn, server_sock, server_h2 = self._connected_h2_pair()
+        try:
+            self._send_response(conn, server_sock, server_h2, "/", b"first")
+
+            server_h2.update_settings(
+                {h2.settings.SettingCodes.MAX_CONCURRENT_STREAMS: 0}
+            )
+            server_sock.sendall(server_h2.data_to_send())
+            assert conn.is_connected
+            server_h2.receive_data(server_sock.recv(65535))
+
+            with pytest.raises(ConnectionError, match="does not currently allow"):
+                conn.request("GET", "/blocked")
+
+            server_h2.update_settings(
+                {h2.settings.SettingCodes.MAX_CONCURRENT_STREAMS: 1}
+            )
+            server_sock.sendall(server_h2.data_to_send())
+            assert conn.is_connected
+            server_h2.receive_data(server_sock.recv(65535))
+
+            self._send_response(conn, server_sock, server_h2, "/restored", b"second")
+        finally:
+            conn.close()
+            server_sock.close()
+
+    def test_stream_owner_prevents_idle_probe_from_consuming_response(self) -> None:
+        conn, server_sock, server_h2 = self._connected_h2_pair()
+        response_owner = object()
+        try:
+            conn.request("GET", "/")
+            events = server_h2.receive_data(server_sock.recv(65535))
+            stream_id = next(
+                event.stream_id
+                for event in events
+                if isinstance(event, h2.events.RequestReceived)
+            )
+            server_h2.send_headers(stream_id, [(":status", "200")])
+            server_h2.send_data(stream_id, b"owned", end_stream=True)
+            server_sock.sendall(server_h2.data_to_send())
+
+            conn._transfer_stream_owner(conn, response_owner)
+            original_stream_id = conn._h2_stream
+            original_request_url = conn._request_url
+            with pytest.raises(CannotSendRequest, match="response stream is active"):
+                conn.request("GET", "/must-not-overwrite-owner")
+            assert conn._stream_owner is response_owner
+            assert conn._h2_stream == original_stream_id
+            assert conn._request_url == original_request_url
+            assert conn._headers == []
+
+            assert conn.is_connected
+            with pytest.raises(RuntimeError, match="different owner"):
+                conn._receive_events(stream_owner=conn)
+
+            response_events = conn._receive_events(stream_owner=response_owner)
+            assert response_events is not None
+            assert any(
+                isinstance(event, h2.events.DataReceived) and event.data == b"owned"
+                for event in response_events
+            )
+            assert any(
+                isinstance(event, h2.events.StreamEnded) for event in response_events
+            )
+            conn._release_stream_owner(response_owner)
+            with pytest.raises(RuntimeError, match="different owner"):
+                conn._receive_events(stream_owner=response_owner)
+        finally:
+            conn.close()
+            server_sock.close()
+
+    def test_active_stream_reset_fails_immediately(self) -> None:
+        conn, server_sock, server_h2 = self._connected_h2_pair()
+        try:
+            conn.request("GET", "/")
+            events = server_h2.receive_data(server_sock.recv(65535))
+            stream_id = next(
+                event.stream_id
+                for event in events
+                if isinstance(event, h2.events.RequestReceived)
+            )
+            server_h2.reset_stream(stream_id, error_code=8)
+            server_sock.sendall(server_h2.data_to_send())
+
+            with pytest.raises(ConnectionError, match="stream was reset.*8"):
+                conn.getresponse()
+        finally:
+            conn.close()
+            server_sock.close()
+
+    def test_active_goaway_fails_immediately(self) -> None:
+        conn, server_sock, server_h2 = self._connected_h2_pair()
+        try:
+            conn.request("GET", "/")
+            server_h2.receive_data(server_sock.recv(65535))
+            server_h2.close_connection(error_code=0, last_stream_id=0)
+            server_sock.sendall(server_h2.data_to_send())
+
+            with pytest.raises(ConnectionError, match="connection was terminated.*0"):
+                conn.getresponse()
+        finally:
+            conn.close()
+            server_sock.close()
+
+    def test_idle_probe_is_bounded_under_continuous_control_frames(self) -> None:
+        conn, server_sock, server_h2 = self._connected_h2_pair()
+
+        class OneFrameSocket:
+            def __init__(self, wrapped: socket.socket) -> None:
+                self.wrapped = wrapped
+                self.recv_calls = 0
+
+            def __getattr__(self, name: str) -> object:
+                return getattr(self.wrapped, name)
+
+            def recv(self, size: int) -> bytes:
+                self.recv_calls += 1
+                return self.wrapped.recv(17)
+
+        try:
+            self._send_response(conn, server_sock, server_h2, "/", b"complete")
+            for ping_id in range(17):
+                server_h2.ping(ping_id.to_bytes(8, "big"))
+            server_sock.sendall(server_h2.data_to_send())
+
+            assert conn.sock is not None
+            one_frame_sock = OneFrameSocket(conn.sock)
+            conn.sock = one_frame_sock
+            assert not conn.is_connected
+            assert one_frame_sock.recv_calls == 16
+        finally:
+            conn.close()
+            server_sock.close()
+
+    def test_idle_probe_timeout_accessor_failure_is_not_reusable(self) -> None:
+        conn, server_sock, server_h2 = self._connected_h2_pair()
+
+        class BrokenTimeoutSocket:
+            def __init__(self, wrapped: socket.socket) -> None:
+                self.wrapped = wrapped
+
+            def __getattr__(self, name: str) -> object:
+                return getattr(self.wrapped, name)
+
+            def gettimeout(self) -> float | None:
+                raise OSError("socket unavailable")
+
+        try:
+            self._send_response(conn, server_sock, server_h2, "/", b"complete")
+            assert conn.sock is not None
+            conn.sock = BrokenTimeoutSocket(conn.sock)
+            assert not conn.is_connected
+        finally:
+            conn.close()
+            server_sock.close()
+
+    def test_idle_probe_treats_zero_timeout_as_no_pending_data(self) -> None:
+        conn, server_sock, server_h2 = self._connected_h2_pair()
+
+        class TimeoutSocket:
+            def __init__(self, wrapped: socket.socket) -> None:
+                self.wrapped = wrapped
+
+            def __getattr__(self, name: str) -> object:
+                return getattr(self.wrapped, name)
+
+            def recv(self, size: int) -> bytes:
+                if self.wrapped.gettimeout() == 0:
+                    raise TimeoutError("non-blocking read would block")
+                return self.wrapped.recv(size)
+
+        try:
+            self._send_response(conn, server_sock, server_h2, "/", b"complete")
+            assert conn.sock is not None
+            timeout_sock = TimeoutSocket(conn.sock)
+            conn.sock = timeout_sock
+            timeout_sock.wrapped.settimeout(7.5)
+
+            assert conn.is_connected
+            assert timeout_sock.wrapped.gettimeout() == 7.5
+        finally:
+            conn.close()
+            server_sock.close()
+
+    def test_failed_idle_control_frame_ack_makes_connection_unusable(self) -> None:
+        conn, server_sock, server_h2 = self._connected_h2_pair()
+
+        class AckFailingSocket:
+            def __init__(self, wrapped: socket.socket) -> None:
+                self.wrapped = wrapped
+                self.send_timeouts: list[float | None] = []
+
+            def __getattr__(self, name: str) -> object:
+                return getattr(self.wrapped, name)
+
+            def sendall(self, data: bytes) -> None:
+                self.send_timeouts.append(self.wrapped.gettimeout())
+                raise BlockingIOError
+
+        try:
+            self._send_response(conn, server_sock, server_h2, "/", b"complete")
+            server_h2.ping(b"12345678")
+            server_sock.sendall(server_h2.data_to_send())
+
+            assert conn.sock is not None
+            failing_sock = AckFailingSocket(conn.sock)
+            conn.sock = failing_sock
+            failing_sock.wrapped.settimeout(9.5)
+
+            assert not conn.is_connected
+            assert failing_sock.wrapped.gettimeout() == 9.5
+            assert failing_sock.send_timeouts == [9.5]
+        finally:
+            conn.close()
+            server_sock.close()
+
+    def test_response_completed_before_goaway_is_returned_but_not_reused(
+        self,
+    ) -> None:
+        conn, server_sock, server_h2 = self._connected_h2_pair()
+        try:
+            conn.request("GET", "/")
+            events = server_h2.receive_data(server_sock.recv(65535))
+            stream_id = next(
+                event.stream_id
+                for event in events
+                if isinstance(event, h2.events.RequestReceived)
+            )
+            server_h2.send_headers(
+                stream_id,
+                [(":status", "200"), ("content-length", "8")],
+            )
+            server_h2.send_data(stream_id, b"complete", end_stream=True)
+            server_h2.close_connection(error_code=0, last_stream_id=stream_id)
+            server_sock.sendall(server_h2.data_to_send())
+
+            assert conn.getresponse().data == b"complete"
+            assert not conn.is_connected
+        finally:
+            conn.close()
+            server_sock.close()
 
     def test_putheader(self) -> None:
         conn = HTTP2Connection("example.com")

--- a/test/test_http2_connection.py
+++ b/test/test_http2_connection.py
@@ -8,6 +8,7 @@ from unittest import mock
 import h2.config
 import h2.connection
 import h2.events
+import h2.exceptions
 import h2.settings
 import pytest
 
@@ -800,6 +801,106 @@ class TestHTTP2Connection:
                 1, b"foo\r\nbar\r\n", end_stream=False
             )
             conn._h2_conn._obj.end_stream.assert_called_with(1)
+
+    def test_transfer_stream_owner_with_wrong_current_owner(self) -> None:
+        conn = HTTP2Connection("example.com")
+        owner_a = object()
+        owner_b = object()
+        conn._stream_owner = owner_a
+        with pytest.raises(RuntimeError, match="different owner"):
+            conn._transfer_stream_owner(owner_b, object())
+        assert conn._stream_owner is owner_a
+
+    def test_getresponse_eof_raises_protocol_error(self) -> None:
+        conn, server_sock, server_h2 = self._connected_h2_pair()
+        try:
+            conn.request("GET", "/")
+            server_h2.receive_data(server_sock.recv(65535))
+
+            # Replace socket with one that returns EOF immediately.
+            original_sock = conn.sock
+            conn.sock = mock.MagicMock(recv=mock.Mock(return_value=b""))
+            assert original_sock is not None
+            original_sock.close()
+
+            with pytest.raises(ConnectionError, match="closed before the response"):
+                conn.getresponse()
+            assert conn._connection_terminated
+        finally:
+            conn.close()
+            server_sock.close()
+
+    def test_idle_probe_set_nonblocking_oserror_is_not_reusable(self) -> None:
+        conn, server_sock, server_h2 = self._connected_h2_pair()
+
+        class SetNonblockingFailingSocket:
+            def __init__(self, wrapped: socket.socket) -> None:
+                self.wrapped = wrapped
+
+            def __getattr__(self, name: str) -> object:
+                return getattr(self.wrapped, name)
+
+            def settimeout(self, timeout: float | None) -> None:
+                if timeout == 0.0:
+                    raise OSError("cannot set non-blocking")
+                self.wrapped.settimeout(timeout)
+
+        try:
+            self._send_response(conn, server_sock, server_h2, "/", b"complete")
+            assert conn.sock is not None
+            failing_sock = SetNonblockingFailingSocket(conn.sock)
+            failing_sock.wrapped.settimeout(5.0)
+            conn.sock = failing_sock
+            assert not conn.is_connected
+        finally:
+            conn.close()
+            server_sock.close()
+
+    def test_idle_probe_restore_timeout_oserror_is_not_reusable(self) -> None:
+        conn, server_sock, server_h2 = self._connected_h2_pair()
+
+        class RestoreTimeoutFailingSocket:
+            def __init__(self, wrapped: socket.socket) -> None:
+                self.wrapped = wrapped
+                self._settimeout_count = 0
+
+            def __getattr__(self, name: str) -> object:
+                return getattr(self.wrapped, name)
+
+            def settimeout(self, timeout: float | None) -> None:
+                self._settimeout_count += 1
+                if self._settimeout_count >= 2:
+                    raise OSError("cannot restore timeout")
+                self.wrapped.settimeout(timeout)
+
+        try:
+            self._send_response(conn, server_sock, server_h2, "/", b"complete")
+            assert conn.sock is not None
+            failing_sock = RestoreTimeoutFailingSocket(conn.sock)
+            failing_sock.wrapped.settimeout(5.0)
+            conn.sock = failing_sock
+            assert not conn.is_connected
+        finally:
+            conn.close()
+            server_sock.close()
+
+    def test_endheaders_too_many_streams_cleans_up(self) -> None:
+        conn = HTTP2Connection("example.com")
+        conn.sock = mock.MagicMock(sendall=mock.Mock(return_value=None))
+        conn._h2_conn._obj.data_to_send = mock.Mock(return_value=b"foo")  # type: ignore[method-assign]
+        conn._h2_conn._obj.get_next_available_stream_id = mock.Mock(return_value=1)  # type: ignore[method-assign]
+        conn._h2_conn._obj.send_headers = mock.Mock(  # type: ignore[method-assign]
+            side_effect=h2.exceptions.TooManyStreamsError
+        )
+
+        conn.putrequest("GET", "/")
+        assert conn._stream_owner is conn
+        with pytest.raises(ConnectionError, match="does not currently allow"):
+            conn.endheaders()
+
+        assert conn._headers == []
+        assert conn._stream_owner is None
+        assert conn._h2_stream is None
 
     def test_send_invalid_type(self) -> None:
         conn = HTTP2Connection("example.com")

--- a/test/with_dummyserver/test_https.py
+++ b/test/with_dummyserver/test_https.py
@@ -151,6 +151,36 @@ class BaseTestHTTPS(HTTPSHypercornDummyServerTestCase):
             assert r.headers["server"] == f"hypercorn-{http_version}"
             assert r.data == b"Dummy server!"
 
+    def test_http2_connection_is_reused(self, http_version: str) -> None:
+        if http_version != "h2":
+            pytest.skip("HTTP/2 connection reuse test")
+
+        with HTTPSConnectionPool(
+            self.host,
+            self.port,
+            ca_certs=DEFAULT_CA,
+            ssl_minimum_version=self.tls_version(),
+            maxsize=1,
+        ) as pool:
+            first_response = pool.request("GET", "/")
+            assert first_response.status == 200
+
+            assert pool.pool is not None
+            conn = pool.pool.get(block=False)
+            first_socket = conn.sock
+            assert first_socket is not None
+            pool._put_conn(conn)
+
+            second_response = pool.request("GET", "/")
+            assert second_response.status == 200
+
+            reused = pool.pool.get(block=False)
+            try:
+                assert reused is conn
+                assert reused.sock is first_socket
+            finally:
+                pool._put_conn(reused)
+
     def test_default_port(self) -> None:
         conn = HTTPSConnection(self.host, port=None)
         assert conn.port == 443


### PR DESCRIPTION
Closes #3301.

## Summary

Keep sequential HTTP/2 connections reusable when control frames arrive while
the connection is idle.

The connection now has one synchronized receive/event path shared by active
responses and idle health probes. Idle PING and SETTINGS frames are processed
and acknowledged, while EOF, GOAWAY, protocol errors, and failed ACK writes
make the connection non-reusable. A request-side preflight closes the race
between pool checkout and stream allocation.

The implementation also introduces explicit stream ownership so a response
body cannot be consumed by an idle probe or overwritten by another sequential
request.

## Root cause

The inherited HTTP/1.1 health check treated any readable idle socket as closed.
For HTTP/2, a readable socket can contain a valid control frame, so healthy
connections were closed instead of returned to the pool.

## Validation

- Full test suite: 2,341 passed, 315 skipped, 4 xfailed
- Pending-PING socket test fails with the old HTTP/1.1 probe and passes with the
  HTTP/2 event pump
- Real TLS integration proves two requests reuse one TCP/TLS connection
- PING/SETTINGS ACKs, idle EOF/GOAWAY, active reset/termination, timeout
  restoration, bounded reads, ACK failures, stream ownership, SETTINGS maximum
  streams zero, and the pool checkout/request race are covered
- Public pool tests prove poisoned connections are discarded and retried on a
  fresh connection
- PyOpenSSL socket timeout behavior is covered
- Black, isort, pyupgrade, flake8, mypy for touched code, towncrier draft, and
  diff check passed

