### PR TITLE
Do not retry methods when allowed_methods is empty

### DIFF
--- a/src/urllib3/util/retry.py
+++ b/src/urllib3/util/retry.py
@@ -265,25 +265,25 @@ class Retry:
         self.backoff_jitter = backoff_jitter
 
     def new(self, **kw: typing.Any) -> Self:
-        params = dict(
-            total=self.total,
-            connect=self.connect,
-            read=self.read,
-            redirect=self.redirect,
-            status=self.status,
-            other=self.other,
-            allowed_methods=self.allowed_methods,
-            status_forcelist=self.status_forcelist,
-            backoff_factor=self.backoff_factor,
-            backoff_max=self.backoff_max,
-            retry_after_max=self.retry_after_max,
-            raise_on_redirect=self.raise_on_redirect,
-            raise_on_status=self.raise_on_status,
-            history=self.history,
-            remove_headers_on_redirect=self.remove_headers_on_redirect,
-            respect_retry_after_header=self.respect_retry_after_header,
-            backoff_jitter=self.backoff_jitter,
-        )
+        params = {
+            "total": self.total,
+            "connect": self.connect,
+            "read": self.read,
+            "redirect": self.redirect,
+            "status": self.status,
+            "other": self.other,
+            "allowed_methods": self.allowed_methods,
+            "status_forcelist": self.status_forcelist,
+            "backoff_factor": self.backoff_factor,
+            "backoff_max": self.backoff_max,
+            "retry_after_max": self.retry_after_max,
+            "raise_on_redirect": self.raise_on_redirect,
+            "raise_on_status": self.raise_on_status,
+            "history": self.history,
+            "remove_headers_on_redirect": self.remove_headers_on_redirect,
+            "respect_retry_after_header": self.respect_retry_after_header,
+            "backoff_jitter": self.backoff_jitter,
+        }
 
         params.update(kw)
         return type(self)(**params)  # type: ignore[arg-type]
@@ -340,10 +340,7 @@ class Retry:
             seconds = retry_date - time.time()
 
         seconds = max(seconds, 0)
-
-        # Check the seconds do not exceed the specified maximum
-        if seconds > self.retry_after_max:
-            seconds = self.retry_after_max
+        seconds = min(seconds, self.retry_after_max)
 
         return seconds
 
@@ -405,8 +402,8 @@ class Retry:
         """Checks if a given HTTP method should be retried upon, depending if
         it is included in the allowed_methods
         """
-        if self.allowed_methods and method.upper() not in self.allowed_methods:
-            return False
+        if self.allowed_methods is not None:
+            return method.upper() in self.allowed_methods
         return True
 
     def is_retry(

--- a/test/test_retry.py
+++ b/test/test_retry.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 import datetime
-from test import DUMMY_POOL
 from unittest import mock
 
 import pytest
 
+from test import DUMMY_POOL
 from urllib3.exceptions import (
     ConnectTimeoutError,
     InvalidHeader,
@@ -314,7 +314,7 @@ class TestRetry:
 
     def test_history(self) -> None:
         retry = Retry(total=10, allowed_methods=frozenset(["GET", "POST"]))
-        assert retry.history == tuple()
+        assert retry.history == ()
         connection_error = ConnectTimeoutError("conntimeout")
         retry = retry.increment("GET", "/test1", None, connection_error)
         test_history1 = (RequestHistory("GET", "/test1", connection_error, None, None),)
@@ -438,3 +438,13 @@ class TestRetry:
                 sleep_mock.assert_called_with(sleep_duration)
             else:
                 sleep_mock.assert_not_called()
+
+
+def test_retry_empty_allowed_methods() -> None:
+    retry = Retry(total=3, allowed_methods=set())
+    assert not retry._is_method_retryable("GET")
+    assert not retry._is_method_retryable("POST")
+
+    retry_none = Retry(total=3, allowed_methods=None)
+    assert retry_none._is_method_retryable("GET")
+    assert retry_none._is_method_retryable("POST")


### PR DESCRIPTION
### Summary
When `Retry(allowed_methods=set())` or an empty container was passed, `_is_method_retryable` evaluated `bool(self.allowed_methods)` as `False` and incorrectly allowed all HTTP methods to be retried.

This change explicitly checks `self.allowed_methods is not None`, ensuring that an empty container properly forbids retrying all methods while preserving the `None` default behavior of allowing all methods.

Fixes #5044

### Changes
- Updated `_is_method_retryable` in `src/urllib3/util/retry.py` to check `self.allowed_methods is not None`.
- Added unit test `test_retry_empty_allowed_methods` in `test/test_retry.py`.