### PR TITLE
Construct auth headers from URL userinfo

### DIFF
--- a/changelog/1999.feature.rst
+++ b/changelog/1999.feature.rst
@@ -1,0 +1,1 @@
+Added support for constructing ``Authorization`` and ``Proxy-Authorization`` headers from credentials in request and proxy URLs.

--- a/src/urllib3/poolmanager.py
+++ b/src/urllib3/poolmanager.py
@@ -12,6 +12,7 @@ from ._request_methods import RequestMethods
 from .connection import ProxyConfig
 from .connectionpool import HTTPConnectionPool, HTTPSConnectionPool, port_by_scheme
 from .exceptions import (
+    InvalidHeader,
     LocationValueError,
     MaxRetryError,
     ProxySchemeUnknown,
@@ -20,6 +21,7 @@ from .exceptions import (
 from .response import BaseHTTPResponse
 from .util.connection import _TYPE_SOCKET_OPTIONS
 from .util.proxy import connection_requires_http_tunnel
+from .util.request import make_headers
 from .util.retry import Retry
 from .util.timeout import Timeout
 from .util.url import Url, parse_url
@@ -159,6 +161,35 @@ key_fn_by_scheme = {
 }
 
 pool_classes_by_scheme = {"http": HTTPConnectionPool, "https": HTTPSConnectionPool}
+
+
+def _url_auth_header(url: Url, *, proxy: bool = False) -> tuple[str, str] | None:
+    auth = url.auth_decoded_joined
+    if auth is None:
+        return None
+
+    if proxy:
+        return (
+            "Proxy-Authorization",
+            make_headers(proxy_basic_auth=auth)["proxy-authorization"],
+        )
+    return "Authorization", make_headers(basic_auth=auth)["authorization"]
+
+
+def _merge_url_auth_header(
+    headers: typing.Mapping[str, str] | None,
+    auth_header: tuple[str, str],
+) -> HTTPHeaderDict:
+    header_name, header_value = auth_header
+    headers_ = HTTPHeaderDict(headers)
+    existing_values = headers_.getlist(header_name)
+    if existing_values and existing_values != [header_value]:
+        raise InvalidHeader(
+            f"{header_name} header conflicts with credentials in the URL"
+        )
+    if not existing_values:
+        headers_[header_name] = header_value
+    return headers_
 
 
 class PoolManager(RequestMethods):
@@ -453,6 +484,12 @@ class PoolManager(RequestMethods):
         if "headers" not in kw:
             kw["headers"] = self.headers
 
+        url_auth_header = _url_auth_header(u)
+        if url_auth_header is not None:
+            kw["headers"] = _merge_url_auth_header(kw["headers"], url_auth_header)
+            u = u._replace(auth=None)
+            url = u.url
+
         if self._proxy_requires_url_absolute_form(u):
             response = conn.urlopen(method, u._replace(fragment=None).url, **kw)
         else:
@@ -499,9 +536,9 @@ class PoolManager(RequestMethods):
         kw["retries"] = retries
         kw["redirect"] = redirect
 
-        log.info("Redirecting %s -> %s", url, redirect_location)
-
         response.drain_conn()
+        redirect_log_location = parse_url(redirect_location)._replace(auth=None).url
+        log.info("Redirecting %s -> %s", url, redirect_log_location)
         return self.urlopen(method, redirect_location, **kw)
 
 
@@ -605,6 +642,13 @@ class ProxyManager(PoolManager):
             port = port_by_scheme.get(proxy.scheme, 80)
             proxy = proxy._replace(port=port)
 
+        self._proxy_url_auth_header = _url_auth_header(proxy, proxy=True)
+        if self._proxy_url_auth_header is not None:
+            proxy_headers = _merge_url_auth_header(
+                proxy_headers, self._proxy_url_auth_header
+            )
+            proxy = proxy._replace(auth=None)
+
         self.proxy = proxy
         self.proxy_headers = proxy_headers or {}
         self.proxy_config = ProxyConfig(
@@ -663,6 +707,8 @@ class ProxyManager(PoolManager):
             # headers on the CONNECT to the proxy. If we're not using CONNECT,
             # we'll definitely need to set 'Host' at the very least.
             headers = kw.get("headers", self.headers)
+            if self._proxy_url_auth_header is not None:
+                headers = _merge_url_auth_header(headers, self._proxy_url_auth_header)
             kw["headers"] = self._set_proxy_headers(url, headers)
 
         return super().urlopen(method, url, redirect=redirect, **kw)

--- a/test/test_proxymanager.py
+++ b/test/test_proxymanager.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import typing
+
 import pytest
 
 from urllib3.exceptions import (
+    InvalidHeader,
     LocationParseError,
     MaxRetryError,
     NewConnectionError,
@@ -60,6 +63,59 @@ class TestProxyManager:
             assert p.proxy is not None
             assert p.proxy.port == 0
 
+    @pytest.mark.parametrize("proxy_scheme", ["http", "https"])
+    def test_proxy_url_auth_sets_proxy_authorization_header(
+        self, proxy_scheme: str
+    ) -> None:
+        with ProxyManager(
+            f"{proxy_scheme}://user%40example.com:p%40ss@proxy:8080"
+        ) as p:
+            assert p.proxy is not None
+            assert p.proxy.auth is None
+            assert (
+                p.proxy_headers["Proxy-Authorization"]
+                == "Basic dXNlckBleGFtcGxlLmNvbTpwQHNz"
+            )
+
+    def test_proxy_url_auth_allows_matching_proxy_header(self) -> None:
+        proxy_headers = {"proxy-authorization": "Basic dXNlcjpwYXNzd29yZA=="}
+
+        with ProxyManager(
+            "http://user:password@proxy:8080", proxy_headers=proxy_headers
+        ) as p:
+            assert (
+                p.proxy_headers["Proxy-Authorization"] == "Basic dXNlcjpwYXNzd29yZA=="
+            )
+        assert proxy_headers == {"proxy-authorization": "Basic dXNlcjpwYXNzd29yZA=="}
+
+    def test_proxy_url_auth_rejects_conflicting_proxy_header(self) -> None:
+        with pytest.raises(InvalidHeader, match="Proxy-Authorization"):
+            ProxyManager(
+                "http://user:password@proxy:8080",
+                proxy_headers={"Proxy-Authorization": "Basic ZGlmZmVyZW50"},
+            )
+
+    @pytest.mark.parametrize(
+        ("manager_headers", "request_headers"),
+        [
+            ({"Proxy-Authorization": "Basic ZGlmZmVyZW50"}, None),
+            (None, {"Proxy-Authorization": "Basic ZGlmZmVyZW50"}),
+        ],
+    )
+    def test_proxy_url_auth_rejects_conflicting_http_request_header(
+        self,
+        manager_headers: dict[str, str] | None,
+        request_headers: dict[str, str] | None,
+    ) -> None:
+        with ProxyManager(
+            "http://user:password@proxy:8080", headers=manager_headers
+        ) as p:
+            with pytest.raises(InvalidHeader, match="Proxy-Authorization"):
+                if request_headers is None:
+                    p.urlopen("GET", "http://example.com/")
+                else:
+                    p.urlopen("GET", "http://example.com/", headers=request_headers)
+
     def test_invalid_scheme(self) -> None:
         with pytest.raises(AssertionError):
             ProxyManager("invalid://host/p")
@@ -82,17 +138,21 @@ class TestProxyManager:
             assert p._proxy_requires_url_absolute_form(https_url)
 
     @pytest.mark.parametrize("proxy_scheme", ["http", "https"])
-    def test_absolute_form_request_target_strips_fragment_for_custom_pool(
+    def test_absolute_form_request_target_strips_fragment_and_userinfo(
         self, proxy_scheme: str
     ) -> None:
         class CustomConnectionPool:
             requested_urls: list[str] = []
+            requested_headers: list[typing.Mapping[str, str]] = []
 
             def __init__(self, host: str, port: int | None = None, **kw: object):
                 pass
 
             def urlopen(self, method: str, url: str, **kw: object) -> HTTPResponse:
                 self.requested_urls.append(url)
+                self.requested_headers.append(
+                    typing.cast(typing.Mapping[str, str], kw["headers"])
+                )
                 return HTTPResponse(status=200)
 
         with ProxyManager(f"{proxy_scheme}://proxy:8080") as p:
@@ -100,11 +160,15 @@ class TestProxyManager:
             p.pool_classes_by_scheme[proxy_scheme] = CustomConnectionPool
             response = p.urlopen(
                 "GET",
-                "http://example.com/path?x=1#marker=value",
+                "http://user:password@example.com/path?x=1#marker=value",
             )
 
         assert response.status == 200
         assert CustomConnectionPool.requested_urls == ["http://example.com/path?x=1"]
+        assert (
+            CustomConnectionPool.requested_headers[0]["Authorization"]
+            == "Basic dXNlcjpwYXNzd29yZA=="
+        )
 
     @pytest.mark.parametrize(
         "url",

--- a/test/with_dummyserver/test_poolmanager.py
+++ b/test/with_dummyserver/test_poolmanager.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import gzip
+import logging
 import typing
 from test import LONG_TIMEOUT
 from unittest import mock
@@ -14,9 +15,10 @@ from dummyserver.testcase import (
 )
 from urllib3 import HTTPHeaderDict, HTTPResponse, request
 from urllib3.connectionpool import port_by_scheme
-from urllib3.exceptions import MaxRetryError, URLSchemeUnknown
+from urllib3.exceptions import InvalidHeader, MaxRetryError, URLSchemeUnknown
 from urllib3.poolmanager import PoolManager
 from urllib3.util.retry import Retry
+from urllib3.util.url import parse_url
 
 
 class TestPoolManager(HypercornDummyServerTestCase):
@@ -507,6 +509,97 @@ class TestPoolManager(HypercornDummyServerTestCase):
             returned_headers = r.json()
             assert returned_headers.get("Foo") is None
             assert returned_headers.get("Baz") == "quux"
+
+    @pytest.mark.parametrize(
+        ("auth", "expected"),
+        [
+            ("user:password", "Basic dXNlcjpwYXNzd29yZA=="),
+            ("user%40example.com:p%40ss", "Basic dXNlckBleGFtcGxlLmNvbTpwQHNz"),
+        ],
+    )
+    def test_authorization_header_from_url_auth(self, auth: str, expected: str) -> None:
+        with PoolManager() as http:
+            r = http.request("GET", f"http://{auth}@{self.host}:{self.port}/headers")
+
+        assert r.json()["Authorization"] == expected
+
+    def test_url_auth_allows_matching_authorization_header(self) -> None:
+        headers = {"authorization": "Basic dXNlcjpwYXNzd29yZA=="}
+
+        with PoolManager() as http:
+            r = http.request(
+                "GET",
+                f"http://user:password@{self.host}:{self.port}/headers",
+                headers=headers,
+            )
+
+        assert r.json()["Authorization"] == "Basic dXNlcjpwYXNzd29yZA=="
+        assert headers == {"authorization": "Basic dXNlcjpwYXNzd29yZA=="}
+
+    def test_url_auth_does_not_persist_between_requests(self) -> None:
+        with PoolManager() as http:
+            authenticated = http.request(
+                "GET",
+                f"http://user:password@{self.host}:{self.port}/headers",
+            )
+            unauthenticated = http.request("GET", f"{self.base_url}/headers")
+
+        assert authenticated.json()["Authorization"] == "Basic dXNlcjpwYXNzd29yZA=="
+        assert "Authorization" not in unauthenticated.json()
+
+    @pytest.mark.parametrize("duplicate", [False, True])
+    def test_url_auth_rejects_conflicting_authorization_header(
+        self, duplicate: bool
+    ) -> None:
+        headers = HTTPHeaderDict()
+        headers.add("Authorization", "Basic dXNlcjpwYXNzd29yZA==")
+        if duplicate:
+            headers.add("Authorization", "Basic dXNlcjpwYXNzd29yZA==")
+        else:
+            headers["Authorization"] = "Basic ZGlmZmVyZW50"
+
+        with PoolManager() as http:
+            with pytest.raises(InvalidHeader, match="Authorization"):
+                http.request(
+                    "GET",
+                    f"http://user:password@{self.host}:{self.port}/headers",
+                    headers=headers,
+                )
+
+    def test_url_auth_redirects(self, caplog: pytest.LogCaptureFixture) -> None:
+        caplog.set_level(logging.INFO, logger="urllib3.poolmanager")
+        with PoolManager() as http:
+            same_host = http.request(
+                "GET",
+                f"http://user:password@{self.host}:{self.port}/redirect",
+                fields={"target": f"{self.base_url}/headers"},
+            )
+            cross_host = http.request(
+                "GET",
+                f"http://user:password@{self.host}:{self.port}/redirect",
+                fields={
+                    "target": (
+                        f"http://other:secret@{self.host_alt}:{self.port}/headers"
+                    )
+                },
+            )
+
+        assert same_host.json()["Authorization"] == "Basic dXNlcjpwYXNzd29yZA=="
+        assert cross_host.json()["Authorization"] == "Basic b3RoZXI6c2VjcmV0"
+        assert same_host.retries is not None
+        assert all(
+            history.url is None or parse_url(history.url).auth is None
+            for history in same_host.retries.history
+        )
+        redirect_logs = [
+            record.getMessage()
+            for record in caplog.records
+            if record.name == "urllib3.poolmanager"
+            and record.getMessage().startswith("Redirecting ")
+        ]
+        assert redirect_logs
+        assert all("user:password@" not in message for message in redirect_logs)
+        assert all("other:secret@" not in message for message in redirect_logs)
 
     def test_headers_http_header_dict(self) -> None:
         # Test uses a list of headers to assert the order

--- a/test/with_dummyserver/test_proxy_poolmanager.py
+++ b/test/with_dummyserver/test_proxy_poolmanager.py
@@ -88,6 +88,34 @@ class TestHTTPProxyManager(HypercornDummyProxyTestCase):
             r = http.request("GET", f"{self.https_url}/")
             assert r.status == 200
 
+    def test_request_and_proxy_url_auth(self) -> None:
+        proxy_url = (
+            f"http://proxy-user:proxy-password@{self.proxy_host}:"
+            f"{int(self.proxy_port)}"
+        )
+
+        with proxy_from_url(proxy_url, ca_certs=DEFAULT_CA) as http:
+            forwarded = http.request(
+                "GET",
+                f"http://user:password@{self.http_host}:"
+                f"{int(self.http_port)}/headers",
+            )
+            tunneled = http.request(
+                "GET",
+                f"https://user:password@{self.https_host}:"
+                f"{int(self.https_port)}/headers",
+            )
+
+        assert forwarded.status == 200
+        assert forwarded.json()["Authorization"] == "Basic dXNlcjpwYXNzd29yZA=="
+        assert (
+            forwarded.json()["Proxy-Authorization"]
+            == "Basic cHJveHktdXNlcjpwcm94eS1wYXNzd29yZA=="
+        )
+        assert tunneled.status == 200
+        assert tunneled.json()["Authorization"] == "Basic dXNlcjpwYXNzd29yZA=="
+        assert "Proxy-Authorization" not in tunneled.json()
+
     def test_https_proxy(self) -> None:
         with proxy_from_url(self.https_proxy_url, ca_certs=DEFAULT_CA) as https:
             r = https.request("GET", f"{self.https_url}/")


### PR DESCRIPTION
This fixes #1999 by turning userinfo in request and proxy URLs into Basic `Authorization` and `Proxy-Authorization` headers.

I kept this within the existing `Url.auth_decoded_joined` and `make_headers` paths instead of adding another decoding or encoding implementation.

Matching explicit headers are accepted while conflicting or duplicate values raise `InvalidHeader`. Only sanitized URLs are passed to the connection pool and proxy authentication stays separate from origin headers when using CONNECT.

One slightly awkward case is plain HTTP through a proxy, where regular and proxy headers share the same request. That is why the proxy conflict check also happens once the final request headers are known.

While testing redirects, I noticed that userinfo in a redirect target could appear in `PoolManager` logs before the next request removed it. The logged destination is now sanitized too.

Tests cover encoded values, conflicts, redirects, proxies, CONNECT and credential isolation between requests.

- 223 related tests
- `mypy` on the modified files
- `black`, `pyupgrade`, `isort`, and `flake8`

Closes #1999.