### PR TITLE
unfold folded response headers with bare-LF line endings

### DIFF
--- a/changelog/5177.bugfix.rst
+++ b/changelog/5177.bugfix.rst
@@ -1,0 +1,4 @@
+Fixed unfolding of obsolete line-folded response headers so raw line breaks no
+longer survive in header values when a server uses bare-LF line endings. A
+folded value such as ``Set-Cookie`` then arrives without a ``\r\n`` substring,
+which previously bypassed the unfolding and left a raw ``\n`` in the value.

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -78,14 +78,22 @@ RECENT_DATE = datetime.date(2025, 1, 1)
 
 _CONTAINS_CONTROL_CHAR_RE = re.compile(r"[^-!#$%&'*+.^_`|~0-9a-zA-Z]")
 # Starting the optional OWS match at the beginning of a whitespace run avoids
-# quadratic backtracking for long header values.
-_OBSOLETE_FOLD_RE = re.compile(r"(?:(?<![ \t])[ \t]+)?\r\n[ \t]+")
+# quadratic backtracking for long header values. http.client accepts responses
+# with bare-LF line endings, so a folded value can arrive with \n or \r rather
+# than \r\n; match all three forms.
+_OBSOLETE_FOLD_RE = re.compile(r"(?:(?<![ \t])[ \t]+)?(?:\r\n|\r|\n)[ \t]+")
 
 
 def _normalize_header_value(value: str) -> str:
-    if "\r\n" not in value:
+    if "\r" not in value and "\n" not in value:
         return value
-    return _OBSOLETE_FOLD_RE.sub(" ", value)
+    value = _OBSOLETE_FOLD_RE.sub(" ", value)
+    # Any CR/LF left after unfolding is not a valid obs-fold (e.g. a bare-LF
+    # server injecting a line break that isn't followed by whitespace). Replace
+    # it so no raw line break survives into the header value.
+    if "\r" in value or "\n" in value:
+        value = value.replace("\r", " ").replace("\n", " ")
+    return value
 
 
 def _normalize_header_values(

--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -218,6 +218,14 @@ class TestConnection:
             ("before \t\r\n\t  after", "before after"),
             ("one\r\n two\t\r\n\tthree", "one two three"),
             ("one\r\n \r\n\tthree", "one  three"),
+            # Bare-LF folding, as produced by http.client for a server that
+            # terminates header lines with \n instead of \r\n.
+            ("before \n\t  after", "before after"),
+            ("one\n two\n\tthree", "one two three"),
+            # A residual bare CR/LF not part of an obs-fold is neutralized.
+            ("value\ninjected", "value injected"),
+            ("value\rinjected", "value injected"),
+            ("one\r\n\ttwo\n three", "one two three"),
         ],
     )
     def test_normalize_header_value(self, value: str, expected: str) -> None:

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -145,6 +145,31 @@ class TestCookies(SocketDummyServerTestCase):
             ]
             assert r._original_response.msg["fold-mixed-repeated"] == "one two three"
 
+    def test_bare_lf_line_folding_is_unfolded(self) -> None:
+        def folded_cookie_response_handler(listener: socket.socket) -> None:
+            with listener.accept()[0] as sock:
+                buf = b""
+                while not buf.endswith(b"\r\n\r\n"):
+                    buf += sock.recv(65536)
+
+                # http.client accepts bare-LF line endings, so a folded value
+                # arrives without a \r\n substring and must still be unfolded.
+                sock.sendall(
+                    b"HTTP/1.1 200 OK\n"
+                    b"Set-Cookie: sessionid=abc\n evil=INJECTED\n"
+                    b"Content-Length: 0\n"
+                    b"\n"
+                )
+
+        self._start_server(folded_cookie_response_handler)
+        with HTTPConnectionPool(self.host, self.port) as pool:
+            r = pool.request("GET", "/", retries=0)
+
+            assert r.headers["set-cookie"] == "sessionid=abc evil=INJECTED"
+            assert all(
+                "\r" not in value and "\n" not in value for value in r.headers.values()
+            )
+
 
 class TestSNI(SocketDummyServerTestCase):
     def test_hostname_in_first_request_packet(self) -> None:


### PR DESCRIPTION
`_normalize_header_value` unfolds obsolete line-folded response headers, but its guard and regex only look for `\r\n`, so a server sending bare-LF (`\n`) line endings produces a folded value such as `Set-Cookie: sessionid=abc\n evil=INJECTED` that keeps a raw `\n` after unfolding. That reaches `response.headers`, `response.info()` (read by `http.cookiejar`) and `getheader()`, and breaks the no-raw-CR/LF-in-values invariant the socket-level tests assert. This matches on any `\r` or `\n`, folds `\r\n`/`\r`/`\n` plus following whitespace, and replaces any leftover bare CR/LF with a space so no raw line break survives regardless of the server's line-ending style.