### PR TITLE
treat empty allowed_methods as retry no methods, not all

### DIFF
--- a/changelog/5044.bugfix.rst
+++ b/changelog/5044.bugfix.rst
@@ -1,0 +1,3 @@
+Fixed ``Retry`` to treat an empty ``allowed_methods`` container as disabling
+method-based retries instead of behaving like ``None`` and retrying on every
+method, which previously allowed retries on non-idempotent verbs such as POST.

--- a/src/urllib3/util/retry.py
+++ b/src/urllib3/util/retry.py
@@ -131,7 +131,8 @@ class Retry:
         idempotent (multiple requests with the same parameters end with the
         same state). See :attr:`Retry.DEFAULT_ALLOWED_METHODS`.
 
-        Set to a ``None`` value to retry on any verb.
+        Set to a ``None`` value to retry on any verb. An empty container
+        disables method-based retries entirely.
 
     :param Collection status_forcelist:
         A set of integer HTTP status codes that we should force a retry on.
@@ -405,7 +406,10 @@ class Retry:
         """Checks if a given HTTP method should be retried upon, depending if
         it is included in the allowed_methods
         """
-        if self.allowed_methods and method.upper() not in self.allowed_methods:
+        if (
+            self.allowed_methods is not None
+            and method.upper() not in self.allowed_methods
+        ):
             return False
         return True
 

--- a/test/test_retry.py
+++ b/test/test_retry.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import datetime
+import typing
 from test import DUMMY_POOL
 from unittest import mock
 
@@ -263,7 +264,7 @@ class TestRetry:
         assert not retry.is_retry("GET", status_code=418)
 
     def test_allowed_methods_with_status_forcelist(self) -> None:
-        # Falsey allowed_methods means to retry on any method.
+        # None allowed_methods means to retry on any method.
         retry = Retry(status_forcelist=[500], allowed_methods=None)
         assert retry.is_retry("GET", status_code=500)
         assert retry.is_retry("POST", status_code=500)
@@ -272,6 +273,16 @@ class TestRetry:
         retry = Retry(status_forcelist=[500], allowed_methods=["POST"])
         assert not retry.is_retry("GET", status_code=500)
         assert retry.is_retry("POST", status_code=500)
+
+    @pytest.mark.parametrize("allowed_methods", [set(), [], frozenset()])
+    def test_empty_allowed_methods(
+        self, allowed_methods: typing.Collection[str]
+    ) -> None:
+        # An empty container is an allowlist with no members, so no method
+        # is retryable. It must not be conflated with None (retry any method).
+        retry = Retry(status_forcelist=[500], allowed_methods=allowed_methods)
+        assert not retry.is_retry("GET", status_code=500)
+        assert not retry.is_retry("POST", status_code=500)
 
     def test_exhausted(self) -> None:
         assert not Retry(0).is_exhausted()


### PR DESCRIPTION
Retry._is_method_retryable gates on `if self.allowed_methods and ...`, so an explicitly empty allowed_methods container is falsy and behaves exactly like None, which makes every method retryable including non-idempotent ones such as POST. An empty allowlist has no members and should disable method-based retries rather than enable all of them, so this checks `is not None` instead: an empty container now denies every method while None keeps the retry-any default. Fixes #5044.