### PR TITLE
Fix `emscripten(firefox)` tests

### DIFF
--- a/changelog/5166.misc.rst
+++ b/changelog/5166.misc.rst
@@ -1,0 +1,1 @@
+Enabled JSPI tests with Firefox in the Emscripten test suite.

--- a/dummyserver/app.py
+++ b/dummyserver/app.py
@@ -392,7 +392,7 @@ def _get_pyodide_template(py_file: str) -> bytes | None:
     # before anything else
     if py_file == "webworker_dev.js":
         return b"""
-            importScripts("./pyodide.js");
+            import { loadPyodide } from "./pyodide.mjs";
 
             onmessage = async function (e) {
                 try {

--- a/noxfile.py
+++ b/noxfile.py
@@ -274,7 +274,7 @@ def emscripten(session: nox.Session, runner: str) -> None:
         dist_dir = Path(os.environ["PYODIDE_ROOT"]) / "dist"
     else:
         # we don't have a build tree
-        pyodide_version = "0.29.3"
+        pyodide_version = "314.0.4"
 
         pyodide_artifacts_path = Path(session.cache_dir) / f"pyodide-{pyodide_version}"
         if not pyodide_artifacts_path.exists():

--- a/test/contrib/emscripten/conftest.py
+++ b/test/contrib/emscripten/conftest.py
@@ -219,12 +219,14 @@ class ServerRunnerInfo:
                 process.chdir('{self.dist_dir}');
                 """
             )
+            worker_options = ""
         else:
             worker_path = f"https://{self.host}:{self.port}/pyodide/webworker_dev.js"
+            worker_options = ", { type: 'module' }"
         coverage_out_binary = bytes(
             self.selenium.run_js(
                 f"""
-            let worker = new Worker('{worker_path}');
+            let worker = new Worker('{worker_path}'{worker_options});
             let p = new Promise((res, rej) => {{
                 worker.onmessageerror = e => rej(e);
                 worker.onerror = e => rej(e);

--- a/test/contrib/emscripten/conftest.py
+++ b/test/contrib/emscripten/conftest.py
@@ -87,7 +87,7 @@ def _get_coverage_code() -> tuple[str, str]:
 
 def _get_jspi_monkeypatch_code(runtime: str, prefer_jspi: bool) -> tuple[str, str]:
     """
-    Return code to make Pyodide think JSPI is disabled in Chrome when a
+    Return code to make Pyodide think JSPI is disabled in browsers when a
     test needs this to check some code paths.
     """
     if runtime == "node" or prefer_jspi:

--- a/test/contrib/emscripten/conftest.py
+++ b/test/contrib/emscripten/conftest.py
@@ -90,7 +90,7 @@ def _get_jspi_monkeypatch_code(runtime: str, prefer_jspi: bool) -> tuple[str, st
     Return code to make Pyodide think JSPI is disabled in Chrome when a
     test needs this to check some code paths.
     """
-    if runtime != "chrome" or prefer_jspi:
+    if runtime == "node" or prefer_jspi:
         return "", ""
     monkeypatch_code = textwrap.dedent(
         """
@@ -303,11 +303,6 @@ def pytest_collection_modifyitems(
             deselected_tests.append(item)
             continue
 
-        # Firefox cannot run JSPI tests.
-        if runtime.startswith("firefox") and item.get_closest_marker("with_jspi"):
-            deselected_tests.append(item)
-            continue
-
         selected_tests.append(item)
 
     config.hook.pytest_deselected(items=deselected_tests)
@@ -332,12 +327,8 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
             else:
                 can_run_with_jspi = True
                 can_run_without_jspi = False
-        # firefox doesn't support JSPI
-        elif metafunc.config.getoption("--runtime").startswith("firefox"):
-            can_run_with_jspi = False
-            can_run_without_jspi = True
         else:
-            # chrome supports JSPI on or off
+            # Chrome and Firefox support JSPI on or off
             can_run_without_jspi = True
             can_run_with_jspi = True
 


### PR DESCRIPTION
`emscripten(firefox)` tests have been failing because Firefox 153 enabled JSPI.
https://github.com/urllib3/urllib3/actions/runs/31872888035/job/94985361383

This PR enables JSPI tests in Firefox and upgrades Pyodide to 314.0.4.

Refs:
- https://bugzilla.mozilla.org/show_bug.cgi?id=2044809
- https://github.com/pyodide/pyodide/pull/6111