### PR TITLE
Add opt-in cleartext HTTP/2 support

### DIFF
--- a/changelog/3301.bugfix.rst
+++ b/changelog/3301.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed HTTP/2 connections being discarded instead of reused when control frames arrive while idle.

--- a/changelog/3303.feature.rst
+++ b/changelog/3303.feature.rst
@@ -1,0 +1,2 @@
+Added opt-in support for cleartext HTTP/2 using prior knowledge or the legacy
+HTTP/1.1 ``Upgrade: h2c`` mechanism.

--- a/docs/advanced-usage.rst
+++ b/docs/advanced-usage.rst
@@ -635,3 +635,32 @@ flag that isn't set by default, and then makes a HTTPS request:
 Note that this is different from passing an ``options`` argument to
 :func:`~urllib3.util.create_urllib3_context` because we don't overwrite
 the default options: we only add a new one.
+
+Cleartext HTTP/2
+----------------
+
+.. warning::
+
+    HTTP/2 support is experimental. Enabling it replaces urllib3's connection
+    implementations process-wide until ``urllib3.http2.extract_from_urllib3()``
+    is called.
+
+HTTP/2 without TLS (h2c) is opt-in and requires the ``h2`` extra. Prior
+knowledge is appropriate when the server is known to support cleartext HTTP/2:
+
+.. code-block:: python
+
+    import urllib3
+    import urllib3.http2
+
+    urllib3.http2.inject_into_urllib3(h2c="prior_knowledge")
+    try:
+        response = urllib3.request("GET", "http://h2c.example/")
+    finally:
+        urllib3.http2.extract_from_urllib3()
+
+For servers that implement the HTTP/1.1 h2c upgrade defined by RFC 7540, pass
+``h2c="upgrade"`` instead. A server that declines the upgrade continues over
+HTTP/1.1. The upgrade mechanism is deprecated by RFC 9113 and is therefore only
+enabled explicitly. Connections through HTTP proxies continue to use HTTP/1.1;
+h2c configuration applies only to direct origin connections.

--- a/src/urllib3/contrib/pyopenssl.py
+++ b/src/urllib3/contrib/pyopenssl.py
@@ -355,8 +355,11 @@ class WrappedSocket:
         except OpenSSL.SSL.Error as e:
             raise ssl.SSLError(f"read error: {e!r}") from e
 
-    def settimeout(self, timeout: float) -> None:
+    def settimeout(self, timeout: float | None) -> None:
         return self.socket.settimeout(timeout)
+
+    def gettimeout(self) -> float | None:
+        return self.socket.gettimeout()
 
     def _send_until_done(self, data: bytes) -> int:
         while True:

--- a/src/urllib3/http2/__init__.py
+++ b/src/urllib3/http2/__init__.py
@@ -10,9 +10,21 @@ __all__ = [
 import typing
 
 orig_HTTPSConnection: typing.Any = None
+orig_HTTPSConnectionPool: typing.Any = None
+orig_HTTPConnection: typing.Any = None
+orig_HTTPConnectionPool: typing.Any = None
 
 
-def inject_into_urllib3() -> None:
+def inject_into_urllib3(
+    *, h2c: bool | typing.Literal["prior_knowledge", "upgrade"] = False
+) -> None:
+    """Enable urllib3's experimental HTTP/2 connection implementations.
+
+    ``h2c`` controls cleartext HTTP/2 for direct ``http`` connections. ``False``
+    keeps HTTP/1.1, ``"prior_knowledge"`` (and its ``True`` alias) sends the
+    HTTP/2 connection preface immediately, and ``"upgrade"`` uses the legacy
+    HTTP/1.1 ``Upgrade: h2c`` mechanism. Proxy connections remain on HTTP/1.1.
+    """
     # First check if h2 version is valid
     h2_version = version("h2")
     if not h2_version.startswith("4."):
@@ -25,15 +37,47 @@ def inject_into_urllib3() -> None:
     # Import here to avoid circular dependencies.
     from .. import connection as urllib3_connection
     from .. import util as urllib3_util
-    from ..connectionpool import HTTPSConnectionPool
+    from ..connectionpool import HTTPConnectionPool, HTTPSConnectionPool
     from ..util import ssl_ as urllib3_util_ssl
-    from .connection import HTTP2Connection
+    from .connection import (
+        HTTP2CleartextConnection,
+        HTTP2Connection,
+        HTTP2UpgradeConnection,
+    )
 
-    global orig_HTTPSConnection
-    orig_HTTPSConnection = urllib3_connection.HTTPSConnection
+    if h2c is True or h2c == "prior_knowledge":
+        http_connection = HTTP2CleartextConnection
+    elif h2c == "upgrade":
+        http_connection = HTTP2UpgradeConnection
+    elif h2c is False:
+        http_connection = None
+    else:
+        raise ValueError("h2c must be True, 'prior_knowledge', 'upgrade', or False")
+
+    global orig_HTTPConnection, orig_HTTPConnectionPool
+    global orig_HTTPSConnection, orig_HTTPSConnectionPool
+    if orig_HTTPSConnection is None:
+        orig_HTTPSConnection = urllib3_connection.HTTPSConnection
+    if orig_HTTPSConnectionPool is None:
+        orig_HTTPSConnectionPool = HTTPSConnectionPool.ConnectionCls
 
     HTTPSConnectionPool.ConnectionCls = HTTP2Connection
     urllib3_connection.HTTPSConnection = HTTP2Connection  # type: ignore[misc]
+
+    if http_connection is None:
+        if orig_HTTPConnection is not None:
+            urllib3_connection.HTTPConnection = orig_HTTPConnection  # type: ignore[misc]
+            orig_HTTPConnection = None
+        if orig_HTTPConnectionPool is not None:
+            HTTPConnectionPool.ConnectionCls = orig_HTTPConnectionPool
+            orig_HTTPConnectionPool = None
+    else:
+        if orig_HTTPConnection is None:
+            orig_HTTPConnection = urllib3_connection.HTTPConnection
+        if orig_HTTPConnectionPool is None:
+            orig_HTTPConnectionPool = HTTPConnectionPool.ConnectionCls
+        urllib3_connection.HTTPConnection = http_connection  # type: ignore[misc]
+        HTTPConnectionPool.ConnectionCls = http_connection
 
     # TODO: Offer 'http/1.1' as well, but for testing purposes this is handy.
     urllib3_util.ALPN_PROTOCOLS = ["h2"]
@@ -43,11 +87,23 @@ def inject_into_urllib3() -> None:
 def extract_from_urllib3() -> None:
     from .. import connection as urllib3_connection
     from .. import util as urllib3_util
-    from ..connectionpool import HTTPSConnectionPool
+    from ..connectionpool import HTTPConnectionPool, HTTPSConnectionPool
     from ..util import ssl_ as urllib3_util_ssl
 
-    HTTPSConnectionPool.ConnectionCls = orig_HTTPSConnection
-    urllib3_connection.HTTPSConnection = orig_HTTPSConnection  # type: ignore[misc]
+    global orig_HTTPConnection, orig_HTTPConnectionPool
+    global orig_HTTPSConnection, orig_HTTPSConnectionPool
+    if orig_HTTPSConnection is not None:
+        urllib3_connection.HTTPSConnection = orig_HTTPSConnection  # type: ignore[misc]
+        orig_HTTPSConnection = None
+    if orig_HTTPSConnectionPool is not None:
+        HTTPSConnectionPool.ConnectionCls = orig_HTTPSConnectionPool
+        orig_HTTPSConnectionPool = None
+    if orig_HTTPConnection is not None:
+        urllib3_connection.HTTPConnection = orig_HTTPConnection  # type: ignore[misc]
+        orig_HTTPConnection = None
+    if orig_HTTPConnectionPool is not None:
+        HTTPConnectionPool.ConnectionCls = orig_HTTPConnectionPool
+        orig_HTTPConnectionPool = None
 
     urllib3_util.ALPN_PROTOCOLS = ["http/1.1"]
     urllib3_util_ssl.ALPN_PROTOCOLS = ["http/1.1"]

--- a/src/urllib3/http2/connection.py
+++ b/src/urllib3/http2/connection.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import http.client
+import io
 import logging
 import re
+import socket
 import ssl
 import threading
 import types
@@ -13,11 +16,19 @@ import h2.connection
 import h2.events
 import h2.exceptions
 
-from .._base_connection import _TYPE_BODY
+from .._base_connection import _TYPE_BODY, _ResponseOptions
 from .._collections import HTTPHeaderDict
-from ..connection import HTTPSConnection, _get_default_user_agent
-from ..exceptions import ProtocolError
-from ..response import BaseHTTPResponse
+from ..connection import (
+    HTTPConnection,
+    HTTPSConnection,
+    _get_default_user_agent,
+    _normalize_header_values,
+)
+from ..exceptions import HeaderParsingError, ProtocolError
+from ..response import BaseHTTPResponse, HTTPResponse
+from ..util import SKIP_HEADER, SKIPPABLE_HEADERS
+from ..util.request import body_to_chunks
+from ..util.response import assert_header_parsing
 
 orig_HTTPSConnection = HTTPSConnection
 
@@ -30,6 +41,122 @@ _MAX_IDLE_READS = 16
 
 RE_IS_LEGAL_HEADER_NAME = re.compile(rb"^[!#$%&'*+\-.^_`|~0-9a-z]+$")
 RE_IS_ILLEGAL_HEADER_VALUE = re.compile(rb"[\0\x00\x0a\x0d\r\n]|^[ \r\n\t]|[ \r\n\t]$")
+RE_IS_LEGAL_HTTP1_HEADER_NAME = re.compile(rb"^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$")
+RE_IS_ILLEGAL_HTTP1_HEADER_VALUE = re.compile(rb"[\x00\r\n]")
+RE_HTTP1_STATUS_LINE = re.compile(
+    rb"^HTTP/(?P<major>[0-9]+)\.(?P<minor>[0-9]+) "
+    rb"(?P<status>[0-9]{3})(?: (?P<reason>[^\r\n]*))?$"
+)
+
+
+class _SocketReader(io.RawIOBase):
+    """Expose prefetched bytes and then a socket as an unbuffered reader.
+
+    The reader deliberately doesn't own the socket. ``http.client`` closes its
+    response file after a fixed-length body, while the connection keeps the
+    underlying socket available for another request.
+    """
+
+    def __init__(self, sock: typing.Any, prefetched: bytes) -> None:
+        self._sock = sock
+        self._prefetched = bytearray(prefetched)
+        self._owns_socket = False
+
+    def take_socket_ownership(self) -> None:
+        """Close the socket with this reader after connection-close responses."""
+        self._owns_socket = True
+        if self.closed:
+            self._sock.close()
+
+    def readable(self) -> bool:
+        return True
+
+    def readinto(self, buffer: typing.Any) -> int:
+        if self._prefetched:
+            size = min(len(buffer), len(self._prefetched))
+            buffer[:size] = self._prefetched[:size]
+            del self._prefetched[:size]
+            return size
+        return typing.cast(int, self._sock.recv_into(buffer))
+
+    def close(self) -> None:
+        try:
+            if self._owns_socket:
+                self._sock.close()
+        finally:
+            super().close()
+
+
+class _PrefetchedSocket:
+    """Socket facade used to hand an already-read response to http.client."""
+
+    def __init__(self, sock: typing.Any, prefetched: bytes) -> None:
+        self._sock = sock
+        self._prefetched = prefetched
+        self._reader: _SocketReader | None = None
+
+    def makefile(self, mode: str, buffering: int | None = None) -> io.BufferedReader:
+        assert mode == "rb"
+        self._reader = _SocketReader(self._sock, self._prefetched)
+        return io.BufferedReader(self._reader)
+
+    def transfer_socket_to_response(self) -> None:
+        assert self._reader is not None
+        self._reader.take_socket_ownership()
+
+
+def _read_http1_response_head(
+    sock: typing.Any, prefetched: bytes = b""
+) -> tuple[bytes, bytes]:
+    data = bytearray(prefetched)
+    while b"\r\n\r\n" not in data:
+        received = sock.recv(65535)
+        if not received:
+            raise ProtocolError("Connection closed while reading h2c upgrade response")
+        data.extend(received)
+        if len(data) > 65536:
+            raise ProtocolError("h2c upgrade response headers are too large")
+    marker = data.index(b"\r\n\r\n") + 4
+    if marker > 65536:
+        raise ProtocolError("h2c upgrade response headers are too large")
+    return bytes(data[:marker]), bytes(data[marker:])
+
+
+def _parse_http1_response_head(
+    head: bytes,
+) -> tuple[int, int, HTTPHeaderDict, http.client.HTTPMessage]:
+    status_line, separator, header_lines = head.partition(b"\r\n")
+    if not separator or (match := RE_HTTP1_STATUS_LINE.fullmatch(status_line)) is None:
+        raise ProtocolError(f"Invalid h2c upgrade status line: {status_line!r}")
+
+    try:
+        message = http.client.parse_headers(io.BytesIO(header_lines))
+    except http.client.HTTPException as e:
+        raise ProtocolError("Invalid h2c upgrade response headers", e) from e
+
+    version = int(match.group("major")) * 10 + int(match.group("minor"))
+    return (
+        version,
+        int(match.group("status")),
+        HTTPHeaderDict(message.items()),
+        message,
+    )
+
+
+def _header_has_token(headers: HTTPHeaderDict, name: str, token: str) -> bool:
+    return token.lower() in {
+        item.strip().lower() for item in headers.get(name, "").split(",")
+    }
+
+
+def _encode_http1_header(name: str, value: str) -> bytes:
+    encoded_name = name.encode("ascii")
+    encoded_value = value.encode("latin-1")
+    if not RE_IS_LEGAL_HTTP1_HEADER_NAME.fullmatch(encoded_name):
+        raise ValueError(f"Illegal header name {name!r}")
+    if RE_IS_ILLEGAL_HTTP1_HEADER_VALUE.search(encoded_value):
+        raise ValueError(f"Illegal header value {value!r}")
+    return encoded_name + b": " + encoded_value + b"\r\n"
 
 
 def _is_legal_header_name(name: bytes) -> bool:
@@ -89,6 +216,9 @@ class _LockedObject(typing.Generic[T]):
 
 
 class HTTP2Connection(HTTPSConnection):
+    _http2_scheme: typing.ClassVar[bytes] = b"https"
+    _http2_default_port: typing.ClassVar[int] = 443
+
     def __init__(
         self, host: str, port: int | None = None, **kwargs: typing.Any
     ) -> None:
@@ -98,6 +228,7 @@ class HTTP2Connection(HTTPSConnection):
         self._headers: list[tuple[bytes, bytes]] = []
         self._connection_terminated = False
         self._has_completed_response = False
+        self._h2_received_data = bytearray()
 
         if "proxy" in kwargs or "proxy_config" in kwargs:  # Defensive:
             raise NotImplementedError("Proxies aren't supported with HTTP/2")
@@ -113,6 +244,9 @@ class HTTP2Connection(HTTPSConnection):
 
     def connect(self) -> None:
         super().connect()
+        self._start_http2_connection()
+
+    def _start_http2_connection(self) -> None:
         self._connection_terminated = False
         with self._h2_conn as conn:
             conn.initiate_connection()
@@ -166,7 +300,11 @@ class HTTP2Connection(HTTPSConnection):
         """
         self._assert_stream_owner(stream_owner)
         assert self.sock is not None
-        received_data = self.sock.recv(65535)
+        if self._h2_received_data:
+            received_data = bytes(self._h2_received_data)
+            self._h2_received_data.clear()
+        else:
+            received_data = self.sock.recv(65535)
         if not received_data:
             self._connection_terminated = True
             return None
@@ -268,13 +406,13 @@ class HTTP2Connection(HTTPSConnection):
         self._request_url = url or "/"
         self._validate_path(url)  # type: ignore[attr-defined]
 
-        port = self.port if self.port is not None else 443
+        port = self.port if self.port is not None else self._http2_default_port
         if ":" in self.host:
             authority = f"[{self.host}]:{port}"
         else:
             authority = f"{self.host}:{port}"
 
-        self._headers.append((b":scheme", b"https"))
+        self._headers.append((b":scheme", self._http2_scheme))
         self._headers.append((b":method", method.encode()))
         self._headers.append((b":authority", authority.encode()))
         self._headers.append((b":path", url.encode()))
@@ -455,7 +593,9 @@ class HTTP2Connection(HTTPSConnection):
             # raise NotImplementedError("`chunked` isn't supported with HTTP/2")
             pass
 
-        if self.sock is not None:
+        if self.sock is None:
+            self.connect()
+        else:
             self.sock.settimeout(self.timeout)
 
         self.putrequest(method, url)
@@ -485,15 +625,376 @@ class HTTP2Connection(HTTPSConnection):
             except Exception:
                 pass
 
-        # Reset all our HTTP/2 connection state.
+        self._reset_http2_state()
+
+        super().close()
+
+    def _reset_http2_state(self) -> None:
         self._h2_conn = self._new_h2_conn()
         self._h2_stream = None
         self._stream_owner = None
         self._headers = []
         self._connection_terminated = False
         self._has_completed_response = False
+        self._h2_received_data.clear()
 
-        super().close()
+
+class HTTP2CleartextConnection(HTTP2Connection):
+    """HTTP/2 over a cleartext TCP connection using prior knowledge."""
+
+    _http2_scheme = b"http"
+    _http2_default_port = 80
+
+    def __init__(
+        self, host: str, port: int | None = None, **kwargs: typing.Any
+    ) -> None:
+        # HTTP proxies keep their existing HTTP/1.1 behavior. h2c configuration
+        # describes the origin connection, not an implicit capability of every
+        # intermediary on the route.
+        self._h2c_http1_fallback = bool(
+            kwargs.get("proxy") is not None or kwargs.get("proxy_config") is not None
+        )
+        if self._h2c_http1_fallback:
+            self._h2_conn = self._new_h2_conn()
+            self._h2_stream = None
+            self._stream_owner = None
+            self._headers = []
+            self._connection_terminated = False
+            self._has_completed_response = False
+            self._h2_received_data = bytearray()
+            HTTPConnection.__init__(
+                self,
+                host,
+                port=self._http2_default_port if port is None else port,
+                **kwargs,
+            )
+        else:
+            super().__init__(
+                host,
+                port=self._http2_default_port if port is None else port,
+                **kwargs,
+            )
+
+    def connect(self) -> None:
+        HTTPConnection.connect(self)
+        if not self._h2c_http1_fallback:
+            self._start_http2_connection()
+
+    def request(self, *args: typing.Any, **kwargs: typing.Any) -> None:
+        if self._h2c_http1_fallback:
+            HTTPConnection.request(self, *args, **kwargs)
+        else:
+            super().request(*args, **kwargs)
+
+    def putrequest(  # type: ignore[override]
+        self, method: str, url: str, **kwargs: typing.Any
+    ) -> None:
+        if self._h2c_http1_fallback:
+            HTTPConnection.putrequest(self, method, url, **kwargs)
+        else:
+            super().putrequest(method, url, **kwargs)
+
+    def putheader(  # type: ignore[override]
+        self, header: str | bytes, *values: str | bytes
+    ) -> None:
+        if self._h2c_http1_fallback:
+            HTTPConnection.putheader(self, header, *values)  # type: ignore[arg-type]
+        else:
+            super().putheader(header, *values)
+
+    def endheaders(  # type: ignore[override]
+        self, message_body: typing.Any = None
+    ) -> None:
+        if self._h2c_http1_fallback:
+            HTTPConnection.endheaders(self, message_body)
+        else:
+            super().endheaders(message_body)
+
+    def send(self, data: typing.Any) -> None:
+        if self._h2c_http1_fallback:
+            HTTPConnection.send(self, data)
+        else:
+            super().send(data)
+
+    def getresponse(self) -> BaseHTTPResponse:  # type: ignore[override]
+        if self._h2c_http1_fallback:
+            return HTTPConnection.getresponse(self)
+        return super().getresponse()
+
+    def close(self) -> None:
+        if self._h2c_http1_fallback:
+            self._reset_http2_state()
+            HTTPConnection.close(self)
+        else:
+            super().close()
+
+
+class HTTP2UpgradeConnection(HTTP2CleartextConnection):
+    """Cleartext HTTP/2 negotiated with the legacy HTTP/1.1 Upgrade path."""
+
+    def __init__(
+        self, host: str, port: int | None = None, **kwargs: typing.Any
+    ) -> None:
+        self._h2c_upgrade_complete = False
+        self._h2c_request_method: str | None = None
+        super().__init__(host, port=port, **kwargs)
+
+    def connect(self) -> None:
+        HTTPConnection.connect(self)
+
+    def request(  # type: ignore[override]
+        self,
+        method: str,
+        url: str,
+        body: _TYPE_BODY | None = None,
+        headers: typing.Mapping[str, str] | None = None,
+        *,
+        chunked: bool = False,
+        preload_content: bool = True,
+        decode_content: bool = True,
+        enforce_content_length: bool = True,
+        **kwargs: typing.Any,
+    ) -> None:
+        if self._h2c_http1_fallback:
+            HTTPConnection.request(
+                self,
+                method,
+                url,
+                body=body,
+                headers=headers,
+                chunked=chunked,
+                preload_content=preload_content,
+                decode_content=decode_content,
+                enforce_content_length=enforce_content_length,
+            )
+            return
+        if self._h2c_upgrade_complete:
+            HTTP2Connection.request(
+                self,
+                method,
+                url,
+                body=body,
+                headers=headers,
+                preload_content=preload_content,
+                decode_content=decode_content,
+                enforce_content_length=enforce_content_length,
+                chunked=chunked,
+                **kwargs,
+            )
+            return
+
+        if kwargs:
+            unknown = ", ".join(sorted(kwargs))
+            raise TypeError(f"Unexpected request arguments for h2c upgrade: {unknown}")
+        if self.sock is None:
+            self.connect()
+        else:
+            self.sock.settimeout(self.timeout)
+
+        self._validate_method(method)  # type: ignore[attr-defined]
+        self._validate_path(url)  # type: ignore[attr-defined]
+        self._response_options = _ResponseOptions(
+            request_method=method,
+            request_url=url,
+            preload_content=preload_content,
+            decode_content=decode_content,
+            enforce_content_length=enforce_content_length,
+        )
+        self._h2c_request_method = method
+        self._request_url = url or "/"
+
+        with self._h2_conn as conn:
+            settings_header = conn.initiate_upgrade_connection()
+        assert settings_header is not None
+        self._h2_stream = 1
+        self._stream_owner = self
+
+        request_headers = HTTPHeaderDict(headers or {})
+        skipped_headers: set[str] = set()
+        for name, value in (headers or {}).items():
+            if value == SKIP_HEADER:
+                lower_name = name.lower()
+                if lower_name not in SKIPPABLE_HEADERS:
+                    skippable = "', '".join(
+                        name.title() for name in sorted(SKIPPABLE_HEADERS)
+                    )
+                    raise ValueError(
+                        f"urllib3.util.SKIP_HEADER only supports '{skippable}'"
+                    )
+                skipped_headers.add(lower_name)
+                request_headers.discard(name)
+        request_headers["Connection"] = "Upgrade, HTTP2-Settings"
+        request_headers["Upgrade"] = "h2c"
+        request_headers["HTTP2-Settings"] = settings_header.decode("ascii")
+
+        chunks_and_length = body_to_chunks(
+            body, method=method, blocksize=self.blocksize
+        )
+        chunks = chunks_and_length.chunks
+        content_length = chunks_and_length.content_length
+        header_names = {name.lower() for name in request_headers}
+        if "host" not in header_names and "host" not in skipped_headers:
+            request_headers["Host"] = self._http2_authority()
+        if (
+            "accept-encoding" not in header_names
+            and "accept-encoding" not in skipped_headers
+        ):
+            request_headers["Accept-Encoding"] = "identity"
+        if "user-agent" not in header_names and "user-agent" not in skipped_headers:
+            request_headers["User-Agent"] = _get_default_user_agent()
+
+        if chunked:
+            if "transfer-encoding" not in header_names:
+                request_headers["Transfer-Encoding"] = "chunked"
+        elif "content-length" in header_names:
+            chunked = False
+        elif "transfer-encoding" in header_names:
+            chunked = True
+        else:
+            if content_length is None:
+                if chunks is not None:
+                    chunked = True
+                    request_headers["Transfer-Encoding"] = "chunked"
+            else:
+                request_headers["Content-Length"] = str(content_length)
+
+        try:
+            request_head = bytearray(
+                f"{method} {url or '/'} HTTP/1.1\r\n".encode("ascii")
+            )
+            for name, value in request_headers.iteritems():
+                request_head.extend(_encode_http1_header(name, value))
+            request_head.extend(b"\r\n")
+            self.sock.sendall(request_head)
+            if chunks is not None:
+                for chunk in chunks:
+                    if not chunk:
+                        continue
+                    encoded_chunk = chunk.encode() if isinstance(chunk, str) else chunk
+                    if chunked:
+                        self.sock.sendall(
+                            b"%x\r\n%b\r\n" % (len(encoded_chunk), encoded_chunk)
+                        )
+                    else:
+                        self.sock.sendall(encoded_chunk)
+            if chunked:
+                self.sock.sendall(b"0\r\n\r\n")
+        except BaseException:
+            self.close()
+            raise
+
+    def _http2_authority(self) -> str:
+        host = f"[{self.host}]" if ":" in self.host else self.host
+        if self.port in (None, self._http2_default_port):
+            return host
+        return f"{host}:{self.port}"
+
+    def getresponse(self) -> BaseHTTPResponse:  # type: ignore[override]
+        if self._h2c_http1_fallback:
+            return HTTPConnection.getresponse(self)
+        if self._h2c_upgrade_complete:
+            return HTTP2Connection.getresponse(self)
+        if self._response_options is None or self._h2c_request_method is None:
+            raise http.client.ResponseNotReady()
+
+        prefetched = b""
+        response_prefix = bytearray()
+        response_head_bytes = 0
+        informational_responses = 0
+        while True:
+            head, prefetched = _read_http1_response_head(self.sock, prefetched)
+            response_head_bytes += len(head)
+            if response_head_bytes > 65536:
+                raise ProtocolError("Too many informational h2c upgrade responses")
+            version, status, response_headers, response_message = (
+                _parse_http1_response_head(head)
+            )
+            if status == 101 or not 100 <= status < 200:
+                response_prefix.extend(head)
+                break
+            informational_responses += 1
+            if informational_responses > 10:
+                raise ProtocolError("Too many informational h2c upgrade responses")
+
+        if status != 101:
+            response_prefix.extend(prefetched)
+            response = self._fallback_response(bytes(response_prefix))
+            self._reset_http2_state()
+            self._response_options = None
+            self._h2c_request_method = None
+            return response
+
+        if version != 11:
+            raise ProtocolError("Invalid h2c Upgrade response: 101 requires HTTP/1.1")
+        try:
+            assert_header_parsing(response_message)
+        except (HeaderParsingError, TypeError) as e:
+            raise ProtocolError("Invalid h2c Upgrade response headers", e) from e
+        if not _header_has_token(response_headers, "connection", "upgrade"):
+            raise ProtocolError(
+                "Invalid h2c Upgrade response: Connection header lacks Upgrade"
+            )
+        if not _header_has_token(response_headers, "upgrade", "h2c"):
+            raise ProtocolError(
+                "Invalid h2c Upgrade response: Upgrade header lacks h2c"
+            )
+
+        self._h2_received_data.extend(prefetched)
+        with self._h2_conn as conn:
+            if data_to_send := conn.data_to_send():
+                self.sock.sendall(data_to_send)
+        self._h2c_upgrade_complete = True
+        h2_response = HTTP2Connection.getresponse(self)
+        self._response_options = None
+        self._h2c_request_method = None
+        return h2_response
+
+    def _fallback_response(self, prefetched: bytes) -> HTTPResponse:
+        assert self._response_options is not None
+        response_options = self._response_options
+        prefetched_socket = _PrefetchedSocket(self.sock, prefetched)
+        original_response = http.client.HTTPResponse(
+            typing.cast(socket.socket, prefetched_socket),
+            method=self._h2c_request_method,
+        )
+        original_response.begin()
+        if original_response.will_close:
+            # Match http.client.HTTPConnection.getresponse(): detach a closing
+            # socket from the connection while leaving the response able to
+            # consume its body. The response reader closes the socket later.
+            prefetched_socket.transfer_socket_to_response()
+            self.sock = None
+        try:
+            assert_header_parsing(original_response.msg)
+        except (HeaderParsingError, TypeError) as e:
+            log.warning("Failed to parse h2c fallback headers: %s", e, exc_info=True)
+        headers = HTTPHeaderDict(_normalize_header_values(original_response.msg))
+        return HTTPResponse(
+            body=original_response,
+            headers=headers,
+            status=original_response.status,
+            version=original_response.version,
+            version_string=f"HTTP/{original_response.version // 10}.{original_response.version % 10}",
+            reason=original_response.reason,
+            preload_content=response_options.preload_content,
+            decode_content=response_options.decode_content,
+            original_response=original_response,
+            enforce_content_length=response_options.enforce_content_length,
+            request_method=response_options.request_method,
+            request_url=response_options.request_url,
+            sock_shutdown=getattr(self.sock, "shutdown", None),
+        )
+
+    def close(self) -> None:
+        was_upgraded = self._h2c_upgrade_complete
+        self._h2c_upgrade_complete = False
+        self._response_options = None
+        self._h2c_request_method = None
+        if was_upgraded:
+            HTTP2Connection.close(self)
+        else:
+            self._reset_http2_state()
+            HTTPConnection.close(self)
 
 
 class HTTP2Response(BaseHTTPResponse):

--- a/src/urllib3/http2/connection.py
+++ b/src/urllib3/http2/connection.py
@@ -2,18 +2,21 @@ from __future__ import annotations
 
 import logging
 import re
+import ssl
 import threading
 import types
 import typing
+from http.client import CannotSendRequest
 
 import h2.config
 import h2.connection
 import h2.events
+import h2.exceptions
 
 from .._base_connection import _TYPE_BODY
 from .._collections import HTTPHeaderDict
 from ..connection import HTTPSConnection, _get_default_user_agent
-from ..exceptions import ConnectionError
+from ..exceptions import ProtocolError
 from ..response import BaseHTTPResponse
 
 orig_HTTPSConnection = HTTPSConnection
@@ -21,6 +24,9 @@ orig_HTTPSConnection = HTTPSConnection
 T = typing.TypeVar("T")
 
 log = logging.getLogger(__name__)
+
+_IDLE_READ_SIZE = 65535
+_MAX_IDLE_READS = 16
 
 RE_IS_LEGAL_HEADER_NAME = re.compile(rb"^[!#$%&'*+\-.^_`|~0-9a-z]+$")
 RE_IS_ILLEGAL_HEADER_VALUE = re.compile(rb"[\0\x00\x0a\x0d\r\n]|^[ \r\n\t]|[ \r\n\t]$")
@@ -88,7 +94,10 @@ class HTTP2Connection(HTTPSConnection):
     ) -> None:
         self._h2_conn = self._new_h2_conn()
         self._h2_stream: int | None = None
+        self._stream_owner: object | None = None
         self._headers: list[tuple[bytes, bytes]] = []
+        self._connection_terminated = False
+        self._has_completed_response = False
 
         if "proxy" in kwargs or "proxy_config" in kwargs:  # Defensive:
             raise NotImplementedError("Proxies aren't supported with HTTP/2")
@@ -104,10 +113,129 @@ class HTTP2Connection(HTTPSConnection):
 
     def connect(self) -> None:
         super().connect()
+        self._connection_terminated = False
         with self._h2_conn as conn:
             conn.initiate_connection()
             if data_to_send := conn.data_to_send():
                 self.sock.sendall(data_to_send)
+
+    def _assert_stream_owner(self, stream_owner: object | None) -> None:
+        if self._stream_owner is not stream_owner:
+            raise RuntimeError("HTTP/2 stream events have a different owner")
+
+    def _transfer_stream_owner(self, current_owner: object, new_owner: object) -> None:
+        """Transfer the right to receive events for the active stream."""
+        if self._stream_owner is not current_owner:
+            raise RuntimeError("HTTP/2 stream events have a different owner")
+        self._stream_owner = new_owner
+
+    def _release_stream_owner(self, stream_owner: object) -> None:
+        """Release an active stream after its response has completed."""
+        self._assert_stream_owner(stream_owner)
+        self._stream_owner = None
+        self._h2_stream = None
+
+    def _process_received_data(
+        self, received_data: bytes, *, stream_owner: object | None
+    ) -> list[h2.events.Event]:
+        """Process HTTP/2 bytes and flush protocol-generated output."""
+        self._assert_stream_owner(stream_owner)
+        with self._h2_conn as conn:
+            events = conn.receive_data(received_data)
+            for event in events:
+                if isinstance(event, h2.events.DataReceived):
+                    conn.acknowledge_received_data(
+                        event.flow_controlled_length, event.stream_id
+                    )
+                elif isinstance(event, h2.events.ConnectionTerminated):
+                    self._connection_terminated = True
+
+            if data_to_send := conn.data_to_send():
+                self.sock.sendall(data_to_send)
+
+        return events
+
+    def _receive_events(
+        self, *, stream_owner: object | None
+    ) -> list[h2.events.Event] | None:
+        """Receive and process one batch of HTTP/2 events.
+
+        ``None`` means the peer reached EOF. Flow-controlled data is always
+        acknowledged and protocol-generated output (for example PING and
+        SETTINGS acknowledgements) is flushed before returning.
+        """
+        self._assert_stream_owner(stream_owner)
+        assert self.sock is not None
+        received_data = self.sock.recv(65535)
+        if not received_data:
+            self._connection_terminated = True
+            return None
+        return self._process_received_data(received_data, stream_owner=stream_owner)
+
+    def _probe_idle_connection(self) -> bool:
+        """Process pending control frames and determine idle connection health."""
+        sock = self.sock
+        if sock is None or self._connection_terminated:
+            return False
+
+        # Never consume response events behind the response reader's back.
+        if self._stream_owner is not None:
+            return True
+
+        try:
+            previous_timeout = sock.gettimeout()
+        except OSError:
+            self._connection_terminated = True
+            return False
+
+        for _ in range(_MAX_IDLE_READS):
+            received_data: bytes | None = None
+            receive_failed = False
+            try:
+                sock.settimeout(0.0)
+                try:
+                    received_data = sock.recv(_IDLE_READ_SIZE)
+                except (BlockingIOError, TimeoutError, ssl.SSLWantReadError):
+                    pass
+                except OSError:
+                    receive_failed = True
+            except OSError:
+                receive_failed = True
+            finally:
+                # Only recv() is non-blocking. Restore the caller's timeout
+                # before parsing because hyper-h2 can generate output which
+                # must be delivered with sendall().
+                if self.sock is sock:
+                    try:
+                        sock.settimeout(previous_timeout)
+                    except OSError:
+                        receive_failed = True
+
+            if receive_failed or received_data == b"":
+                self._connection_terminated = True
+                return False
+            if received_data is None:
+                return True
+
+            try:
+                self._process_received_data(received_data, stream_owner=None)
+            except (OSError, h2.exceptions.ProtocolError):
+                # If generated protocol output can't be sent then this
+                # connection is no longer safe to reuse. The pool will close
+                # it instead of losing bytes and continuing the session.
+                self._connection_terminated = True
+                return False
+            if self._connection_terminated:
+                return False
+
+        # A peer that can keep the socket continuously readable can otherwise
+        # starve the pool indefinitely. Conservatively discard the connection.
+        self._connection_terminated = True
+        return False
+
+    @property
+    def is_connected(self) -> bool:
+        return self._probe_idle_connection()
 
     def putrequest(  # type: ignore[override]
         self,
@@ -124,6 +252,19 @@ class HTTP2Connection(HTTPSConnection):
         if "skip_accept_encoding" in kwargs:
             raise NotImplementedError("`skip_accept_encoding` isn't supported")
 
+        if self._stream_owner is not None:
+            raise CannotSendRequest(
+                "Cannot send a new HTTP/2 request while a response stream is active"
+            )
+
+        if self._has_completed_response and not self._probe_idle_connection():
+            raise ProtocolError("HTTP/2 connection is no longer reusable")
+
+        with self._h2_conn as conn:
+            if conn.remote_settings.max_concurrent_streams == 0:
+                raise ProtocolError("HTTP/2 peer does not currently allow new streams")
+            stream_id = conn.get_next_available_stream_id()
+
         self._request_url = url or "/"
         self._validate_path(url)  # type: ignore[attr-defined]
 
@@ -138,8 +279,8 @@ class HTTP2Connection(HTTPSConnection):
         self._headers.append((b":authority", authority.encode()))
         self._headers.append((b":path", url.encode()))
 
-        with self._h2_conn as conn:
-            self._h2_stream = conn.get_next_available_stream_id()
+        self._h2_stream = stream_id
+        self._stream_owner = self
 
     def putheader(self, header: str | bytes, *values: str | bytes) -> None:  # type: ignore[override]
         # TODO SKIPPABLE_HEADERS from urllib3 are ignored.
@@ -156,14 +297,21 @@ class HTTP2Connection(HTTPSConnection):
 
     def endheaders(self, message_body: typing.Any = None) -> None:  # type: ignore[override]
         if self._h2_stream is None:
-            raise ConnectionError("Must call `putrequest` first.")
+            raise ProtocolError("Must call `putrequest` first.")
 
         with self._h2_conn as conn:
-            conn.send_headers(
-                stream_id=self._h2_stream,
-                headers=self._headers,
-                end_stream=(message_body is None),
-            )
+            try:
+                conn.send_headers(
+                    stream_id=self._h2_stream,
+                    headers=self._headers,
+                    end_stream=(message_body is None),
+                )
+            except h2.exceptions.TooManyStreamsError as e:
+                self._headers = []
+                self._release_stream_owner(self)
+                raise ProtocolError(
+                    "HTTP/2 peer does not currently allow new streams"
+                ) from e
             if data_to_send := conn.data_to_send():
                 self.sock.sendall(data_to_send)
         self._headers = []  # Reset headers for the next request.
@@ -174,7 +322,7 @@ class HTTP2Connection(HTTPSConnection):
         that support a .read() method.
         """
         if self._h2_stream is None:
-            raise ConnectionError("Must call `putrequest` first.")
+            raise ProtocolError("Must call `putrequest` first.")
 
         with self._h2_conn as conn:
             if data_to_send := conn.data_to_send():
@@ -228,37 +376,60 @@ class HTTP2Connection(HTTPSConnection):
         self,
     ) -> HTTP2Response:
         status = None
+        headers = HTTPHeaderDict()
         data = bytearray()
-        with self._h2_conn as conn:
-            end_stream = False
-            while not end_stream:
-                # TODO: Arbitrary read value.
-                if received_data := self.sock.recv(65535):
-                    events = conn.receive_data(received_data)
-                    for event in events:
-                        if isinstance(event, h2.events.ResponseReceived):
-                            headers = HTTPHeaderDict()
-                            for header, value in event.headers:
-                                if header == b":status":
-                                    status = int(value.decode())
-                                else:
-                                    headers.add(
-                                        header.decode("ascii"), value.decode("ascii")
-                                    )
+        stream_id = self._h2_stream
+        end_stream = False
+        while not end_stream:
+            events = self._receive_events(stream_owner=self)
+            if events is None:
+                raise ProtocolError(
+                    "HTTP/2 connection closed before the response completed"
+                )
 
-                        elif isinstance(event, h2.events.DataReceived):
-                            data += event.data
-                            conn.acknowledge_received_data(
-                                event.flow_controlled_length, event.stream_id
-                            )
+            for event in events:
+                if (
+                    isinstance(event, h2.events.ResponseReceived)
+                    and event.stream_id == stream_id
+                ):
+                    headers = HTTPHeaderDict()
+                    for header, value in event.headers:
+                        if header == b":status":
+                            status = int(value.decode())
+                        else:
+                            headers.add(header.decode("ascii"), value.decode("ascii"))
 
-                        elif isinstance(event, h2.events.StreamEnded):
-                            end_stream = True
+                elif (
+                    isinstance(event, h2.events.DataReceived)
+                    and event.stream_id == stream_id
+                ):
+                    data += event.data
 
-                if data_to_send := conn.data_to_send():
-                    self.sock.sendall(data_to_send)
+                elif (
+                    isinstance(event, h2.events.StreamEnded)
+                    and event.stream_id == stream_id
+                ):
+                    end_stream = True
+
+                elif (
+                    isinstance(event, h2.events.StreamReset)
+                    and event.stream_id == stream_id
+                ):
+                    raise ProtocolError(
+                        "HTTP/2 stream was reset by the peer "
+                        f"(error code {event.error_code})"
+                    )
+
+                elif isinstance(event, h2.events.ConnectionTerminated):
+                    if not end_stream:
+                        raise ProtocolError(
+                            "HTTP/2 connection was terminated by the peer "
+                            f"(error code {event.error_code})"
+                        )
 
         assert status is not None
+        self._release_stream_owner(self)
+        self._has_completed_response = True
         return HTTP2Response(
             status=status,
             headers=headers,
@@ -317,7 +488,10 @@ class HTTP2Connection(HTTPSConnection):
         # Reset all our HTTP/2 connection state.
         self._h2_conn = self._new_h2_conn()
         self._h2_stream = None
+        self._stream_owner = None
         self._headers = []
+        self._connection_terminated = False
+        self._has_completed_response = False
 
         super().close()
 
@@ -349,6 +523,14 @@ class HTTP2Response(BaseHTTPResponse):
     @property
     def data(self) -> bytes:
         return self._data
+
+    @property
+    def url(self) -> str | None:
+        return self._request_url
+
+    @url.setter
+    def url(self, url: str | None) -> None:
+        self._request_url = url
 
     def get_redirect_location(self) -> None:
         return None

--- a/test/contrib/test_pyopenssl.py
+++ b/test/contrib/test_pyopenssl.py
@@ -9,7 +9,11 @@ try:
     from cryptography import x509
     from OpenSSL.crypto import FILETYPE_PEM, load_certificate
 
-    from urllib3.contrib.pyopenssl import _dnsname_to_stdlib, get_subj_alt_name
+    from urllib3.contrib.pyopenssl import (
+        WrappedSocket,
+        _dnsname_to_stdlib,
+        get_subj_alt_name,
+    )
 except ImportError:
     pass
 
@@ -56,6 +60,14 @@ class TestPyOpenSSLHelpers:
     """
     Tests for PyOpenSSL helper functions.
     """
+
+    def test_wrapped_socket_gettimeout(self) -> None:
+        socket = mock.Mock()
+        socket.gettimeout.return_value = 12.5
+        wrapped_socket = WrappedSocket(mock.Mock(), socket)
+
+        assert wrapped_socket.gettimeout() == 12.5
+        socket.gettimeout.assert_called_once_with()
 
     def test_dnsname_to_stdlib_simple(self) -> None:
         """

--- a/test/test_http2_connection.py
+++ b/test/test_http2_connection.py
@@ -1,14 +1,23 @@
 from __future__ import annotations
 
 import socket
+import threading
+from http.client import CannotSendRequest
 from unittest import mock
 
+import h2.config
+import h2.connection
+import h2.events
+import h2.settings
 import pytest
 
+from urllib3 import HTTPSConnectionPool
+from urllib3._collections import HTTPHeaderDict
 from urllib3.connection import _get_default_user_agent
 from urllib3.exceptions import ConnectionError
 from urllib3.http2.connection import (
     HTTP2Connection,
+    HTTP2Response,
     _is_illegal_header_value,
     _is_legal_header_name,
 )
@@ -17,6 +26,50 @@ from urllib3.http2.connection import (
 
 
 class TestHTTP2Connection:
+    @staticmethod
+    def _connected_h2_pair(
+        connection_class: type[HTTP2Connection] = HTTP2Connection,
+    ) -> tuple[HTTP2Connection, socket.socket, h2.connection.H2Connection]:
+        client_sock, server_sock = socket.socketpair()
+        server_h2 = h2.connection.H2Connection(
+            config=h2.config.H2Configuration(client_side=False)
+        )
+        conn = connection_class("example.com")
+        conn.sock = client_sock
+
+        with conn._h2_conn as client_h2:
+            client_h2.initiate_connection()
+            client_sock.sendall(client_h2.data_to_send())
+
+        server_h2.initiate_connection()
+        server_h2.receive_data(server_sock.recv(65535))
+        server_sock.sendall(server_h2.data_to_send())
+        return conn, server_sock, server_h2
+
+    @staticmethod
+    def _send_response(
+        conn: HTTP2Connection,
+        server_sock: socket.socket,
+        server_h2: h2.connection.H2Connection,
+        path: str,
+        body: bytes,
+    ) -> int:
+        conn.request("GET", path)
+        events = server_h2.receive_data(server_sock.recv(65535))
+        stream_id = next(
+            event.stream_id
+            for event in events
+            if isinstance(event, h2.events.RequestReceived)
+        )
+        server_h2.send_headers(
+            stream_id,
+            [(":status", "200"), ("content-length", str(len(body)))],
+        )
+        server_h2.send_data(stream_id, body, end_stream=True)
+        server_sock.sendall(server_h2.data_to_send())
+        assert conn.getresponse().data == body
+        return stream_id
+
     def test__is_legal_header_name(self) -> None:
         assert _is_legal_header_name(b"foo"), "foo"
         assert _is_legal_header_name(b"foo-bar"), "foo-bar"
@@ -79,6 +132,522 @@ class TestHTTP2Connection:
         conn = HTTP2Connection("example.com")
         assert conn.socket_options == [(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)]
         assert conn.port == 443
+
+    def test_response_url_can_be_updated_for_retry_history(self) -> None:
+        response = HTTP2Response(200, HTTPHeaderDict(), "/original", b"")
+
+        assert response.url == "/original"
+        response.url = "/retried"
+        assert response.url == "/retried"
+
+    def test_pool_reuses_connection_after_processing_idle_ping(self) -> None:
+        conn, server_sock, server_h2 = self._connected_h2_pair()
+        pool = HTTPSConnectionPool("example.com", maxsize=1)
+
+        class RecordingSocket:
+            def __init__(self, wrapped: socket.socket) -> None:
+                self.wrapped = wrapped
+                self.send_timeouts: list[float | None] = []
+
+            def __getattr__(self, name: str) -> object:
+                return getattr(self.wrapped, name)
+
+            def sendall(self, data: bytes) -> None:
+                self.send_timeouts.append(self.wrapped.gettimeout())
+                self.wrapped.sendall(data)
+
+        try:
+            first_stream_id = self._send_response(
+                conn, server_sock, server_h2, "/", b"first"
+            )
+
+            server_h2.ping(b"12345678")
+            server_sock.sendall(server_h2.data_to_send())
+
+            original_timeout = 12.5
+            assert conn.sock is not None
+            recording_sock = RecordingSocket(conn.sock)
+            conn.sock = recording_sock
+            recording_sock.wrapped.settimeout(original_timeout)
+            assert conn.is_connected
+            assert recording_sock.wrapped.gettimeout() == original_timeout
+            assert recording_sock.send_timeouts == [original_timeout]
+
+            events = server_h2.receive_data(server_sock.recv(65535))
+            assert any(isinstance(event, h2.events.PingAckReceived) for event in events)
+
+            assert pool.pool is not None
+            pool.pool.get(block=False)
+            pool._put_conn(conn)
+            reused = pool._get_conn()
+            assert reused is conn
+            assert reused.sock is not None
+
+            second_stream_id = self._send_response(
+                reused, server_sock, server_h2, "/again", b"second"
+            )
+            assert second_stream_id > first_stream_id
+        finally:
+            conn.close()
+            pool.close()
+            server_sock.close()
+
+    def test_idle_eof_is_not_reusable(self) -> None:
+        conn, server_sock, _ = self._connected_h2_pair()
+        try:
+            server_sock.close()
+            assert not conn.is_connected
+        finally:
+            conn.close()
+
+    def test_idle_goaway_is_not_reusable(self) -> None:
+        conn, server_sock, server_h2 = self._connected_h2_pair()
+        try:
+            stream_id = self._send_response(
+                conn, server_sock, server_h2, "/", b"complete"
+            )
+            server_h2.close_connection(error_code=0, last_stream_id=stream_id)
+            server_sock.sendall(server_h2.data_to_send())
+
+            assert not conn.is_connected
+        finally:
+            conn.close()
+            server_sock.close()
+
+    def test_request_rechecks_for_goaway_after_pool_probe(self) -> None:
+        conn, server_sock, server_h2 = self._connected_h2_pair()
+        try:
+            stream_id = self._send_response(
+                conn, server_sock, server_h2, "/", b"complete"
+            )
+            assert conn.is_connected
+
+            server_h2.close_connection(error_code=0, last_stream_id=stream_id)
+            server_sock.sendall(server_h2.data_to_send())
+
+            with pytest.raises(ConnectionError, match="no longer reusable"):
+                conn.request("GET", "/must-not-be-sent")
+        finally:
+            conn.close()
+            server_sock.close()
+
+    def test_pool_retries_on_goaway_between_health_check_and_request(self) -> None:
+        class GoawayAfterProbeConnection(HTTP2Connection):
+            server_sock: socket.socket
+            server_h2: h2.connection.H2Connection
+            sent_goaway = False
+
+            def _probe_idle_connection(self) -> bool:
+                reusable = super()._probe_idle_connection()
+                if self._has_completed_response and reusable and not self.sent_goaway:
+                    self.server_h2.close_connection(
+                        error_code=0,
+                        last_stream_id=self.server_h2.highest_inbound_stream_id,
+                    )
+                    self.server_sock.sendall(self.server_h2.data_to_send())
+                    self.sent_goaway = True
+                return reusable
+
+        first_conn, first_server_sock, first_server_h2 = self._connected_h2_pair(
+            GoawayAfterProbeConnection
+        )
+        assert isinstance(first_conn, GoawayAfterProbeConnection)
+        first_conn.server_sock = first_server_sock
+        first_conn.server_h2 = first_server_h2
+        first_conn.is_verified = True
+        second_conn, second_server_sock, second_server_h2 = self._connected_h2_pair()
+        second_conn.is_verified = True
+
+        class TwoConnectionPool(HTTPSConnectionPool):
+            def __init__(self) -> None:
+                super().__init__("example.com", maxsize=1)
+                self.available_connections = [first_conn, second_conn]
+
+            def _new_conn(self) -> HTTP2Connection:
+                self.num_connections += 1
+                return self.available_connections.pop(0)
+
+        def serve_one_response(
+            server_sock: socket.socket,
+            server_h2: h2.connection.H2Connection,
+            body: bytes,
+        ) -> None:
+            events = server_h2.receive_data(server_sock.recv(65535))
+            stream_id = next(
+                event.stream_id
+                for event in events
+                if isinstance(event, h2.events.RequestReceived)
+            )
+            server_h2.send_headers(
+                stream_id,
+                [(":status", "200"), ("content-length", str(len(body)))],
+            )
+            server_h2.send_data(stream_id, body, end_stream=True)
+            server_sock.sendall(server_h2.data_to_send())
+
+        pool = TwoConnectionPool()
+        first_server = threading.Thread(
+            target=serve_one_response,
+            args=(first_server_sock, first_server_h2, b"first"),
+        )
+        first_server.start()
+        try:
+            first_response = pool.request("GET", "/first", retries=1)
+            first_server.join(timeout=1)
+            assert not first_server.is_alive()
+            assert first_response.data == b"first"
+
+            second_server = threading.Thread(
+                target=serve_one_response,
+                args=(second_server_sock, second_server_h2, b"second"),
+            )
+            second_server.start()
+            second_response = pool.request("GET", "/second", retries=1)
+            second_server.join(timeout=1)
+            assert not second_server.is_alive()
+
+            assert second_response.data == b"second"
+            assert first_conn.sent_goaway
+            assert first_conn.sock is None
+            assert pool.num_connections == 2
+        finally:
+            pool.close()
+            first_conn.close()
+            second_conn.close()
+            first_server_sock.close()
+            second_server_sock.close()
+
+    def test_pool_retries_when_peer_disables_new_streams(self) -> None:
+        first_conn, first_server_sock, first_server_h2 = self._connected_h2_pair()
+        second_conn, second_server_sock, second_server_h2 = self._connected_h2_pair()
+        first_conn.is_verified = True
+        second_conn.is_verified = True
+
+        class TwoConnectionPool(HTTPSConnectionPool):
+            def __init__(self) -> None:
+                super().__init__("example.com", maxsize=1)
+                self.available_connections = [first_conn, second_conn]
+
+            def _new_conn(self) -> HTTP2Connection:
+                self.num_connections += 1
+                return self.available_connections.pop(0)
+
+        def serve_one_response(
+            server_sock: socket.socket,
+            server_h2: h2.connection.H2Connection,
+            body: bytes,
+        ) -> None:
+            events = server_h2.receive_data(server_sock.recv(65535))
+            stream_id = next(
+                event.stream_id
+                for event in events
+                if isinstance(event, h2.events.RequestReceived)
+            )
+            server_h2.send_headers(
+                stream_id,
+                [(":status", "200"), ("content-length", str(len(body)))],
+            )
+            server_h2.send_data(stream_id, body, end_stream=True)
+            server_sock.sendall(server_h2.data_to_send())
+
+        pool = TwoConnectionPool()
+        first_server = threading.Thread(
+            target=serve_one_response,
+            args=(first_server_sock, first_server_h2, b"first"),
+        )
+        first_server.start()
+        try:
+            first_response = pool.request("GET", "/first", retries=1)
+            first_server.join(timeout=1)
+            assert not first_server.is_alive()
+            assert first_response.data == b"first"
+
+            first_server_h2.update_settings(
+                {h2.settings.SettingCodes.MAX_CONCURRENT_STREAMS: 0}
+            )
+            first_server_sock.sendall(first_server_h2.data_to_send())
+
+            second_server = threading.Thread(
+                target=serve_one_response,
+                args=(second_server_sock, second_server_h2, b"second"),
+            )
+            second_server.start()
+            second_response = pool.request("GET", "/second", retries=1)
+            second_server.join(timeout=1)
+            assert not second_server.is_alive()
+
+            assert second_response.data == b"second"
+            assert first_conn.sock is None
+            assert pool.num_connections == 2
+        finally:
+            pool.close()
+            first_conn.close()
+            second_conn.close()
+            first_server_sock.close()
+            second_server_sock.close()
+
+    def test_idle_settings_are_processed_and_acknowledged(self) -> None:
+        conn, server_sock, server_h2 = self._connected_h2_pair()
+        try:
+            self._send_response(conn, server_sock, server_h2, "/", b"complete")
+            server_h2.update_settings(
+                {h2.settings.SettingCodes.MAX_CONCURRENT_STREAMS: 1}
+            )
+            server_sock.sendall(server_h2.data_to_send())
+
+            assert conn.is_connected
+            events = server_h2.receive_data(server_sock.recv(65535))
+            assert any(
+                isinstance(event, h2.events.SettingsAcknowledged) for event in events
+            )
+        finally:
+            conn.close()
+            server_sock.close()
+
+    def test_zero_max_concurrent_streams_is_explicit_and_can_be_restored(
+        self,
+    ) -> None:
+        conn, server_sock, server_h2 = self._connected_h2_pair()
+        try:
+            self._send_response(conn, server_sock, server_h2, "/", b"first")
+
+            server_h2.update_settings(
+                {h2.settings.SettingCodes.MAX_CONCURRENT_STREAMS: 0}
+            )
+            server_sock.sendall(server_h2.data_to_send())
+            assert conn.is_connected
+            server_h2.receive_data(server_sock.recv(65535))
+
+            with pytest.raises(ConnectionError, match="does not currently allow"):
+                conn.request("GET", "/blocked")
+
+            server_h2.update_settings(
+                {h2.settings.SettingCodes.MAX_CONCURRENT_STREAMS: 1}
+            )
+            server_sock.sendall(server_h2.data_to_send())
+            assert conn.is_connected
+            server_h2.receive_data(server_sock.recv(65535))
+
+            self._send_response(conn, server_sock, server_h2, "/restored", b"second")
+        finally:
+            conn.close()
+            server_sock.close()
+
+    def test_stream_owner_prevents_idle_probe_from_consuming_response(self) -> None:
+        conn, server_sock, server_h2 = self._connected_h2_pair()
+        response_owner = object()
+        try:
+            conn.request("GET", "/")
+            events = server_h2.receive_data(server_sock.recv(65535))
+            stream_id = next(
+                event.stream_id
+                for event in events
+                if isinstance(event, h2.events.RequestReceived)
+            )
+            server_h2.send_headers(stream_id, [(":status", "200")])
+            server_h2.send_data(stream_id, b"owned", end_stream=True)
+            server_sock.sendall(server_h2.data_to_send())
+
+            conn._transfer_stream_owner(conn, response_owner)
+            original_stream_id = conn._h2_stream
+            original_request_url = conn._request_url
+            with pytest.raises(CannotSendRequest, match="response stream is active"):
+                conn.request("GET", "/must-not-overwrite-owner")
+            assert conn._stream_owner is response_owner
+            assert conn._h2_stream == original_stream_id
+            assert conn._request_url == original_request_url
+            assert conn._headers == []
+
+            assert conn.is_connected
+            with pytest.raises(RuntimeError, match="different owner"):
+                conn._receive_events(stream_owner=conn)
+
+            response_events = conn._receive_events(stream_owner=response_owner)
+            assert response_events is not None
+            assert any(
+                isinstance(event, h2.events.DataReceived) and event.data == b"owned"
+                for event in response_events
+            )
+            assert any(
+                isinstance(event, h2.events.StreamEnded) for event in response_events
+            )
+            conn._release_stream_owner(response_owner)
+            with pytest.raises(RuntimeError, match="different owner"):
+                conn._receive_events(stream_owner=response_owner)
+        finally:
+            conn.close()
+            server_sock.close()
+
+    def test_active_stream_reset_fails_immediately(self) -> None:
+        conn, server_sock, server_h2 = self._connected_h2_pair()
+        try:
+            conn.request("GET", "/")
+            events = server_h2.receive_data(server_sock.recv(65535))
+            stream_id = next(
+                event.stream_id
+                for event in events
+                if isinstance(event, h2.events.RequestReceived)
+            )
+            server_h2.reset_stream(stream_id, error_code=8)
+            server_sock.sendall(server_h2.data_to_send())
+
+            with pytest.raises(ConnectionError, match="stream was reset.*8"):
+                conn.getresponse()
+        finally:
+            conn.close()
+            server_sock.close()
+
+    def test_active_goaway_fails_immediately(self) -> None:
+        conn, server_sock, server_h2 = self._connected_h2_pair()
+        try:
+            conn.request("GET", "/")
+            server_h2.receive_data(server_sock.recv(65535))
+            server_h2.close_connection(error_code=0, last_stream_id=0)
+            server_sock.sendall(server_h2.data_to_send())
+
+            with pytest.raises(ConnectionError, match="connection was terminated.*0"):
+                conn.getresponse()
+        finally:
+            conn.close()
+            server_sock.close()
+
+    def test_idle_probe_is_bounded_under_continuous_control_frames(self) -> None:
+        conn, server_sock, server_h2 = self._connected_h2_pair()
+
+        class OneFrameSocket:
+            def __init__(self, wrapped: socket.socket) -> None:
+                self.wrapped = wrapped
+                self.recv_calls = 0
+
+            def __getattr__(self, name: str) -> object:
+                return getattr(self.wrapped, name)
+
+            def recv(self, size: int) -> bytes:
+                self.recv_calls += 1
+                return self.wrapped.recv(17)
+
+        try:
+            self._send_response(conn, server_sock, server_h2, "/", b"complete")
+            for ping_id in range(17):
+                server_h2.ping(ping_id.to_bytes(8, "big"))
+            server_sock.sendall(server_h2.data_to_send())
+
+            assert conn.sock is not None
+            one_frame_sock = OneFrameSocket(conn.sock)
+            conn.sock = one_frame_sock
+            assert not conn.is_connected
+            assert one_frame_sock.recv_calls == 16
+        finally:
+            conn.close()
+            server_sock.close()
+
+    def test_idle_probe_timeout_accessor_failure_is_not_reusable(self) -> None:
+        conn, server_sock, server_h2 = self._connected_h2_pair()
+
+        class BrokenTimeoutSocket:
+            def __init__(self, wrapped: socket.socket) -> None:
+                self.wrapped = wrapped
+
+            def __getattr__(self, name: str) -> object:
+                return getattr(self.wrapped, name)
+
+            def gettimeout(self) -> float | None:
+                raise OSError("socket unavailable")
+
+        try:
+            self._send_response(conn, server_sock, server_h2, "/", b"complete")
+            assert conn.sock is not None
+            conn.sock = BrokenTimeoutSocket(conn.sock)
+            assert not conn.is_connected
+        finally:
+            conn.close()
+            server_sock.close()
+
+    def test_idle_probe_treats_zero_timeout_as_no_pending_data(self) -> None:
+        conn, server_sock, server_h2 = self._connected_h2_pair()
+
+        class TimeoutSocket:
+            def __init__(self, wrapped: socket.socket) -> None:
+                self.wrapped = wrapped
+
+            def __getattr__(self, name: str) -> object:
+                return getattr(self.wrapped, name)
+
+            def recv(self, size: int) -> bytes:
+                if self.wrapped.gettimeout() == 0:
+                    raise TimeoutError("non-blocking read would block")
+                return self.wrapped.recv(size)
+
+        try:
+            self._send_response(conn, server_sock, server_h2, "/", b"complete")
+            assert conn.sock is not None
+            timeout_sock = TimeoutSocket(conn.sock)
+            conn.sock = timeout_sock
+            timeout_sock.wrapped.settimeout(7.5)
+
+            assert conn.is_connected
+            assert timeout_sock.wrapped.gettimeout() == 7.5
+        finally:
+            conn.close()
+            server_sock.close()
+
+    def test_failed_idle_control_frame_ack_makes_connection_unusable(self) -> None:
+        conn, server_sock, server_h2 = self._connected_h2_pair()
+
+        class AckFailingSocket:
+            def __init__(self, wrapped: socket.socket) -> None:
+                self.wrapped = wrapped
+                self.send_timeouts: list[float | None] = []
+
+            def __getattr__(self, name: str) -> object:
+                return getattr(self.wrapped, name)
+
+            def sendall(self, data: bytes) -> None:
+                self.send_timeouts.append(self.wrapped.gettimeout())
+                raise BlockingIOError
+
+        try:
+            self._send_response(conn, server_sock, server_h2, "/", b"complete")
+            server_h2.ping(b"12345678")
+            server_sock.sendall(server_h2.data_to_send())
+
+            assert conn.sock is not None
+            failing_sock = AckFailingSocket(conn.sock)
+            conn.sock = failing_sock
+            failing_sock.wrapped.settimeout(9.5)
+
+            assert not conn.is_connected
+            assert failing_sock.wrapped.gettimeout() == 9.5
+            assert failing_sock.send_timeouts == [9.5]
+        finally:
+            conn.close()
+            server_sock.close()
+
+    def test_response_completed_before_goaway_is_returned_but_not_reused(
+        self,
+    ) -> None:
+        conn, server_sock, server_h2 = self._connected_h2_pair()
+        try:
+            conn.request("GET", "/")
+            events = server_h2.receive_data(server_sock.recv(65535))
+            stream_id = next(
+                event.stream_id
+                for event in events
+                if isinstance(event, h2.events.RequestReceived)
+            )
+            server_h2.send_headers(
+                stream_id,
+                [(":status", "200"), ("content-length", "8")],
+            )
+            server_h2.send_data(stream_id, b"complete", end_stream=True)
+            server_h2.close_connection(error_code=0, last_stream_id=stream_id)
+            server_sock.sendall(server_h2.data_to_send())
+
+            assert conn.getresponse().data == b"complete"
+            assert not conn.is_connected
+        finally:
+            conn.close()
+            server_sock.close()
 
     def test_putheader(self) -> None:
         conn = HTTP2Connection("example.com")

--- a/test/test_http2_h2c.py
+++ b/test/test_http2_h2c.py
@@ -68,7 +68,7 @@ class H2CServer:
 
     def __enter__(self) -> H2CServer:
         self._thread.start()
-        assert self._ready.wait(2)
+        assert self._ready.wait(5)
         return self
 
     def __exit__(
@@ -78,7 +78,7 @@ class H2CServer:
         exc_tb: typing.Any,
     ) -> None:
         self._listener.close()
-        self._thread.join(3)
+        self._thread.join(10)
         assert not self._thread.is_alive(), "h2c server did not terminate"
         if exc_type is None:
             assert self.errors == []
@@ -88,7 +88,7 @@ class H2CServer:
         try:
             conn, _ = self._listener.accept()
             self.accept_count += 1
-            conn.settimeout(2)
+            conn.settimeout(5)
             with conn:
                 if self.mode == "prior":
                     self._serve_prior(conn)
@@ -96,6 +96,18 @@ class H2CServer:
                     self._serve_fallback(conn)
                 else:
                     self._serve_upgrade(conn)
+                # Half-close the write side and drain any unread data so
+                # that close() sends FIN rather than RST.  Without this,
+                # Windows raises ConnectionAbortedError (WinError 10053)
+                # on the client when the server socket is closed while
+                # the client still has buffered reads pending.
+                try:
+                    conn.shutdown(socket.SHUT_WR)
+                    conn.settimeout(1)
+                    while conn.recv(4096):
+                        pass
+                except OSError:
+                    pass
         except BaseException as e:
             self.errors.append(e)
 
@@ -272,7 +284,7 @@ class H2CServer:
         if self.after_first == "none":
             return True
 
-        assert self.release_after_first.wait(2), "client didn't consume first response"
+        assert self.release_after_first.wait(5), "client didn't consume first response"
         if self.after_first == "control":
             self.control_acks.clear()
             server.ping(b"h2c-ping")
@@ -381,7 +393,7 @@ def _send_h2_response(
 
 def test_h2c_prior_knowledge_uses_cleartext_preface_and_http_scheme() -> None:
     with H2CServer("prior") as server:
-        conn = HTTP2CleartextConnection(server.host, server.port, timeout=1)
+        conn = HTTP2CleartextConnection(server.host, server.port, timeout=5)
         try:
             conn.request("GET", "/resource?q=1")
             response = conn.getresponse()
@@ -405,7 +417,7 @@ def test_h2c_upgrade_preserves_immediate_or_fragmented_http2_bytes(
     mode: typing.Literal["upgrade-coalesced", "upgrade-fragmented"],
 ) -> None:
     with H2CServer(mode) as server:
-        conn = _TrackingHTTP2UpgradeConnection(server.host, server.port, timeout=1)
+        conn = _TrackingHTTP2UpgradeConnection(server.host, server.port, timeout=5)
         try:
             conn.request("GET", "/upgrade")
             if mode == "upgrade-fragmented":
@@ -427,7 +439,7 @@ def test_h2c_upgrade_preserves_immediate_or_fragmented_http2_bytes(
 
 def test_h2c_upgrade_accepts_100_before_switching_protocols() -> None:
     with H2CServer("upgrade-continue") as server:
-        conn = HTTP2UpgradeConnection(server.host, server.port, timeout=1)
+        conn = HTTP2UpgradeConnection(server.host, server.port, timeout=5)
         try:
             conn.request("POST", "/upgrade", body=b"body")
             response = conn.getresponse()
@@ -440,7 +452,7 @@ def test_h2c_upgrade_accepts_100_before_switching_protocols() -> None:
 
 def test_h2c_upgrade_accepts_103_before_switching_protocols() -> None:
     with H2CServer("upgrade-early-hints") as server:
-        conn = HTTP2UpgradeConnection(server.host, server.port, timeout=1)
+        conn = HTTP2UpgradeConnection(server.host, server.port, timeout=5)
         try:
             conn.request("GET", "/upgrade")
             response = conn.getresponse()
@@ -453,7 +465,7 @@ def test_h2c_upgrade_accepts_103_before_switching_protocols() -> None:
 
 def test_h2c_upgrade_discards_103_before_http1_fallback() -> None:
     with H2CServer("fallback-early-hints") as server:
-        conn = HTTP2UpgradeConnection(server.host, server.port, timeout=1)
+        conn = HTTP2UpgradeConnection(server.host, server.port, timeout=5)
         try:
             conn.request("GET", "/fallback")
             response = conn.getresponse()
@@ -466,7 +478,7 @@ def test_h2c_upgrade_discards_103_before_http1_fallback() -> None:
 
 def test_h2c_upgrade_bounds_informational_responses() -> None:
     with H2CServer("upgrade-too-many-continue") as server:
-        conn = HTTP2UpgradeConnection(server.host, server.port, timeout=1)
+        conn = HTTP2UpgradeConnection(server.host, server.port, timeout=5)
         try:
             conn.request("GET", "/upgrade")
             with pytest.raises(ProtocolError, match="Too many informational"):
@@ -482,7 +494,7 @@ def test_h2c_upgrade_validates_response_upgrade_tokens(
     mode: typing.Literal["upgrade-invalid-connection", "upgrade-invalid-token"],
 ) -> None:
     with H2CServer(mode) as server:
-        conn = HTTP2UpgradeConnection(server.host, server.port, timeout=1)
+        conn = HTTP2UpgradeConnection(server.host, server.port, timeout=5)
         try:
             conn.request("GET", "/")
             with pytest.raises(ProtocolError, match="Upgrade"):
@@ -493,7 +505,7 @@ def test_h2c_upgrade_validates_response_upgrade_tokens(
 
 def test_h2c_upgrade_sends_fixed_length_body_before_switching() -> None:
     with H2CServer("upgrade-coalesced") as server:
-        conn = HTTP2UpgradeConnection(server.host, server.port, timeout=1)
+        conn = HTTP2UpgradeConnection(server.host, server.port, timeout=5)
         try:
             conn.request("POST", "/submit", body=b"request-body")
             response = conn.getresponse()
@@ -519,7 +531,7 @@ def test_h2c_upgrade_sends_chunked_bodies_before_switching(
     expected: bytes,
 ) -> None:
     with H2CServer("upgrade-coalesced") as server:
-        conn = HTTP2UpgradeConnection(server.host, server.port, timeout=1)
+        conn = HTTP2UpgradeConnection(server.host, server.port, timeout=5)
         try:
             conn.request("POST", "/submit", body=body, headers=headers)
             response = conn.getresponse()
@@ -533,7 +545,7 @@ def test_h2c_upgrade_sends_chunked_bodies_before_switching(
 
 def test_h2c_upgrade_honors_skippable_headers() -> None:
     with H2CServer("upgrade-coalesced") as server:
-        conn = HTTP2UpgradeConnection(server.host, server.port, timeout=1)
+        conn = HTTP2UpgradeConnection(server.host, server.port, timeout=5)
         try:
             conn.request(
                 "GET",
@@ -554,7 +566,7 @@ def test_h2c_upgrade_honors_skippable_headers() -> None:
 
 def test_h2c_upgrade_rejects_skip_header_for_unsupported_fields() -> None:
     client, server = socket.socketpair()
-    conn = HTTP2UpgradeConnection("example.test", timeout=1)
+    conn = HTTP2UpgradeConnection("example.test", timeout=5)
     conn.sock = client
     try:
         with pytest.raises(ValueError, match="SKIP_HEADER only supports"):
@@ -569,7 +581,7 @@ def test_h2c_upgrade_rejects_skip_header_for_unsupported_fields() -> None:
 
 def test_h2c_upgrade_non_101_falls_back_and_reuses_http1_connection() -> None:
     with H2CServer("fallback", request_count=2) as server:
-        conn = HTTP2UpgradeConnection(server.host, server.port, timeout=1)
+        conn = HTTP2UpgradeConnection(server.host, server.port, timeout=5)
         try:
             conn.request("GET", "/first", preload_content=False)
             first = conn.getresponse()
@@ -588,7 +600,7 @@ def test_h2c_upgrade_non_101_falls_back_and_reuses_http1_connection() -> None:
 
 def test_h2c_upgrade_fallback_detaches_connection_close_response() -> None:
     with H2CServer("fallback-close") as server:
-        conn = HTTP2UpgradeConnection(server.host, server.port, timeout=1)
+        conn = HTTP2UpgradeConnection(server.host, server.port, timeout=5)
         try:
             conn.request("GET", "/fallback", preload_content=False)
             response = conn.getresponse()
@@ -608,7 +620,7 @@ def test_h2c_upgrade_fallback_preserves_http1_parser_behavior(
     mode: typing.Literal["fallback-continue", "fallback-malformed"],
 ) -> None:
     with H2CServer(mode) as server:
-        conn = HTTP2UpgradeConnection(server.host, server.port, timeout=1)
+        conn = HTTP2UpgradeConnection(server.host, server.port, timeout=5)
         try:
             conn.request("GET", "/fallback")
             response = conn.getresponse()
@@ -629,7 +641,7 @@ def test_h2c_mode_preserves_http1_proxy_connections(
         conn = connection_class(
             server.host,
             server.port,
-            timeout=1,
+            timeout=5,
             proxy=parse_url(f"http://{server.host}:{server.port}"),
             proxy_config=ProxyConfig(None, False, None, None),
         )
@@ -655,7 +667,7 @@ def test_h2c_mode_preserves_proxy_manager_http1_connections(
         try:
             urllib3.http2.inject_into_urllib3(h2c=mode)
             with urllib3.ProxyManager(
-                f"http://{server.host}:{server.port}", timeout=1
+                f"http://{server.host}:{server.port}", timeout=5
             ) as proxy:
                 response = proxy.request(
                     "GET", "http://example.test/resource", retries=False
@@ -685,7 +697,7 @@ def test_h2c_modes_work_through_http_connection_pool(
     with H2CServer(server_mode) as server:
         try:
             urllib3.http2.inject_into_urllib3(h2c=mode)
-            with HTTPConnectionPool(server.host, server.port, timeout=1) as pool:
+            with HTTPConnectionPool(server.host, server.port, timeout=5) as pool:
                 response = pool.request("GET", "/pool", retries=False)
         finally:
             urllib3.http2.extract_from_urllib3()
@@ -709,7 +721,7 @@ def test_h2c_pool_reuses_one_connection_for_sequential_streams(
     with H2CServer(server_mode, request_count=2) as server:
         try:
             urllib3.http2.inject_into_urllib3(h2c=mode)
-            with HTTPConnectionPool(server.host, server.port, timeout=1) as pool:
+            with HTTPConnectionPool(server.host, server.port, timeout=5) as pool:
                 first = pool.request("GET", "/first", retries=False)
                 second = pool.request("GET", "/second", retries=False)
                 assert pool.num_connections == 1
@@ -736,12 +748,12 @@ def test_h2c_pool_processes_idle_controls_before_reusing_connection(
     with H2CServer(server_mode, request_count=2, after_first="control") as server:
         try:
             urllib3.http2.inject_into_urllib3(h2c=mode)
-            with HTTPConnectionPool(server.host, server.port, timeout=1) as pool:
+            with HTTPConnectionPool(server.host, server.port, timeout=5) as pool:
                 first = pool.request("GET", "/first", retries=False)
                 server.release_after_first.set()
-                assert server.after_first_sent.wait(1)
+                assert server.after_first_sent.wait(5)
                 second = pool.request("GET", "/second", retries=False)
-                assert server.control_acks_received.wait(1)
+                assert server.control_acks_received.wait(5)
                 assert pool.num_connections == 1
         finally:
             urllib3.http2.extract_from_urllib3()
@@ -766,12 +778,12 @@ def test_h2c_connection_is_not_reusable_after_peer_shutdown(
     after_first: typing.Literal["goaway", "eof"],
 ) -> None:
     with H2CServer(server_mode, after_first=after_first) as server:
-        conn = connection_class(server.host, server.port, timeout=1)
+        conn = connection_class(server.host, server.port, timeout=5)
         try:
             conn.request("GET", "/first")
             response = conn.getresponse()
             server.release_after_first.set()
-            assert server.after_first_sent.wait(1)
+            assert server.after_first_sent.wait(5)
             assert conn.sock is not None
             readable, _, _ = select.select([conn.sock], [], [], 1)
             assert readable

--- a/test/test_http2_h2c.py
+++ b/test/test_http2_h2c.py
@@ -1,0 +1,828 @@
+from __future__ import annotations
+
+import io
+import select
+import socket
+import threading
+import typing
+
+import h2.config
+import h2.connection
+import h2.events
+import h2.settings
+import pytest
+
+import urllib3.connection
+import urllib3.http2
+from urllib3.connection import HTTPConnection, ProxyConfig
+from urllib3.connectionpool import HTTPConnectionPool
+from urllib3.exceptions import ProtocolError
+from urllib3.http2.connection import (
+    HTTP2CleartextConnection,
+    HTTP2UpgradeConnection,
+)
+from urllib3.util import SKIP_HEADER, parse_url
+
+
+class H2CServer:
+    def __init__(
+        self,
+        mode: typing.Literal[
+            "prior",
+            "upgrade-coalesced",
+            "upgrade-continue",
+            "upgrade-early-hints",
+            "upgrade-too-many-continue",
+            "upgrade-fragmented",
+            "upgrade-invalid-connection",
+            "upgrade-invalid-token",
+            "fallback",
+            "fallback-close",
+            "fallback-continue",
+            "fallback-early-hints",
+            "fallback-malformed",
+        ],
+        *,
+        request_count: int = 1,
+        after_first: typing.Literal["none", "control", "goaway", "eof"] = "none",
+    ) -> None:
+        self.mode = mode
+        self.request_count = request_count
+        self.after_first = after_first
+        self.requests: list[bytes] = []
+        self.bodies: list[bytes] = []
+        self.streams: list[int] = []
+        self.control_acks: list[str] = []
+        self.errors: list[BaseException] = []
+        self.accept_count = 0
+        self.release_after_first = threading.Event()
+        self.after_first_sent = threading.Event()
+        self.control_acks_received = threading.Event()
+        self._ready = threading.Event()
+        self._listener = socket.socket()
+        self._listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self._listener.bind(("127.0.0.1", 0))
+        self._listener.listen(1)
+        self.host, self.port = self._listener.getsockname()
+        self._thread = threading.Thread(target=self._run, daemon=True)
+
+    def __enter__(self) -> H2CServer:
+        self._thread.start()
+        assert self._ready.wait(2)
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: typing.Any,
+    ) -> None:
+        self._listener.close()
+        self._thread.join(3)
+        assert not self._thread.is_alive(), "h2c server did not terminate"
+        if exc_type is None:
+            assert self.errors == []
+
+    def _run(self) -> None:
+        self._ready.set()
+        try:
+            conn, _ = self._listener.accept()
+            self.accept_count += 1
+            conn.settimeout(2)
+            with conn:
+                if self.mode == "prior":
+                    self._serve_prior(conn)
+                elif self.mode.startswith("fallback"):
+                    self._serve_fallback(conn)
+                else:
+                    self._serve_upgrade(conn)
+        except BaseException as e:
+            self.errors.append(e)
+
+    def _serve_prior(self, conn: socket.socket) -> None:
+        server = h2.connection.H2Connection(
+            config=h2.config.H2Configuration(client_side=False)
+        )
+        server.initiate_connection()
+        conn.sendall(server.data_to_send())
+        self._receive_h2_requests(conn, server, start_index=0)
+
+    def _serve_upgrade(self, conn: socket.socket) -> None:
+        request, body = _read_http1_request(conn)
+        self.requests.append(request)
+        self.bodies.append(body)
+
+        settings = _header_value(request, b"http2-settings")
+        assert settings is not None
+        assert (
+            sum(
+                line.lower().startswith(b"http2-settings:")
+                for line in request.split(b"\r\n")
+            )
+            == 1
+        )
+        assert b"=" not in settings
+        assert _header_value(request, b"upgrade") == b"h2c"
+        connection_tokens = {
+            token.strip().lower()
+            for token in (_header_value(request, b"connection") or b"").split(b",")
+        }
+        assert {b"upgrade", b"http2-settings"} <= connection_tokens
+
+        if self.mode == "upgrade-invalid-token":
+            conn.sendall(
+                b"HTTP/1.1 101 Switching Protocols\r\n"
+                b"Connection: Upgrade\r\n"
+                b"Upgrade: websocket\r\n\r\n"
+            )
+            return
+        if self.mode == "upgrade-invalid-connection":
+            conn.sendall(
+                b"HTTP/1.1 101 Switching Protocols\r\n"
+                b"Connection: keep-alive\r\n"
+                b"Upgrade: h2c\r\n\r\n"
+            )
+            return
+
+        if self.mode == "upgrade-too-many-continue":
+            conn.sendall(b"HTTP/1.1 100 Continue\r\n\r\n" * 11)
+            return
+
+        server = h2.connection.H2Connection(
+            config=h2.config.H2Configuration(client_side=False)
+        )
+        server.initiate_upgrade_connection(settings)
+        self.streams.append(1)
+        _send_h2_response(server, 1, b"upgraded")
+        response = (
+            b"HTTP/1.1 101 Switching Protocols\r\n"
+            b"Connection: Upgrade\r\n"
+            b"Upgrade: h2c\r\n\r\n" + server.data_to_send()
+        )
+        if self.mode == "upgrade-continue":
+            response = b"HTTP/1.1 100 Continue\r\n\r\n" + response
+        if self.mode == "upgrade-early-hints":
+            response = (
+                b"HTTP/1.1 103 Early Hints\r\nLink: </style.css>; rel=preload\r\n\r\n"
+                + response
+            )
+        if self.mode == "upgrade-fragmented":
+            for byte in response:
+                conn.sendall(bytes((byte,)))
+        else:
+            # RFC 7540 permits the server preface and stream-1 response to
+            # immediately follow the 101, including in the same TCP packet.
+            conn.sendall(response)
+
+        # The client preface is still required even though the response was
+        # already available. Parsing it proves the transition completed.
+        received = conn.recv(65535)
+        server.receive_data(received)
+        if not self._run_after_first_action(conn, server):
+            return
+        if self.request_count > 1:
+            self._receive_h2_requests(conn, server, start_index=1)
+
+    def _serve_fallback(self, conn: socket.socket) -> None:
+        for index in range(self.request_count):
+            request, body = _read_http1_request(conn)
+            self.requests.append(request)
+            self.bodies.append(body)
+            payload = f"fallback-{index}".encode()
+            response = (
+                b"HTTP/1.1 200 OK\r\n"
+                + f"Content-Length: {len(payload)}\r\n".encode()
+                + (
+                    b"Connection: close\r\n"
+                    if self.mode == "fallback-close"
+                    else b"Connection: keep-alive\r\n"
+                )
+            )
+            if self.mode == "fallback-malformed":
+                response += b"BadHeader\r\n"
+            response += b"\r\n" + payload
+            if self.mode == "fallback-continue":
+                response = b"HTTP/1.1 100 Continue\r\n\r\n" + response
+            if self.mode == "fallback-early-hints":
+                response = (
+                    b"HTTP/1.1 103 Early Hints\r\n"
+                    b"Link: </style.css>; rel=preload\r\n\r\n" + response
+                )
+            conn.sendall(response)
+
+    def _receive_h2_requests(
+        self,
+        conn: socket.socket,
+        server: h2.connection.H2Connection,
+        *,
+        start_index: int,
+    ) -> None:
+        responses = 0
+        ran_after_first_action = start_index > 0
+        while responses < self.request_count - start_index:
+            received = conn.recv(65535)
+            if not received:
+                raise AssertionError("client closed before receiving all responses")
+            for event in server.receive_data(received):
+                if isinstance(event, h2.events.RequestReceived):
+                    headers = dict(event.headers)
+                    self.streams.append(event.stream_id)
+                    self.requests.append(repr(headers).encode())
+                    _send_h2_response(
+                        server,
+                        event.stream_id,
+                        f"prior-{start_index + responses}".encode(),
+                    )
+                    responses += 1
+                elif isinstance(event, h2.events.DataReceived):
+                    server.acknowledge_received_data(
+                        event.flow_controlled_length, event.stream_id
+                    )
+                else:
+                    self._record_control_ack(event)
+            if data := server.data_to_send():
+                conn.sendall(data)
+            if responses == 1 and not ran_after_first_action:
+                ran_after_first_action = True
+                if not self._run_after_first_action(conn, server):
+                    return
+        while self.after_first == "control" and not {
+            "ping",
+            "settings",
+        }.issubset(self.control_acks):
+            received = conn.recv(65535)
+            if not received:
+                raise AssertionError(
+                    "client closed before acknowledging control frames"
+                )
+            for event in server.receive_data(received):
+                self._record_control_ack(event)
+        if self.after_first == "control":
+            self.control_acks_received.set()
+
+    def _record_control_ack(self, event: h2.events.Event) -> None:
+        if isinstance(event, h2.events.PingAckReceived):
+            self.control_acks.append("ping")
+        elif isinstance(event, h2.events.SettingsAcknowledged):
+            self.control_acks.append("settings")
+
+    def _run_after_first_action(
+        self, conn: socket.socket, server: h2.connection.H2Connection
+    ) -> bool:
+        if self.after_first == "none":
+            return True
+
+        assert self.release_after_first.wait(2), "client didn't consume first response"
+        if self.after_first == "control":
+            self.control_acks.clear()
+            server.ping(b"h2c-ping")
+            server.update_settings(
+                {h2.settings.SettingCodes.MAX_CONCURRENT_STREAMS: 10}
+            )
+            conn.sendall(server.data_to_send())
+            self.after_first_sent.set()
+            return True
+        if self.after_first == "goaway":
+            server.close_connection(error_code=0)
+            conn.sendall(server.data_to_send())
+            self.after_first_sent.set()
+            return False
+
+        conn.shutdown(socket.SHUT_RDWR)
+        self.after_first_sent.set()
+        return False
+
+
+class _OneByteRecvSocket:
+    """Keep a real socket while making response fragmentation deterministic."""
+
+    def __init__(self, sock: socket.socket) -> None:
+        self._sock = sock
+
+    def recv(self, size: int, flags: int = 0) -> bytes:
+        return self._sock.recv(min(size, 1), flags)
+
+    def __getattr__(self, name: str) -> typing.Any:
+        return getattr(self._sock, name)
+
+
+class _TrackingHTTP2UpgradeConnection(HTTP2UpgradeConnection):
+    def __init__(self, *args: typing.Any, **kwargs: typing.Any) -> None:
+        self.receive_owners: list[object | None] = []
+        super().__init__(*args, **kwargs)
+
+    def _receive_events(
+        self, *, stream_owner: object | None
+    ) -> list[h2.events.Event] | None:
+        self.receive_owners.append(stream_owner)
+        return super()._receive_events(stream_owner=stream_owner)
+
+
+def _read_http1_request(conn: socket.socket) -> tuple[bytes, bytes]:
+    data = bytearray()
+    while b"\r\n\r\n" not in data:
+        chunk = conn.recv(4096)
+        if not chunk:
+            raise AssertionError("client closed during HTTP/1.1 headers")
+        data.extend(chunk)
+    marker = data.index(b"\r\n\r\n") + 4
+    head = bytes(data[:marker])
+    body = bytearray(data[marker:])
+    if (_header_value(head, b"transfer-encoding") or b"").lower() == b"chunked":
+        return head, _read_chunked_body(conn, body)
+    content_length = int(_header_value(head, b"content-length") or b"0")
+    while len(body) < content_length:
+        body.extend(conn.recv(content_length - len(body)))
+    return head, bytes(body[:content_length])
+
+
+def _read_chunked_body(conn: socket.socket, initial: bytearray) -> bytes:
+    encoded = initial
+    decoded = bytearray()
+
+    def read_line() -> bytes:
+        while b"\r\n" not in encoded:
+            encoded.extend(conn.recv(4096))
+        marker = encoded.index(b"\r\n")
+        line = bytes(encoded[:marker])
+        del encoded[: marker + 2]
+        return line
+
+    while True:
+        size = int(read_line().split(b";", 1)[0], 16)
+        if size == 0:
+            assert read_line() == b""
+            return bytes(decoded)
+        while len(encoded) < size + 2:
+            encoded.extend(conn.recv(4096))
+        decoded.extend(encoded[:size])
+        assert encoded[size : size + 2] == b"\r\n"
+        del encoded[: size + 2]
+
+
+def _header_value(head: bytes, name: bytes) -> bytes | None:
+    for line in head.split(b"\r\n")[1:]:
+        if b":" in line:
+            field, value = line.split(b":", 1)
+            if field.lower() == name:
+                return value.strip()
+    return None
+
+
+def _send_h2_response(
+    conn: h2.connection.H2Connection, stream_id: int, body: bytes
+) -> None:
+    conn.send_headers(
+        stream_id,
+        [(b":status", b"200"), (b"content-length", str(len(body)).encode())],
+    )
+    conn.send_data(stream_id, body, end_stream=True)
+
+
+def test_h2c_prior_knowledge_uses_cleartext_preface_and_http_scheme() -> None:
+    with H2CServer("prior") as server:
+        conn = HTTP2CleartextConnection(server.host, server.port, timeout=1)
+        try:
+            conn.request("GET", "/resource?q=1")
+            response = conn.getresponse()
+        finally:
+            conn.close()
+
+    assert response.status == 200
+    assert response.data == b"prior-0"
+    assert server.streams == [1]
+    assert b"b':scheme': b'http'" in server.requests[0]
+    assert b"b':path': b'/resource?q=1'" in server.requests[0]
+
+
+def test_h2c_cleartext_connections_default_to_port_80() -> None:
+    assert HTTP2CleartextConnection("example.test").port == 80
+    assert HTTP2UpgradeConnection("example.test").port == 80
+
+
+@pytest.mark.parametrize("mode", ["upgrade-coalesced", "upgrade-fragmented"])
+def test_h2c_upgrade_preserves_immediate_or_fragmented_http2_bytes(
+    mode: typing.Literal["upgrade-coalesced", "upgrade-fragmented"],
+) -> None:
+    with H2CServer(mode) as server:
+        conn = _TrackingHTTP2UpgradeConnection(server.host, server.port, timeout=1)
+        try:
+            conn.request("GET", "/upgrade")
+            if mode == "upgrade-fragmented":
+                conn.sock = typing.cast(typing.Any, _OneByteRecvSocket(conn.sock))
+            response = conn.getresponse()
+            assert conn.receive_owners
+            assert all(owner is conn for owner in conn.receive_owners)
+            assert conn._h2_received_data == bytearray()
+            assert conn._stream_owner is None
+            assert conn._h2_stream is None
+            assert conn._has_completed_response
+        finally:
+            conn.close()
+
+    assert response.status == 200
+    assert response.data == b"upgraded"
+    assert server.streams == [1]
+
+
+def test_h2c_upgrade_accepts_100_before_switching_protocols() -> None:
+    with H2CServer("upgrade-continue") as server:
+        conn = HTTP2UpgradeConnection(server.host, server.port, timeout=1)
+        try:
+            conn.request("POST", "/upgrade", body=b"body")
+            response = conn.getresponse()
+        finally:
+            conn.close()
+
+    assert response.data == b"upgraded"
+    assert server.bodies == [b"body"]
+
+
+def test_h2c_upgrade_accepts_103_before_switching_protocols() -> None:
+    with H2CServer("upgrade-early-hints") as server:
+        conn = HTTP2UpgradeConnection(server.host, server.port, timeout=1)
+        try:
+            conn.request("GET", "/upgrade")
+            response = conn.getresponse()
+        finally:
+            conn.close()
+
+    assert response.data == b"upgraded"
+    assert server.streams == [1]
+
+
+def test_h2c_upgrade_discards_103_before_http1_fallback() -> None:
+    with H2CServer("fallback-early-hints") as server:
+        conn = HTTP2UpgradeConnection(server.host, server.port, timeout=1)
+        try:
+            conn.request("GET", "/fallback")
+            response = conn.getresponse()
+        finally:
+            conn.close()
+
+    assert response.status == 200
+    assert response.data == b"fallback-0"
+
+
+def test_h2c_upgrade_bounds_informational_responses() -> None:
+    with H2CServer("upgrade-too-many-continue") as server:
+        conn = HTTP2UpgradeConnection(server.host, server.port, timeout=1)
+        try:
+            conn.request("GET", "/upgrade")
+            with pytest.raises(ProtocolError, match="Too many informational"):
+                conn.getresponse()
+        finally:
+            conn.close()
+
+
+@pytest.mark.parametrize(
+    "mode", ["upgrade-invalid-connection", "upgrade-invalid-token"]
+)
+def test_h2c_upgrade_validates_response_upgrade_tokens(
+    mode: typing.Literal["upgrade-invalid-connection", "upgrade-invalid-token"],
+) -> None:
+    with H2CServer(mode) as server:
+        conn = HTTP2UpgradeConnection(server.host, server.port, timeout=1)
+        try:
+            conn.request("GET", "/")
+            with pytest.raises(ProtocolError, match="Upgrade"):
+                conn.getresponse()
+        finally:
+            conn.close()
+
+
+def test_h2c_upgrade_sends_fixed_length_body_before_switching() -> None:
+    with H2CServer("upgrade-coalesced") as server:
+        conn = HTTP2UpgradeConnection(server.host, server.port, timeout=1)
+        try:
+            conn.request("POST", "/submit", body=b"request-body")
+            response = conn.getresponse()
+        finally:
+            conn.close()
+
+    assert response.data == b"upgraded"
+    assert server.bodies == [b"request-body"]
+    assert _header_value(server.requests[0], b"content-length") == b"12"
+
+
+@pytest.mark.parametrize(
+    ("body", "headers", "expected"),
+    [
+        (b"chunked-body", {"Transfer-Encoding": "chunked"}, b"chunked-body"),
+        ([b"iterable-", b"body"], None, b"iterable-body"),
+        (io.BytesIO(b"file-body"), None, b"file-body"),
+    ],
+)
+def test_h2c_upgrade_sends_chunked_bodies_before_switching(
+    body: typing.Any,
+    headers: dict[str, str] | None,
+    expected: bytes,
+) -> None:
+    with H2CServer("upgrade-coalesced") as server:
+        conn = HTTP2UpgradeConnection(server.host, server.port, timeout=1)
+        try:
+            conn.request("POST", "/submit", body=body, headers=headers)
+            response = conn.getresponse()
+        finally:
+            conn.close()
+
+    assert response.data == b"upgraded"
+    assert server.bodies == [expected]
+    assert _header_value(server.requests[0], b"transfer-encoding") == b"chunked"
+
+
+def test_h2c_upgrade_honors_skippable_headers() -> None:
+    with H2CServer("upgrade-coalesced") as server:
+        conn = HTTP2UpgradeConnection(server.host, server.port, timeout=1)
+        try:
+            conn.request(
+                "GET",
+                "/upgrade",
+                headers={
+                    "Accept-Encoding": SKIP_HEADER,
+                    "User-Agent": SKIP_HEADER,
+                },
+            )
+            response = conn.getresponse()
+        finally:
+            conn.close()
+
+    assert response.data == b"upgraded"
+    assert _header_value(server.requests[0], b"accept-encoding") is None
+    assert _header_value(server.requests[0], b"user-agent") is None
+
+
+def test_h2c_upgrade_rejects_skip_header_for_unsupported_fields() -> None:
+    client, server = socket.socketpair()
+    conn = HTTP2UpgradeConnection("example.test", timeout=1)
+    conn.sock = client
+    try:
+        with pytest.raises(ValueError, match="SKIP_HEADER only supports"):
+            conn.request("GET", "/", headers={"X-Custom": SKIP_HEADER})
+        server.settimeout(0.01)
+        with pytest.raises(TimeoutError):
+            server.recv(1)
+    finally:
+        conn.close()
+        server.close()
+
+
+def test_h2c_upgrade_non_101_falls_back_and_reuses_http1_connection() -> None:
+    with H2CServer("fallback", request_count=2) as server:
+        conn = HTTP2UpgradeConnection(server.host, server.port, timeout=1)
+        try:
+            conn.request("GET", "/first", preload_content=False)
+            first = conn.getresponse()
+            assert first.data == b"fallback-0"
+            conn.request("GET", "/second")
+            second = conn.getresponse()
+        finally:
+            conn.close()
+
+    assert first.version == 11
+    assert first.data == b"fallback-0"
+    assert second.data == b"fallback-1"
+    assert server.accept_count == 1
+    assert len(server.requests) == 2
+
+
+def test_h2c_upgrade_fallback_detaches_connection_close_response() -> None:
+    with H2CServer("fallback-close") as server:
+        conn = HTTP2UpgradeConnection(server.host, server.port, timeout=1)
+        try:
+            conn.request("GET", "/fallback", preload_content=False)
+            response = conn.getresponse()
+
+            # The response owns the closing socket, matching http.client's
+            # lifecycle, while its unread body remains available to callers.
+            assert conn.sock is None
+            assert response.data == b"fallback-0"
+        finally:
+            conn.close()
+
+    assert server.accept_count == 1
+
+
+@pytest.mark.parametrize("mode", ["fallback-continue", "fallback-malformed"])
+def test_h2c_upgrade_fallback_preserves_http1_parser_behavior(
+    mode: typing.Literal["fallback-continue", "fallback-malformed"],
+) -> None:
+    with H2CServer(mode) as server:
+        conn = HTTP2UpgradeConnection(server.host, server.port, timeout=1)
+        try:
+            conn.request("GET", "/fallback")
+            response = conn.getresponse()
+        finally:
+            conn.close()
+
+    assert response.status == 200
+    assert response.data == b"fallback-0"
+
+
+@pytest.mark.parametrize(
+    "connection_class", [HTTP2CleartextConnection, HTTP2UpgradeConnection]
+)
+def test_h2c_mode_preserves_http1_proxy_connections(
+    connection_class: type[HTTP2CleartextConnection],
+) -> None:
+    with H2CServer("fallback") as server:
+        conn = connection_class(
+            server.host,
+            server.port,
+            timeout=1,
+            proxy=parse_url(f"http://{server.host}:{server.port}"),
+            proxy_config=ProxyConfig(None, False, None, None),
+        )
+        try:
+            conn.request("GET", "http://example.test/resource")
+            response = conn.getresponse()
+        finally:
+            conn.close()
+
+    assert response.status == 200
+    assert response.data == b"fallback-0"
+    assert server.requests[0].startswith(
+        b"GET http://example.test/resource HTTP/1.1\r\n"
+    )
+    assert _header_value(server.requests[0], b"upgrade") is None
+
+
+@pytest.mark.parametrize("mode", ["prior_knowledge", "upgrade"])
+def test_h2c_mode_preserves_proxy_manager_http1_connections(
+    mode: typing.Literal["prior_knowledge", "upgrade"],
+) -> None:
+    with H2CServer("fallback") as server:
+        try:
+            urllib3.http2.inject_into_urllib3(h2c=mode)
+            with urllib3.ProxyManager(
+                f"http://{server.host}:{server.port}", timeout=1
+            ) as proxy:
+                response = proxy.request(
+                    "GET", "http://example.test/resource", retries=False
+                )
+        finally:
+            urllib3.http2.extract_from_urllib3()
+
+    assert response.status == 200
+    assert response.data == b"fallback-0"
+    assert server.requests[0].startswith(
+        b"GET http://example.test/resource HTTP/1.1\r\n"
+    )
+    assert _header_value(server.requests[0], b"upgrade") is None
+
+
+@pytest.mark.parametrize(
+    ("mode", "server_mode"),
+    [
+        ("prior_knowledge", "prior"),
+        ("upgrade", "upgrade-coalesced"),
+    ],
+)
+def test_h2c_modes_work_through_http_connection_pool(
+    mode: typing.Literal["prior_knowledge", "upgrade"],
+    server_mode: typing.Literal["prior", "upgrade-coalesced"],
+) -> None:
+    with H2CServer(server_mode) as server:
+        try:
+            urllib3.http2.inject_into_urllib3(h2c=mode)
+            with HTTPConnectionPool(server.host, server.port, timeout=1) as pool:
+                response = pool.request("GET", "/pool", retries=False)
+        finally:
+            urllib3.http2.extract_from_urllib3()
+
+    assert response.status == 200
+    expected = b"prior-0" if mode == "prior_knowledge" else b"upgraded"
+    assert response.data == expected
+
+
+@pytest.mark.parametrize(
+    ("mode", "server_mode"),
+    [
+        ("prior_knowledge", "prior"),
+        ("upgrade", "upgrade-coalesced"),
+    ],
+)
+def test_h2c_pool_reuses_one_connection_for_sequential_streams(
+    mode: typing.Literal["prior_knowledge", "upgrade"],
+    server_mode: typing.Literal["prior", "upgrade-coalesced"],
+) -> None:
+    with H2CServer(server_mode, request_count=2) as server:
+        try:
+            urllib3.http2.inject_into_urllib3(h2c=mode)
+            with HTTPConnectionPool(server.host, server.port, timeout=1) as pool:
+                first = pool.request("GET", "/first", retries=False)
+                second = pool.request("GET", "/second", retries=False)
+                assert pool.num_connections == 1
+        finally:
+            urllib3.http2.extract_from_urllib3()
+
+    assert first.data == (b"prior-0" if mode == "prior_knowledge" else b"upgraded")
+    assert second.data == b"prior-1"
+    assert server.accept_count == 1
+    assert server.streams == [1, 3]
+
+
+@pytest.mark.parametrize(
+    ("mode", "server_mode"),
+    [
+        ("prior_knowledge", "prior"),
+        ("upgrade", "upgrade-coalesced"),
+    ],
+)
+def test_h2c_pool_processes_idle_controls_before_reusing_connection(
+    mode: typing.Literal["prior_knowledge", "upgrade"],
+    server_mode: typing.Literal["prior", "upgrade-coalesced"],
+) -> None:
+    with H2CServer(server_mode, request_count=2, after_first="control") as server:
+        try:
+            urllib3.http2.inject_into_urllib3(h2c=mode)
+            with HTTPConnectionPool(server.host, server.port, timeout=1) as pool:
+                first = pool.request("GET", "/first", retries=False)
+                server.release_after_first.set()
+                assert server.after_first_sent.wait(1)
+                second = pool.request("GET", "/second", retries=False)
+                assert server.control_acks_received.wait(1)
+                assert pool.num_connections == 1
+        finally:
+            urllib3.http2.extract_from_urllib3()
+
+    assert first.status == second.status == 200
+    assert server.accept_count == 1
+    assert server.streams == [1, 3]
+    assert {"ping", "settings"} <= set(server.control_acks)
+
+
+@pytest.mark.parametrize(
+    ("connection_class", "server_mode"),
+    [
+        (HTTP2CleartextConnection, "prior"),
+        (HTTP2UpgradeConnection, "upgrade-coalesced"),
+    ],
+)
+@pytest.mark.parametrize("after_first", ["goaway", "eof"])
+def test_h2c_connection_is_not_reusable_after_peer_shutdown(
+    connection_class: type[HTTP2CleartextConnection],
+    server_mode: typing.Literal["prior", "upgrade-coalesced"],
+    after_first: typing.Literal["goaway", "eof"],
+) -> None:
+    with H2CServer(server_mode, after_first=after_first) as server:
+        conn = connection_class(server.host, server.port, timeout=1)
+        try:
+            conn.request("GET", "/first")
+            response = conn.getresponse()
+            server.release_after_first.set()
+            assert server.after_first_sent.wait(1)
+            assert conn.sock is not None
+            readable, _, _ = select.select([conn.sock], [], [], 1)
+            assert readable
+            assert not conn.is_connected
+        finally:
+            conn.close()
+
+    assert response.status == 200
+    assert server.streams == [1]
+
+
+def test_h2c_injection_modes_restore_http_connection() -> None:
+    original = HTTPConnectionPool.ConnectionCls
+    try:
+        urllib3.http2.inject_into_urllib3(h2c="prior_knowledge")
+        assert HTTPConnectionPool.ConnectionCls is HTTP2CleartextConnection
+        urllib3.http2.inject_into_urllib3(h2c="upgrade")
+        assert HTTPConnectionPool.ConnectionCls is HTTP2UpgradeConnection
+        urllib3.http2.inject_into_urllib3(h2c=False)
+        assert HTTPConnectionPool.ConnectionCls is original
+    finally:
+        urllib3.http2.extract_from_urllib3()
+
+    assert HTTPConnectionPool.ConnectionCls is original
+
+
+def test_h2c_injection_preserves_distinct_custom_http_connection_classes() -> None:
+    module_original = urllib3.connection.HTTPConnection
+    pool_original = HTTPConnectionPool.ConnectionCls
+
+    class CustomModuleHTTPConnection(HTTPConnection):
+        pass
+
+    class CustomPoolHTTPConnection(HTTPConnection):
+        pass
+
+    setattr(urllib3.connection, "HTTPConnection", CustomModuleHTTPConnection)
+    setattr(HTTPConnectionPool, "ConnectionCls", CustomPoolHTTPConnection)
+    try:
+        urllib3.http2.inject_into_urllib3()
+        assert urllib3.connection.HTTPConnection is CustomModuleHTTPConnection
+        assert HTTPConnectionPool.ConnectionCls is CustomPoolHTTPConnection
+
+        urllib3.http2.inject_into_urllib3(h2c="upgrade")
+        assert urllib3.connection.HTTPConnection is HTTP2UpgradeConnection
+        assert getattr(HTTPConnectionPool, "ConnectionCls") is HTTP2UpgradeConnection
+
+        urllib3.http2.extract_from_urllib3()
+        assert urllib3.connection.HTTPConnection is CustomModuleHTTPConnection
+        assert HTTPConnectionPool.ConnectionCls is CustomPoolHTTPConnection
+    finally:
+        urllib3.http2.extract_from_urllib3()
+        setattr(urllib3.connection, "HTTPConnection", module_original)
+        setattr(HTTPConnectionPool, "ConnectionCls", pool_original)

--- a/test/with_dummyserver/test_https.py
+++ b/test/with_dummyserver/test_https.py
@@ -151,6 +151,36 @@ class BaseTestHTTPS(HTTPSHypercornDummyServerTestCase):
             assert r.headers["server"] == f"hypercorn-{http_version}"
             assert r.data == b"Dummy server!"
 
+    def test_http2_connection_is_reused(self, http_version: str) -> None:
+        if http_version != "h2":
+            pytest.skip("HTTP/2 connection reuse test")
+
+        with HTTPSConnectionPool(
+            self.host,
+            self.port,
+            ca_certs=DEFAULT_CA,
+            ssl_minimum_version=self.tls_version(),
+            maxsize=1,
+        ) as pool:
+            first_response = pool.request("GET", "/")
+            assert first_response.status == 200
+
+            assert pool.pool is not None
+            conn = pool.pool.get(block=False)
+            first_socket = conn.sock
+            assert first_socket is not None
+            pool._put_conn(conn)
+
+            second_response = pool.request("GET", "/")
+            assert second_response.status == 200
+
+            reused = pool.pool.get(block=False)
+            try:
+                assert reused is conn
+                assert reused.sock is first_socket
+            finally:
+                pool._put_conn(reused)
+
     def test_default_port(self) -> None:
         conn = HTTPSConnection(self.host, port=None)
         assert conn.port == 443


### PR DESCRIPTION
Closes #3303.

Depends on #3301, whose connection-level HTTP/2 event manager is used for
cleartext connection reuse and lifecycle handling.

## Summary

Add explicit opt-in cleartext HTTP/2 support through:

- prior knowledge (`h2c="prior_knowledge"` or `h2c=True`)
- the legacy HTTP/1.1 Upgrade mechanism (`h2c="upgrade"`)

The Upgrade negotiator preserves bytes coalesced after the 101 response,
supports fixed-length and chunked request bodies, validates the response
Upgrade tokens, handles bounded informational responses, and preserves normal
HTTP/1.1 fallback behavior when the server declines the upgrade.

Ordinary HTTP remains HTTP/1.1 by default. Existing HTTP proxy paths also stay
on HTTP/1.1; h2c configuration applies to direct origin connections. The docs
identify Upgrade as a legacy mechanism removed from RFC 9113.

## Validation

- Full stacked test suite: 2,377 passed, 315 skipped, 4 xfailed
- Real socket tests prove prior knowledge and Upgrade reuse one accepted socket
  for stream IDs 1 and 3
- Coalesced and byte-fragmented 101 plus HTTP/2 bytes are preserved
- Idle PING/SETTINGS frames are acknowledged before reuse; GOAWAY and EOF
  prevent reuse
- Fixed and chunked bodies are fully sent before switching protocols
- 100 and 103 informational responses are handled before both 101 and 200
  outcomes, with count and cumulative-size bounds
- Non-101 fallback supports preloaded and streaming bodies, persistent reuse,
  malformed-header tolerance, and `Connection: close` socket ownership
- Real ProxyManager tests prove existing HTTP proxy behavior is preserved
- Injection/extraction restores distinct custom connection classes
- Black, isort, pyupgrade, flake8, mypy for touched code, Sphinx references,
  towncrier draft, and diff check passed

