### PR TITLE
docs: update GitCoin Grants sponsor link

### DIFF
--- a/changelog/5172.misc.rst
+++ b/changelog/5172.misc.rst
@@ -1,0 +1,1 @@
+Updated the historical GitCoin Grants sponsor URL to the current grants site.

--- a/docs/sponsors.rst
+++ b/docs/sponsors.rst
@@ -35,7 +35,7 @@ Let us know and we'll be glad to add you to our sponsors list.
 
 * `Spotify <https://engineering.atspotify.com/opensource/>`_ (June 2nd, 2022)
 
-* `GitCoin Grants <https://gitcoin.co/grants>`_ (2019-2020), sponsored `@sethmlarson <https://github.com/sethmlarson>`_
+* `GitCoin Grants <https://grants.gitcoin.co>`_ (2019-2020), sponsored `@sethmlarson <https://github.com/sethmlarson>`_
   and `@pquentin <https://github.com/pquentin>`_
 
 * `Abbott <https://abbott.com>`_ (2018-2019), sponsored `@sethmlarson <https://github.com/sethmlarson>`_


### PR DESCRIPTION
## Problem

The historical GitCoin Grants sponsor entry linked to `https://gitcoin.co/grants`.
A GET request to that URL returns 404. The grants explorer now lives at
`https://grants.gitcoin.co`.

Verified:

    GET https://gitcoin.co/grants -> 404
    GET https://grants.gitcoin.co -> 200

## Solution

Update the historical sponsor link to the current grants site.

## Verification

GET `https://grants.gitcoin.co` returns 200.

This is a documentation-only change.
