### PR TITLE
Merge fields into an existing query instead of appending a second '?'

### DIFF
--- a/changelog/5169.bugfix.rst
+++ b/changelog/5169.bugfix.rst
@@ -1,0 +1,4 @@
+Fixed ``fields`` being appended to a URL that already had a query or a
+fragment. The parameters are now merged into the existing query; previously
+they produced a second ``?``, or were silently dropped from the request when
+the URL had a fragment.

--- a/src/urllib3/_request_methods.py
+++ b/src/urllib3/_request_methods.py
@@ -177,7 +177,9 @@ class RequestMethods:
         extra_kw.update(urlopen_kw)
 
         if fields:
-            url += "?" + urlencode(fields)
+            base, fragment_sep, fragment = url.partition("#")
+            separator = "&" if "?" in base else "?"
+            url = f"{base}{separator}{urlencode(fields)}{fragment_sep}{fragment}"
 
         return self.urlopen(method, url, **extra_kw)
 

--- a/test/test_poolmanager.py
+++ b/test/test_poolmanager.py
@@ -514,3 +514,27 @@ class TestPoolManager:
 
         # Connection should be closed, because reference to pool_1 is gone.
         assert conn_queue.qsize() == 0
+
+    @pytest.mark.parametrize(
+        ["url", "expected_url"],
+        [
+            # An existing query is joined with '&', not a second '?'.
+            ("http://example.com/p?a=b", "http://example.com/p?a=b&q=1"),
+            # A '?' inside the fragment is not a query, and the fragment stays.
+            ("http://example.com/p#a?b", "http://example.com/p?q=1#a?b"),
+        ],
+    )
+    def test_request_encode_url_merges_fields(
+        self, url: str, expected_url: str
+    ) -> None:
+        """Fields join an existing query and stay ahead of the fragment.
+
+        The fragment is kept because ``RequestMethods`` is a documented mixin:
+        urllib3's own pools drop it before sending, but a third-party
+        ``urlopen`` may not.
+        """
+        with PoolManager() as http:
+            with patch.object(PoolManager, "urlopen") as mock_urlopen:
+                http.request_encode_url("GET", url, fields={"q": "1"})
+
+        assert mock_urlopen.call_args[0][1] == expected_url


### PR DESCRIPTION
### The bug

`RequestMethods.request_encode_url()` appends the encoded fields unconditionally:

```python
url += "?" + urlencode(fields)
```

That is only correct when the URL has neither a query nor a fragment. Request lines observed against a local server, calling `http.request("GET", url, fields={"q": "1"})`:

| `url` passed by the caller | request line before | request line after |
| --- | --- | --- |
| `/p` | `GET /p?q=1` | `GET /p?q=1` (unchanged) |
| `/p?a=b` | `GET /p?a=b?q=1` | `GET /p?a=b&q=1` |
| `/p#frag` | `GET /p` — **`q=1` never sent** | `GET /p?q=1` |
| `/p?a=b#frag` | `GET /p?a=b` — **`q=1` never sent** | `GET /p?a=b&q=1` |

Two distinct problems. With an existing query the target carries a second `?`, so the server parses `a` as `b?q=1` and never sees `q`. With a fragment the fields land *inside* the fragment, and since both `PoolManager.urlopen()` and `HTTPConnectionPool.urlopen()` strip fragments via `_replace(fragment=None)` before sending, the parameters are silently discarded — no exception, no warning, just a request missing its arguments.

### The fix

```python
base, fragment_sep, fragment = url.partition("#")
separator = "&" if "?" in base else "?"
url = f"{base}{separator}{urlencode(fields)}{fragment_sep}{fragment}"
```

Splitting the fragment off first matters: testing `"?" in url` on the unsplit string would treat a `?` inside a fragment as a query and pick `&`, producing `/p&q=1`.

Merging with `&` rather than starting a second query matches what `requests` does in `PreparedRequest.prepare_url()`, so behaviour is consistent for anyone moving between the two.

The fragment is preserved rather than dropped. urllib3's own pools discard it, so this is invisible in-tree — but `RequestMethods` is exported in `__all__` and documented as a *"convenience mixin for classes who implement a `urlopen` method"*, with an abstract `urlopen()` that instructs subclasses to provide their own. A third-party `urlopen()` may well care.

I deliberately did **not** use `urlsplit()`/`urlparse()` even though they hand back `.query` directly. Both silently strip ASCII control characters:

```
input     'http://exa\nmple.com/p?a=1'
urlsplit  -> netloc='example.com'
parse_url -> raises LocationParseError
```

Routing the URL through them would turn an input urllib3 currently rejects into a successful request to a different host. urllib3's own `parse_url()` rejects correctly but normalises everything else (`http://EXAMPLE.com/a/../b` becomes `http://example.com/b`), which is more change than this bug warrants.

Performance is unaffected: the added work measures 13–48 ns against ~695 ns for the `urlencode()` call it sits beside, and it does not scale with URL length.

### Tests

Two parametrized cases in `test/test_poolmanager.py`. Both fail against `main` and pass with the fix.

The set is small on purpose. I checked it by mutation testing — seven plausible wrong implementations (original bug, always `&`, always `?`, reordered `?` check, `partition("?")` typo, fragment dropped two ways) — and these two cases detect all seven. No single case detects all seven, so two is the minimum rather than a rounding-down.

**No integration tests are included.** I wrote a set against the `/echo_uri` endpoint first and then measured them: against every one of those seven mutations they were strictly weaker than the unit tests, catching nothing the unit tests missed while themselves missing the two fragment-dropping mutations — the fragment is stripped before the wire, so it cannot be observed there. What they *would* add is a guard at the level the symptom actually appears, tying the fix to "the parameters reach the server" rather than to an intermediate URL string. Happy to add them if you would rather have that, either as a sibling to `test_encode_http_target` or trimmed to the single `#fragment` case as an end-to-end witness — just say which.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
