### PR TITLE
Accept bytes in request header type annotations

### DIFF
--- a/changelog/3047.bugfix.rst
+++ b/changelog/3047.bugfix.rst
@@ -1,0 +1,2 @@
+Updated request header type annotations to accept ``str`` or ``bytes`` header
+names and values without widening response header types.

--- a/src/urllib3/__init__.py
+++ b/src/urllib3/__init__.py
@@ -13,7 +13,7 @@ from logging import NullHandler
 
 from . import exceptions
 from ._base_connection import _TYPE_BODY
-from ._collections import HTTPHeaderDict
+from ._collections import _TYPE_HEADER_MAPPING, HTTPHeaderDict
 from ._version import __version__
 from .connectionpool import HTTPConnectionPool, HTTPSConnectionPool, connection_from_url
 from .filepost import _TYPE_FIELDS, encode_multipart_formdata
@@ -120,7 +120,7 @@ def request(
     *,
     body: _TYPE_BODY | None = None,
     fields: _TYPE_FIELDS | None = None,
-    headers: typing.Mapping[str, str] | None = None,
+    headers: _TYPE_HEADER_MAPPING | None = None,
     preload_content: bool | None = True,
     decode_content: bool | None = True,
     redirect: bool | None = True,

--- a/src/urllib3/_collections.py
+++ b/src/urllib3/_collections.py
@@ -28,6 +28,12 @@ _VT = typing.TypeVar("_VT")
 # Default type
 _DT = typing.TypeVar("_DT")
 
+_TYPE_HEADER_MAPPING: typing.TypeAlias = (
+    typing.Mapping[str, str | bytes]
+    | typing.Mapping[bytes, str | bytes]
+    | typing.Mapping[str | bytes, str | bytes]
+)
+
 ValidHTTPHeaderSource = typing.Union[
     "HTTPHeaderDict",
     typing.Mapping[str, str],

--- a/src/urllib3/_request_methods.py
+++ b/src/urllib3/_request_methods.py
@@ -5,11 +5,60 @@ import typing
 from urllib.parse import urlencode
 
 from ._base_connection import _TYPE_BODY
-from ._collections import HTTPHeaderDict
+from ._collections import _TYPE_HEADER_MAPPING, HTTPHeaderDict
 from .filepost import _TYPE_FIELDS, encode_multipart_formdata
 from .response import BaseHTTPResponse
 
 __all__ = ["RequestMethods"]
+
+
+def _copy_request_headers(
+    headers: _TYPE_HEADER_MAPPING,
+) -> HTTPHeaderDict | dict[str | bytes, str | bytes]:
+    """Copy request headers without coercing opaque bytes values."""
+    if isinstance(headers, HTTPHeaderDict):
+        return headers.copy()
+    if all(
+        isinstance(key, str) and isinstance(value, str)
+        for key, value in headers.items()
+    ):
+        return HTTPHeaderDict(typing.cast(typing.Mapping[str, str], headers))
+    return dict(typing.cast(typing.Mapping[str | bytes, str | bytes], headers))
+
+
+def _prepare_request_headers_for_method_change(
+    headers: _TYPE_HEADER_MAPPING,
+) -> HTTPHeaderDict | dict[str | bytes, str | bytes]:
+    """Copy request headers and remove entity headers after a 303 redirect."""
+    copied_headers = _copy_request_headers(headers)
+    if isinstance(copied_headers, HTTPHeaderDict):
+        return copied_headers._prepare_for_method_change()
+
+    entity_headers = {
+        "content-encoding",
+        "content-language",
+        "content-location",
+        "content-type",
+        "content-length",
+        "digest",
+        "last-modified",
+    }
+    for header in tuple(copied_headers):
+        if _is_header_in(header, entity_headers):
+            del copied_headers[header]
+    return copied_headers
+
+
+def _is_header_in(header: str | bytes, header_names: typing.Collection[str]) -> bool:
+    """Match a request header name without decoding opaque bytes."""
+    header_lower = header.lower()
+    if isinstance(header_lower, bytes):
+        return any(
+            name.isascii() and header_lower == name.encode("ascii")
+            for name in header_names
+        )
+    return header_lower in header_names
+
 
 _TYPE_ENCODE_URL_FIELDS = typing.Union[
     typing.Sequence[tuple[str, typing.Union[str, bytes]]],
@@ -48,7 +97,7 @@ class RequestMethods:
 
     _encode_url_methods = {"DELETE", "GET", "HEAD", "OPTIONS"}
 
-    def __init__(self, headers: typing.Mapping[str, str] | None = None) -> None:
+    def __init__(self, headers: _TYPE_HEADER_MAPPING | None = None) -> None:
         self.headers = headers or {}
 
     def urlopen(
@@ -56,7 +105,7 @@ class RequestMethods:
         method: str,
         url: str,
         body: _TYPE_BODY | None = None,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADER_MAPPING | None = None,
         encode_multipart: bool = True,
         multipart_boundary: str | None = None,
         **kw: typing.Any,
@@ -72,7 +121,7 @@ class RequestMethods:
         url: str,
         body: _TYPE_BODY | None = None,
         fields: _TYPE_FIELDS | None = None,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADER_MAPPING | None = None,
         json: typing.Any | None = None,
         **urlopen_kw: typing.Any,
     ) -> BaseHTTPResponse:
@@ -120,8 +169,8 @@ class RequestMethods:
             if headers is None:
                 headers = self.headers
 
-            if not ("content-type" in map(str.lower, headers.keys())):
-                headers = HTTPHeaderDict(headers)
+            if not any(_is_header_in(key, {"content-type"}) for key in headers):
+                headers = _copy_request_headers(headers)
                 headers["Content-Type"] = "application/json"
 
             body = _json.dumps(json, separators=(",", ":"), ensure_ascii=False).encode(
@@ -149,7 +198,7 @@ class RequestMethods:
         method: str,
         url: str,
         fields: _TYPE_ENCODE_URL_FIELDS | None = None,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADER_MAPPING | None = None,
         **urlopen_kw: str,
     ) -> BaseHTTPResponse:
         """
@@ -186,7 +235,7 @@ class RequestMethods:
         method: str,
         url: str,
         fields: _TYPE_FIELDS | None = None,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADER_MAPPING | None = None,
         encode_multipart: bool = True,
         multipart_boundary: str | None = None,
         **urlopen_kw: str,
@@ -251,7 +300,7 @@ class RequestMethods:
         if headers is None:
             headers = self.headers
 
-        extra_kw: dict[str, typing.Any] = {"headers": HTTPHeaderDict(headers)}
+        extra_kw: dict[str, typing.Any] = {"headers": _copy_request_headers(headers)}
         body: bytes | str
 
         if fields:
@@ -271,7 +320,14 @@ class RequestMethods:
                 )
 
             extra_kw["body"] = body
-            extra_kw["headers"].setdefault("Content-Type", content_type)
+            request_headers = typing.cast(
+                HTTPHeaderDict | dict[str | bytes, str | bytes],
+                extra_kw["headers"],
+            )
+            if not any(
+                _is_header_in(header, {"content-type"}) for header in request_headers
+            ):
+                request_headers["Content-Type"] = content_type
 
         extra_kw.update(urlopen_kw)
 

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -16,11 +16,13 @@ from http.client import ResponseNotReady
 from socket import timeout as SocketTimeout
 
 if typing.TYPE_CHECKING:
+    from typing_extensions import Buffer
+
     from .response import HTTPResponse
     from .util.ssl_ import _TYPE_PEER_CERT_RET_DICT
     from .util.ssltransport import SSLTransport
 
-from ._collections import HTTPHeaderDict
+from ._collections import _TYPE_HEADER_MAPPING, HTTPHeaderDict
 from .http2 import probe as http2_probe
 from .util.response import assert_header_parsing
 from .util.timeout import _DEFAULT_TIMEOUT, _TYPE_TIMEOUT, Timeout
@@ -474,7 +476,9 @@ class HTTPConnection(_HTTPConnection):
             method, url, skip_host=skip_host, skip_accept_encoding=skip_accept_encoding
         )
 
-    def putheader(self, header: str, *values: str) -> None:  # type: ignore[override]
+    def putheader(
+        self, header: str | bytes, *values: str | bytes | int | Buffer
+    ) -> None:
         """"""
         if not any(isinstance(v, str) and v == SKIP_HEADER for v in values):
             super().putheader(header, *values)
@@ -493,7 +497,7 @@ class HTTPConnection(_HTTPConnection):
         method: str,
         url: str,
         body: _TYPE_BODY | None = None,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADER_MAPPING | None = None,
         *,
         chunked: bool = False,
         preload_content: bool = True,
@@ -590,7 +594,7 @@ class HTTPConnection(_HTTPConnection):
         method: str,
         url: str,
         body: _TYPE_BODY | None = None,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADER_MAPPING | None = None,
     ) -> None:
         """
         Alternative to the common request method, which sends the

--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -11,8 +11,13 @@ from socket import timeout as SocketTimeout
 from types import TracebackType
 
 from ._base_connection import _TYPE_BODY
-from ._collections import HTTPHeaderDict
-from ._request_methods import RequestMethods
+from ._collections import _TYPE_HEADER_MAPPING, HTTPHeaderDict
+from ._request_methods import (
+    RequestMethods,
+    _copy_request_headers,
+    _is_header_in,
+    _prepare_request_headers_for_method_change,
+)
 from .connection import (
     BaseSSLError,
     BrokenPipeError,
@@ -61,6 +66,73 @@ if typing.TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 _TYPE_TIMEOUT = typing.Union[Timeout, float, _TYPE_DEFAULT, None]
+
+
+def _normalize_proxy_tunnel_headers(
+    headers: _TYPE_HEADER_MAPPING,
+) -> HTTPHeaderDict:
+    """Adapt opaque bytes for stdlib's Latin-1 HTTP CONNECT serialization."""
+    normalized = HTTPHeaderDict()
+    for key, value in headers.items():
+        normalized.add(
+            key.decode("latin-1") if isinstance(key, bytes) else key,
+            value.decode("latin-1") if isinstance(value, bytes) else value,
+        )
+    return normalized
+
+
+def _copy_and_merge_proxy_headers(
+    headers: _TYPE_HEADER_MAPPING, proxy_headers: _TYPE_HEADER_MAPPING
+) -> _TYPE_HEADER_MAPPING:
+    """Copy and merge headers while preserving capable custom mappings."""
+    if isinstance(headers, HTTPHeaderDict):
+        copied_headers = headers.copy()
+        # HTTPHeaderDict is string-only. Latin-1 is the codec used later by
+        # http.client, so this conversion preserves every input byte on wire.
+        for key, value in _normalize_proxy_tunnel_headers(proxy_headers).itermerged():
+            copied_headers[key] = value
+        return copied_headers
+
+    if hasattr(headers, "copy"):
+        candidate = typing.cast(typing.Any, headers).copy()
+    else:
+        candidate = None
+    if candidate is headers or not isinstance(candidate, typing.MutableMapping):
+        candidate = dict(typing.cast(typing.Mapping[str | bytes, str | bytes], headers))
+
+    merged_headers = typing.cast(
+        typing.MutableMapping[str | bytes, str | bytes], candidate
+    )
+    proxy_items = (
+        proxy_headers.itermerged()
+        if isinstance(proxy_headers, HTTPHeaderDict)
+        else proxy_headers.items()
+    )
+    for proxy_key, proxy_value in proxy_items:
+        matching_keys = [
+            request_key
+            for request_key in merged_headers
+            if _header_names_equal(request_key, proxy_key)
+        ]
+        if matching_keys:
+            # Keep the first semantic header in its existing ordered slot.
+            merged_headers[matching_keys[0]] = proxy_value
+            for duplicate_key in matching_keys[1:]:
+                del merged_headers[duplicate_key]
+        else:
+            merged_headers[proxy_key] = proxy_value
+    return merged_headers
+
+
+def _header_names_equal(left: str | bytes, right: str | bytes) -> bool:
+    """Compare HTTP header names without decoding bytes."""
+    if isinstance(left, bytes):
+        if isinstance(right, bytes):
+            return left.lower() == right.lower()
+        return right.isascii() and left.lower() == right.lower().encode("ascii")
+    if isinstance(right, str):
+        return left.lower() == right.lower()
+    return left.isascii() and left.lower().encode("ascii") == right.lower()
 
 
 # Pool objects
@@ -179,10 +251,10 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         timeout: _TYPE_TIMEOUT | None = _DEFAULT_TIMEOUT,
         maxsize: int = 1,
         block: bool = False,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADER_MAPPING | None = None,
         retries: Retry | bool | int | None = None,
         _proxy: Url | None = None,
-        _proxy_headers: typing.Mapping[str, str] | None = None,
+        _proxy_headers: _TYPE_HEADER_MAPPING | None = None,
         _proxy_config: ProxyConfig | None = None,
         **conn_kw: typing.Any,
     ):
@@ -380,7 +452,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         method: str,
         url: str,
         body: _TYPE_BODY | None = None,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADER_MAPPING | None = None,
         retries: Retry | None = None,
         timeout: _TYPE_TIMEOUT = _DEFAULT_TIMEOUT,
         chunked: bool = False,
@@ -494,7 +566,9 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
                 method,
                 url,
                 body=body,
-                headers=headers,
+                # BaseHTTPConnection also describes the experimental HTTP/2
+                # implementation, whose request headers remain string-only.
+                headers=typing.cast(typing.Mapping[str, str] | None, headers),
                 chunked=chunked,
                 preload_content=preload_content,
                 decode_content=decode_content,
@@ -594,7 +668,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         method: str,
         url: str,
         body: _TYPE_BODY | None = None,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADER_MAPPING | None = None,
         retries: Retry | bool | int | None = None,
         redirect: bool = True,
         assert_same_host: bool = True,
@@ -746,8 +820,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         # have to copy the headers dict so we can safely change it without those
         # changes being reflected in anyone else's copy.
         if not http_tunnel_required:
-            headers = headers.copy()  # type: ignore[attr-defined]
-            headers.update(self.proxy_headers)  # type: ignore[union-attr]
+            headers = _copy_and_merge_proxy_headers(headers, self.proxy_headers)
 
         # Must keep the exception bound to a separate variable or else Python 3
         # complains about UnboundLocalError.
@@ -903,7 +976,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
                 method = "GET"
                 # And lose the body not to transfer anything sensitive.
                 body = None
-                headers = HTTPHeaderDict(headers)._prepare_for_method_change()
+                headers = _prepare_request_headers_for_method_change(headers)
 
             # Strip headers marked as unsafe to forward to the redirected location.
             # Check remove_headers_on_redirect to avoid a potential network call within
@@ -911,10 +984,13 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
             if retries.remove_headers_on_redirect and not self.is_same_host(
                 redirect_location
             ):
-                new_headers = headers.copy()  # type: ignore[union-attr]
+                new_headers = _copy_request_headers(headers)
                 for header in headers:
-                    if header.lower() in retries.remove_headers_on_redirect:
-                        new_headers.pop(header, None)
+                    if _is_header_in(header, retries.remove_headers_on_redirect):
+                        if isinstance(new_headers, HTTPHeaderDict):
+                            new_headers.discard(typing.cast(str, header))
+                        else:
+                            new_headers.pop(header, None)
                 headers = new_headers
 
             try:
@@ -1005,10 +1081,10 @@ class HTTPSConnectionPool(HTTPConnectionPool):
         timeout: _TYPE_TIMEOUT | None = _DEFAULT_TIMEOUT,
         maxsize: int = 1,
         block: bool = False,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADER_MAPPING | None = None,
         retries: Retry | bool | int | None = None,
         _proxy: Url | None = None,
-        _proxy_headers: typing.Mapping[str, str] | None = None,
+        _proxy_headers: _TYPE_HEADER_MAPPING | None = None,
         key_file: str | None = None,
         cert_file: str | None = None,
         cert_reqs: int | str | None = None,
@@ -1058,7 +1134,9 @@ class HTTPSConnectionPool(HTTPConnectionPool):
             scheme=tunnel_scheme,
             host=self._tunnel_host,
             port=self.port,
-            headers=self.proxy_headers,
+            # http.client serializes tunnel strings as Latin-1. Decode bytes
+            # with the same codec here so they round-trip to identical octets.
+            headers=_normalize_proxy_tunnel_headers(self.proxy_headers),
         )
         conn.connect()
 

--- a/src/urllib3/contrib/emscripten/connection.py
+++ b/src/urllib3/contrib/emscripten/connection.py
@@ -8,6 +8,7 @@ from http.client import HTTPException as HTTPException  # noqa: F401
 from http.client import ResponseNotReady
 
 from ..._base_connection import _TYPE_BODY
+from ..._collections import _TYPE_HEADER_MAPPING
 from ...connection import HTTPConnection, ProxyConfig, port_by_scheme
 from ...exceptions import TimeoutError
 from ...response import BaseHTTPResponse
@@ -20,6 +21,11 @@ from .response import EmscriptenHttpResponseWrapper, EmscriptenResponse
 
 if typing.TYPE_CHECKING:
     from ..._base_connection import BaseHTTPConnection, BaseHTTPSConnection
+
+
+def _normalize_request_header(value: str | bytes) -> str:
+    """Convert a header to the Web API's string form without changing octets."""
+    return value.decode("latin-1") if isinstance(value, bytes) else value
 
 
 class EmscriptenHTTPConnection:
@@ -74,7 +80,7 @@ class EmscriptenHTTPConnection:
         self,
         host: str,
         port: int | None = 0,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADER_MAPPING | None = None,
         scheme: str = "http",
     ) -> None:
         pass
@@ -87,7 +93,7 @@ class EmscriptenHTTPConnection:
         method: str,
         url: str,
         body: _TYPE_BODY | None = None,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADER_MAPPING | None = None,
         # We know *at least* botocore is depending on the order of the
         # first 3 parameters so to be safe we only mark the later ones
         # as keyword-only to ensure we have space to extend.
@@ -114,7 +120,11 @@ class EmscriptenHTTPConnection:
         request.set_body(body)
         if headers:
             for k, v in headers.items():
-                request.set_header(k, v)
+                # Fetch and XMLHttpRequest accept Web IDL ByteString values.
+                # Latin-1 maps each input byte to the same code point.
+                request.set_header(
+                    _normalize_request_header(k), _normalize_request_header(v)
+                )
         self._response = None
         try:
             if not preload_content:

--- a/src/urllib3/contrib/socks.py
+++ b/src/urllib3/contrib/socks.py
@@ -60,6 +60,7 @@ except ImportError:
 import typing
 from socket import timeout as SocketTimeout
 
+from .._collections import _TYPE_HEADER_MAPPING
 from ..connection import HTTPConnection, HTTPSConnection
 from ..connectionpool import HTTPConnectionPool, HTTPSConnectionPool
 from ..exceptions import ConnectTimeoutError, NewConnectionError
@@ -187,7 +188,7 @@ class SOCKSProxyManager(PoolManager):
         username: str | None = None,
         password: str | None = None,
         num_pools: int = 10,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADER_MAPPING | None = None,
         **connection_pool_kw: typing.Any,
     ):
         parsed = parse_url(proxy_url)

--- a/src/urllib3/poolmanager.py
+++ b/src/urllib3/poolmanager.py
@@ -7,8 +7,13 @@ import warnings
 from types import TracebackType
 from urllib.parse import urljoin
 
-from ._collections import HTTPHeaderDict, RecentlyUsedContainer
-from ._request_methods import RequestMethods
+from ._collections import _TYPE_HEADER_MAPPING, RecentlyUsedContainer
+from ._request_methods import (
+    RequestMethods,
+    _copy_request_headers,
+    _is_header_in,
+    _prepare_request_headers_for_method_change,
+)
 from .connection import ProxyConfig
 from .connectionpool import HTTPConnectionPool, HTTPSConnectionPool, port_by_scheme
 from .exceptions import (
@@ -201,7 +206,7 @@ class PoolManager(RequestMethods):
     def __init__(
         self,
         num_pools: int = 10,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADER_MAPPING | None = None,
         **connection_pool_kw: typing.Any,
     ) -> None:
         super().__init__(headers)
@@ -470,7 +475,7 @@ class PoolManager(RequestMethods):
             method = "GET"
             # And lose the body not to transfer anything sensitive.
             kw["body"] = None
-            kw["headers"] = HTTPHeaderDict(kw["headers"])._prepare_for_method_change()
+            kw["headers"] = _prepare_request_headers_for_method_change(kw["headers"])
 
         retries = kw.get("retries", response.retries)
         if not isinstance(retries, Retry):
@@ -482,9 +487,9 @@ class PoolManager(RequestMethods):
         if retries.remove_headers_on_redirect and not conn.is_same_host(
             redirect_location
         ):
-            new_headers = kw["headers"].copy()
+            new_headers = _copy_request_headers(kw["headers"])
             for header in kw["headers"]:
-                if header.lower() in retries.remove_headers_on_redirect:
+                if _is_header_in(header, retries.remove_headers_on_redirect):
                     new_headers.pop(header, None)
             kw["headers"] = new_headers
 
@@ -566,8 +571,8 @@ class ProxyManager(PoolManager):
         self,
         proxy_url: str,
         num_pools: int = 10,
-        headers: typing.Mapping[str, str] | None = None,
-        proxy_headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADER_MAPPING | None = None,
+        proxy_headers: _TYPE_HEADER_MAPPING | None = None,
         proxy_ssl_context: ssl.SSLContext | None = None,
         use_forwarding_for_https: bool = False,
         proxy_assert_hostname: None | str | typing.Literal[False] = None,
@@ -637,20 +642,27 @@ class ProxyManager(PoolManager):
         )
 
     def _set_proxy_headers(
-        self, url: str, headers: typing.Mapping[str, str] | None = None
-    ) -> typing.Mapping[str, str]:
+        self, url: str, headers: _TYPE_HEADER_MAPPING | None = None
+    ) -> typing.Mapping[str | bytes, str | bytes]:
         """
         Sets headers needed by proxies: specifically, the Accept and Host
         headers. Only sets headers not provided by the user.
         """
-        headers_ = {"Accept": "*/*"}
+        headers_: dict[str | bytes, str | bytes] = {}
+        header_names = tuple(headers) if headers is not None else ()
+        if not any(_is_header_in(header, {"accept"}) for header in header_names):
+            headers_["Accept"] = "*/*"
 
         netloc = parse_url(url).netloc
-        if netloc:
+        if netloc and not any(
+            _is_header_in(header, {"host"}) for header in header_names
+        ):
             headers_["Host"] = netloc
 
         if headers:
-            headers_.update(headers)
+            headers_.update(
+                typing.cast(typing.Mapping[str | bytes, str | bytes], headers)
+            )
         return headers_
 
     def urlopen(  # type: ignore[override]

--- a/test/contrib/emscripten/test_emscripten.py
+++ b/test/contrib/emscripten/test_emscripten.py
@@ -1331,3 +1331,28 @@ def test_pool_no_port(selenium_coverage: typing.Any) -> None:
         pool = HTTPConnectionPool("example.com", maxsize=10, block=True)
 
         pool.request("GET", "/")
+
+
+@run_in_pyodide  # type: ignore[untyped-decorator]
+def test_bytes_request_headers_are_converted_losslessly(
+    selenium_coverage: typing.Any,
+) -> None:
+    from unittest.mock import patch
+
+    from urllib3.contrib.emscripten.connection import EmscriptenHTTPConnection
+    from urllib3.contrib.emscripten.request import EmscriptenRequest
+    from urllib3.contrib.emscripten.response import EmscriptenResponse
+
+    def send_request(request: EmscriptenRequest) -> EmscriptenResponse:
+        assert request.headers["X-bytes"].encode("latin-1") == b"\xff\xfe"
+        assert all(
+            isinstance(name, str) and isinstance(value, str)
+            for name, value in request.headers.items()
+        )
+        return EmscriptenResponse(
+            status_code=200, headers={}, body=b"", request=request
+        )
+
+    connection = EmscriptenHTTPConnection("example.com")
+    with patch("urllib3.contrib.emscripten.connection.send_request", new=send_request):
+        connection.request("GET", "/", headers={b"X-Bytes": b"\xff\xfe"})

--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -326,9 +326,9 @@ class TestConnection:
     @pytest.mark.parametrize("chunked", [True, False])
     def test_skip_header(
         self,
-        accept_encoding: str | None,
-        host: str | None,
-        user_agent: str | None,
+        accept_encoding: str | bytes | None,
+        host: str | bytes | None,
+        user_agent: str | bytes | None,
         chunked: bool,
     ) -> None:
         headers = {}

--- a/test/test_header_input.py
+++ b/test/test_header_input.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import typing
+
+import pytest
+
+from urllib3._collections import HTTPHeaderDict
+from urllib3._request_methods import _prepare_request_headers_for_method_change
+from urllib3.connectionpool import _copy_and_merge_proxy_headers
+
+
+@pytest.mark.parametrize("use_bytes", [False, True])
+def test_method_change_removes_the_same_entity_headers(use_bytes: bool) -> None:
+    removable = [
+        "Content-Encoding",
+        "Content-Language",
+        "Content-Location",
+        "Content-Type",
+        "Content-Length",
+        "Digest",
+        "Last-Modified",
+    ]
+    source: typing.Mapping[str | bytes, str | bytes]
+    if use_bytes:
+        source = {
+            **{name.encode(): b"value" for name in removable},
+            b"Transfer-Encoding": b"chunked",
+            b"X-Keep": b"value",
+        }
+    else:
+        source = {
+            **{name: "value" for name in removable},
+            "Transfer-Encoding": "chunked",
+            "X-Keep": "value",
+        }
+    original = dict(source)
+
+    prepared = _prepare_request_headers_for_method_change(source)
+
+    expected = (
+        {b"Transfer-Encoding": b"chunked", b"X-Keep": b"value"}
+        if use_bytes
+        else {"Transfer-Encoding": "chunked", "X-Keep": "value"}
+    )
+    assert dict(prepared) == expected
+    assert source == original
+
+
+def test_forward_proxy_merge_accepts_read_only_mapping() -> None:
+    class ReadOnlyHeaders(typing.Mapping[bytes, bytes]):
+        def __init__(self, values: dict[bytes, bytes]) -> None:
+            self._data = values
+
+        def __getitem__(self, key: bytes) -> bytes:
+            return self._data[key]
+
+        def __iter__(self) -> typing.Iterator[bytes]:
+            return iter(self._data)
+
+        def __len__(self) -> int:
+            return len(self._data)
+
+    headers = ReadOnlyHeaders({b"X-Request": b"value"})
+    merged = _copy_and_merge_proxy_headers(headers, {b"X-Proxy": b"value"})
+
+    assert dict(merged) == {b"X-Request": b"value", b"X-Proxy": b"value"}
+    assert dict(headers) == {b"X-Request": b"value"}
+
+
+def test_proxy_headers_override_mixed_case_and_preserve_repeated_headers() -> None:
+    request_headers = HTTPHeaderDict()
+    request_headers.add("X-Repeat", "one")
+    request_headers.add("X-Repeat", "two")
+    request_headers["proxy-authorization"] = "request"
+
+    merged = _copy_and_merge_proxy_headers(
+        request_headers,
+        {b"Proxy-Authorization": b"configured", b"X-Opaque": b"\xff"},
+    )
+
+    assert isinstance(merged, HTTPHeaderDict)
+    assert merged.getlist("X-Repeat") == ["one", "two"]
+    assert merged["Proxy-Authorization"] == "configured"
+    assert merged["X-Opaque"].encode("latin-1") == b"\xff"
+
+
+def test_repeated_proxy_headers_are_combined_without_reordering() -> None:
+    request_headers = HTTPHeaderDict(
+        {
+            "A": "a",
+            "Proxy-Authorization": "request",
+            "B": "b",
+        }
+    )
+    proxy_headers = HTTPHeaderDict()
+    proxy_headers.add("Proxy-Authorization", "one")
+    proxy_headers.add("Proxy-Authorization", "two")
+
+    merged = _copy_and_merge_proxy_headers(request_headers, proxy_headers)
+
+    assert isinstance(merged, HTTPHeaderDict)
+    assert list(merged.items()) == [
+        ("A", "a"),
+        ("Proxy-Authorization", "one, two"),
+        ("B", "b"),
+    ]

--- a/test/test_header_typing.py
+++ b/test/test_header_typing.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import typing
+
+if typing.TYPE_CHECKING:
+    import urllib3
+    from urllib3 import HTTPConnectionPool, HTTPSConnectionPool
+    from urllib3._collections import HTTPHeaderDict
+    from urllib3._request_methods import RequestMethods
+    from urllib3.connection import HTTPConnection
+    from urllib3.contrib.emscripten.connection import EmscriptenHTTPConnection
+    from urllib3.contrib.socks import SOCKSProxyManager
+    from urllib3.poolmanager import PoolManager, ProxyManager
+
+    headers_str: typing.Mapping[str, str] = {"X-Header": "value"}
+    headers_str_bytes: typing.Mapping[str, bytes] = {"X-Header": b"value"}
+    headers_bytes_str: typing.Mapping[bytes, str] = {b"X-Header": "value"}
+    headers_bytes: typing.Mapping[bytes, bytes] = {b"X-Header": b"value"}
+    headers_mixed: typing.Mapping[str | bytes, str | bytes] = {
+        "X-String": b"bytes",
+        b"X-Bytes": "string",
+    }
+    headers_http = HTTPHeaderDict({"X-Header": "value"})
+    response = urllib3.HTTPResponse(headers={"X-Response": "value"})
+    typing.assert_type(response.headers["X-Response"], str)
+
+    for headers in (
+        headers_str,
+        headers_str_bytes,
+        headers_bytes_str,
+        headers_bytes,
+        headers_mixed,
+        headers_http,
+    ):
+        urllib3.request("GET", "https://example.com", headers=headers)
+        PoolManager(headers=headers).request(
+            "GET", "https://example.com", headers=headers
+        )
+        HTTPConnectionPool("example.com", headers=headers).request(
+            "GET", "/", headers=headers
+        )
+
+    request_methods = RequestMethods(headers=headers_mixed)
+    request_methods.urlopen("GET", "https://example.com", headers=headers_mixed)
+    request_methods.request("GET", "https://example.com", headers=headers_mixed)
+    request_methods.request_encode_url(
+        "GET", "https://example.com", headers=headers_mixed
+    )
+    request_methods.request_encode_body(
+        "POST", "https://example.com", headers=headers_mixed
+    )
+
+    HTTPConnection("example.com").request("GET", "/", headers=headers_mixed)
+    HTTPConnection("example.com").putheader(b"X-Header", b"value")
+    HTTPConnection("example.com").request_chunked("GET", "/", headers=headers_mixed)
+    HTTPSConnectionPool("example.com", headers=headers_mixed).request(
+        "GET", "/", headers=headers_mixed
+    )
+    ProxyManager(
+        "http://proxy.example.com",
+        headers=headers_mixed,
+        proxy_headers=headers_mixed,
+    )
+    SOCKSProxyManager("socks5://proxy.example.com", headers=headers_mixed)
+    EmscriptenHTTPConnection("example.com").request("GET", "/", headers=headers_mixed)

--- a/test/test_proxymanager.py
+++ b/test/test_proxymanager.py
@@ -47,6 +47,22 @@ class TestProxyManager:
 
             assert headers == expected_headers
 
+    def test_proxy_headers_do_not_duplicate_bytes_defaults(self) -> None:
+        provided_headers = {
+            b"Accept": b"application/example",
+            b"Host": b"example.invalid",
+            b"X-Opaque": b"\xff",
+        }
+        original_headers = provided_headers.copy()
+
+        with ProxyManager("http://something:1234") as proxy:
+            headers = proxy._set_proxy_headers(
+                "http://pypi.org/project/urllib3/", provided_headers
+            )
+
+        assert headers == provided_headers
+        assert provided_headers == original_headers
+
     def test_default_port(self) -> None:
         with ProxyManager("http://something") as p:
             assert p.proxy is not None

--- a/test/with_dummyserver/test_poolmanager.py
+++ b/test/with_dummyserver/test_poolmanager.py
@@ -290,6 +290,61 @@ class TestPoolManager(HypercornDummyServerTestCase):
             assert "cookie" not in data
             assert "Cookie" not in data
 
+    def test_redirect_cross_host_removes_bytes_header_names(self) -> None:
+        headers: typing.Mapping[bytes, bytes] = {
+            b"Authorization": b"foo",
+            b"Proxy-Authorization": b"bar",
+            b"Cookie": b"foo=bar",
+        }
+        original_headers = dict(headers)
+
+        with PoolManager() as http:
+            response = http.request(
+                "GET",
+                f"{self.base_url}/redirect",
+                fields={"target": f"{self.base_url_alt}/headers"},
+                headers=headers,
+            )
+
+        assert response.status == 200
+        data = response.json()
+        assert "Authorization" not in data
+        assert "Proxy-Authorization" not in data
+        assert "Cookie" not in data
+        assert headers == original_headers
+
+    def test_redirect_cross_host_accepts_read_only_bytes_mapping(self) -> None:
+        class ReadOnlyHeaders(typing.Mapping[bytes, bytes]):
+            def __init__(self, values: dict[bytes, bytes]) -> None:
+                self._data = values
+
+            def __getitem__(self, key: bytes) -> bytes:
+                return self._data[key]
+
+            def __iter__(self) -> typing.Iterator[bytes]:
+                return iter(self._data)
+
+            def __len__(self) -> int:
+                return len(self._data)
+
+        headers = ReadOnlyHeaders({b"Authorization": b"secret", b"X-Keep": b"value"})
+
+        with PoolManager() as http:
+            response = http.request(
+                "GET",
+                f"{self.base_url}/redirect",
+                fields={"target": f"{self.base_url_alt}/headers"},
+                headers=headers,
+            )
+
+        data = response.json()
+        assert "Authorization" not in data
+        assert data["X-Keep"] == "value"
+        assert dict(headers) == {
+            b"Authorization": b"secret",
+            b"X-Keep": b"value",
+        }
+
     def test_redirect_cross_host_no_remove_headers(self) -> None:
         with PoolManager() as http:
             r = http.request(
@@ -390,6 +445,26 @@ class TestPoolManager(HypercornDummyServerTestCase):
         data = response.json()
         assert data["params"] == {}
         assert "Content-Type" not in HTTPHeaderDict(data["headers"])
+
+    def test_303_redirect_removes_bytes_entity_headers(self) -> None:
+        headers: typing.Mapping[bytes, bytes] = {
+            b"Content-Type": b"application/octet-stream"
+        }
+        original_headers = dict(headers)
+
+        with PoolManager() as http:
+            response = http.request(
+                "POST",
+                f"{self.base_url}/redirect"
+                "?target=%2Fheaders_and_params&status=303%20See%20Other",
+                body=b"secret",
+                headers=headers,
+            )
+
+        data = response.json()
+        assert data["params"] == {}
+        assert "Content-Type" not in HTTPHeaderDict(data["headers"])
+        assert headers == original_headers
 
     def test_unknown_scheme(self) -> None:
         with PoolManager() as http:
@@ -774,6 +849,21 @@ class TestPoolManager(HypercornDummyServerTestCase):
             assert "application/json" in r.headers["Content-Type"].replace(
                 " ", ""
             ).split(",")
+
+    def test_request_with_json_accepts_bytes_content_type_header(self) -> None:
+        headers: typing.Mapping[bytes, bytes] = {b"Content-Type": b"application/json"}
+        original_headers = dict(headers)
+
+        response = request(
+            method="POST",
+            url=f"{self.base_url}/echo_json",
+            headers=headers,
+            json={"attribute": "value"},
+        )
+
+        assert response.status == 200
+        assert response.json() == {"attribute": "value"}
+        assert headers == original_headers
 
     def test_top_level_request_with_body_and_json(self) -> None:
         match = "request got values for both 'body' and 'json' parameters which are mutually exclusive"

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -1542,6 +1542,57 @@ class TestProxyManager(SocketDummyServerTestCase):
                 == "Tunnel connection failed: 501 Not Implemented"
             )
 
+    def test_bytes_proxy_tunnel_headers_are_sent_unchanged(self) -> None:
+        received = bytearray()
+
+        def http_socket_handler(listener: socket.socket) -> None:
+            sock = listener.accept()[0]
+            while not received.endswith(b"\r\n\r\n"):
+                received.extend(sock.recv(65536))
+            sock.send(b"HTTP/1.0 501 Not Implemented\r\nConnection: close\r\n\r\n")
+            sock.close()
+
+        self._start_server(http_socket_handler)
+        base_url = f"http://{self.host}:{self.port}"
+        proxy_headers: typing.Mapping[bytes, bytes] = {
+            b"Proxy-Authorization": b"\xff\xfe"
+        }
+
+        with ProxyManager(base_url, proxy_headers=proxy_headers) as proxy:
+            with pytest.raises(MaxRetryError):
+                proxy.request("GET", "https://example.com", retries=0)
+
+        assert b"Proxy-Authorization: \xff\xfe\r\n" in received
+
+    def test_bytes_proxy_headers_override_request_headers(self) -> None:
+        received = bytearray()
+
+        def http_socket_handler(listener: socket.socket) -> None:
+            sock = listener.accept()[0]
+            while not received.endswith(b"\r\n\r\n"):
+                received.extend(sock.recv(65536))
+            sock.send(b"HTTP/1.1 204 No Content\r\nContent-Length: 0\r\n\r\n")
+            sock.close()
+
+        self._start_server(http_socket_handler)
+        base_url = f"http://{self.host}:{self.port}"
+
+        with ProxyManager(
+            base_url,
+            proxy_headers={b"Proxy-Authorization": b"configured"},
+        ) as proxy:
+            response = proxy.request(
+                "GET",
+                "http://example.com/",
+                headers={"proxy-authorization": "request"},
+                retries=0,
+            )
+
+        assert response.status == 204
+        header_block = bytes(received).split(b"\r\n\r\n", 1)[0].lower()
+        assert header_block.count(b"proxy-authorization:") == 1
+        assert b"proxy-authorization: configured\r\n" in header_block + b"\r\n"
+
     def test_early_eof_doesnt_cause_infinite_loop(self) -> None:
         def http_socket_handler(listener: socket.socket) -> None:
             sock = listener.accept()[0]
@@ -2109,6 +2160,57 @@ class TestHeaders(SocketDummyServerTestCase):
         with HTTPConnectionPool(self.host, self.port, retries=False) as pool:
             pool.request("GET", "/", headers=HTTPHeaderDict(headers))
             assert expected_headers == self.parsed_headers
+
+    def test_bytes_header_names_and_values_are_sent_unchanged(self) -> None:
+        received = bytearray()
+
+        def socket_handler(listener: socket.socket) -> None:
+            sock = listener.accept()[0]
+            while not received.endswith(b"\r\n\r\n"):
+                received.extend(sock.recv(65536))
+            sock.sendall(b"HTTP/1.1 204 No Content\r\nContent-Length: 0\r\n\r\n")
+            sock.close()
+
+        self._start_server(socket_handler)
+        headers: typing.Mapping[str | bytes, str | bytes] = {
+            b"X-Bytes": b"\xff\xfe",
+            "X-Mixed": b"\x80",
+        }
+
+        with HTTPConnectionPool(self.host, self.port, retries=False) as pool:
+            response = pool.request("GET", "/", headers=headers)
+
+        assert response.status == 204
+        assert b"X-Bytes: \xff\xfe\r\n" in received
+        assert b"X-Mixed: \x80\r\n" in received
+
+    @pytest.mark.parametrize("content_type", ["content-type", b"Content-Type"])
+    def test_multipart_bytes_content_type_is_not_duplicated(
+        self, content_type: str | bytes
+    ) -> None:
+        received = bytearray()
+
+        def socket_handler(listener: socket.socket) -> None:
+            sock = listener.accept()[0]
+            while b"\r\n\r\n" not in received:
+                received.extend(sock.recv(65536))
+            sock.sendall(b"HTTP/1.1 204 No Content\r\nContent-Length: 0\r\n\r\n")
+            sock.close()
+
+        self._start_server(socket_handler)
+        headers: typing.Mapping[str | bytes, str | bytes] = {
+            content_type: b"application/example"
+        }
+
+        with HTTPConnectionPool(self.host, self.port, retries=False) as pool:
+            response = pool.request(
+                "POST", "/", fields={"field": "value"}, headers=headers
+            )
+
+        assert response.status == 204
+        header_block = bytes(received).split(b"\r\n\r\n", 1)[0].lower()
+        assert header_block.count(b"content-type:") == 1
+        assert b"content-type: application/example\r\n" in header_block + b"\r\n"
 
     def test_ua_header_can_be_overridden(self) -> None:
         headers = {"uSeR-AgENt": "Definitely not urllib3!"}


### PR DESCRIPTION
Closes #3047.

## Summary

This updates request-header annotations to consistently accept `str` or `bytes` names and values across urllib3's request-facing APIs.

- A variance-safe mapping alias accepts string-only, bytes-only, cross-typed, mixed, and `HTTPHeaderDict` inputs.
- Response headers and `HTTPHeaderDict` outputs remain string-valued for existing response-side ergonomics.
- `HTTPConnection.putheader()` now matches the bytes support of its underlying standard-library API.
- Redirect, multipart, proxy, and JSON-header handling remain case-insensitive for string and bytes names.
- Boundary adapters preserve opaque byte values when an underlying string-only API, such as CONNECT tunneling or the browser Fetch API, must be used.
- Experimental HTTP/2 sources are untouched.

## Motivation

urllib3 can send bytes header names and values, but its public request annotations rejected them inconsistently. A single `Mapping[str | bytes, str | bytes]` is not sufficient because mapping key types are invariant: it rejects ordinary `dict[str, str]` and `HTTPHeaderDict` values. The alias used here expresses all homogeneous and mixed forms without widening response types.

The runtime adjustments cover second-order behavior exposed by the corrected contract, including lowercase bytes `Content-Type`, 303 content-header removal, cross-origin credential stripping, read-only mappings, proxy override ordering, repeated proxy fields, and lossless CONNECT serialization.

## Validation

- The typing reproduction reports 20 relevant errors on pristine `main` and passes with this change.
- Full urllib3 suite: 2,334 passed, 303 skipped, 4 expected failures.
- Changed-area tests under `python -bb`: 497 passed, 8 skipped.
- Requests downstream suite: 619 passed, 15 skipped, 1 expected failure.
- Botocore downstream suite: 60,613 passed, 126 skipped.
- Pyodide Chrome Emscripten validation: 2 passed.
- Real socket tests verify ordinary, proxy, and CONNECT header bytes without value corruption.
- All formatting and lint hooks passed.
- Full mypy adds no diagnostics; the sole reported `Final` diagnostic is also present on upstream `main`.

