### PR TITLE
Drop request body framing state on 303 redirects

### DIFF
--- a/changelog/5161.bugfix.rst
+++ b/changelog/5161.bugfix.rst
@@ -1,5 +1,1 @@
-Fixed following a 303 redirect to send the redirected ``GET`` request without
-the framing of the dropped request body. Previously the redirected request
-still carried ``Transfer-Encoding: chunked`` with an empty chunked body, and a
-file-like body made the redirect fail with
-``ValueError: body_pos must be of type integer, instead it was <class 'int'>``.
+Fixed handling of HTTP 303 redirects for requests with chunked or file-like bodies.

--- a/changelog/5161.bugfix.rst
+++ b/changelog/5161.bugfix.rst
@@ -1,0 +1,5 @@
+Fixed following a 303 redirect to send the redirected ``GET`` request without
+the framing of the dropped request body. Previously the redirected request
+still carried ``Transfer-Encoding: chunked`` with an empty chunked body, and a
+file-like body made the redirect fail with
+``ValueError: body_pos must be of type integer, instead it was <class 'int'>``.

--- a/dummyserver/app.py
+++ b/dummyserver/app.py
@@ -230,6 +230,9 @@ async def encodingrequest() -> ResponseReturnValue:
 @pyodide_testing_app.route("/redirect", methods=["GET", "POST", "PUT"])
 async def redirect() -> ResponseReturnValue:
     "Perform a redirect to ``target``"
+    # Read the body even when it is not a form, so that it does not linger in
+    # the socket and desynchronize the next request on a reused connection.
+    await request.get_data(parse_form_data=True)
     values = await request.values
     target = values.get("target", "/")
     status = values.get("status", "303 See Other")

--- a/src/urllib3/_collections.py
+++ b/src/urllib3/_collections.py
@@ -400,6 +400,9 @@ class HTTPHeaderDict(typing.MutableMapping[str, str]):
         """
         Remove content-specific header fields before changing the request
         method to GET or HEAD according to RFC 9110, Section 15.4.
+
+        ``Transfer-Encoding`` goes as well: it frames a request body that is
+        no longer going to be sent.
         """
         content_specific_headers = [
             "Content-Encoding",
@@ -409,6 +412,7 @@ class HTTPHeaderDict(typing.MutableMapping[str, str]):
             "Content-Length",
             "Digest",
             "Last-Modified",
+            "Transfer-Encoding",
         ]
         for header in content_specific_headers:
             self.discard(header)

--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -909,6 +909,11 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
                 method = "GET"
                 # And lose the body not to transfer anything sensitive.
                 body = None
+                # The body is gone, so the state that describes it has to go
+                # too: there is nothing left to frame with chunked transfer
+                # encoding, and nothing left to rewind.
+                chunked = False
+                body_pos = None
                 headers = HTTPHeaderDict(headers)._prepare_for_method_change()
 
             # Strip headers marked as unsafe to forward to the redirected location.

--- a/src/urllib3/poolmanager.py
+++ b/src/urllib3/poolmanager.py
@@ -470,6 +470,11 @@ class PoolManager(RequestMethods):
             method = "GET"
             # And lose the body not to transfer anything sensitive.
             kw["body"] = None
+            # The body is gone, so the state that describes it has to go too:
+            # there is nothing left to frame with chunked transfer encoding,
+            # and nothing left to rewind.
+            kw["chunked"] = False
+            kw["body_pos"] = None
             kw["headers"] = HTTPHeaderDict(kw["headers"])._prepare_for_method_change()
 
         retries = kw.get("retries", response.retries)

--- a/test/with_dummyserver/test_connectionpool.py
+++ b/test/with_dummyserver/test_connectionpool.py
@@ -544,16 +544,22 @@ class TestConnectionPool(HypercornDummyServerTestCase):
     ) -> None:
         # The body is dropped, so the redirected GET must not keep announcing
         # a chunked body that it is never going to send.
+        #
+        # The server does not read the chunked body, since nothing routes it to
+        # a form parser, so the connection is closed instead of being reused:
+        # otherwise the leftover body would desynchronize the redirected GET.
+        headers = {"Connection": "close"}
         kw: dict[str, typing.Any] = {}
         if chunked_via == "kwarg":
             kw["chunked"] = True
         else:
-            kw["headers"] = {"Transfer-Encoding": "chunked"}
+            headers["Transfer-Encoding"] = "chunked"
         with HTTPConnectionPool(self.host, self.port) as pool:
             response = pool.request(
                 "POST",
                 "/redirect?target=/headers_and_params",
                 body=iter([b"xxxxxxxx"]),
+                headers=headers,
                 **kw,
             )
         headers = HTTPHeaderDict(response.json()["headers"])

--- a/test/with_dummyserver/test_connectionpool.py
+++ b/test/with_dummyserver/test_connectionpool.py
@@ -545,21 +545,22 @@ class TestConnectionPool(HypercornDummyServerTestCase):
         # The body is dropped, so the redirected GET must not keep announcing
         # a chunked body that it is never going to send.
         #
-        # The server does not read the chunked body, since nothing routes it to
-        # a form parser, so the connection is closed instead of being reused:
-        # otherwise the leftover body would desynchronize the redirected GET.
-        headers = {"Connection": "close"}
+        # The body has to be announced as a form, otherwise the server never
+        # reads it and the leftover bytes desynchronize the redirected GET on
+        # the reused connection. The header itself is dropped by the change of
+        # method, so it does not affect what is asserted below.
+        request_headers = {"Content-Type": "application/x-www-form-urlencoded"}
         kw: dict[str, typing.Any] = {}
         if chunked_via == "kwarg":
             kw["chunked"] = True
         else:
-            headers["Transfer-Encoding"] = "chunked"
+            request_headers["Transfer-Encoding"] = "chunked"
         with HTTPConnectionPool(self.host, self.port) as pool:
             response = pool.request(
                 "POST",
                 "/redirect?target=/headers_and_params",
                 body=iter([b"xxxxxxxx"]),
-                headers=headers,
+                headers=request_headers,
                 **kw,
             )
         headers = HTTPHeaderDict(response.json()["headers"])

--- a/test/with_dummyserver/test_connectionpool.py
+++ b/test/with_dummyserver/test_connectionpool.py
@@ -1443,7 +1443,8 @@ class TestFileBodiesOnRetryOrRedirect(HypercornDummyServerTestCase):
                 raise OSError
 
         body = BadTellObject(b"the data")
-        url = "/redirect?target=/successful_retry"
+        # A 307 keeps the body, so it has to be rewound for the redirect.
+        url = "/redirect?target=/successful_retry&status=307"
         # httplib uses fileno if Content-Length isn't supplied,
         # which is unsupported by BytesIO.
         headers = {"Content-Length": "8"}
@@ -1452,6 +1453,23 @@ class TestFileBodiesOnRetryOrRedirect(HypercornDummyServerTestCase):
                 UnrewindableBodyError, match="Unable to record file position for"
             ):
                 pool.urlopen("PUT", url, headers=headers, body=body)
+
+    def test_303_redirect_with_failed_tell(self) -> None:
+        """A 303 drops the body, so it never needs to be rewound"""
+
+        class BadTellObject(io.BytesIO):
+            def tell(self) -> typing.NoReturn:
+                raise OSError
+
+        body = BadTellObject(b"the data")
+        url = "/redirect?target=/echo"
+        # httplib uses fileno if Content-Length isn't supplied,
+        # which is unsupported by BytesIO.
+        headers = {"Content-Length": "8"}
+        with HTTPConnectionPool(self.host, self.port, timeout=LONG_TIMEOUT) as pool:
+            resp = pool.urlopen("PUT", url, headers=headers, body=body)
+        assert resp.status == 200
+        assert resp.data == b""
 
 
 class TestRetryPoolSize(HypercornDummyServerTestCase):

--- a/test/with_dummyserver/test_connectionpool.py
+++ b/test/with_dummyserver/test_connectionpool.py
@@ -538,6 +538,28 @@ class TestConnectionPool(HypercornDummyServerTestCase):
         assert data["params"] == {}
         assert "Content-Type" not in HTTPHeaderDict(data["headers"])
 
+    @pytest.mark.parametrize("chunked_via", ["kwarg", "header"])
+    def test_303_redirect_makes_request_lose_body_framing(
+        self, chunked_via: str
+    ) -> None:
+        # The body is dropped, so the redirected GET must not keep announcing
+        # a chunked body that it is never going to send.
+        kw: dict[str, typing.Any] = {}
+        if chunked_via == "kwarg":
+            kw["chunked"] = True
+        else:
+            kw["headers"] = {"Transfer-Encoding": "chunked"}
+        with HTTPConnectionPool(self.host, self.port) as pool:
+            response = pool.request(
+                "POST",
+                "/redirect?target=/headers_and_params",
+                body=iter([b"xxxxxxxx"]),
+                **kw,
+            )
+        headers = HTTPHeaderDict(response.json()["headers"])
+        assert "Transfer-Encoding" not in headers
+        assert "Content-Length" not in headers
+
     def test_bad_connect(self) -> None:
         with HTTPConnectionPool("badhost.invalid", self.port) as pool:
             with pytest.raises(MaxRetryError) as e:

--- a/test/with_dummyserver/test_connectionpool.py
+++ b/test/with_dummyserver/test_connectionpool.py
@@ -544,12 +544,7 @@ class TestConnectionPool(HypercornDummyServerTestCase):
     ) -> None:
         # The body is dropped, so the redirected GET must not keep announcing
         # a chunked body that it is never going to send.
-        #
-        # The body has to be announced as a form, otherwise the server never
-        # reads it and the leftover bytes desynchronize the redirected GET on
-        # the reused connection. The header itself is dropped by the change of
-        # method, so it does not affect what is asserted below.
-        request_headers = {"Content-Type": "application/x-www-form-urlencoded"}
+        request_headers: dict[str, str] = {}
         kw: dict[str, typing.Any] = {}
         if chunked_via == "kwarg":
             kw["chunked"] = True

--- a/test/with_dummyserver/test_poolmanager.py
+++ b/test/with_dummyserver/test_poolmanager.py
@@ -398,16 +398,22 @@ class TestPoolManager(HypercornDummyServerTestCase):
     ) -> None:
         # The body is dropped, so the redirected GET must not keep announcing
         # a chunked body that it is never going to send.
+        #
+        # The server does not read the chunked body, since nothing routes it to
+        # a form parser, so the connection is closed instead of being reused:
+        # otherwise the leftover body would desynchronize the redirected GET.
+        headers = {"Connection": "close"}
         kw: dict[str, typing.Any] = {}
         if chunked_via == "kwarg":
             kw["chunked"] = True
         else:
-            kw["headers"] = {"Transfer-Encoding": "chunked"}
+            headers["Transfer-Encoding"] = "chunked"
         with PoolManager() as http:
             response = http.request(
                 "POST",
                 f"{self.base_url}/redirect?target={self.base_url}/headers_and_params",
                 body=iter([b"xxxxxxxx"]),
+                headers=headers,
                 **kw,
             )
         headers = HTTPHeaderDict(response.json()["headers"])

--- a/test/with_dummyserver/test_poolmanager.py
+++ b/test/with_dummyserver/test_poolmanager.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import gzip
+import io
 import typing
 from test import LONG_TIMEOUT
 from unittest import mock
@@ -390,6 +391,42 @@ class TestPoolManager(HypercornDummyServerTestCase):
         data = response.json()
         assert data["params"] == {}
         assert "Content-Type" not in HTTPHeaderDict(data["headers"])
+
+    @pytest.mark.parametrize("chunked_via", ["kwarg", "header"])
+    def test_303_redirect_makes_request_lose_body_framing(
+        self, chunked_via: str
+    ) -> None:
+        # The body is dropped, so the redirected GET must not keep announcing
+        # a chunked body that it is never going to send.
+        kw: dict[str, typing.Any] = {}
+        if chunked_via == "kwarg":
+            kw["chunked"] = True
+        else:
+            kw["headers"] = {"Transfer-Encoding": "chunked"}
+        with PoolManager() as http:
+            response = http.request(
+                "POST",
+                f"{self.base_url}/redirect?target={self.base_url}/headers_and_params",
+                body=iter([b"xxxxxxxx"]),
+                **kw,
+            )
+        headers = HTTPHeaderDict(response.json()["headers"])
+        assert "Transfer-Encoding" not in headers
+        assert "Content-Length" not in headers
+
+    def test_303_redirect_with_body_pos(self) -> None:
+        # The body is dropped, so the position recorded to rewind it has to go
+        # as well, otherwise the redirect tries to rewind a body that is gone.
+        with PoolManager() as http:
+            response = http.urlopen(
+                "POST",
+                f"{self.base_url}/redirect?target={self.base_url}/echo",
+                body=io.BytesIO(b"the data"),
+                headers={"Content-Length": "8"},
+                body_pos=0,
+            )
+        assert response.status == 200
+        assert response.data == b""
 
     def test_unknown_scheme(self) -> None:
         with PoolManager() as http:

--- a/test/with_dummyserver/test_poolmanager.py
+++ b/test/with_dummyserver/test_poolmanager.py
@@ -399,21 +399,22 @@ class TestPoolManager(HypercornDummyServerTestCase):
         # The body is dropped, so the redirected GET must not keep announcing
         # a chunked body that it is never going to send.
         #
-        # The server does not read the chunked body, since nothing routes it to
-        # a form parser, so the connection is closed instead of being reused:
-        # otherwise the leftover body would desynchronize the redirected GET.
-        headers = {"Connection": "close"}
+        # The body has to be announced as a form, otherwise the server never
+        # reads it and the leftover bytes desynchronize the redirected GET on
+        # the reused connection. The header itself is dropped by the change of
+        # method, so it does not affect what is asserted below.
+        request_headers = {"Content-Type": "application/x-www-form-urlencoded"}
         kw: dict[str, typing.Any] = {}
         if chunked_via == "kwarg":
             kw["chunked"] = True
         else:
-            headers["Transfer-Encoding"] = "chunked"
+            request_headers["Transfer-Encoding"] = "chunked"
         with PoolManager() as http:
             response = http.request(
                 "POST",
                 f"{self.base_url}/redirect?target={self.base_url}/headers_and_params",
                 body=iter([b"xxxxxxxx"]),
-                headers=headers,
+                headers=request_headers,
                 **kw,
             )
         headers = HTTPHeaderDict(response.json()["headers"])

--- a/test/with_dummyserver/test_poolmanager.py
+++ b/test/with_dummyserver/test_poolmanager.py
@@ -398,12 +398,7 @@ class TestPoolManager(HypercornDummyServerTestCase):
     ) -> None:
         # The body is dropped, so the redirected GET must not keep announcing
         # a chunked body that it is never going to send.
-        #
-        # The body has to be announced as a form, otherwise the server never
-        # reads it and the leftover bytes desynchronize the redirected GET on
-        # the reused connection. The header itself is dropped by the change of
-        # method, so it does not affect what is asserted below.
-        request_headers = {"Content-Type": "application/x-www-form-urlencoded"}
+        request_headers: dict[str, str] = {}
         kw: dict[str, typing.Any] = {}
         if chunked_via == "kwarg":
             kw["chunked"] = True

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -39,6 +39,7 @@ from urllib3 import (
     HTTPConnectionPool,
     HTTPResponse,
     HTTPSConnectionPool,
+    PoolManager,
     ProxyManager,
     util,
 )
@@ -2853,3 +2854,92 @@ class TestContentFraming(SocketDummyServerTestCase):
 
             sent_bytes = bytes(buffer)
             assert sent_bytes.endswith(expected)
+
+    def _start_303_redirect_server(self, requests: list[bytearray]) -> None:
+        """Answer the first request with a 303 and the second one with a 200.
+
+        Each request is read up to the end of its body, so that the bytes
+        recorded in ``requests`` include any framing the client emitted.
+        """
+
+        def read_request(sock: socket.socket) -> bytearray:
+            buffer = bytearray()
+            while b"\r\n\r\n" not in buffer:
+                buffer += sock.recv(65536)
+            # A chunked body is terminated by a zero-length chunk, everything
+            # else that urllib3 may send here is header-only.
+            if b"transfer-encoding" in buffer.lower():
+                while not buffer.endswith(b"0\r\n\r\n"):
+                    buffer += sock.recv(65536)
+            return buffer
+
+        def socket_handler(listener: socket.socket) -> None:
+            for response in (
+                b"HTTP/1.1 303 See Other\r\n"
+                b"Location: /done\r\n"
+                b"Content-Length: 0\r\n\r\n",
+                b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n",
+            ):
+                sock = listener.accept()[0]
+                sock.settimeout(LONG_TIMEOUT)
+                requests.append(read_request(sock))
+                sock.sendall(response)
+                sock.close()
+
+        self._start_server(socket_handler)
+
+    @pytest.mark.parametrize("use_pool_manager", [True, False])
+    @pytest.mark.parametrize("chunked_via", ["kwarg", "header"])
+    def test_303_redirect_drops_chunked_framing(
+        self, use_pool_manager: bool, chunked_via: str
+    ) -> None:
+        # A 303 makes urllib3 drop the request body, so the redirected GET
+        # must not keep announcing a chunked body it will never send.
+        requests: list[bytearray] = []
+        self._start_303_redirect_server(requests)
+
+        kw: dict[str, typing.Any] = {"body": iter([b"xxxxxxxx"])}
+        if chunked_via == "kwarg":
+            kw["chunked"] = True
+        else:
+            kw["headers"] = {"Transfer-Encoding": "chunked"}
+
+        if use_pool_manager:
+            with PoolManager(timeout=LONG_TIMEOUT) as http:
+                resp = http.request("POST", f"http://{self.host}:{self.port}/", **kw)
+        else:
+            with HTTPConnectionPool(self.host, self.port, timeout=LONG_TIMEOUT) as pool:
+                resp = pool.request("POST", "/", **kw)
+        assert resp.status == 200
+
+        assert len(requests) == 2
+        original, redirected = (bytes(request) for request in requests)
+        assert original.startswith(b"POST / ")
+        assert b"Transfer-Encoding: chunked\r\n" in original
+        assert original.endswith(b"8\r\nxxxxxxxx\r\n0\r\n\r\n")
+
+        assert redirected.startswith(b"GET /done ")
+        assert b"transfer-encoding" not in redirected.lower()
+        assert b"content-length" not in redirected.lower()
+        assert redirected.endswith(b"\r\n\r\n")
+
+    @pytest.mark.parametrize("use_pool_manager", [True, False])
+    def test_303_redirect_with_file_body(self, use_pool_manager: bool) -> None:
+        # The dropped body must not leave a body position behind, otherwise
+        # rewinding a body that is no longer there fails the whole request.
+        requests: list[bytearray] = []
+        self._start_303_redirect_server(requests)
+
+        body = io.BytesIO(b"xxxxxxxx")
+        if use_pool_manager:
+            with PoolManager(timeout=LONG_TIMEOUT) as http:
+                resp = http.request(
+                    "POST", f"http://{self.host}:{self.port}/", body=body, body_pos=0
+                )
+        else:
+            with HTTPConnectionPool(self.host, self.port, timeout=LONG_TIMEOUT) as pool:
+                resp = pool.request("POST", "/", body=body)
+        assert resp.status == 200
+
+        assert len(requests) == 2
+        assert bytes(requests[1]).startswith(b"GET /done ")

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -39,7 +39,6 @@ from urllib3 import (
     HTTPConnectionPool,
     HTTPResponse,
     HTTPSConnectionPool,
-    PoolManager,
     ProxyManager,
     util,
 )
@@ -2854,92 +2853,3 @@ class TestContentFraming(SocketDummyServerTestCase):
 
             sent_bytes = bytes(buffer)
             assert sent_bytes.endswith(expected)
-
-    def _start_303_redirect_server(self, requests: list[bytearray]) -> None:
-        """Answer the first request with a 303 and the second one with a 200.
-
-        Each request is read up to the end of its body, so that the bytes
-        recorded in ``requests`` include any framing the client emitted.
-        """
-
-        def read_request(sock: socket.socket) -> bytearray:
-            buffer = bytearray()
-            while b"\r\n\r\n" not in buffer:
-                buffer += sock.recv(65536)
-            # A chunked body is terminated by a zero-length chunk, everything
-            # else that urllib3 may send here is header-only.
-            if b"transfer-encoding" in buffer.lower():
-                while not buffer.endswith(b"0\r\n\r\n"):
-                    buffer += sock.recv(65536)
-            return buffer
-
-        def socket_handler(listener: socket.socket) -> None:
-            for response in (
-                b"HTTP/1.1 303 See Other\r\n"
-                b"Location: /done\r\n"
-                b"Content-Length: 0\r\n\r\n",
-                b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n",
-            ):
-                sock = listener.accept()[0]
-                sock.settimeout(LONG_TIMEOUT)
-                requests.append(read_request(sock))
-                sock.sendall(response)
-                sock.close()
-
-        self._start_server(socket_handler)
-
-    @pytest.mark.parametrize("use_pool_manager", [True, False])
-    @pytest.mark.parametrize("chunked_via", ["kwarg", "header"])
-    def test_303_redirect_drops_chunked_framing(
-        self, use_pool_manager: bool, chunked_via: str
-    ) -> None:
-        # A 303 makes urllib3 drop the request body, so the redirected GET
-        # must not keep announcing a chunked body it will never send.
-        requests: list[bytearray] = []
-        self._start_303_redirect_server(requests)
-
-        kw: dict[str, typing.Any] = {"body": iter([b"xxxxxxxx"])}
-        if chunked_via == "kwarg":
-            kw["chunked"] = True
-        else:
-            kw["headers"] = {"Transfer-Encoding": "chunked"}
-
-        if use_pool_manager:
-            with PoolManager(timeout=LONG_TIMEOUT) as http:
-                resp = http.request("POST", f"http://{self.host}:{self.port}/", **kw)
-        else:
-            with HTTPConnectionPool(self.host, self.port, timeout=LONG_TIMEOUT) as pool:
-                resp = pool.request("POST", "/", **kw)
-        assert resp.status == 200
-
-        assert len(requests) == 2
-        original, redirected = (bytes(request) for request in requests)
-        assert original.startswith(b"POST / ")
-        assert b"Transfer-Encoding: chunked\r\n" in original
-        assert original.endswith(b"8\r\nxxxxxxxx\r\n0\r\n\r\n")
-
-        assert redirected.startswith(b"GET /done ")
-        assert b"transfer-encoding" not in redirected.lower()
-        assert b"content-length" not in redirected.lower()
-        assert redirected.endswith(b"\r\n\r\n")
-
-    @pytest.mark.parametrize("use_pool_manager", [True, False])
-    def test_303_redirect_with_file_body(self, use_pool_manager: bool) -> None:
-        # The dropped body must not leave a body position behind, otherwise
-        # rewinding a body that is no longer there fails the whole request.
-        requests: list[bytearray] = []
-        self._start_303_redirect_server(requests)
-
-        body = io.BytesIO(b"xxxxxxxx")
-        if use_pool_manager:
-            with PoolManager(timeout=LONG_TIMEOUT) as http:
-                resp = http.request(
-                    "POST", f"http://{self.host}:{self.port}/", body=body, body_pos=0
-                )
-        else:
-            with HTTPConnectionPool(self.host, self.port, timeout=LONG_TIMEOUT) as pool:
-                resp = pool.request("POST", "/", body=body)
-        assert resp.status == 200
-
-        assert len(requests) == 2
-        assert bytes(requests[1]).startswith(b"GET /done ")


### PR DESCRIPTION
Following a 303 redirect, urllib3 switches the method to `GET` and drops the request body per RFC 9110, Section 15.4.4 — but the state that *describes* that body survives the switch. Two things go wrong as a result.

### 1. The redirected GET announces a body it never sends

With `chunked=True` (or an explicit `Transfer-Encoding: chunked` header), the follow-up request goes out as:

```
GET /done HTTP/1.1
Host: 127.0.0.1:8080
Accept-Encoding: identity
Transfer-Encoding: chunked
User-Agent: python-urllib3/2.x

0
```

A bodyless `GET` framed with chunked transfer encoding. Harmless against tolerant servers, but it is invalid framing for a request with no content, and strict servers and intermediaries reject it.

### 2. A file-like body makes the redirect fail outright

`body_pos` also survives the body being set to `None`, so urllib3 then tries to rewind a body that no longer exists:

```python
import urllib3

pool = urllib3.HTTPConnectionPool(host, port)
pool.urlopen("POST", "/", body=open("payload.bin", "rb"), redirect=True)
```

against a server answering `303 See Other`:

```
  File "urllib3/connectionpool.py", line 768, in urlopen
    body_pos = set_file_position(body, body_pos)
  File "urllib3/util/request.py", line 184, in set_file_position
    rewind_body(body, pos)
  File "urllib3/util/request.py", line 221, in rewind_body
    raise ValueError(
ValueError: body_pos must be of type integer, instead it was <class 'int'>.
```

The message is self-contradictory because it reports the type of `body_pos` while the actual failure is that `body` is `None` and has no `seek()`.

Both problems affect `HTTPConnectionPool.urlopen()` and `PoolManager.urlopen()`, so the top-level `urllib3.request()` is affected too.

## The fix

When the body is dropped, the state describing it goes with it:

- `HTTPConnectionPool.urlopen()` and `PoolManager.urlopen()`: reset `chunked = False` and `body_pos = None` in the 303 branch, alongside the existing `body = None`.
- `HTTPHeaderDict._prepare_for_method_change()`: also discard `Transfer-Encoding`. This covers the case where the body was framed by an explicit header rather than by the `chunked=` keyword. The method already discards `Content-Length`, so dropping the sibling framing header is consistent with what it does today.

## Testing

Seven new tests, all of which fail before this change and pass after:

- `TestContentFraming::test_303_redirect_drops_chunked_framing` — socket-level, parametrized over `HTTPConnectionPool` × `PoolManager` and over `chunked=True` × explicit `Transfer-Encoding` header. Asserts the exact bytes on the wire: the original `POST` carries the chunked body, the redirected `GET` carries no framing headers and no body.
- `TestContentFraming::test_303_redirect_with_file_body` — socket-level, both pool types, covers the `ValueError`.
- `TestFileBodiesOnRetryOrRedirect::test_303_redirect_with_failed_tell` — pins the behaviour that a 303 never needs to rewind, so an unrewindable body is not an error.

### One existing test changed

`test_redirect_with_failed_tell` used `/redirect`, which defaults to `303 See Other`. That meant it was asserting the buggy behaviour: `UnrewindableBodyError` raised for a body that never needed rewinding, because the 303 had already discarded it.

I pointed it at `status=307`, which genuinely preserves the body and so genuinely requires a rewind. This keeps the test exercising the path its docstring describes, and matches how its sibling `test_redirect_put_file` in the same class already selects `status=307` for body-preserving redirect coverage. The 303 case it used to cover incidentally is now covered explicitly by the new `test_303_redirect_with_failed_tell`.

## Relationship to #3779 / #3780

Issue #3779 reports the same confusing `ValueError` message from a different trigger: a user-supplied body with `tell()` but no `seek()`. Open PR #3780 proposes changing `rewind_body()` to raise `UnrewindableBodyError` instead.

These are complementary, not overlapping — different functions, no conflicting lines. Worth noting that #3780 alone would not fix the case in this PR: it would only rename the exception, because here the real problem is that there is nothing left to rewind at all. Conversely this PR does not address #3779, which is about a body urllib3 still intends to send.

## Checks

- Full test suite run before and after; the only difference is the seven new tests flipping from fail to pass, no regressions.
- `black`, `isort`, `flake8`, `pyupgrade`, and `mypy` clean on all changed files.
