### PR TITLE
docs: document best practices for retry backoff_factor and jitter (closes #3677)

### DIFF
--- a/changelog/3677.misc.rst
+++ b/changelog/3677.misc.rst
@@ -1,0 +1,1 @@
+Documented best practices for configuring ``Retry.backoff_factor`` and ``backoff_jitter`` in production environments.

--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -626,8 +626,34 @@ specify the retry at the :class:`~urllib3.poolmanager.PoolManager` level:
         retries=urllib3.Retry(5, redirect=2)
     )
 
-You still override this pool-level retry policy by specifying ``retries`` to
+You can still override this pool-level retry policy by specifying ``retries`` to
 :meth:`~urllib3.PoolManager.request`.
+
+Configuring Exponential Backoff
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+By default, :class:`~urllib3.util.Retry` does not sleep between retry attempts
+(``backoff_factor=0``). In production systems, retrying immediately can overwhelm
+a recovering server or quickly exhaust API rate limits.
+
+It is recommended to set a non-zero ``backoff_factor`` (typically between ``0.5``
+and ``1.0`` seconds) to introduce exponential delays between retries:
+
+.. code-block:: python
+
+    import urllib3
+
+    # Retries wait 0.0s (immediate 2nd attempt), 1.0s, 2.0s, 4.0s...
+    retries = urllib3.Retry(
+        total=3,
+        backoff_factor=0.5,
+        backoff_jitter=0.5,
+        status_forcelist=[429, 500, 502, 503, 504],
+    )
+    http = urllib3.PoolManager(retries=retries)
+
+Adding ``backoff_jitter`` introduces random variance to avoid the "thundering
+herd" problem where many clients retry in lockstep against a server.
 
 Errors & Exceptions
 -------------------

--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -643,7 +643,7 @@ and ``1.0`` seconds) to introduce exponential delays between retries:
 
     import urllib3
 
-    # Retries wait 0.0s (immediate 2nd attempt), 1.0s, 2.0s, 4.0s...
+    # Retries wait 0.0s (immediate 2nd attempt), 1.0s, and 2.0s (plus jitter)
     retries = urllib3.Retry(
         total=3,
         backoff_factor=0.5,

--- a/src/urllib3/util/retry.py
+++ b/src/urllib3/util/retry.py
@@ -155,7 +155,9 @@ class Retry:
         sleep for [0.0s, 0.2s, 0.4s, 0.8s, ...] between retries. No backoff will ever
         be longer than `backoff_max`.
 
-        By default, backoff is disabled (factor set to 0).
+        By default, backoff is disabled (factor set to 0). In production services,
+        setting a non-zero factor (e.g. 0.5 to 1.0) along with `backoff_jitter` is
+        recommended to prevent overloading servers with immediate retries.
 
     :param float backoff_max:
         The maximum backoff time (in seconds) between retry attempts.


### PR DESCRIPTION
Closes #3677

### Summary of Changes

As discussed in #3677, `Retry` defaults to `backoff_factor=0` (no delay between retries). For production services, immediate retries can easily lead to thundering herd problems or exhaust API rate limits.

This PR clarifies and documents recommended retry backoff practices:
1. **`docs/user-guide.rst`**: Added a new **"Configuring Exponential Backoff"** subsection under *Retrying Requests* that shows how to configure `Retry` with exponential backoff (`backoff_factor`) and randomized `backoff_jitter` alongside common status codes (`status_forcelist=[429, 500, 502, 503, 504]`).
2. **`src/urllib3/util/retry.py`**: Updated the docstring for `backoff_factor` to explicitly recommend configuring a non-zero backoff factor (e.g. 0.5 to 1.0) and jitter in production environments.

### Verification
- Ran test suite: `uv run pytest test/test_retry.py` -> 44 passed, 18 skipped, 0 errors.
