### PR TITLE
Warn once when a connection pool is full

### DIFF
--- a/changelog/3167.feature.rst
+++ b/changelog/3167.feature.rst
@@ -1,0 +1,1 @@
+Logged only the first connection discarded because a pool is full at warning level, and logged subsequent occurrences at debug level.

--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -4,6 +4,7 @@ import errno
 import logging
 import queue
 import sys
+import threading
 import typing
 import warnings
 import weakref
@@ -206,6 +207,8 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
 
         self.pool: queue.LifoQueue[typing.Any] | None = self._new_pool_queue(maxsize)
         self.block = block
+        self._pool_full_warning_lock = threading.Lock()
+        self._pool_full_warning_emitted = False
 
         self.proxy = _proxy
         self.proxy_headers = _proxy_headers or {}
@@ -297,6 +300,21 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
 
         return conn or self._new_conn()
 
+    def _log_connection_pool_full(self, pool_size: int) -> None:
+        should_warn = False
+        if not self._pool_full_warning_emitted:
+            with self._pool_full_warning_lock:
+                if not self._pool_full_warning_emitted:
+                    self._pool_full_warning_emitted = True
+                    should_warn = True
+
+        log_method = log.warning if should_warn else log.debug
+        log_method(
+            "Connection pool is full, discarding connection: %s. Connection pool size: %s",
+            self.host,
+            pool_size,
+        )
+
     def _put_conn(self, conn: BaseHTTPConnection | None) -> None:
         """
         Put a connection back into the pool.
@@ -330,11 +348,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
                         "Pool reached maximum size and no more connections are allowed.",
                     ) from None
 
-                log.warning(
-                    "Connection pool is full, discarding connection: %s. Connection pool size: %s",
-                    self.host,
-                    self.pool.qsize(),
-                )
+                self._log_connection_pool_full(self.pool.qsize())
 
         # Connection never got put back into the pool, close it.
         if conn:

--- a/test/test_connectionpool.py
+++ b/test/test_connectionpool.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 import http.client as httplib
+import logging
 import queue
 import ssl
+import threading
 import typing
+from concurrent.futures import ThreadPoolExecutor
 from http.client import HTTPException
 from queue import Empty
 from socket import error as SocketError
@@ -318,6 +321,33 @@ class TestConnectionPool:
             assert pool.num_connections == 3
             assert "Connection pool is full, discarding connection" in caplog.text
             assert "Connection pool size: 1" in caplog.text
+
+    def test_put_conn_when_pool_is_full_warns_once_per_pool(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        with caplog.at_level(logging.DEBUG, logger="urllib3.connectionpool"):
+            for _ in range(2):
+                with HTTPConnectionPool(
+                    host="localhost", maxsize=1, block=False
+                ) as pool:
+                    barrier = threading.Barrier(4)
+
+                    def put_conn(conn: Mock) -> None:
+                        barrier.wait()
+                        pool._put_conn(conn)
+
+                    with ThreadPoolExecutor(max_workers=4) as executor:
+                        list(executor.map(put_conn, [Mock() for _ in range(4)]))
+
+        records = [
+            record
+            for record in caplog.records
+            if record.getMessage().startswith(
+                "Connection pool is full, discarding connection"
+            )
+        ]
+        assert sum(record.levelno == logging.WARNING for record in records) == 2
+        assert sum(record.levelno == logging.DEBUG for record in records) == 6
 
     def test_put_conn_when_pool_is_full_blocking(self) -> None:
         """


### PR DESCRIPTION
This fixes #3167 by keeping the first "Connection pool is full" message at warning level and moving later occurrences from the same pool to debug.

I started with the per-pool behavior, then tightened it for the multithreaded case where this warning usually appears. The first-warning check uses a short double-checked lock; later discards take the fast path. The log call stays outside the lock so custom handlers are not part of the critical section.

The regression test fills two separate pools from synchronized worker threads. Each pool emits one warning and sends the remaining messages to debug.

Verification:
- 102 connection pool unit tests
- 122 connection pool dummyserver tests
- concurrent stress across 20 pools
- `mypy` and the repository pre-commit hooks

Closes #3167.
