### PR TITLE
Raise ProtocolError when an HTTP/2 response ends prematurely

### DIFF
--- a/changelog/5167.bugfix.rst
+++ b/changelog/5167.bugfix.rst
@@ -1,0 +1,4 @@
+Fixed a hang when an HTTP/2 server closed the connection before sending a
+complete response. This now raises ``urllib3.exceptions.ProtocolError``, as do
+``h2`` errors raised while parsing a response, which previously escaped
+uncaught.

--- a/src/urllib3/http2/connection.py
+++ b/src/urllib3/http2/connection.py
@@ -9,11 +9,12 @@ import typing
 import h2.config
 import h2.connection
 import h2.events
+import h2.exceptions
 
 from .._base_connection import _TYPE_BODY
 from .._collections import HTTPHeaderDict
 from ..connection import HTTPSConnection, _get_default_user_agent
-from ..exceptions import ConnectionError
+from ..exceptions import ConnectionError, ProtocolError
 from ..response import BaseHTTPResponse
 
 orig_HTTPSConnection = HTTPSConnection
@@ -234,7 +235,10 @@ class HTTP2Connection(HTTPSConnection):
             while not end_stream:
                 # TODO: Arbitrary read value.
                 if received_data := self.sock.recv(65535):
-                    events = conn.receive_data(received_data)
+                    try:
+                        events = conn.receive_data(received_data)
+                    except h2.exceptions.H2Error as e:
+                        raise ProtocolError(f"Connection broken: {e!r}", e) from e
                     for event in events:
                         if isinstance(event, h2.events.ResponseReceived):
                             headers = HTTPHeaderDict()
@@ -254,6 +258,8 @@ class HTTP2Connection(HTTPSConnection):
 
                         elif isinstance(event, h2.events.StreamEnded):
                             end_stream = True
+                else:  # The peer closed the connection.
+                    raise ProtocolError("Response ended prematurely")
 
                 if data_to_send := conn.data_to_send():
                     self.sock.sendall(data_to_send)

--- a/test/test_http2_connection.py
+++ b/test/test_http2_connection.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 import socket
 from unittest import mock
 
+import h2.exceptions
 import pytest
 
 from urllib3.connection import _get_default_user_agent
-from urllib3.exceptions import ConnectionError
+from urllib3.exceptions import ConnectionError, ProtocolError
 from urllib3.http2.connection import (
     HTTP2Connection,
     _is_illegal_header_value,
@@ -384,3 +385,29 @@ class TestHTTP2Connection:
         )
 
         close_connection.assert_called_with()
+
+    def test_getresponse_peer_closed_connection(self) -> None:
+        conn = HTTP2Connection("example.com")
+        conn.sock = mock.MagicMock(
+            recv=mock.Mock(return_value=b""),
+        )
+
+        with pytest.raises(ProtocolError, match="Response ended prematurely"):
+            conn.getresponse()
+
+        # An empty read used to leave 'end_stream' false and re-enter the
+        # loop, so 'recv()' was called until the process was killed.
+        assert conn.sock.recv.call_count == 1
+
+    def test_getresponse_h2_error(self) -> None:
+        conn = HTTP2Connection("example.com")
+        conn.sock = mock.MagicMock(
+            recv=mock.Mock(return_value=b"not-a-valid-frame"),
+        )
+        h2_error = h2.exceptions.ProtocolError("cannot receive data before headers")
+        conn._h2_conn._obj.receive_data = mock.Mock(side_effect=h2_error)  # type: ignore[method-assign]
+
+        with pytest.raises(ProtocolError, match="Connection broken") as excinfo:
+            conn.getresponse()
+
+        assert excinfo.value.__cause__ is h2_error


### PR DESCRIPTION
Fixes #5167.

### The bug

`HTTP2Connection.getresponse()` only leaves its read loop on a `StreamEnded` event. When `self.sock.recv(65535)` returns `b""` — an orderly close by the peer — the walrus condition is false, no branch runs, and nothing raises, so `end_stream` stays false and the loop calls `recv()` again immediately. It never returns, pegs a CPU core at roughly 220k `recv()` calls per second, and can't be interrupted by the socket's read timeout because no syscall ever blocks.

Three ordinary server behaviours trigger it: closing without a response, closing mid-body after headers, and closing after a 1xx informational response.

### The fix

Raise `ProtocolError("Response ended prematurely")`, reusing the message the HTTP/1.1 path already uses for a truncated response (`response.py:1358`). `ProtocolError` is already in the `except` tuple in `connectionpool.urlopen()`, so the connection is discarded rather than returned to the pool, and `Retry._is_read_error()` already covers it, so idempotent requests retry — the same treatment HTTP/1.1 gets.

The commit also wraps `h2`'s exceptions from `receive_data()` in `ProtocolError`, following the existing `f"Connection broken: {e!r}"` pattern from `response.py:932`. Without it, sending `END_STREAM` with no preceding `HEADERS` surfaces a raw `h2.exceptions.ProtocolError` to callers who only catch `urllib3.exceptions.HTTPError`. `H2Error` is the base class, so this covers the whole family, and `receive_data()` is the only call here that parses peer-controlled bytes — `acknowledge_received_data()` catches `StreamClosedError` internally and otherwise only raises `ValueError` for arguments h2's own events can't produce.

The `raise` sits in an `else:` on the existing walrus-`if` deliberately: an early-return guard would have re-indented the whole event loop and buried a 4-line change in a 40-line diff.

### Verification

Behaviour against a scripted h2 server, before and after:

| Server behaviour | Before | After |
| --- | --- | --- |
| Clean FIN, no response | spins forever | `ProtocolError: Response ended prematurely` |
| Headers, then FIN mid-body | spins forever | same |
| 103 informational, then FIN | spins forever | same |
| `END_STREAM` with no `HEADERS` | raw `h2.exceptions.ProtocolError` | wrapped, `__cause__` preserved |
| Normal 200 / trailers | OK | OK |

I also confirmed the `h2` `RLock` is released when the new `raise` fires — a leaked acquisition would have deadlocked `close()`, which re-enters the same lock on the error path — and that the connection closes and resets cleanly afterwards.

Coverage of `http2/connection.py` from `test/test_http2_connection.py` goes from 79% to 84%; both new branches are covered and the remaining misses are a strict subset of what upstream already misses. The happy path stays covered by the `http_version` dummyserver fixture, as before.

### Not included

Two adjacent problems in the same function, described in #5167, that seemed like separate changes. `RST_STREAM` and `GOAWAY` aren't handled at all — they don't spin, but they block until the read timeout (indefinitely when it's `None`, the default) and then report a misleading `TimeoutError`. Happy to fold that in here if you'd rather have one change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
