### PR TITLE
Add streaming multipart encoder and decoder

### DIFF
--- a/changelog/624.feature.rst
+++ b/changelog/624.feature.rst
@@ -1,0 +1,4 @@
+Added ``urllib3.multipart.MultipartEncoder`` and ``MultipartDecoder`` for
+streaming ``multipart/form-data`` encoding and decoding. ``encode_multipart_formdata``
+now uses ``MultipartEncoder`` internally. The encoder supports ``seek(0, 0)`` to
+rewind all body parts for retries and redirects.

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -10,5 +10,6 @@ API Reference
    urllib3.exceptions
    urllib3.response
    urllib3.fields
+   urllib3.multipart
    urllib3.util
    contrib/index

--- a/docs/reference/urllib3.multipart.rst
+++ b/docs/reference/urllib3.multipart.rst
@@ -1,0 +1,44 @@
+Multipart Encoder and Decoder
+=============================
+
+.. module:: urllib3.multipart
+
+Encoder
+-------
+
+.. class:: MultipartEncoder(fields, *, boundary=None, encoding="utf-8", blocksize=32768)
+
+   A file-like, memory-efficient streaming ``multipart/form-data`` encoder.
+
+   .. automethod:: urllib3.multipart.MultipartEncoder.read
+   .. automethod:: urllib3.multipart.MultipartEncoder.tell
+   .. automethod:: urllib3.multipart.MultipartEncoder.seek
+   .. automethod:: urllib3.multipart.MultipartEncoder.seekable
+   .. autoattribute:: urllib3.multipart.MultipartEncoder.boundary
+   .. autoattribute:: urllib3.multipart.MultipartEncoder.content_type
+   .. autoattribute:: urllib3.multipart.MultipartEncoder.content_length
+   .. autoattribute:: urllib3.multipart.MultipartEncoder.headers
+
+.. class:: Part(headers, body)
+
+   A streaming multipart body part containing headers and a body stream.
+
+   .. automethod:: urllib3.multipart.Part.read
+   .. automethod:: urllib3.multipart.Part.peek
+   .. automethod:: urllib3.multipart.Part.rewind
+
+Decoder
+-------
+
+.. autoclass:: urllib3.multipart.MultipartDecoder
+    :members:
+
+.. autoclass:: urllib3.multipart.BodyPart
+    :members:
+
+Exceptions
+----------
+
+.. autoclass:: urllib3.multipart.ImproperBodyPartContentError
+
+.. autoclass:: urllib3.multipart.NonMultipartContentTypeError

--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -386,6 +386,28 @@ to specify the file's MIME type explicitly:
         }
     )
 
+For large files, stream the upload with :class:`~urllib3.multipart.MultipartEncoder`
+so the whole body is not buffered in memory. Pass the encoder as ``body`` and
+use ``encoder.headers`` for ``Content-Type`` and ``Content-Length``:
+
+.. code-block:: python
+
+    from urllib3.multipart import MultipartEncoder
+
+    with open("example.txt", "rb") as fp:
+        encoder = MultipartEncoder(
+            fields={"filefield": ("example.txt", fp, "text/plain")}
+        )
+        resp = urllib3.request(
+            "POST",
+            "https://httpbin.org/post",
+            body=encoder,
+            headers=encoder.headers,
+        )
+
+The encoder supports ``seek(0, 0)`` to rewind all parts for retries and redirects
+when every part body is seekable.
+
 For sending raw binary data simply specify the ``body`` argument. It's also
 recommended to set the ``Content-Type`` header:
 

--- a/src/urllib3/filepost.py
+++ b/src/urllib3/filepost.py
@@ -1,14 +1,10 @@
 from __future__ import annotations
 
 import binascii
-import codecs
 import os
 import typing
-from io import BytesIO
 
 from .fields import _TYPE_FIELD_VALUE_TUPLE, RequestField
-
-writer = codecs.lookup("utf-8")[3]
 
 _TYPE_FIELDS_SEQUENCE = typing.Sequence[
     typing.Union[tuple[str, _TYPE_FIELD_VALUE_TUPLE], RequestField]
@@ -62,28 +58,8 @@ def encode_multipart_formdata(
         If not specified, then a random boundary will be generated using
         :func:`urllib3.filepost.choose_boundary`.
     """
-    body = BytesIO()
-    if boundary is None:
-        boundary = choose_boundary()
+    # Lazy import to avoid a circular dependency with urllib3.multipart.encoder.
+    from .multipart import MultipartEncoder
 
-    for field in iter_field_objects(fields):
-        body.write(f"--{boundary}\r\n".encode("latin-1"))
-
-        writer(body).write(field.render_headers())
-        data = field.data
-
-        if isinstance(data, int):
-            data = str(data)  # Backwards compatibility
-
-        if isinstance(data, str):
-            writer(body).write(data)
-        else:
-            body.write(data)
-
-        body.write(b"\r\n")
-
-    body.write(f"--{boundary}--\r\n".encode("latin-1"))
-
-    content_type = f"multipart/form-data; boundary={boundary}"
-
-    return body.getvalue(), content_type
+    encoder = MultipartEncoder(typing.cast(typing.Any, fields), boundary=boundary)
+    return encoder.read(), encoder.content_type

--- a/src/urllib3/multipart/__init__.py
+++ b/src/urllib3/multipart/__init__.py
@@ -1,0 +1,22 @@
+"""Multipart support for urllib3."""
+
+from __future__ import annotations
+
+from .decoder import BodyPart as BodyPart
+from .decoder import ImproperBodyPartContentError as ImproperBodyPartContentError
+from .decoder import MultipartDecoder as MultipartDecoder
+from .decoder import NonMultipartContentTypeError as NonMultipartContentTypeError
+from .encoder import MultipartEncoder as MultipartEncoder
+from .encoder import Part as Part
+
+__authors__ = "Ian Stapleton Cordasco, Cory Benfield, Alex Chan"
+__copyright__ = "Copyright 2014 Ian Stapleton Cordasco, Cory Benfield"
+
+__all__ = [
+    "BodyPart",
+    "ImproperBodyPartContentError",
+    "MultipartDecoder",
+    "MultipartEncoder",
+    "NonMultipartContentTypeError",
+    "Part",
+]

--- a/src/urllib3/multipart/decoder.py
+++ b/src/urllib3/multipart/decoder.py
@@ -1,0 +1,151 @@
+"""Logic for parsing and decomposing a multipart response body."""
+
+from __future__ import annotations
+
+import email.parser
+import re
+import typing
+
+from .. import _collections
+from .. import response as _response
+from ..exceptions import HTTPError
+from ..util.util import to_bytes
+
+
+class ImproperBodyPartContentError(HTTPError):
+    """Raised when a body part does not contain a header/body separator."""
+
+
+class NonMultipartContentTypeError(HTTPError):
+    """Raised when Content-Type is not a multipart media type."""
+
+
+def _header_parser(headers: bytes) -> typing.Sequence[tuple[str, str]]:
+    parser = email.parser.BytesHeaderParser()
+    message = parser.parsebytes(headers + b"\r\n\r\n")
+    return list(message.raw_items())
+
+
+class BodyPart:
+    """This provides an easy way to interact with a single part of the body.
+
+    Body parts expose their headers and raw body bytes, similarly to
+    :class:`urllib3.response.HTTPResponse`.
+    """
+
+    def __init__(self, content: bytes, *, encoding: str = "utf-8"):
+        # Split into header section (if any) and the content
+        headerbytes, separator, bodybytes = content.partition(b"\r\n\r\n")
+        if b"\r\n\r\n" != separator:
+            raise ImproperBodyPartContentError("content does not contain CR-LF-CR-LF")
+
+        #: The bytes containing the body of this part.
+        self.data = bodybytes
+        if headerbytes != b"":
+            headers = _header_parser(headerbytes.lstrip())
+        else:
+            headers = []
+        #: The headers associated with this part
+        self.headers = _collections.HTTPHeaderDict(headers)
+
+
+class MultipartDecoder:
+    """This parses the full multipart/form-data payload.
+
+    The ``MultipartDecoder`` object parses the multipart payload of
+    a bytestring into a tuple of ``Response``-like ``BodyPart`` objects.
+
+    The basic usage is::
+
+        import urllib3
+        from urllib3.multipart import MultipartDecoder
+
+        response = urllib3.request("GET", url)
+        decoder = MultipartDecoder.from_response(response)
+        for part in decoder.parts:
+            print(part.headers['content-type'])
+
+    If the multipart content is not from a response, basic usage is::
+
+        from urllib3.multipart import MultipartDecoder
+
+        decoder = MultipartDecoder(content, content_type=content_type)
+        for part in decoder.parts:
+            print(part.headers['content-type'])
+
+    ``content_type`` and ``encoding`` are keyword-only arguments.
+    """
+
+    def __init__(self, content: bytes, *, content_type: str, encoding: str = "utf-8"):
+        #: Original Content-Type header
+        self.content_type = content_type
+        #: Response body encoding
+        self.encoding = encoding
+        #: Parsed parts of the multipart response body
+        self.parts: tuple[BodyPart, ...] = ()
+        self.boundary: bytes
+        self._find_boundary()
+        self._parse_body(content)
+
+    def _find_boundary(self) -> None:
+        if not self.content_type.strip():
+            raise NonMultipartContentTypeError("Content-Type must not be empty")
+
+        boundary_parameter = re.search(
+            r"(?:^|;)\s*boundary\s*=\s*", self.content_type, flags=re.IGNORECASE
+        )
+        if boundary_parameter is not None:
+            raw_value = self.content_type[boundary_parameter.end() :]
+            if (
+                raw_value.startswith('"')
+                and re.match(r'^"(?:[^"\\]|\\.)*"', raw_value) is None
+            ):
+                raise NonMultipartContentTypeError(
+                    f"Unterminated boundary parameter in Content-Type: "
+                    f"{self.content_type!r}"
+                )
+
+        parser = email.parser.HeaderParser()
+        message = parser.parsestr(f"Content-Type: {self.content_type}\n\n")
+        mime_type = message.get_content_type()
+        if mime_type.split("/", 1)[0].lower() != "multipart":
+            raise NonMultipartContentTypeError(
+                f"Unexpected MIME type in Content-Type: {mime_type!r}"
+            )
+        boundary = message.get_param("boundary", header="Content-Type")
+        if isinstance(boundary, str) and boundary:
+            self.boundary = to_bytes(boundary, self.encoding)
+            return
+        raise NonMultipartContentTypeError(
+            f"No boundary parameter found in Content-Type: {self.content_type!r}"
+        )
+
+    def _parse_body(self, content: bytes) -> None:
+        delimiter = re.compile(
+            rb"(?:^|\r\n)--"
+            + re.escape(self.boundary)
+            + rb"(?P<close>--)?[ \t]*(?:\r\n|$)"
+        )
+        matches = list(delimiter.finditer(content))
+        parts: list[BodyPart] = []
+        for index, match in enumerate(matches):
+            if match.group("close") is not None:
+                break
+            if index + 1 >= len(matches):
+                break
+            next_match = matches[index + 1]
+            part_data = content[match.end() : next_match.start()]
+            parts.append(BodyPart(part_data, encoding=self.encoding))
+        self.parts = tuple(parts)
+
+    @classmethod
+    def from_response(
+        cls,
+        response: _response.HTTPResponse,
+        encoding: str = "utf-8",
+    ) -> MultipartDecoder:
+        content = response.data
+        content_type = response.headers.get("content-type", None)
+        if content_type is None:
+            raise ValueError("Cannot determine Content-Type header from response")
+        return cls(content, content_type=content_type, encoding=encoding)

--- a/src/urllib3/multipart/encoder.py
+++ b/src/urllib3/multipart/encoder.py
@@ -1,0 +1,812 @@
+"""Streaming multipart/form-data encoder."""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import operator
+import os
+import typing
+
+from .. import _collections, fields, filepost
+from ..exceptions import UnrewindableBodyError
+from ..fields import RequestField
+from ..util.util import to_bytes
+
+P = typing.TypeVar("P", bound="Part")
+
+
+class Part:
+    """A single multipart body part (headers + body stream).
+
+    Provides :meth:`read` and :meth:`peek` similar to
+    :class:`io.BufferedReader`, streaming headers then body without buffering
+    the entire part.
+    """
+
+    def __init__(
+        self,
+        headers: bytes,
+        body: io.BytesIO | io.BufferedReader | FileWrapper | _CustomBytesIO,
+    ) -> None:
+        self.headers = headers
+        self.body = body
+        self._header_pos = 0
+        self.len = len(self.headers) + total_len(self.body)
+
+    def rewind(self) -> None:
+        """Reset part state for reuse. Seeks body to start if seekable.
+
+        :raises UnrewindableBodyError: If the body stream cannot be rewound.
+        """
+        self._header_pos = 0
+        body = self.body
+        if isinstance(body, FileWrapper):
+            fd = body.fd
+            if not hasattr(fd, "seek"):
+                raise UnrewindableBodyError(
+                    "Cannot rewind MultipartEncoder: part body stream has no "
+                    "seek() method. Use a seekable stream (such as an open file) "
+                    "to enable request retries and redirects."
+                )
+            if hasattr(fd, "seekable") and not fd.seekable():
+                raise UnrewindableBodyError(
+                    "Cannot rewind MultipartEncoder: part body is a non-seekable "
+                    "stream. Use a seekable stream (such as an open file) to enable "
+                    "request retries and redirects."
+                )
+            fd.seek(0)
+        elif hasattr(body, "seek"):
+            body.seek(0)
+
+    @classmethod
+    def from_field(cls: type[P], field: fields.RequestField, encoding: str) -> P:
+        """Create a part from a :class:`~urllib3.fields.RequestField`."""
+        headers = typing.cast(bytes, encode_with(field.render_headers(), encoding))
+        data: typing.Any = field.data
+        if isinstance(data, int):
+            data = str(data)  # Backwards compatibility
+        body = coerce_data(data, encoding)
+        return cls(headers, body)
+
+    def bytes_left_to_write(self) -> int:
+        """Return the number of unread bytes in this part."""
+        return (len(self.headers) - self._header_pos) + total_len(self.body)
+
+    def read(self, size: int | None = -1) -> bytes:
+        """Read up to ``size`` bytes from headers, then the body."""
+        if size is None or size < 0:
+            size = -1
+        if size == 0:
+            return b""
+
+        chunks: list[bytes] = []
+        remaining = size
+
+        if self._header_pos < len(self.headers):
+            header_left = self.headers[self._header_pos :]
+            if size == -1:
+                chunks.append(header_left)
+                self._header_pos = len(self.headers)
+            else:
+                take = header_left[:remaining]
+                chunks.append(take)
+                self._header_pos += len(take)
+                remaining -= len(take)
+                if remaining == 0:
+                    return b"".join(chunks)
+
+        if size == -1:
+            chunks.append(self.body.read(-1) or b"")
+        else:
+            chunks.append(self.body.read(remaining) or b"")
+
+        return b"".join(chunks)
+
+    def peek(self, size: int = 0) -> bytes:
+        """Return bytes without advancing the read position."""
+        if size < 0:
+            size = 0
+        header_left = self.headers[self._header_pos :]
+        if header_left:
+            if size == 0:
+                return header_left
+            return header_left[:size]
+
+        body = self.body
+        if hasattr(body, "peek"):
+            peeked = body.peek(size)
+            return peeked if peeked is not None else b""
+
+        if hasattr(body, "tell") and hasattr(body, "seek"):
+            pos = body.tell()
+            try:
+                if size == 0:
+                    peek_amount = 4096
+                    body_len = total_len(body)
+                    if body_len >= 0:
+                        peek_amount = min(peek_amount, body_len)
+                    return body.read(peek_amount) or b""
+                return body.read(size) or b""
+            finally:
+                body.seek(pos)
+
+        return b""
+
+    def write_to(self, buffer: _CustomBytesIO, size: int) -> int:
+        """Thin helper over :meth:`read` for the encoder buffer."""
+        return buffer.append(self.read(size))
+
+
+class _CustomBytesIO(io.BytesIO):
+    def __init__(
+        self,
+        buffer: typing.BinaryIO | str | bytes | None = None,
+        encoding: str = "utf-8",
+    ) -> None:
+        if buffer is None:
+            buffer = b""
+        if isinstance(buffer, (io.RawIOBase, io.BufferedIOBase)):
+            bufferbytes = buffer.read() or b""
+        elif isinstance(buffer, (str, bytes)):
+            bufferbytes = encode_with(buffer, encoding)
+        else:
+            bufferbytes = buffer.read()
+        super().__init__(bufferbytes)
+
+    def _get_end(self) -> int:
+        current_pos = self.tell()
+        self.seek(0, 2)
+        length = self.tell()
+        self.seek(current_pos, 0)
+        return length
+
+    @property
+    def len(self) -> int:
+        length = self._get_end()
+        return length - self.tell()
+
+    def append(self, data: bytes) -> int:
+        with reset(self):
+            written = self.write(data)
+        return written
+
+    def smart_truncate(self) -> None:
+        to_be_read = total_len(self)
+        already_read = self._get_end() - to_be_read
+
+        if already_read >= to_be_read:
+            old_bytes = self.read()
+            self.seek(0, 0)
+            self.truncate()
+            self.write(old_bytes)
+            self.seek(0, 0)
+
+
+class FileWrapper:
+    def __init__(self, file_object: typing.BinaryIO):
+        self.fd = file_object
+        self._total_len = total_len(self.fd)
+
+    @property
+    def len(self) -> int:
+        return self._total_len - self.fd.tell()
+
+    def read(self, length: int = -1) -> bytes:
+        return self.fd.read(length)
+
+    def peek(self, size: int = 0) -> bytes:
+        if hasattr(self.fd, "peek"):
+            return typing.cast(bytes, self.fd.peek(size))
+        if not self.rewindable():
+            return b""
+        position = self.fd.tell()
+        try:
+            return self.fd.read(size or 4096)
+        finally:
+            self.fd.seek(position)
+
+    def rewindable(self) -> bool:
+        if not hasattr(self.fd, "seek"):
+            return False
+        if hasattr(self.fd, "seekable") and not self.fd.seekable():
+            return False
+        try:
+            position = self.fd.tell()
+            self.fd.seek(position)
+        except (OSError, ValueError):
+            return False
+        return True
+
+
+BytesLike: typing.TypeAlias = bytes | bytearray | memoryview
+
+PartTuples = typing.Union[
+    tuple[str, typing.Union[BytesLike, str, typing.BinaryIO]],
+    tuple[
+        str,
+        typing.Union[BytesLike, str, typing.BinaryIO],
+        typing.Union[bytes, str],
+    ],
+    tuple[
+        str,
+        typing.Union[BytesLike, str, typing.BinaryIO],
+        typing.Union[bytes, str],
+        typing.Mapping[str, str],
+    ],
+]
+
+FieldValue: typing.TypeAlias = typing.Union[
+    BytesLike, str, int, PartTuples, typing.BinaryIO
+]
+
+Fields = typing.Union[
+    typing.Mapping[str, FieldValue],
+    typing.Sequence[tuple[str, FieldValue] | RequestField],
+]
+
+
+class MultipartEncoder:
+    """A memory-efficient way of streaming large files in multipart/form-data format.
+
+    The basic usage is:
+
+    .. code-block:: python
+
+        import urllib3
+        from urllib3.multipart import MultipartEncoder
+
+        pm = urllib3.PoolManager()
+        encoder = MultipartEncoder({'field': 'value',
+                                    'other_field': 'other_value'})
+        r = pm.urlopen(
+            method='POST',
+            url='https://httpbin.org/post',
+            body=encoder,
+            headers=encoder.headers,
+        )
+
+    If you do not need to take advantage of streaming the post body, you can
+    also do:
+
+    .. code-block:: python
+
+        import urllib3
+        from urllib3.multipart import MultipartEncoder
+
+        pm = urllib3.PoolManager()
+        encoder = MultipartEncoder({'field': 'value',
+                                    'other_field': 'other_value'})
+        r = pm.urlopen(
+            method='POST',
+            url='https://httpbin.org/post',
+            body=encoder.read(),
+            headers=encoder.headers,
+        )
+
+    If you want the encoder to use a specific order, you can use an
+    :class:`~urllib3.HTTPHeaderDict` or a list of tuples:
+
+    .. code-block:: python
+
+        encoder = MultipartEncoder([('field', 'value'),
+                                    ('other_field', 'other_value')])
+
+    You can also provide tuples as part values in the same formats as are
+    supported by :meth:`~urllib3.fields.RequestField.from_tuples`
+
+    .. code-block:: python
+
+        encoder = MultipartEncoder({
+            'field': ('file_name', b'{"a": "b"}', 'application/json',
+                      {'X-My-Header': 'my-value'})
+        })
+
+    Bare file-like objects with a ``.name`` attribute use
+    ``os.path.basename(name)`` as the filename; objects without ``.name``
+    (for example :class:`io.BytesIO`) omit a filename.
+
+    Finally, you can also optionally specify the boundary string to use.
+
+    The encoder supports :meth:`seek` (0, 0) to rewind to the start, enabling
+    request retries and redirects. Use :meth:`tell` to get the current read
+    position.
+    """
+
+    def __init__(
+        self,
+        fields: Fields,
+        *,
+        boundary: str | None = None,
+        encoding: str = "utf-8",
+        blocksize: int = 8192 * 4,
+    ):
+        self._boundary_value: str = (
+            boundary if boundary is not None else filepost.choose_boundary()
+        )
+        self._boundary: str = f"--{self._boundary_value}"
+        self._enc: str = encoding
+        # Keep compatibility with encode_multipart_formdata(), which has always
+        # encoded boundary delimiters as latin-1 independently of field data.
+        self._encoded_boundary = to_bytes(self._boundary + "\r\n", "latin-1")
+        self._fields = fields
+        if blocksize <= 0:
+            raise ValueError("blocksize must be greater than zero")
+        self._blocksize = blocksize
+        self._finished: bool = False
+        self._current_part: Part | None = None
+        self._len: int | None = None
+        self._bytes_read: int = 0
+        self._buffer = _CustomBytesIO(encoding=encoding)
+        self._parts, self._iter_parts = self._prepare_parts()
+        self._write_boundary()
+
+    @property
+    def boundary(self) -> str:
+        """Boundary value either passed in by the user or generated."""
+        return self._boundary_value
+
+    @property
+    def blocksize(self) -> int:
+        """Number of bytes read per iteration."""
+        return self._blocksize
+
+    @property
+    def encoding(self) -> str:
+        """Encoding of the data being passed in."""
+        return self._enc
+
+    @property
+    def fields(self) -> Fields:
+        """Fields provided by the user."""
+        return self._fields
+
+    @property
+    def finished(self) -> bool:
+        """Whether the encoder has been consumed."""
+        return self._finished
+
+    def __iter__(self) -> typing.Iterator[bytes]:
+        while chunk := self.read(self._blocksize):
+            yield chunk
+
+    def __next__(self) -> bytes:
+        chunk = self.read(self._blocksize)
+        if not chunk:
+            raise StopIteration()
+        return chunk
+
+    @property
+    def len(self) -> int:
+        """Length of the multipart/form-data body.
+
+        This is a property instead of ``__len__`` so bodies larger than
+        :data:`sys.maxsize` remain representable on all Python platforms.
+        """
+        return self._len if self._len is not None else self._calculate_length()
+
+    def __repr__(self) -> str:
+        return f"<MultipartEncoder: {self._fields!r}>"
+
+    def _calculate_length(self) -> int:
+        """
+        This uses the parts to calculate the length of the body.
+
+        This returns the calculated length so :attr:`len` can be lazy.
+        """
+        boundarycrnl_len = len(to_bytes(self._boundary, "latin-1")) + len(b"\r\n\r\n")
+        self._len = sum(total_len(p) for p in self._parts) + (
+            boundarycrnl_len * (len(self._parts) + 1)
+        )
+        return self._len
+
+    def _calculate_load_amount(self, read_size: int) -> int:
+        """This calculates how many bytes need to be added to the buffer.
+
+        When a consumer reads ``x`` from the buffer, there are two cases to
+        satisfy:
+
+            1. Enough data in the buffer to return the requested amount
+            2. Not enough data
+
+        This function uses the amount of unread bytes in the buffer and
+        determines how much the Encoder has to load before it can return the
+        requested amount of bytes.
+
+        :param int read_size: the number of bytes the consumer requests
+        :returns: int -- the number of bytes that must be loaded into the
+            buffer before the read can be satisfied. This will be strictly
+            non-negative
+        """
+        amount = read_size - total_len(self._buffer)
+        return amount if amount > 0 else 0
+
+    def _load(self, amount: int) -> None:
+        """Load ``amount`` number of bytes into the buffer."""
+        self._buffer.smart_truncate()
+        part = self._current_part or self._next_part()
+        while amount == -1 or amount > 0:
+            written = 0
+            if part and not part.bytes_left_to_write():
+                written += self._write(b"\r\n")
+                written += self._write_boundary()
+                part = self._next_part()
+
+            if not part:
+                written += self._write_closing_boundary()
+                self._finished = True
+                break
+
+            part_written = part.write_to(self._buffer, amount)
+            if part_written == 0 and part.bytes_left_to_write():
+                raise OSError("Multipart body stream ended before its declared length")
+            written += part_written
+
+            if amount != -1:
+                amount -= written
+
+    def _next_part(self) -> Part | None:
+        try:
+            p = self._current_part = next(self._iter_parts)
+            if isinstance(p.body, FileWrapper) and p.body.rewindable():
+                p.body.fd.seek(0)
+            return p
+        except StopIteration:
+            return None
+
+    def _iter_fields(self) -> typing.Iterator[RequestField]:
+        for item in to_list(self._fields):
+            if isinstance(item, RequestField):
+                yield item
+                continue
+
+            name, v = item
+            filename: str | None = None
+            content_type: str | bytes | None = None
+            headers: typing.Mapping[str, str] | None = None
+            if isinstance(v, (list, tuple)):
+                if len(v) == 2:
+                    filename, data = typing.cast(tuple[str, typing.Any], v)
+                    content_type = fields.guess_content_type(filename)
+                elif len(v) == 3:
+                    filename, data, content_type = typing.cast(
+                        tuple[str, typing.Any, str | bytes], v
+                    )
+                elif len(v) == 4:
+                    filename, data, content_type, headers = typing.cast(
+                        tuple[
+                            str,
+                            typing.Any,
+                            str | bytes,
+                            typing.Mapping[str, str],
+                        ],
+                        v,
+                    )
+                else:
+                    raise ValueError(
+                        "multipart field tuples must contain 2, 3, or 4 items"
+                    )
+            else:
+                data = v
+                if (
+                    filename is None
+                    and hasattr(data, "read")
+                    and not isinstance(data, (str, bytes, int))
+                ):
+                    # Bare file-like: use basename of .name when present.
+                    # Do not invent a filename for objects like BytesIO.
+                    name_attr = getattr(data, "name", None)
+                    if isinstance(name_attr, (str, bytes)) and name_attr:
+                        if isinstance(name_attr, bytes):
+                            name_attr = name_attr.decode("utf-8", errors="replace")
+                        if not name_attr.startswith("<") and name_attr not in (
+                            "stdin",
+                            "stdout",
+                            "stderr",
+                        ):
+                            filename = os.path.basename(name_attr)
+                            content_type = fields.guess_content_type(filename)
+
+            if isinstance(data, int):
+                data = str(data)  # Backwards compatibility
+
+            field = fields.RequestField(
+                name=name, data=data, filename=filename, headers=headers
+            )
+            if isinstance(content_type, bytes):
+                content_type = content_type.decode("utf-8")
+            field.make_multipart(content_type=content_type)
+            yield field
+
+    def _prepare_parts(self) -> tuple[list[Part], typing.Iterator[Part]]:
+        """This uses the fields provided by the user and creates Part objects.
+
+        It returns the new value for the `parts` attribute and creates a
+        generator for iteration.
+        """
+        enc = self._enc
+        parts = [Part.from_field(f, enc) for f in self._iter_fields()]
+        seen_streams: set[int] = set()
+        for part in parts:
+            if not isinstance(part.body, FileWrapper):
+                continue
+            stream_id = id(part.body.fd)
+            if stream_id in seen_streams and not part.body.rewindable():
+                raise ValueError(
+                    "The same non-seekable stream cannot be used for multiple "
+                    "multipart fields"
+                )
+            seen_streams.add(stream_id)
+        return parts, iter(parts)
+
+    def _write(self, bytes_to_write: bytes | bytearray) -> int:
+        """Write the bytes to the end of the buffer.
+
+        :param bytes bytes_to_write: byte-string (or bytearray) to append to
+            the buffer
+        :returns: int -- the number of bytes written
+        """
+        return self._buffer.append(bytes_to_write)
+
+    def _write_boundary(self) -> int:
+        """Write the boundary to the end of the buffer."""
+        return self._write(self._encoded_boundary)
+
+    def _write_closing_boundary(self) -> int:
+        """Write the bytes necessary to finish a multipart/form-data body.
+
+        This overwrites the trailing ``\\r\\n`` of the last boundary with
+        ``--\\r\\n``, converting it into a closing boundary.  Four bytes are
+        written in total, but two of them replace bytes that already existed in
+        the buffer, so the net growth of the readable buffer is 2.  That net
+        figure is what callers use to update their ``amount`` counter; it is
+        returned here for consistency even though :meth:`_load` always breaks
+        immediately after this call and never reads the return value.
+        """
+        with reset(self._buffer):
+            self._buffer.seek(-2, 2)
+            self._buffer.write(b"--\r\n")
+        return 2  # net bytes added (4 written − 2 overwritten)
+
+    @property
+    def content_type(self) -> str:
+        return f"multipart/form-data; boundary={self._boundary_value}"
+
+    @property
+    def content_length(self) -> str:
+        return str(self.len)
+
+    @property
+    def headers(self) -> _collections.HTTPHeaderDict:
+        return _collections.HTTPHeaderDict(
+            {
+                "Content-Type": self.content_type,
+                "Content-Length": self.content_length,
+            }
+        )
+
+    def read(self, size: int | None = -1) -> bytes:
+        """Read data from the streaming encoder.
+
+        :param int size: (optional), If provided, ``read`` will return exactly
+            that many bytes. If ``-1`` or ``None``, it will return all
+            remaining bytes.
+        :returns: bytes
+        """
+        if size is None or size < 0:
+            size = -1
+
+        if self._finished:
+            data = self._buffer.read(size)
+            self._bytes_read += len(data)
+            return data
+
+        if size == -1:
+            bytes_to_load: int = -1
+        else:
+            bytes_to_load = self._calculate_load_amount(size)
+
+        self._load(bytes_to_load)
+        data = self._buffer.read(size)
+        self._bytes_read += len(data)
+        return data
+
+    def tell(self) -> int:
+        """Return the number of bytes read so far."""
+        return self._bytes_read
+
+    def seek(self, pos: int, whence: int = 0) -> int:
+        """Seek to a position in the stream.
+
+        Only ``seek(0, 0)`` (rewind to start) is supported. This allows
+        request retries and redirects to work correctly.
+
+        :param int pos: Position to seek to.
+        :param int whence: Seek mode (0=start, 1=current, 2=end).
+        :returns: The new position.
+        :raises UnrewindableBodyError: If any part uses a non-seekable stream.
+        :raises ValueError: If seeking to a non-zero position.
+        """
+        if whence != 0 or pos != 0:
+            raise UnrewindableBodyError(
+                "MultipartEncoder only supports seek(0, 0) to rewind to the start. "
+                "Use seek(0) for retries and redirects."
+            )
+        if any(
+            isinstance(part.body, FileWrapper) and not hasattr(part.body.fd, "seek")
+            for part in self._parts
+        ):
+            raise UnrewindableBodyError(
+                "Cannot rewind MultipartEncoder: at least one part body stream "
+                "has no seek() method. Use seekable streams to enable request "
+                "retries and redirects."
+            )
+        if any(
+            isinstance(part.body, FileWrapper) and not part.body.rewindable()
+            for part in self._parts
+        ):
+            raise UnrewindableBodyError(
+                "Cannot rewind MultipartEncoder: at least one part body is a "
+                "non-seekable stream. Use seekable streams to enable request "
+                "retries and redirects."
+            )
+        for part in self._parts:
+            part.rewind()
+        self._finished = False
+        self._current_part = None
+        self._iter_parts = iter(self._parts)
+        self._bytes_read = 0
+        self._buffer.truncate(0)
+        self._buffer.seek(0)
+        self._write_boundary()
+        return 0
+
+    def seekable(self) -> bool:
+        """Return whether all multipart body streams can be rewound."""
+        return all(
+            not isinstance(part.body, FileWrapper) or part.body.rewindable()
+            for part in self._parts
+        )
+
+
+def encode_with(string: str | bytes | None, encoding: str) -> bytes | None:
+    """Encode ``string`` with ``encoding`` if necessary.
+
+    :param str string: If string is a bytes object, it will not encode it.
+        Otherwise, this function will encode it with the provided encoding.
+    :param str encoding: The encoding with which to encode string.
+    :returns: encoded bytes object
+    """
+    if string is None:
+        return None
+    return to_bytes(string, encoding)
+
+
+def total_len(
+    o: (
+        Part
+        | FileWrapper
+        | typing.AnyStr
+        | typing.TextIO
+        | typing.BinaryIO
+        | typing.Sized
+    ),
+) -> int:
+    if hasattr(o, "__len__"):
+        o = typing.cast(typing.Union[typing.Sized, typing.AnyStr], o)
+        length = operator.index(o.__len__())
+        if length < 0:
+            raise ValueError("__len__() should return >= 0")
+        return length
+
+    if hasattr(o, "len"):
+        o = typing.cast(typing.Union[Part, FileWrapper, _CustomBytesIO], o)
+        return o.len
+
+    if hasattr(o, "fileno"):
+        try:
+            fileno = o.fileno()
+        except io.UnsupportedOperation:
+            pass
+        else:
+            return os.fstat(fileno).st_size
+
+    if hasattr(o, "getvalue"):
+        o = typing.cast(typing.Union[io.BytesIO, io.StringIO], o)
+        return len(o.getvalue())
+
+    raise ValueError("Unable to compute size", o)
+
+
+@contextlib.contextmanager
+def reset(buffer: typing.BinaryIO) -> typing.Iterator[None]:
+    """Keep track of the buffer's current position and write to the end.
+
+    This is a context manager meant to be used when adding data to the buffer.
+    It eliminates the need for every function to be concerned with the
+    position of the cursor in the buffer.
+    """
+    original_position = buffer.tell()
+    buffer.seek(0, 2)
+    yield
+    buffer.seek(original_position, 0)
+
+
+def coerce_data(
+    data: _CustomBytesIO | io.BytesIO | typing.BinaryIO | str | BytesLike,
+    encoding: str,
+) -> _CustomBytesIO | FileWrapper:
+    """Ensure that every object's __len__ behaves uniformly."""
+    if not isinstance(data, _CustomBytesIO):
+        if isinstance(data, io.BytesIO):
+            data.seek(0)
+            return FileWrapper(data)
+
+        if isinstance(data, (bytes, bytearray, memoryview)):
+            return _CustomBytesIO(bytes(data), encoding)
+
+        if isinstance(data, str):
+            return _CustomBytesIO(data, encoding)
+
+        try:
+            buffer = memoryview(typing.cast(typing.Any, data))
+        except TypeError:
+            pass
+        else:
+            return _CustomBytesIO(bytes(buffer), encoding)
+
+        if hasattr(data, "fileno"):
+            if hasattr(data, "seekable") and data.seekable():
+                data.seek(0)
+            elif hasattr(data, "tell"):
+                if data.tell() != 0:
+                    raise ValueError(
+                        "Non-seekable stream is at a non-zero position; "
+                        "cannot encode partial data. Seek to position 0 before passing "
+                        "this stream, or use a seekable stream."
+                    )
+            else:
+                raise ValueError(
+                    "Stream has no tell() method; cannot verify it is at position 0. "
+                    "Use a seekable stream, or provide a stream with a tell() method."
+                )
+            return FileWrapper(data)
+
+        # Sized, file-like objects can be streamed without a file descriptor.
+        if hasattr(data, "read"):
+            if hasattr(data, "seekable") and data.seekable():
+                data.seek(0)
+            elif hasattr(data, "tell"):
+                if data.tell() != 0:
+                    raise ValueError(
+                        "Non-seekable stream is at a non-zero position; "
+                        "cannot encode partial data. Seek to position 0 before passing "
+                        "this stream, or use a seekable stream."
+                    )
+            else:
+                raise ValueError(
+                    "Stream has no tell() method; cannot verify it is at position 0. "
+                    "Use a seekable stream, or provide a stream with a tell() method."
+                )
+            total_len(data)
+            return FileWrapper(data)
+
+        raise TypeError(
+            f"Unsupported data type for multipart encoding: {type(data)!r}. "
+            "Expected str, bytes, io.BytesIO, or a file-like object with a "
+            "fileno() method."
+        )
+
+    return data
+
+
+def to_list(
+    fields: Fields,
+) -> list[tuple[str, FieldValue] | RequestField]:
+    if isinstance(fields, typing.Mapping):
+        return list(fields.items())
+
+    result: list[tuple[str, FieldValue] | RequestField] = []
+    for item in fields:
+        result.append(item)
+    return result

--- a/test/multipart/test_decoder.py
+++ b/test/multipart/test_decoder.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import pytest
+
+from urllib3 import HTTPResponse
+from urllib3.exceptions import HTTPError
+from urllib3.multipart import (
+    ImproperBodyPartContentError,
+    MultipartDecoder,
+    MultipartEncoder,
+    NonMultipartContentTypeError,
+)
+from urllib3.multipart.decoder import BodyPart
+
+
+class TestMultipartDecoder:
+    def test_basic_decode(self) -> None:
+        encoder = MultipartEncoder([("a", "1"), ("b", "2")], boundary="bound")
+        body = encoder.read()
+        decoder = MultipartDecoder(body, content_type=encoder.content_type)
+        assert len(decoder.parts) == 2
+        assert decoder.parts[0].data == b"1"
+        assert decoder.parts[1].data == b"2"
+        assert decoder.parts[0].headers["Content-Disposition"] == (
+            'form-data; name="a"'
+        )
+
+    def test_body_part_text(self) -> None:
+        part = BodyPart(b'Content-Disposition: form-data; name="x"\r\n\r\nhello')
+        assert part.data == b"hello"
+
+    def test_body_part_without_headers(self) -> None:
+        part = BodyPart(b"\r\n\r\nbody")
+        assert part.data == b"body"
+        assert not part.headers
+
+    def test_duplicate_part_headers_are_preserved(self) -> None:
+        part = BodyPart(b"X-Value: one\r\nX-Value: two\r\n\r\ndata")
+        assert part.headers.getlist("X-Value") == ["one", "two"]
+
+    def test_decoder_errors_are_http_errors(self) -> None:
+        assert issubclass(ImproperBodyPartContentError, HTTPError)
+        assert issubclass(NonMultipartContentTypeError, HTTPError)
+
+    def test_improper_body_part(self) -> None:
+        with pytest.raises(ImproperBodyPartContentError):
+            BodyPart(b"no-separator")
+
+    def test_non_multipart_content_type(self) -> None:
+        with pytest.raises(NonMultipartContentTypeError):
+            MultipartDecoder(b"x", content_type="text/plain")
+
+    def test_missing_boundary(self) -> None:
+        with pytest.raises(NonMultipartContentTypeError):
+            MultipartDecoder(b"x", content_type="multipart/form-data")
+
+    def test_empty_content_type(self) -> None:
+        with pytest.raises(NonMultipartContentTypeError, match="must not be empty"):
+            MultipartDecoder(b"x", content_type="")
+
+    def test_unterminated_quoted_boundary(self) -> None:
+        with pytest.raises(NonMultipartContentTypeError, match="Unterminated boundary"):
+            MultipartDecoder(
+                b"x", content_type='multipart/form-data; boundary="missing'
+            )
+
+    def test_quoted_boundary_with_semicolon(self) -> None:
+        decoder = MultipartDecoder(
+            b'--a;b\r\nContent-Disposition: form-data; name="x"\r\n\r\ny\r\n--a;b--\r\n',
+            content_type='multipart/form-data; boundary="a;b"',
+        )
+        assert decoder.boundary == b"a;b"
+        assert decoder.parts[0].data == b"y"
+
+    def test_preamble_and_epilogue_are_ignored(self) -> None:
+        decoder = MultipartDecoder(
+            b'preamble\r\n--b\r\nContent-Disposition: form-data; name="x"'
+            b"\r\n\r\ny\r\n--b--\r\nepilogue",
+            content_type="multipart/form-data; boundary=b",
+        )
+        assert len(decoder.parts) == 1
+        assert decoder.parts[0].data == b"y"
+
+    def test_boundary_prefix_inside_body_is_not_a_delimiter(self) -> None:
+        decoder = MultipartDecoder(
+            b'--b\r\nContent-Disposition: form-data; name="x"\r\n\r\n'
+            b"first\r\n--boundary-is-data\r\nlast\r\n--b--\r\n",
+            content_type="multipart/form-data; boundary=b",
+        )
+        assert decoder.parts[0].data == (b"first\r\n--boundary-is-data\r\nlast")
+
+    def test_opening_boundary_without_following_boundary_has_no_parts(self) -> None:
+        decoder = MultipartDecoder(
+            b"--b\r\nContent-Disposition: form-data\r\n\r\ndata",
+            content_type="multipart/form-data; boundary=b",
+        )
+        assert decoder.parts == ()
+
+    def test_closing_boundary_before_parts_has_no_parts(self) -> None:
+        decoder = MultipartDecoder(
+            b"--b--\r\n", content_type="multipart/form-data; boundary=b"
+        )
+        assert decoder.parts == ()
+
+    def test_body_without_any_boundary_has_no_parts(self) -> None:
+        decoder = MultipartDecoder(
+            b"not a multipart delimiter",
+            content_type="multipart/form-data; boundary=b",
+        )
+        assert decoder.parts == ()
+
+    def test_from_response(self) -> None:
+        response = HTTPResponse(
+            body=(
+                b'--b\r\nContent-Disposition: form-data; name="x"\r\n\r\n'
+                b"data\r\n--b--\r\n"
+            ),
+            headers={"Content-Type": "multipart/form-data; boundary=b"},
+        )
+        decoder = MultipartDecoder.from_response(response)
+        assert decoder.parts[0].data == b"data"
+
+    def test_from_response_requires_content_type(self) -> None:
+        with pytest.raises(ValueError, match="Cannot determine Content-Type"):
+            MultipartDecoder.from_response(HTTPResponse(body=b"data"))
+
+    def test_file_part_round_trip(self) -> None:
+        encoder = MultipartEncoder(
+            [("file", ("name.bin", b"\x00\x01", "application/octet-stream"))],
+            boundary="b",
+        )
+        body = encoder.read()
+        decoder = MultipartDecoder(body, content_type=encoder.content_type)
+        assert len(decoder.parts) == 1
+        assert decoder.parts[0].data == b"\x00\x01"
+        assert decoder.parts[0].headers["Content-Type"] == "application/octet-stream"

--- a/test/multipart/test_encoder.py
+++ b/test/multipart/test_encoder.py
@@ -1,0 +1,915 @@
+from __future__ import annotations
+
+import io
+import os
+import tempfile
+import typing
+import unittest
+
+import pytest
+
+from urllib3 import filepost
+from urllib3.exceptions import UnrewindableBodyError
+from urllib3.fields import RequestField
+from urllib3.multipart import MultipartDecoder, MultipartEncoder, Part
+from urllib3.multipart.encoder import (
+    FileWrapper,
+    _CustomBytesIO,
+    coerce_data,
+    encode_with,
+    total_len,
+)
+
+
+class LargeFileMock:
+    """Simulates a large file-like object without allocating real memory."""
+
+    def __init__(self) -> None:
+        self.bytes_read = 0
+        self.bytes_max = 1024 * 1024 * 1024  # 1 GB
+
+    def fileno(self) -> int:
+        raise io.UnsupportedOperation("mock file has no real fd")
+
+    @property
+    def name(self) -> str:
+        return "fake_name.py"
+
+    def __len__(self) -> int:
+        return self.bytes_max
+
+    def read(self, size: int | None = None) -> bytes:
+        if self.bytes_read >= self.bytes_max:
+            return b""
+
+        if size is None:
+            length = self.bytes_max - self.bytes_read
+        else:
+            length = size
+
+        length = int(length)
+        length = min(length, self.bytes_max - self.bytes_read)
+
+        self.bytes_read += length
+
+        return b"a" * length
+
+    def tell(self) -> int:
+        return self.bytes_read
+
+
+class TestCustomBytesIO(unittest.TestCase):
+    def setUp(self) -> None:
+        self.instance = _CustomBytesIO()
+
+    def test_can_read_after_writing_to(self) -> None:
+        self.instance.write(b"example text")
+        self.instance.seek(0, 0)
+        assert self.instance.read() == b"example text"
+
+    def test_can_get_length(self) -> None:
+        self.instance.write(b"example")
+        self.instance.seek(0, 0)
+        assert self.instance.len == 7
+
+    def test_truncates_intelligently(self) -> None:
+        self.instance.write(b"abcdefghijklmnopqrstuvwxyzabcd")  # 30 bytes
+        assert self.instance.tell() == 30
+        self.instance.seek(-10, 2)
+        self.instance.smart_truncate()
+        assert self.instance.len == 10
+        assert self.instance.read() == b"uvwxyzabcd"
+
+    def test_constructs_from_buffered_io(self) -> None:
+        instance = _CustomBytesIO(io.BytesIO(b"buffered"))
+        assert instance.read() == b"buffered"
+
+    def test_constructs_from_generic_reader(self) -> None:
+        class Reader:
+            def read(self) -> bytes:
+                return b"generic"
+
+        instance = _CustomBytesIO(Reader())  # type: ignore[arg-type]
+        assert instance.read() == b"generic"
+
+
+class TestFileWrapper:
+    def test_peek_seekable_unbuffered_stream_does_not_advance(self) -> None:
+        class Stream:
+            def __init__(self) -> None:
+                self.position = 0
+
+            def __len__(self) -> int:
+                return 3
+
+            def tell(self) -> int:
+                return self.position
+
+            def seek(self, position: int) -> int:
+                self.position = position
+                return position
+
+            def read(self, size: int = -1) -> bytes:
+                end = 3 if size < 0 else self.position + size
+                value = b"abc"[self.position : end]
+                self.position += len(value)
+                return value
+
+        stream = Stream()
+        wrapper = FileWrapper(stream)  # type: ignore[arg-type]
+        assert wrapper.peek(2) == b"ab"
+        assert stream.tell() == 0
+
+    def test_peek_nonrewindable_stream_returns_empty(self) -> None:
+        class Stream:
+            def __len__(self) -> int:
+                return 1
+
+            def tell(self) -> int:
+                return 0
+
+            def read(self, size: int = -1) -> bytes:
+                return b"x"
+
+        wrapper = FileWrapper(Stream())  # type: ignore[arg-type]
+        assert wrapper.peek() == b""
+
+
+class TestPart(unittest.TestCase):
+    def test_read_streams_headers_then_body(self) -> None:
+        part = Part(b"HDR\r\n\r\n", _CustomBytesIO(b"BODY"))
+        assert part.read(3) == b"HDR"
+        assert part.read(4) == b"\r\n\r\n"
+        assert part.read() == b"BODY"
+        assert part.read() == b""
+
+    def test_read_zero_does_not_advance(self) -> None:
+        part = Part(b"HDR", _CustomBytesIO(b"BODY"))
+        assert part.read(0) == b""
+        assert part.read() == b"HDRBODY"
+
+    def test_read_all_accepts_any_negative_size_or_none(self) -> None:
+        for size in (None, -1, -2):
+            part = Part(b"HDR", _CustomBytesIO(b"BODY"))
+            assert part.read(size) == b"HDRBODY"
+
+    def test_peek_does_not_advance(self) -> None:
+        part = Part(b"ABCDEF", _CustomBytesIO(b"body"))
+        assert part.peek(3) == b"ABC"
+        assert part.peek() == b"ABCDEF"
+        assert part.read(2) == b"AB"
+        assert part.peek(2) == b"CD"
+        assert part.read() == b"CDEFbody"
+
+    def test_peek_with_negative_size_returns_available_data(self) -> None:
+        part = Part(b"ABCDEF", _CustomBytesIO(b"body"))
+        assert part.peek(-1) == b"ABCDEF"
+
+    def test_peek_body_after_headers(self) -> None:
+        part = Part(b"H", _CustomBytesIO(b"xyz"))
+        assert part.read(1) == b"H"
+        assert part.peek(2) == b"xy"
+        assert part.read() == b"xyz"
+
+    def test_peek_body_with_default_size(self) -> None:
+        part = Part(b"H", _CustomBytesIO(b"xyz"))
+        part.read(1)
+        assert part.peek() == b"xyz"
+
+    def test_peek_unseekable_body_without_peek_returns_empty(self) -> None:
+        class Body:
+            def __len__(self) -> int:
+                return 1
+
+            def read(self, size: int = -1) -> bytes:
+                return b"x"
+
+        part = Part(b"", Body())  # type: ignore[arg-type]
+        assert part.peek() == b""
+
+    def test_peek_default_size_handles_unknown_remaining_length(self) -> None:
+        class Body:
+            len = -1
+
+            def __init__(self) -> None:
+                self.position = 0
+
+            def tell(self) -> int:
+                return self.position
+
+            def seek(self, position: int) -> int:
+                self.position = position
+                return position
+
+            def read(self, size: int = -1) -> bytes:
+                data = b"body"[self.position :]
+                self.position += len(data)
+                return data
+
+        body = Body()
+        part = Part(b"", body)  # type: ignore[arg-type]
+        assert part.peek() == b"body"
+        assert body.tell() == 0
+
+    def test_peek_open_file_body_without_advancing(self) -> None:
+        with open(__file__, "rb") as file_obj:
+            part = Part(b"H", FileWrapper(file_obj))
+            assert part.read(1) == b"H"
+            position = file_obj.tell()
+            peeked = part.peek(4)
+            assert file_obj.tell() == position
+            assert peeked.startswith(part.read(4))
+
+    def test_write_to_uses_read(self) -> None:
+        part = Part(b"hdr", _CustomBytesIO(b"data"))
+        buf = _CustomBytesIO()
+        written = part.write_to(buf, 4)
+        assert written == 4
+        assert buf.read() == b"hdrd"
+
+    def test_rewind_rejects_file_wrapper_without_seek(self) -> None:
+        class Body:
+            def __len__(self) -> int:
+                return 1
+
+            def tell(self) -> int:
+                return 0
+
+            def read(self, size: int = -1) -> bytes:
+                return b"x"
+
+        part = Part(b"", FileWrapper(Body()))  # type: ignore[arg-type]
+        with pytest.raises(UnrewindableBodyError, match=r"no seek\(\) method"):
+            part.rewind()
+
+    def test_rewind_rejects_file_wrapper_reporting_unseekable(self) -> None:
+        class Body:
+            def __len__(self) -> int:
+                return 1
+
+            def tell(self) -> int:
+                return 0
+
+            def seekable(self) -> bool:
+                return False
+
+            def seek(self, position: int) -> int:
+                raise AssertionError("seek must not be called")
+
+            def read(self, size: int = -1) -> bytes:
+                return b"x"
+
+        part = Part(b"", FileWrapper(Body()))  # type: ignore[arg-type]
+        with pytest.raises(UnrewindableBodyError, match="non-seekable"):
+            part.rewind()
+
+    def test_rewind_body_without_seek_only_resets_headers(self) -> None:
+        class Body:
+            def __len__(self) -> int:
+                return 1
+
+            def read(self, size: int = -1) -> bytes:
+                return b"x"
+
+        part = Part(b"H", Body())  # type: ignore[arg-type]
+        part.read(1)
+        part.rewind()
+        assert part.read(1) == b"H"
+
+    def test_from_field_converts_integer_for_backwards_compatibility(self) -> None:
+        field = RequestField("field", 42)  # type: ignore[arg-type]
+        field.make_multipart()
+        part = Part.from_field(field, "utf-8")
+        assert part.read().endswith(b"42")
+
+
+class TestMultipartEncoder(unittest.TestCase):
+    def setUp(self) -> None:
+        self.parts = [("field", "value"), ("other_field", "other_value")]
+        self.boundary = "this-is-a-boundary"
+        self.instance = MultipartEncoder(self.parts, boundary=self.boundary)
+
+    def test_content_type(self) -> None:
+        expected = "multipart/form-data; boundary=this-is-a-boundary"
+        assert self.instance.content_type == expected
+
+    def test_public_configuration_properties_and_repr(self) -> None:
+        assert self.instance.blocksize == 8192 * 4
+        assert self.instance.encoding == "utf-8"
+        assert self.instance.fields is self.parts
+        assert repr(self.instance) == f"<MultipartEncoder: {self.parts!r}>"
+
+    def test_blocksize_must_be_positive(self) -> None:
+        with pytest.raises(ValueError, match="greater than zero"):
+            MultipartEncoder([], blocksize=0)
+
+    def test_next_returns_chunks_then_stops(self) -> None:
+        encoder = MultipartEncoder([("field", "value")], boundary="b", blocksize=2)
+        chunks = []
+        while True:
+            try:
+                chunks.append(next(encoder))
+            except StopIteration:
+                break
+        expected = filepost.encode_multipart_formdata(
+            [("field", "value")], boundary="b"
+        )[0]
+        assert b"".join(chunks) == expected
+
+    def test_encodes_data_the_same_as_filepost(self) -> None:
+        encoded = filepost.encode_multipart_formdata(self.parts, self.boundary)[0]
+        assert encoded == self.instance.read()
+
+    def test_encode_multipart_formdata_uses_encoder(self) -> None:
+        encoded, content_type = filepost.encode_multipart_formdata(
+            self.parts, self.boundary
+        )
+        encoder = MultipartEncoder(self.parts, boundary=self.boundary)
+        assert encoded == encoder.read()
+        assert content_type == encoder.content_type
+
+    def test_streams_its_data(self) -> None:
+        large_file = LargeFileMock()
+        parts: dict[str, str | LargeFileMock] = {
+            "some field": "value",
+            "some file": large_file,
+        }
+        encoder = MultipartEncoder(parts)  # type: ignore[arg-type]
+        total_size = encoder.len
+        read_size = 1024 * 1024 * 128
+        already_read = 0
+        while True:
+            read = encoder.read(read_size)
+            already_read += len(read)
+            if not read:
+                break
+
+        assert encoder._buffer.tell() <= read_size
+        assert already_read == total_size
+
+    def test_does_not_buffer_sized_custom_stream_during_construction(self) -> None:
+        class SizedStream:
+            def __init__(self, data: bytes) -> None:
+                self.data = data
+                self.position = 0
+                self.read_calls = 0
+
+            def __len__(self) -> int:
+                return len(self.data)
+
+            def tell(self) -> int:
+                return self.position
+
+            def seek(self, position: int) -> int:
+                self.position = position
+                return position
+
+            def seekable(self) -> bool:
+                return True
+
+            def read(self, size: int = -1) -> bytes:
+                self.read_calls += 1
+                end = len(self.data) if size < 0 else self.position + size
+                chunk = self.data[self.position : end]
+                self.position += len(chunk)
+                return chunk
+
+        stream = SizedStream(b"x" * (1024 * 1024))
+        encoder = MultipartEncoder(
+            [("file", ("data.bin", stream, "application/octet-stream"))],  # type: ignore[list-item]
+            boundary=self.boundary,
+        )
+
+        assert stream.read_calls == 0
+        assert len(encoder.read(1024)) == 1024
+        assert stream.read_calls == 1
+
+    def test_stream_ending_before_declared_length_raises(self) -> None:
+        class TruncatedStream:
+            def __init__(self) -> None:
+                self.position = 0
+
+            def __len__(self) -> int:
+                return 10
+
+            def tell(self) -> int:
+                return self.position
+
+            def read(self, size: int = -1) -> bytes:
+                if self.position:
+                    return b""
+                self.position = 3
+                return b"abc"
+
+        encoder = MultipartEncoder(
+            [("file", ("data.bin", TruncatedStream(), "application/octet-stream"))],  # type: ignore[list-item]
+            boundary=self.boundary,
+        )
+        with pytest.raises(OSError, match="ended before its declared length"):
+            encoder.read()
+
+    @pytest.mark.limit_memory("3 MB", current_thread_only=True)
+    def test_memory_usage_streaming_large_file(self) -> None:
+        """Streaming a 10 MB file should stay under a 3 MB memory limit."""
+        file_size_mb = 10
+        chunk_size = 8192 * 4
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".bin") as tmp:
+            tmp.write(b"x" * (file_size_mb * 1024 * 1024))
+            tmp_name = tmp.name
+        try:
+            with open(tmp_name, "rb") as fd:
+                encoder = MultipartEncoder(
+                    [
+                        ("field", "value"),
+                        ("file", ("data.bin", fd, "application/octet-stream")),
+                    ],
+                    boundary=self.boundary,
+                )
+                total_size = encoder.len
+                read_so_far = 0
+                while True:
+                    chunk = encoder.read(chunk_size)
+                    if not chunk:
+                        break
+                    read_so_far += len(chunk)
+                assert read_so_far == total_size
+        finally:
+            os.unlink(tmp_name)
+
+    def test_length_is_correct(self) -> None:
+        encoded = filepost.encode_multipart_formdata(self.parts, self.boundary)[0]
+        assert len(encoded) == self.instance.len
+
+    def test_length_larger_than_platform_ssize_is_supported(self) -> None:
+        class HugeStream:
+            position = 0
+
+            def __len__(self) -> int:
+                return 2**100
+
+            def tell(self) -> int:
+                return self.position
+
+            def read(self, size: int = -1) -> bytes:
+                return b""
+
+        encoder = MultipartEncoder(
+            [("file", ("huge.bin", HugeStream(), "application/octet-stream"))],  # type: ignore[list-item]
+            boundary="b",
+        )
+        assert encoder.len > 2**100
+        assert encoder.content_length == str(encoder.len)
+
+    def test_encodes_with_readable_data_without_invented_filename(self) -> None:
+        s = io.BytesIO(b"value")
+        m = MultipartEncoder([("field", s)], boundary=self.boundary)
+        body = m.read()
+        assert body == (
+            b"--this-is-a-boundary\r\n"
+            b'Content-Disposition: form-data; name="field"\r\n\r\n'
+            b"value\r\n"
+            b"--this-is-a-boundary--\r\n"
+        )
+        assert b'filename="unknown"' not in body
+
+    def test_bytesio_is_not_copied_during_construction(self) -> None:
+        stream = io.BytesIO(b"x" * (1024 * 1024))
+        encoder = MultipartEncoder(
+            [("file", ("data.bin", stream, "application/octet-stream"))],
+            boundary=self.boundary,
+        )
+        assert isinstance(encoder._parts[0].body, FileWrapper)
+        assert encoder._parts[0].body.fd is stream
+
+    def test_reads_open_file_objects(self) -> None:
+        with open(__file__, "rb") as fd:
+            m = MultipartEncoder([("field", "foo"), ("file", fd)])
+            assert m.read() is not None
+
+    def test_file_object_at_nonzero_position_sends_full_content(self) -> None:
+        with tempfile.NamedTemporaryFile(delete=False) as tmp:
+            tmp.write(b"full content")
+            tmp_name = tmp.name
+        try:
+            with open(tmp_name, "rb") as fd:
+                fd.read(5)
+                m = MultipartEncoder(
+                    [("file", ("data.bin", fd, "application/octet-stream"))]
+                )
+                body = m.read()
+            assert b"full content" in body
+        finally:
+            os.unlink(tmp_name)
+
+    def test_non_seekable_stream_at_nonzero_position_raises(self) -> None:
+        class NonSeekableReader(io.RawIOBase):
+            def __init__(self, data: bytes) -> None:
+                self._data = memoryview(data)
+                self._pos = 0
+
+            def readinto(self, b: bytearray) -> int:  # type: ignore[override]
+                n = len(b)
+                chunk = bytes(self._data[self._pos : self._pos + n])
+                b[: len(chunk)] = chunk
+                self._pos += len(chunk)
+                return len(chunk)
+
+            def readable(self) -> bool:
+                return True
+
+            def seekable(self) -> bool:
+                return False
+
+            def tell(self) -> int:
+                return self._pos
+
+        raw = NonSeekableReader(b"full content")
+        reader = io.BufferedReader(raw)  # type: ignore[type-var]
+        reader.read(5)
+        with pytest.raises(
+            ValueError, match="Non-seekable stream is at a non-zero position"
+        ):
+            MultipartEncoder(
+                [("file", ("data.bin", reader, "application/octet-stream"))]
+            )
+
+    def test_int_field_value_backwards_compat(self) -> None:
+        m = MultipartEncoder([("n", 42)], boundary=self.boundary)
+        assert b"42" in m.read()
+
+    def test_filename_hinting_from_file_object(self) -> None:
+        with open(__file__, "rb") as fd:
+            m = MultipartEncoder([("file", fd)])
+            body = m.read().decode("utf-8", errors="replace")
+            expected_name = os.path.basename(__file__)
+            assert f'filename="{expected_name}"' in body
+
+    def test_filename_hinting_not_applied_to_tuple_values(self) -> None:
+        with open(__file__, "rb") as fd:
+            m = MultipartEncoder([("file", ("custom.txt", fd, "text/plain"))])
+            body = m.read().decode("utf-8", errors="replace")
+            assert 'filename="custom.txt"' in body
+
+    def test_accepts_custom_headers(self) -> None:
+        fields = [
+            (
+                "test",
+                (
+                    "filename",
+                    b"filecontent",
+                    "application/json",
+                    {"X-My-Header": "my-value"},
+                ),
+            )
+        ]
+        m = MultipartEncoder(fields=fields)
+        output = m.read().decode("utf-8")
+        assert output.index("X-My-Header: my-value\r\n") > 0
+
+    def test_accepts_request_field_sequence_items(self) -> None:
+        field = RequestField("field", b"value")
+        field.make_multipart()
+        encoder = MultipartEncoder([field], boundary="b")
+        assert encoder.read() == (
+            b"--b\r\n"
+            b'Content-Disposition: form-data; name="field"\r\n\r\n'
+            b"value\r\n--b--\r\n"
+        )
+
+    def test_two_item_file_tuple_guesses_content_type(self) -> None:
+        encoder = MultipartEncoder(
+            [("file", ("example.txt", b"value"))], boundary="b"
+        )
+        assert b"Content-Type: text/plain\r\n" in encoder.read()
+
+    def test_invalid_file_tuple_length_raises(self) -> None:
+        with pytest.raises(ValueError, match="must contain 2, 3, or 4 items"):
+            MultipartEncoder(
+                [("file", ("name", b"value", "text/plain", {}, "extra"))],  # type: ignore[list-item]
+                boundary="b",
+            )
+
+    def test_bytes_filename_hint_and_content_type(self) -> None:
+        class Stream(io.BytesIO):
+            name = b"example.bin"
+
+        encoder = MultipartEncoder(
+            [("file", Stream(b"value"))], boundary="b"
+        )
+        body = encoder.read()
+        assert b'filename="example.bin"' in body
+        assert b"Content-Type: application/octet-stream\r\n" in body
+
+    def test_pseudo_filename_is_not_used(self) -> None:
+        class Stream(io.BytesIO):
+            name = "<stdin>"
+
+        encoder = MultipartEncoder(
+            [("file", Stream(b"value"))], boundary="b"
+        )
+        assert b"filename=" not in encoder.read()
+
+    def test_bytes_content_type_is_decoded(self) -> None:
+        encoder = MultipartEncoder(
+            [("file", ("name", b"value", b"application/example"))],
+            boundary="b",
+        )
+        assert b"Content-Type: application/example\r\n" in encoder.read()
+
+    def test_no_parts(self) -> None:
+        fields: list[tuple[str, str]] = []
+        boundary = "--90967316f8404798963cce746a4f4ef9"
+        m = MultipartEncoder(fields=fields, boundary=boundary)
+        output = m.read().decode("utf-8")
+        assert output == "----90967316f8404798963cce746a4f4ef9--\r\n"
+
+    def test_empty_boundary_preserves_filepost_behavior(self) -> None:
+        encoder = MultipartEncoder([], boundary="")
+        assert encoder.read() == b"----\r\n"
+
+    def test_boundary_property_is_unprefixed(self) -> None:
+        assert self.instance.boundary == self.boundary
+
+    def test_bytes_like_fields_preserve_filepost_compatibility(self) -> None:
+        for value in (bytearray(b"x"), memoryview(b"x")):
+            body, content_type = filepost.encode_multipart_formdata(
+                [("field", value)], boundary="b"
+            )
+            assert body == (
+                b"--b\r\n"
+                b'Content-Disposition: form-data; name="field"\r\n\r\n'
+                b"x\r\n"
+                b"--b--\r\n"
+            )
+            assert content_type == "multipart/form-data; boundary=b"
+
+    def test_arbitrary_buffer_protocol_preserves_filepost_compatibility(self) -> None:
+        from array import array
+
+        body, _ = filepost.encode_multipart_formdata(
+            [("field", array("B", [65, 66]))],  # type: ignore[list-item]
+            boundary="b",
+        )
+        assert body == (
+            b"--b\r\n"
+            b'Content-Disposition: form-data; name="field"\r\n\r\n'
+            b"AB\r\n"
+            b"--b--\r\n"
+        )
+
+    def test_headers_property(self) -> None:
+        headers = self.instance.headers
+        assert headers["Content-Type"] == self.instance.content_type
+        assert headers["Content-Length"] == self.instance.content_length
+
+    def test_iterable_interface(self) -> None:
+        chunks = list(self.instance)
+        combined = b"".join(chunks)
+        expected = filepost.encode_multipart_formdata(self.parts, self.boundary)[0]
+        assert combined == expected
+
+    def test_iterator_drains_buffer_after_closing_boundary_is_generated(self) -> None:
+        encoder = MultipartEncoder([("field", b"")], boundary="b", blocksize=1)
+        expected = filepost.encode_multipart_formdata([("field", b"")], boundary="b")[0]
+        assert b"".join(encoder) == expected
+
+    def test_seek_rewinds_to_start(self) -> None:
+        expected = filepost.encode_multipart_formdata(self.parts, self.boundary)[0]
+        first_read = self.instance.read()
+        assert first_read == expected
+        assert self.instance.finished
+        assert self.instance.tell() == len(expected)
+
+        self.instance.seek(0, 0)
+        assert not self.instance.finished
+        assert self.instance.tell() == 0
+        second_read = self.instance.read()
+        assert second_read == expected
+
+    def test_seek_rewinds_with_file_parts(self) -> None:
+        with open(__file__, "rb") as fd:
+            m = MultipartEncoder(
+                [("field", "value"), ("file", ("test.py", fd, "text/plain"))],
+                boundary=self.boundary,
+            )
+            first = m.read()
+            m.seek(0)
+            second = m.read()
+        assert first == second
+
+    def test_same_seekable_stream_can_be_used_for_multiple_parts(self) -> None:
+        stream = io.BytesIO(b"abc")
+        encoder = MultipartEncoder(
+            [
+                ("one", ("one.bin", stream, "application/octet-stream")),
+                ("two", ("two.bin", stream, "application/octet-stream")),
+            ],
+            boundary="b",
+        )
+        body = encoder.read()
+        decoder = MultipartDecoder(body, content_type=encoder.content_type)
+
+        assert len(body) == encoder.len
+        assert [part.data for part in decoder.parts] == [b"abc", b"abc"]
+
+    def test_same_nonseekable_stream_cannot_be_used_for_multiple_parts(self) -> None:
+        class Stream:
+            def __init__(self) -> None:
+                self.position = 0
+
+            def __len__(self) -> int:
+                return 3
+
+            def tell(self) -> int:
+                return self.position
+
+            def read(self, size: int = -1) -> bytes:
+                data = b"abc"[self.position :]
+                self.position += len(data)
+                return data
+
+        stream = Stream()
+        with pytest.raises(ValueError, match="same non-seekable stream"):
+            MultipartEncoder(
+                [("one", stream), ("two", stream)],  # type: ignore[list-item]
+                boundary="b",
+            )
+
+    def test_seek_nonzero_raises(self) -> None:
+        with pytest.raises(UnrewindableBodyError, match="only supports seek\\(0"):
+            self.instance.seek(10, 0)
+
+    def test_seek_with_non_seekable_part_raises_unrewindable(self) -> None:
+        class NonSeekableStream:
+            def __init__(self, data: bytes) -> None:
+                self._data = data
+                self._pos = 0
+
+            def fileno(self) -> int:
+                raise io.UnsupportedOperation("no real fd")
+
+            def seekable(self) -> bool:
+                return False
+
+            def seek(self, pos: int, whence: int = 0) -> int:
+                raise io.UnsupportedOperation("underlying stream is not seekable")
+
+            def tell(self) -> int:
+                return self._pos
+
+            def __len__(self) -> int:
+                return len(self._data)
+
+            def read(self, size: int = -1) -> bytes:
+                if size == -1:
+                    chunk = self._data[self._pos :]
+                    self._pos = len(self._data)
+                else:
+                    chunk = self._data[self._pos : self._pos + size]
+                    self._pos += len(chunk)
+                return chunk
+
+        stream = NonSeekableStream(b"streaming content")
+        m = MultipartEncoder(
+            [("file", ("data.bin", stream, "application/octet-stream"))],  # type: ignore[list-item]
+            boundary=self.boundary,
+        )
+        m.read()
+        with pytest.raises(UnrewindableBodyError, match="non-seekable stream"):
+            m.seek(0, 0)
+
+    def test_seek_with_no_seek_method_raises_unrewindable(self) -> None:
+        class NoSeekStream:
+            def __init__(self, data: bytes) -> None:
+                self._data = data
+                self._pos = 0
+
+            def fileno(self) -> int:
+                raise io.UnsupportedOperation("no real fd")
+
+            def tell(self) -> int:
+                return self._pos
+
+            def __len__(self) -> int:
+                return len(self._data)
+
+            def read(self, size: int = -1) -> bytes:
+                if size == -1:
+                    chunk = self._data[self._pos :]
+                    self._pos = len(self._data)
+                else:
+                    chunk = self._data[self._pos : self._pos + size]
+                    self._pos += len(chunk)
+                return chunk
+
+        stream = NoSeekStream(b"content")
+        m = MultipartEncoder(
+            [("file", ("data.bin", stream, "application/octet-stream"))],  # type: ignore[list-item]
+            boundary=self.boundary,
+        )
+        m.read()
+        with pytest.raises(UnrewindableBodyError, match="no seek\\(\\) method"):
+            m.seek(0, 0)
+
+    def test_seek_method_raising_unsupported_is_unrewindable(self) -> None:
+        class FailingSeekStream:
+            def __init__(self) -> None:
+                self.position = 0
+
+            def __len__(self) -> int:
+                return 7
+
+            def tell(self) -> int:
+                return self.position
+
+            def seek(self, position: int) -> typing.NoReturn:
+                raise io.UnsupportedOperation("not seekable")
+
+            def read(self, size: int = -1) -> bytes:
+                data = b"content"[self.position :]
+                self.position += len(data)
+                return data
+
+        encoder = MultipartEncoder(
+            [
+                (  # type: ignore[list-item]
+                    "file",
+                    (
+                        "data.bin",
+                        FailingSeekStream(),
+                        "application/octet-stream",
+                    ),
+                )
+            ],
+            boundary=self.boundary,
+        )
+        assert not encoder.seekable()
+        with pytest.raises(UnrewindableBodyError, match="non-seekable stream"):
+            encoder.seek(0)
+
+    def test_decoder_round_trip(self) -> None:
+        body = self.instance.read()
+        decoder = MultipartDecoder(body, content_type=self.instance.content_type)
+        assert len(decoder.parts) == 2
+        assert decoder.parts[0].data == b"value"
+        assert decoder.parts[1].data == b"other_value"
+
+    def test_unsupported_data_type_raises_type_error(self) -> None:
+        with pytest.raises(
+            TypeError, match="Unsupported data type for multipart encoding"
+        ):
+            coerce_data(12345, "utf-8")  # type: ignore[arg-type]
+
+    def test_total_len_unsupported_type_raises(self) -> None:
+        with pytest.raises(ValueError, match="Unable to compute size"):
+            total_len(object())  # type: ignore[arg-type]
+
+    def test_encode_with_none_preserves_none(self) -> None:
+        assert encode_with(None, "utf-8") is None
+
+    def test_total_len_rejects_negative_dunder_len(self) -> None:
+        class NegativeLength:
+            def __len__(self) -> int:
+                return -1
+
+        with pytest.raises(ValueError, match="should return >= 0"):
+            total_len(NegativeLength())
+
+    def test_coerce_data_preserves_custom_bytes_io(self) -> None:
+        data = _CustomBytesIO(b"data")
+        assert coerce_data(data, "utf-8") is data
+
+    def test_coerce_data_rejects_fileno_stream_without_position(self) -> None:
+        class Stream:
+            def fileno(self) -> int:
+                raise io.UnsupportedOperation
+
+            def read(self, size: int = -1) -> bytes:
+                return b"data"
+
+        with pytest.raises(ValueError, match=r"no tell\(\) method"):
+            coerce_data(Stream(), "utf-8")  # type: ignore[arg-type]
+
+    def test_coerce_data_rejects_reader_without_position(self) -> None:
+        class Stream:
+            def read(self, size: int = -1) -> bytes:
+                return b"data"
+
+        with pytest.raises(ValueError, match=r"no tell\(\) method"):
+            coerce_data(Stream(), "utf-8")  # type: ignore[arg-type]
+
+    def test_read_with_none_size_returns_all_data(self) -> None:
+        expected = filepost.encode_multipart_formdata(self.parts, self.boundary)[0]
+        result = self.instance.read(None)
+        assert result == expected
+
+    def test_read_with_other_negative_size_returns_all_data(self) -> None:
+        expected = filepost.encode_multipart_formdata(self.parts, self.boundary)[0]
+        assert self.instance.read(-2) == expected
+
+    def test_latin1_boundary_matches_encode_multipart_formdata(self) -> None:
+        boundary = "caf\xe9"
+        expected = filepost.encode_multipart_formdata(self.parts, boundary)[0]
+        encoder = MultipartEncoder(self.parts, boundary=boundary)
+        assert encoder.read() == expected
+        assert encoder.len == len(expected)

--- a/test/with_dummyserver/test_connectionpool.py
+++ b/test/with_dummyserver/test_connectionpool.py
@@ -30,6 +30,7 @@ from urllib3.exceptions import (
     UnrewindableBodyError,
 )
 from urllib3.fields import _TYPE_FIELD_VALUE_TUPLE
+from urllib3.multipart import MultipartEncoder
 from urllib3.util import SKIP_HEADER, SKIPPABLE_HEADERS
 from urllib3.util.retry import RequestHistory, Retry
 from urllib3.util.timeout import _TYPE_TIMEOUT, Timeout
@@ -652,6 +653,30 @@ class TestConnectionPool(HypercornDummyServerTestCase):
                 b"world\r\n",
                 b"--boundary--\r\n",
             ]
+
+    def test_post_with_streaming_multipart_encoder(self) -> None:
+        file_data = b"streamed file content" * 1024
+        encoder = MultipartEncoder(
+            [
+                ("field", "value"),
+                (
+                    "file",
+                    ("example.bin", io.BytesIO(file_data), "application/octet-stream"),
+                ),
+            ],
+            boundary="streaming-boundary",
+            blocksize=1024,
+        )
+        expected_body = encoder.read()
+        encoder.seek(0)
+
+        with HTTPConnectionPool(self.host, self.port) as pool:
+            response = pool.request(
+                "POST", "/echo", body=encoder, headers=encoder.headers
+            )
+
+        assert response.data == expected_body
+        assert encoder.tell() == len(expected_body)
 
     def test_check_gzip(self) -> None:
         with HTTPConnectionPool(self.host, self.port) as pool:
@@ -1387,6 +1412,44 @@ class TestRetryAfter(HypercornDummyServerTestCase):
 
 
 class TestFileBodiesOnRetryOrRedirect(HypercornDummyServerTestCase):
+    def test_redirect_rewinds_streaming_multipart_encoder(self) -> None:
+        file_data = b"A" * 65535
+        boundary = "redirect-boundary"
+        encoder = MultipartEncoder(
+            [
+                ("field", "value"),
+                (
+                    "file",
+                    ("example.bin", io.BytesIO(file_data), "application/octet-stream"),
+                ),
+            ],
+            boundary=boundary,
+            blocksize=1024,
+        )
+        expected = MultipartEncoder(
+            [
+                ("field", "value"),
+                (
+                    "file",
+                    ("example.bin", file_data, "application/octet-stream"),
+                ),
+            ],
+            boundary=boundary,
+        ).read()
+
+        with HTTPConnectionPool(self.host, self.port, timeout=LONG_TIMEOUT) as pool:
+            response = pool.urlopen(
+                "PUT",
+                "/redirect?target=/echo&status=307",
+                headers=encoder.headers,
+                body=encoder,
+                retries=Retry(total=1),
+                redirect=True,
+            )
+
+        assert response.status == 200
+        assert response.data == expected
+
     def test_retries_put_filehandle(self) -> None:
         """HTTP PUT retry with a file-like object should not timeout"""
         with HTTPConnectionPool(self.host, self.port, timeout=LONG_TIMEOUT) as pool:


### PR DESCRIPTION
Closes #624.

## Summary

This adds a public streaming multipart implementation under `urllib3.multipart`:

- `MultipartEncoder` incrementally encodes fields and sized file-like objects without buffering complete uploads in memory.
- `MultipartDecoder` and `Part` provide response-side multipart parsing with buffered `read()` and `peek()` behavior.
- seekable inputs support complete rewind with `seek(0, 0)`, allowing urllib3 redirects and retries to replay the body safely.
- the existing `encode_multipart_formdata()` API delegates to the encoder while preserving its established wire format and bytes-like input behavior.
- reference documentation, user-guide examples, and a changelog fragment describe the new API.

## Motivation

The existing multipart helper constructs the entire encoded body in memory. Large file uploads therefore require memory proportional to the complete request body. The new encoder keeps only a bounded working buffer while retaining deterministic content length and compatibility with urllib3's request-body rewind machinery.

## Compatibility and edge cases

The implementation covers empty fields, custom and quoted boundaries, duplicate headers, preambles and epilogues, premature EOF, arbitrary buffer-protocol values, files larger than `sys.maxsize`, shared seekable inputs, rejection of unsafe shared non-seekable inputs, and iteration at very small block sizes.

Legacy multipart output is checked against fixed golden payloads rather than using the new encoder as its own oracle.

## Validation

- 106 focused multipart, filepost, socket, redirect, and replay tests passed under memray.
- Encoder and decoder tests reached 100% statement and branch coverage (449 statements and 172 branches).
- A real socket POST and urllib3-driven 307 replay verify transmission and rewind end to end.
- Memray assertions verify bounded memory use for large streamed inputs.
- Requests downstream suite: 619 passed, 15 skipped, 1 expected failure.
- All formatting and lint hooks passed.
- Focused mypy checks passed.
- Documentation builds introduce no new warnings.

