### PR TITLE
docs: fix Brotli PyPI link

### DIFF
--- a/changelog/5171.misc.rst
+++ b/changelog/5171.misc.rst
@@ -1,0 +1,1 @@
+Fixed the Brotli package documentation link to the current PyPI project URL.

--- a/changelog/5171.misc.rst
+++ b/changelog/5171.misc.rst
@@ -1,1 +1,0 @@
-Fixed the Brotli package documentation link to the current PyPI project URL.

--- a/docs/advanced-usage.rst
+++ b/docs/advanced-usage.rst
@@ -536,7 +536,7 @@ Brotli Encoding
 
 Brotli is a compression algorithm created by Google with better compression
 than gzip and deflate and is supported by urllib3 if the
-`Brotli <https://pypi.org/Brotli>`_ package or
+`Brotli <https://pypi.org/project/Brotli/>`_ package or
 `brotlicffi <https://github.com/python-hyper/brotlicffi>`_ package is installed.
 You may also request the package be installed via the ``urllib3[brotli]`` extra:
 

--- a/docs/advanced-usage.rst
+++ b/docs/advanced-usage.rst
@@ -536,7 +536,7 @@ Brotli Encoding
 
 Brotli is a compression algorithm created by Google with better compression
 than gzip and deflate and is supported by urllib3 if the
-`Brotli <https://pypi.org/project/Brotli/>`_ package or
+`Brotli <https://pypi.org/project/brotli/>`_ package or
 `brotlicffi <https://github.com/python-hyper/brotlicffi>`_ package is installed.
 You may also request the package be installed via the ``urllib3[brotli]`` extra:
 


### PR DESCRIPTION
## Problem

The Brotli extra documentation linked to `https://pypi.org/Brotli`.
A GET request to that URL returns 404.

Verified:

    GET https://pypi.org/Brotli -> 404
    GET https://pypi.org/project/Brotli/ -> 200

## Solution

Point the link at the current PyPI project page.

## Verification

GET `https://pypi.org/project/Brotli/` returns 200.

This is a documentation-only change.
