### PR TITLE
Raise when Retry-After exceeds configured wait limit

### DIFF
--- a/changelog/1338.feature.rst
+++ b/changelog/1338.feature.rst
@@ -1,0 +1,4 @@
+Added ``max_retry_wait_length`` to :class:`urllib3.util.Retry` to raise
+``MaxRetryWaitError`` when a server requests a longer ``Retry-After`` delay.
+The raising limit is evaluated before ``retry_after_max`` silently caps the
+server-provided value.

--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -629,6 +629,20 @@ specify the retry at the :class:`~urllib3.poolmanager.PoolManager` level:
 You still override this pool-level retry policy by specifying ``retries`` to
 :meth:`~urllib3.PoolManager.request`.
 
+Servers can use ``Retry-After`` to request a delay before the next attempt.
+``retry_after_max`` silently caps that delay (to six hours by default). To
+fail fast instead, set ``max_retry_wait_length`` and catch
+:class:`~urllib3.exceptions.MaxRetryWaitError`. The exception preserves the
+uncapped server-requested delay:
+
+.. code-block:: python
+
+    retry = urllib3.Retry(max_retry_wait_length=60)
+    try:
+        urllib3.request("GET", "https://example.com", retries=retry)
+    except urllib3.exceptions.MaxRetryWaitError as error:
+        print(f"Server requested a {error.retry_after}-second delay")
+
 Errors & Exceptions
 -------------------
 

--- a/dummyserver/app.py
+++ b/dummyserver/app.py
@@ -265,11 +265,14 @@ async def redirect_after() -> ResponseReturnValue:
 async def retry_after() -> ResponseReturnValue:
     global LAST_RETRY_AFTER_REQ
     params = request.args
-    if datetime.datetime.now() - LAST_RETRY_AFTER_REQ < datetime.timedelta(seconds=1):
+    if params.get("always") == "true" or (
+        datetime.datetime.now() - LAST_RETRY_AFTER_REQ < datetime.timedelta(seconds=1)
+    ):
         status = params.get("status", "429 Too Many Requests")
         status_code = status.split(" ")[0]
+        retry_after = params.get("retry_after", "1")
 
-        return await make_response("", status_code, [("Retry-After", "1")])
+        return await make_response("", status_code, [("Retry-After", retry_after)])
 
     LAST_RETRY_AFTER_REQ = datetime.datetime.now()
     return await make_response("", 200)

--- a/src/urllib3/exceptions.py
+++ b/src/urllib3/exceptions.py
@@ -106,6 +106,26 @@ class MaxRetryError(RequestError):
         return self.__class__, (None, self.url, self.reason)
 
 
+class MaxRetryWaitError(HTTPError):
+    """The server requested a retry delay longer than the configured maximum.
+
+    :param retry_after: The delay requested by the server, in seconds.
+    :param max_retry_wait_length: The configured maximum acceptable delay, in
+        seconds.
+    """
+
+    def __init__(self, retry_after: float, max_retry_wait_length: float) -> None:
+        self.retry_after = retry_after
+        self.max_retry_wait_length = max_retry_wait_length
+        super().__init__(
+            f"Retry-After value of {retry_after} seconds exceeds the configured "
+            f"maximum of {max_retry_wait_length} seconds"
+        )
+
+    def __reduce__(self) -> _TYPE_REDUCE_RESULT:
+        return self.__class__, (self.retry_after, self.max_retry_wait_length)
+
+
 class HostChangedError(RequestError):
     """Raised when an existing pool gets a request for a foreign host."""
 

--- a/src/urllib3/util/retry.py
+++ b/src/urllib3/util/retry.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import email
 import logging
+import math
 import random
 import re
 import time
@@ -13,6 +14,7 @@ from ..exceptions import (
     ConnectTimeoutError,
     InvalidHeader,
     MaxRetryError,
+    MaxRetryWaitError,
     ProtocolError,
     ProxyError,
     ReadTimeoutError,
@@ -191,6 +193,13 @@ class Retry:
         Retry-After headers. Defaults to :attr:`Retry.DEFAULT_RETRY_AFTER_MAX`.
         Any Retry-After headers larger than this value will be limited to this
         value.
+
+    :param float max_retry_wait_length:
+        If set, raise :class:`~urllib3.exceptions.MaxRetryWaitError` when a
+        Retry-After header requests a longer delay. The exception exposes the
+        server-requested delay so callers can choose how and when to retry.
+        This limit is checked against the original parsed value before
+        ``retry_after_max`` can cap that value.
     """
 
     #: Default methods to be used for ``allowed_methods``
@@ -238,6 +247,7 @@ class Retry:
         ] = DEFAULT_REMOVE_HEADERS_ON_REDIRECT,
         backoff_jitter: float = 0.0,
         retry_after_max: int = DEFAULT_RETRY_AFTER_MAX,
+        max_retry_wait_length: float | None = None,
     ) -> None:
         self.total = total
         self.connect = connect
@@ -255,6 +265,13 @@ class Retry:
         self.backoff_factor = backoff_factor
         self.backoff_max = backoff_max
         self.retry_after_max = retry_after_max
+        if max_retry_wait_length is not None and (
+            not math.isfinite(max_retry_wait_length) or max_retry_wait_length < 0
+        ):
+            raise ValueError(
+                "max_retry_wait_length must be a finite number greater than or equal to 0"
+            )
+        self.max_retry_wait_length = max_retry_wait_length
         self.raise_on_redirect = raise_on_redirect
         self.raise_on_status = raise_on_status
         self.history = history or ()
@@ -277,6 +294,7 @@ class Retry:
             backoff_factor=self.backoff_factor,
             backoff_max=self.backoff_max,
             retry_after_max=self.retry_after_max,
+            max_retry_wait_length=self.max_retry_wait_length,
             raise_on_redirect=self.raise_on_redirect,
             raise_on_status=self.raise_on_status,
             history=self.history,
@@ -340,6 +358,12 @@ class Retry:
             seconds = retry_date - time.time()
 
         seconds = max(seconds, 0)
+
+        if (
+            self.max_retry_wait_length is not None
+            and seconds > self.max_retry_wait_length
+        ):
+            raise MaxRetryWaitError(seconds, self.max_retry_wait_length)
 
         # Check the seconds do not exceed the specified maximum
         if seconds > self.retry_after_max:

--- a/test/test_exceptions.py
+++ b/test/test_exceptions.py
@@ -18,6 +18,7 @@ from urllib3.exceptions import (
     HTTPError,
     LocationParseError,
     MaxRetryError,
+    MaxRetryWaitError,
     NameResolutionError,
     NewConnectionError,
     ReadTimeoutError,
@@ -25,6 +26,15 @@ from urllib3.exceptions import (
 
 
 class TestPickle:
+    def test_max_retry_wait_error_preserves_wait_information(self) -> None:
+        error = MaxRetryWaitError(3600, 60)
+
+        result = pickle.loads(pickle.dumps(error))
+
+        assert result.retry_after == 3600
+        assert result.max_retry_wait_length == 60
+        assert str(result) == str(error)
+
     @pytest.mark.parametrize(
         "exception",
         [
@@ -36,6 +46,7 @@ class TestPickle:
             HTTPError("foo"),
             HTTPError("foo", IOError("foo")),
             MaxRetryError(HTTPConnectionPool("localhost"), "/", None),
+            MaxRetryWaitError(3600, 60),
             LocationParseError("fake location"),
             ClosedPoolError(HTTPConnectionPool("localhost"), ""),
             EmptyPoolError(HTTPConnectionPool("localhost"), ""),

--- a/test/test_retry.py
+++ b/test/test_retry.py
@@ -10,6 +10,7 @@ from urllib3.exceptions import (
     ConnectTimeoutError,
     InvalidHeader,
     MaxRetryError,
+    MaxRetryWaitError,
     ReadTimeoutError,
     ResponseError,
     SSLError,
@@ -192,6 +193,98 @@ class TestRetry:
         retry = Retry(retry_after_max=1)
         assert retry.parse_retry_after(str(1)) == 1
         assert retry.parse_retry_after(str(2)) == 1
+
+    def test_excessive_retry_after_raises_with_wait_information(self) -> None:
+        retry = Retry(max_retry_wait_length=60)
+        response = HTTPResponse(headers={"Retry-After": "3600"})
+
+        with pytest.raises(MaxRetryWaitError) as exc_info:
+            retry.get_retry_after(response)
+
+        assert exc_info.value.retry_after == 3600
+        assert exc_info.value.max_retry_wait_length == 60
+
+    def test_excessive_retry_after_is_ignored_when_configured(self) -> None:
+        retry = Retry(
+            respect_retry_after_header=False,
+            max_retry_wait_length=60,
+        )
+        response = HTTPResponse(status=503, headers={"Retry-After": "3600"})
+
+        with mock.patch("time.sleep") as sleep_mock:
+            retry.sleep(response)
+
+        sleep_mock.assert_not_called()
+
+    def test_excessive_retry_after_is_checked_before_default_cap(self) -> None:
+        retry = Retry(max_retry_wait_length=60)
+
+        with pytest.raises(MaxRetryWaitError) as exc_info:
+            retry.parse_retry_after(str(Retry.DEFAULT_RETRY_AFTER_MAX + 1))
+
+        assert exc_info.value.retry_after == Retry.DEFAULT_RETRY_AFTER_MAX + 1
+
+    def test_maximum_retry_wait_and_silent_cap_are_applied_in_order(self) -> None:
+        retry = Retry(retry_after_max=10, max_retry_wait_length=60)
+
+        assert retry.parse_retry_after("30") == 10
+        with pytest.raises(MaxRetryWaitError) as exc_info:
+            retry.parse_retry_after("61")
+
+        assert exc_info.value.retry_after == 61
+
+    def test_default_retry_after_cap_is_unchanged(self) -> None:
+        retry = Retry()
+
+        assert (
+            retry.parse_retry_after(str(Retry.DEFAULT_RETRY_AFTER_MAX + 1))
+            == Retry.DEFAULT_RETRY_AFTER_MAX
+        )
+
+    def test_retry_after_equal_to_maximum_wait_is_accepted(self) -> None:
+        retry = Retry(max_retry_wait_length=60)
+
+        assert retry.parse_retry_after("60") == 60
+
+    def test_zero_maximum_retry_wait_rejects_positive_delay(self) -> None:
+        retry = Retry(max_retry_wait_length=0)
+
+        with pytest.raises(MaxRetryWaitError):
+            retry.parse_retry_after("1")
+
+        assert retry.parse_retry_after("0") == 0
+
+    @pytest.mark.parametrize("value", [-1, float("nan"), float("inf")])
+    def test_invalid_maximum_retry_wait_is_rejected(self, value: float) -> None:
+        with pytest.raises(
+            ValueError,
+            match="max_retry_wait_length must be a finite number greater than or equal to 0",
+        ):
+            Retry(max_retry_wait_length=value)
+
+    def test_maximum_retry_wait_is_propagated_to_new_retry(self) -> None:
+        retry = Retry(max_retry_wait_length=60).increment(method="GET")
+
+        assert retry.max_retry_wait_length == 60
+        with pytest.raises(MaxRetryWaitError):
+            retry.parse_retry_after("61")
+
+    def test_http_date_exceeding_maximum_retry_wait_raises(self) -> None:
+        retry = Retry(max_retry_wait_length=60)
+        retry_date = "Mon, 3 Jun 2019 12:00:00 UTC"
+
+        with (
+            mock.patch(
+                "time.time",
+                return_value=datetime.datetime(
+                    2019, 6, 3, 11, tzinfo=datetime.timezone.utc
+                ).timestamp(),
+            ),
+            pytest.raises(MaxRetryWaitError) as exc_info,
+        ):
+            retry.parse_retry_after(retry_date)
+
+        assert exc_info.value.retry_after == 3600
 
     def test_backoff_jitter(self) -> None:
         """Backoff with jitter is computed correctly"""

--- a/test/with_dummyserver/test_connectionpool.py
+++ b/test/with_dummyserver/test_connectionpool.py
@@ -24,6 +24,7 @@ from urllib3.exceptions import (
     DecodeError,
     EmptyPoolError,
     MaxRetryError,
+    MaxRetryWaitError,
     NameResolutionError,
     NewConnectionError,
     ReadTimeoutError,
@@ -1300,6 +1301,44 @@ class TestRetry(HypercornDummyServerTestCase):
 
 
 class TestRetryAfter(HypercornDummyServerTestCase):
+    def test_excessive_retry_after_raises_without_retrying(self) -> None:
+        fields = {
+            "status": "503 Service Unavailable",
+            "retry_after": "3600",
+            "always": "true",
+        }
+        with HTTPConnectionPool(self.host, self.port) as pool:
+            with (
+                mock.patch("time.sleep") as sleep_mock,
+                pytest.raises(MaxRetryWaitError) as exc_info,
+            ):
+                pool.request(
+                    "GET",
+                    "/retry_after",
+                    fields=fields,
+                    retries=Retry(total=1, max_retry_wait_length=60),
+                )
+
+            assert exc_info.value.retry_after == 3600
+            assert exc_info.value.max_retry_wait_length == 60
+            sleep_mock.assert_not_called()
+
+    def test_excessive_retry_after_on_non_retry_status_is_returned(self) -> None:
+        fields = {
+            "status": "418 I'm a teapot",
+            "retry_after": "3600",
+            "always": "true",
+        }
+        with HTTPConnectionPool(self.host, self.port) as pool:
+            response = pool.request(
+                "GET",
+                "/retry_after",
+                fields=fields,
+                retries=Retry(total=1, max_retry_wait_length=60),
+            )
+
+        assert response.status == 418
+
     def test_retry_after(self) -> None:
         # Request twice in a second to get a 429 response.
         with HTTPConnectionPool(self.host, self.port) as pool:


### PR DESCRIPTION
Closes #1338.

## Summary

Add an opt-in `Retry.max_retry_wait_length` threshold that raises
`MaxRetryWaitError` when a server requests a longer `Retry-After` delay. The
exception retains both the uncapped server delay and the configured threshold,
allowing callers to persist the request and retry it later.

The strict threshold is evaluated before the existing `retry_after_max` cap.
The default remains `None`, so existing retry behavior is unchanged unless the
new option is configured.

## Why

`Retry-After` is server-controlled. Silently sleeping—even with the newer
default cap—does not let callers distinguish a short in-process retry from a
delay that should be scheduled elsewhere. This implements the fail-fast API
suggested in the issue while preserving backwards compatibility.

## Validation

- Full test suite: 2,305 passed, 333 skipped, 4 xfailed
- Focused retry and exception suite: 99 passed
- Deterministic Hypercorn integration test proves a real 503 response raises,
  makes exactly one request, and never calls sleep
- Integer and HTTP-date values, boundaries, zero, invalid/non-finite values,
  `Retry.new()` propagation, cap ordering, disabled-header behavior, and
  exception pickling are covered
- Requests downstream probe passed against a real HTTP server
- Black, isort, pyupgrade, flake8, towncrier draft, and diff check passed

