### PR TITLE
docs: fix grammar in iter_field_objects docstring

### DIFF
--- a/src/urllib3/filepost.py
+++ b/src/urllib3/filepost.py
@@ -30,7 +30,7 @@ def iter_field_objects(fields: _TYPE_FIELDS) -> typing.Iterable[RequestField]:
     """
     Iterate over fields.
 
-    Supports list of (k, v) tuples and dicts, and lists of
+    Supports a list of (k, v) tuples and dicts, and lists of
     :class:`~urllib3.fields.RequestField`.
 
     """


### PR DESCRIPTION
### Summary
- Add missing article 'a' to `iter_field_objects` docstring in `src/urllib3/filepost.py` (`Supports list of` -> `Supports a list of`).