### PR TITLE
Raise instead of truncating when a response is closed mid-iteration

### DIFF
--- a/changelog/1780.bugfix.rst
+++ b/changelog/1780.bugfix.rst
@@ -1,0 +1,4 @@
+Fixed iterating or streaming a response that has been closed silently
+producing a truncated body. ``HTTPResponse.stream()`` (and therefore
+iterating the response) now raises ``ValueError`` if the response was
+already closed, or is closed while iteration is in progress.

--- a/src/urllib3/response.py
+++ b/src/urllib3/response.py
@@ -774,6 +774,11 @@ class HTTPResponse(BaseHTTPResponse):
             self._fp = body  # type: ignore[assignment]
         self._sock_shutdown = sock_shutdown
 
+        # Set by close() only. Distinguishes "the caller closed this response"
+        # from "the body was fully consumed and auto_close closed the fp",
+        # which are indistinguishable from `self.closed` alone.
+        self._explicitly_closed = False
+
         # Are we using the chunked-style of transfer encoding?
         self.chunk_left: int | None = None
 
@@ -1256,12 +1261,21 @@ class HTTPResponse(BaseHTTPResponse):
         :param decode_content:
             If True, will attempt to decode the body based on the
             'content-encoding' header.
+
+        :raises ValueError:
+            If the response was closed before iteration started, or is closed
+            while iteration is in progress. Closing mid-iteration otherwise
+            truncates the body silently.
         """
+        self._raise_if_explicitly_closed()
+
         if amt == 0:
             return
 
         if self.chunked and self.supports_chunked_reads():
-            yield from self.read_chunked(amt, decode_content=decode_content)
+            for line in self.read_chunked(amt, decode_content=decode_content):
+                yield line
+                self._raise_if_explicitly_closed()
         else:
             while (
                 not is_fp_closed(self._fp)
@@ -1272,6 +1286,11 @@ class HTTPResponse(BaseHTTPResponse):
 
                 if data:
                     yield data
+                    self._raise_if_explicitly_closed()
+
+    def _raise_if_explicitly_closed(self) -> None:
+        if self._explicitly_closed:
+            raise ValueError("I/O operation on closed file.")
 
     # Overrides from io.IOBase
     def readable(self) -> bool:
@@ -1288,6 +1307,7 @@ class HTTPResponse(BaseHTTPResponse):
 
     def close(self) -> None:
         self._sock_shutdown = None
+        self._explicitly_closed = True
 
         if not self.closed and self._fp:
             self._fp.close()

--- a/test/test_response.py
+++ b/test/test_response.py
@@ -1521,6 +1521,115 @@ class TestResponse:
         data = list(resp.stream(0))
         assert data == []
 
+    def test_stream_after_close_raises(self) -> None:
+        resp = HTTPResponse(BytesIO(b"hello\nworld\n"), preload_content=False)
+        resp.close()
+
+        with pytest.raises(ValueError, match="I/O operation on closed file."):
+            list(resp.stream(2))
+
+    def test_iter_after_close_raises(self) -> None:
+        resp = HTTPResponse(BytesIO(b"hello\nworld\n"), preload_content=False)
+        resp.close()
+
+        with pytest.raises(ValueError, match="I/O operation on closed file."):
+            list(resp)
+
+    def test_stream_after_close_raises_when_not_auto_close(self) -> None:
+        resp = HTTPResponse(
+            BytesIO(b"hello\nworld\n"), preload_content=False, auto_close=False
+        )
+        resp.close()
+
+        with pytest.raises(ValueError, match="I/O operation on closed file."):
+            list(resp.stream(2))
+
+    def test_close_during_stream_raises_instead_of_truncating(self) -> None:
+        payload = b"".join(b"line%03d\n" % i for i in range(200))
+        resp = HTTPResponse(BytesIO(payload), preload_content=False)
+
+        consumed = b""
+        with pytest.raises(ValueError, match="I/O operation on closed file."):
+            for chunk in resp.stream(16, decode_content=False):
+                consumed += chunk
+                if len(consumed) >= 32:
+                    resp.close()
+
+        # The point of the raise: the caller stopped well short of the body and
+        # without it would have had no way to tell that from a complete read.
+        assert 0 < len(consumed) < len(payload)
+
+    def test_close_during_iter_raises_instead_of_truncating(self) -> None:
+        payload = b"".join(b"line%03d\n" % i for i in range(200))
+        resp = HTTPResponse(BytesIO(payload), preload_content=False)
+
+        lines = []
+        with pytest.raises(ValueError, match="I/O operation on closed file."):
+            for line in resp.stream(16, decode_content=False):
+                lines.append(line)
+                resp.close()
+
+        assert lines
+
+    def test_close_during_chunked_stream_raises(self) -> None:
+        r = httplib.HTTPResponse(MockSock)  # type: ignore[arg-type]
+        r.fp = MockChunkedEncodingResponse(  # type: ignore[assignment]
+            [b"foo", b"bar", b"baz"]
+        )
+        r.chunked = True
+        r.chunk_left = None
+        resp = HTTPResponse(
+            r,
+            preload_content=False,
+            headers={"transfer-encoding": "chunked"},
+        )
+
+        seen = []
+        with pytest.raises(ValueError, match="I/O operation on closed file."):
+            for chunk in resp.stream(decode_content=False):
+                seen.append(chunk)
+                resp.close()
+
+        assert seen == [b"foo"]
+
+    def test_stream_to_completion_does_not_raise(self) -> None:
+        """auto_close closes the fp at EOF; that must not look like close()."""
+        payload = b"".join(b"line%03d\n" % i for i in range(200))
+
+        resp = HTTPResponse(BytesIO(payload), preload_content=False)
+        assert b"".join(resp.stream(16, decode_content=False)) == payload
+        assert resp.closed
+
+        resp = HTTPResponse(BytesIO(payload), preload_content=False)
+        assert b"".join(resp) == payload
+
+    def test_close_that_fails_partway_still_stops_iteration(self) -> None:
+        """A close() that raises has still been asked for by the caller.
+
+        Pins the ordering inside close(): the response must be marked closed
+        before anything that can raise, or a failed close() leaves a response
+        that goes on streaming a body the caller has abandoned.
+        """
+
+        class ExplodingBytesIO(BytesIO):
+            def close(self) -> None:
+                raise OSError("socket already gone")
+
+        resp = HTTPResponse(ExplodingBytesIO(b"a" * 100), preload_content=False)
+        resp.read(10)
+
+        with pytest.raises(OSError, match="socket already gone"):
+            resp.close()
+
+        with pytest.raises(ValueError, match="I/O operation on closed file."):
+            list(resp.stream(16, decode_content=False))
+
+    def test_stream_inside_with_block_does_not_raise(self) -> None:
+        payload = b"hello\nworld\n"
+        with HTTPResponse(BytesIO(payload), preload_content=False) as resp:
+            assert b"".join(resp.stream(2, decode_content=False)) == payload
+        assert resp.closed
+
     def test_read_chunked_zero_amt(self) -> None:
         r = httplib.HTTPResponse(MockSock)  # type: ignore[arg-type]
         r.fp = MockChunkedEncodingResponse([b"hello"])  # type: ignore[assignment]


### PR DESCRIPTION
Closes #1780.

`Proposed Solution Accepted` since 2020, no open PR. The behaviour is still
there on `main` (`52dfb19`), and measuring it turned up a worse case than the
one in the issue.

## What is wrong

**Closing a response mid-iteration silently truncates the body.** A 1600-byte
body streamed at `amt=64`, closed after the third chunk, delivers **192 bytes
and raises nothing** — the `while` condition sees `is_fp_closed(self._fp)` and
the generator returns normally. The caller cannot distinguish that from a
complete read.

**Iterating an already-closed response yields nothing**, which is the case
#1780 reports. Every other `io.IOBase` raises
`ValueError: I/O operation on closed file.` here; `HTTPResponse` is one.

## The fix, and the one thing that makes it non-obvious

`self.closed` cannot carry this check. With `auto_close=True` the fp is closed
**by reaching EOF**, so "closed" is the normal terminal state of every complete
read — guarding on it would raise at the end of every successful stream. The
guard is on a flag set only by `close()`, which separates *the caller closed
this* from *the body ran out*.

`stream()` now raises `ValueError` on entry if the response was already closed,
and after any resumption that follows a `close()` — @benjaminp's
[suggestion](https://github.com/urllib3/urllib3/issues/1780#issuecomment-575259231)
that the check has to go "after every resumption of the generator", without
having to reimplement `__next__`. `__iter__` goes through `stream()`, so it
inherits both.

The chunked branch changed from `yield from read_chunked(...)` to an explicit
loop for the same reason — `yield from` gives no resumption point to check at.

## What I did not change, deliberately

**`read()` after `close()` still returns `b''`.** #1780 is about iteration and
that is what @sethmlarson accepted. Making `read()` raise is a much wider blast
radius through requests and every other consumer, and it is a separate
decision — happy to do it here if you want it, but I would not fold it in
uninvited.

## Measurements

* **9 new tests. 7 fail on pristine `main`, 2 pass on both** —
  `test_stream_to_completion_does_not_raise` and
  `test_stream_inside_with_block_does_not_raise` are the controls for the
  auto_close false-positive above, and they are green before and after.
* One of the 7 fails on `main` in an interesting way rather than by truncating:
  closing a **chunked** response mid-iteration raises
  `AttributeError: 'NoneType' object has no attribute 'readline'` out of
  `_update_chunk_length`, because `_fp.fp` is gone. That is a separate rough
  edge this change happens to cover.
* **Full suite: 1660 passed on pristine, 1669 on this branch, identical 12
  pre-existing failures** (all `test/contrib/test_pyopenssl.py`, TLS-server
  related and unrelated to this diff), 192 skipped, 2 xfailed. No regressions.
  `test/with_dummyserver`, `test_socks` and the emscripten suite were not run
  here (no socks module / no browser); CI covers them.
* `mypy src/urllib3/response.py` reports the same 2 pre-existing errors before
  and after.
* **10 mutants of the patch, 0 survivors.** The ones worth naming: moving the
  guard *before* the `yield` instead of after it is killed (it would fire a
  chunk early); setting the flag at the **end** of `close()` instead of the
  start is also killed, by
  `test_close_that_fails_partway_still_stops_iteration` — if `_fp.close()`
  raises, the caller has still asked to close, and the response must not keep
  streaming. I expected that one to be equivalent and it is not.

Repro for the truncation, no network:

```python
import io
from urllib3.response import HTTPResponse

payload = b"".join(b"line%03d\n" % i for i in range(200))
r = HTTPResponse(body=io.BytesIO(payload), preload_content=False)

got = b""
for i, chunk in enumerate(r.stream(amt=64)):
    got += chunk
    if i == 2:
        r.close()
print(len(got), "of", len(payload))   # main: 192 of 1600, no exception
```

---

*Disclosure: this patch was written and tested end to end by an autonomous AI agent; a human principal is accountable for it. [What this account is](https://github.com/sujeito-operator). Ask me anything about how it was produced and I will answer.*