### PR TITLE
Handle HTTP/2 stream reset and connection termination events

### DIFF
--- a/src/urllib3/http2/connection.py
+++ b/src/urllib3/http2/connection.py
@@ -13,7 +13,7 @@ import h2.events
 from .._base_connection import _TYPE_BODY
 from .._collections import HTTPHeaderDict
 from ..connection import HTTPSConnection, _get_default_user_agent
-from ..exceptions import ConnectionError
+from ..exceptions import ConnectionError, ProtocolError
 from ..response import BaseHTTPResponse
 
 orig_HTTPSConnection = HTTPSConnection
@@ -49,6 +49,27 @@ def _is_illegal_header_value(value: bytes) -> bool:
     0x20 or 0x09)." (https://httpwg.org/specs/rfc9113.html#n-field-validity)
     """
     return bool(RE_IS_ILLEGAL_HEADER_VALUE.search(value))
+
+
+def _format_h2_error(error_code: object) -> str:
+    if hasattr(error_code, "name") and hasattr(error_code, "value"):
+        return f"{error_code.name} ({error_code.value})"
+    return str(error_code)
+
+
+def _raise_for_h2_error_event(event: object) -> None:
+    if isinstance(event, h2.events.StreamReset):
+        raise ProtocolError(
+            "HTTP/2 stream was reset by the peer: "
+            f"stream_id={event.stream_id}, error_code="
+            f"{_format_h2_error(event.error_code)}"
+        )
+
+    if isinstance(event, h2.events.ConnectionTerminated):
+        raise ProtocolError(
+            "HTTP/2 connection was terminated by the peer: "
+            f"error_code={_format_h2_error(event.error_code)}"
+        )
 
 
 class _LockedObject(typing.Generic[T]):
@@ -236,6 +257,13 @@ class HTTP2Connection(HTTPSConnection):
                 if received_data := self.sock.recv(65535):
                     events = conn.receive_data(received_data)
                     for event in events:
+                        try:
+                            _raise_for_h2_error_event(event)
+                        except ProtocolError:
+                            if isinstance(event, h2.events.ConnectionTerminated):
+                                self.close()
+                            raise
+
                         if isinstance(event, h2.events.ResponseReceived):
                             headers = HTTPHeaderDict()
                             for header, value in event.headers:

--- a/test/test_http2_connection.py
+++ b/test/test_http2_connection.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 import socket
 from unittest import mock
 
+import h2.events
 import pytest
 
 from urllib3.connection import _get_default_user_agent
-from urllib3.exceptions import ConnectionError
+from urllib3.exceptions import ConnectionError, ProtocolError
 from urllib3.http2.connection import (
     HTTP2Connection,
     _is_illegal_header_value,
@@ -17,6 +18,15 @@ from urllib3.http2.connection import (
 
 
 class TestHTTP2Connection:
+    def make_h2_event(self, event_type: type[object], **kwargs: object) -> object:
+        try:
+            return event_type(**kwargs)
+        except TypeError:
+            event = event_type()
+            for key, value in kwargs.items():
+                setattr(event, key, value)
+            return event
+
     def test__is_legal_header_name(self) -> None:
         assert _is_legal_header_name(b"foo"), "foo"
         assert _is_legal_header_name(b"foo-bar"), "foo-bar"
@@ -384,3 +394,50 @@ class TestHTTP2Connection:
         )
 
         close_connection.assert_called_with()
+
+    def test_getresponse_raises_on_http2_stream_reset(self) -> None:
+        conn = HTTP2Connection("example.com")
+        conn.sock = mock.MagicMock(
+            recv=mock.Mock(return_value=b"reset"),
+            sendall=mock.Mock(return_value=None),
+        )
+        conn._h2_conn._obj.get_next_available_stream_id = mock.Mock(return_value=1)  # type: ignore[method-assign]
+        conn._h2_conn._obj.data_to_send = mock.Mock(return_value=b"")  # type: ignore[method-assign]
+        conn._h2_conn._obj.receive_data = mock.Mock(  # type: ignore[method-assign]
+            return_value=[
+                self.make_h2_event(
+                    h2.events.StreamReset,
+                    stream_id=1,
+                    error_code=8,
+                )
+            ]
+        )
+
+        conn.request("GET", "/", preload_content=False)
+
+        with pytest.raises(ProtocolError, match="HTTP/2 stream was reset"):
+            conn.getresponse()
+
+    def test_getresponse_raises_on_http2_connection_terminated(self) -> None:
+        conn = HTTP2Connection("example.com")
+        conn.sock = mock.MagicMock(
+            recv=mock.Mock(return_value=b"terminated"),
+            sendall=mock.Mock(return_value=None),
+        )
+        conn._h2_conn._obj.get_next_available_stream_id = mock.Mock(return_value=1)  # type: ignore[method-assign]
+        conn._h2_conn._obj.data_to_send = mock.Mock(return_value=b"")  # type: ignore[method-assign]
+        conn._h2_conn._obj.receive_data = mock.Mock(  # type: ignore[method-assign]
+            return_value=[
+                self.make_h2_event(
+                    h2.events.ConnectionTerminated,
+                    error_code=1,
+                )
+            ]
+        )
+        conn.close = mock.Mock(return_value=None)  # type: ignore[method-assign]
+
+        conn.request("GET", "/", preload_content=False)
+
+        with pytest.raises(ProtocolError, match="HTTP/2 connection was terminated"):
+            conn.getresponse()
+        conn.close.assert_called_once_with()


### PR DESCRIPTION
### Summary

- Translate HTTP/2 `StreamReset` events into urllib3 `ProtocolError`.
- Translate HTTP/2 `ConnectionTerminated` events into urllib3 `ProtocolError` and close the connection.
- Add unit coverage for both HTTP/2 error event types.

### Testing

- `python -m pytest test/test_http2_connection.py -q`