### PR TITLE
require chunked to be the final transfer coding for response framing

### DIFF
--- a/changelog/5173.bugfix.rst
+++ b/changelog/5173.bugfix.rst
@@ -1,0 +1,4 @@
+Fixed response framing to treat a body as chunked only when ``chunked`` is
+the final ``Transfer-Encoding`` coding, per RFC 9112 section 6.1. A value
+such as ``chunked, gzip`` where ``chunked`` is not last is no longer read as
+chunked, matching how ``http.client`` frames the same response.

--- a/src/urllib3/response.py
+++ b/src/urllib3/response.py
@@ -493,9 +493,12 @@ class BaseHTTPResponse(io.IOBase):
 
         self.chunked = False
         tr_enc = self.headers.get("transfer-encoding", "").lower()
-        # Don't incur the penalty of creating a list and then discarding it
-        encodings = (enc.strip() for enc in tr_enc.split(","))
-        if "chunked" in encodings:
+        # Per RFC 9112 section 6.1 "chunked" must be the final transfer
+        # coding. Only treat the body as chunk-framed when it is, so a
+        # malformed value such as "chunked, gzip" (where "chunked" is not
+        # last) is not read as chunked while http.client frames it otherwise.
+        encodings = [enc.strip() for enc in tr_enc.split(",") if enc.strip()]
+        if encodings and encodings[-1] == "chunked":
             self.chunked = True
 
         self._decoder: ContentDecoder | None = None

--- a/test/test_response.py
+++ b/test/test_response.py
@@ -263,6 +263,31 @@ class TestResponse:
         assert r._body is None
         assert r.data == b""
 
+    @pytest.mark.parametrize(
+        "transfer_encoding, chunked",
+        [
+            ("chunked", True),
+            ("chunked ", True),
+            ("chunked,", True),
+            (", chunked", True),
+            ("gzip, chunked", True),
+            # "chunked" is not the final transfer coding (RFC 9112 section 6.1),
+            # so the body is not chunk-framed.
+            ("chunked, gzip", False),
+            ("gzip, chunked, identity", False),
+            ("gzip", False),
+        ],
+    )
+    def test_chunked_requires_final_transfer_coding(
+        self, transfer_encoding: str, chunked: bool
+    ) -> None:
+        r = HTTPResponse(
+            BytesIO(b""),
+            headers={"transfer-encoding": transfer_encoding},
+            preload_content=False,
+        )
+        assert r.chunked is chunked
+
     def test_default(self) -> None:
         r = HTTPResponse()
         assert r.data is None


### PR DESCRIPTION
**Response chunked framing accepts a non-final `chunked`**

`BaseHTTPResponse.__init__` flags the body as chunk-framed whenever `chunked` appears anywhere in a comma-split `Transfer-Encoding`, so a server value like `chunked, gzip` sets `self.chunked` even though RFC 9112 section 6.1 requires `chunked` to be the final coding and the `http.client` layer that `read()` frames through matches it exactly (`tr_enc.lower() == "chunked"`). That leaves `.stream()`/`read_chunked()` parsing chunk sizes off the socket while `.read()` frames by Content-Length or close, which desyncs a response when urllib3 forwards it from a proxy or gateway. The check now treats the body as chunked only when `chunked` is the last non-empty coding, so no valid response changes.