### PR TITLE
decode HTTP/2 response header values as latin-1

### DIFF
--- a/changelog/5159.bugfix.rst
+++ b/changelog/5159.bugfix.rst
@@ -1,0 +1,4 @@
+Fixed ``HTTP2Connection.getresponse()`` raising ``UnicodeDecodeError`` on
+response header values containing ``obs-text`` bytes (``0x80``-``0xFF``). Such
+values are accepted on the HTTP/1.1 path, which decodes header bytes as
+latin-1, so HTTP/2 now decodes them the same way.

--- a/src/urllib3/http2/connection.py
+++ b/src/urllib3/http2/connection.py
@@ -242,8 +242,13 @@ class HTTP2Connection(HTTPSConnection):
                                 if header == b":status":
                                     status = int(value.decode())
                                 else:
+                                    # Field values may carry obs-text (bytes
+                                    # 0x80-0xFF), which http.client decodes as
+                                    # latin-1 on the HTTP/1.1 path. Match that
+                                    # so an HTTP/2 response is not rejected.
                                     headers.add(
-                                        header.decode("ascii"), value.decode("ascii")
+                                        header.decode("latin-1"),
+                                        value.decode("latin-1"),
                                     )
 
                         elif isinstance(event, h2.events.DataReceived):

--- a/test/test_http2_connection.py
+++ b/test/test_http2_connection.py
@@ -384,3 +384,53 @@ class TestHTTP2Connection:
         )
 
         close_connection.assert_called_with()
+
+    def test_getresponse_obs_text_header_value(self) -> None:
+        # A field value carrying obs-text (bytes 0x80-0xFF) is legal per
+        # RFC 9110 and is accepted on the HTTP/1.1 path (http.client decodes
+        # header bytes as latin-1). getresponse() must not reject it.
+        import h2.config
+        import h2.connection
+
+        conn = HTTP2Connection("example.com")
+        conn.sock = mock.MagicMock()
+        conn._request_url = "/"
+
+        server = h2.connection.H2Connection(
+            config=h2.config.H2Configuration(client_side=False)
+        )
+        server.initiate_connection()
+
+        client = conn._h2_conn._obj
+        client.initiate_connection()
+        server.receive_data(client.data_to_send())
+        client.receive_data(server.data_to_send())
+
+        client.send_headers(
+            1,
+            [
+                (":method", "GET"),
+                (":scheme", "https"),
+                (":authority", "example.com"),
+                (":path", "/"),
+            ],
+            end_stream=True,
+        )
+        server.receive_data(client.data_to_send())
+
+        server.send_headers(
+            1,
+            [
+                (":status", "200"),
+                ("content-disposition", b"attachment; filename=caf\xe9.txt"),
+            ],
+            end_stream=True,
+        )
+        conn.sock.recv.side_effect = [server.data_to_send(), b""]
+
+        response = conn.getresponse()
+
+        assert response.status == 200
+        assert (
+            response.headers["content-disposition"] == "attachment; filename=café.txt"
+        )


### PR DESCRIPTION
HTTP2Connection.getresponse decodes each response header name and value with .decode("ascii"). A field value may legally carry obs-text (bytes 0x80-0xFF), which the HTTP/1.1 path accepts because http.client decodes header bytes as latin-1, so a server response that works over HTTP/1.1 raises an uncaught UnicodeDecodeError over HTTP/2 (for example a non-ASCII Content-Disposition filename). Decode the name and value as latin-1 to match http.client.