### PR TITLE
Fix PoolManager file body rewinding across redirects

### DIFF
--- a/changelog/5181.bugfix.rst
+++ b/changelog/5181.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed ``PoolManager`` silently sending an empty seekable file-like request body after a body-preserving redirect.

--- a/src/urllib3/poolmanager.py
+++ b/src/urllib3/poolmanager.py
@@ -20,6 +20,7 @@ from .exceptions import (
 from .response import BaseHTTPResponse
 from .util.connection import _TYPE_SOCKET_OPTIONS
 from .util.proxy import connection_requires_http_tunnel
+from .util.request import set_file_position
 from .util.retry import Retry
 from .util.timeout import Timeout
 from .util.url import Url, parse_url
@@ -453,6 +454,14 @@ class PoolManager(RequestMethods):
         if "headers" not in kw:
             kw["headers"] = self.headers
 
+        body_pos = kw.pop("body_pos", None)
+        if body_pos is None:
+            # Keep this position for a possible PoolManager redirect, but let the
+            # connection pool handle the first request without rewinding it.
+            body_pos = set_file_position(kw.get("body"), None)
+        else:
+            kw["body_pos"] = body_pos
+
         if self._proxy_requires_url_absolute_form(u):
             response = conn.urlopen(method, u._replace(fragment=None).url, **kw)
         else:
@@ -470,6 +479,7 @@ class PoolManager(RequestMethods):
             method = "GET"
             # And lose the body not to transfer anything sensitive.
             kw["body"] = None
+            body_pos = None
             kw["headers"] = HTTPHeaderDict(kw["headers"])._prepare_for_method_change()
 
         retries = kw.get("retries", response.retries)
@@ -498,6 +508,7 @@ class PoolManager(RequestMethods):
 
         kw["retries"] = retries
         kw["redirect"] = redirect
+        kw["body_pos"] = body_pos
 
         log.info("Redirecting %s -> %s", url, redirect_location)
 

--- a/test/with_dummyserver/test_poolmanager.py
+++ b/test/with_dummyserver/test_poolmanager.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import gzip
+import io
 import typing
 from test import LONG_TIMEOUT
 from unittest import mock
@@ -14,9 +15,20 @@ from dummyserver.testcase import (
 )
 from urllib3 import HTTPHeaderDict, HTTPResponse, request
 from urllib3.connectionpool import port_by_scheme
-from urllib3.exceptions import MaxRetryError, URLSchemeUnknown
+from urllib3.exceptions import MaxRetryError, UnrewindableBodyError, URLSchemeUnknown
 from urllib3.poolmanager import PoolManager
 from urllib3.util.retry import Retry
+
+
+class _TellOnlyBody:
+    def __init__(self, data: bytes) -> None:
+        self._body = io.BytesIO(data)
+
+    def read(self, size: int = -1) -> bytes:
+        return self._body.read(size)
+
+    def tell(self) -> int:
+        return self._body.tell()
 
 
 class TestPoolManager(HypercornDummyServerTestCase):
@@ -376,6 +388,61 @@ class TestPoolManager(HypercornDummyServerTestCase):
             assert r._pool.num_requests == 2
             assert r._pool.num_connections == 1
             assert len(http.pools) == 1
+
+    def test_non_redirecting_tell_only_file_body(self) -> None:
+        data = b"PAYLOAD-DATA"
+        body = _TellOnlyBody(data)
+        with PoolManager() as http:
+            response = http.request(
+                "PUT",
+                f"{self.base_url}/echo",
+                body=body,  # type: ignore[arg-type]
+            )
+
+        assert response.status == 200
+        assert response.data == data
+
+    @pytest.mark.parametrize("status", (307, 308))
+    def test_redirect_rewinds_file_body(self, status: int) -> None:
+        data = b"PAYLOAD-DATA"
+        uploaded_file = io.BytesIO(b"prefix" + data)
+        uploaded_file.seek(len(b"prefix"))
+        with PoolManager() as http:
+            response = http.request(
+                "PUT",
+                f"{self.base_url}/redirect?target=/echo&status={status}",
+                body=uploaded_file,
+                retries=Retry(total=2, redirect=2),
+            )
+
+        assert response.status == 200
+        assert response.data == data
+
+    def test_redirect_tell_only_file_body_fails_after_first_request(self) -> None:
+        data = b"PAYLOAD-DATA"
+        body = _TellOnlyBody(data)
+        with PoolManager() as http:
+            with pytest.raises(ValueError, match="body_pos must be of type integer"):
+                http.request(
+                    "PUT",
+                    f"{self.base_url}/redirect?target=/echo&status=307",
+                    body=body,  # type: ignore[arg-type]
+                )
+
+        assert body.tell() == len(data)
+
+    def test_redirect_with_failed_tell(self) -> None:
+        class BadTellObject(io.BytesIO):
+            def tell(self) -> typing.NoReturn:
+                raise OSError
+
+        with PoolManager() as http:
+            with pytest.raises(UnrewindableBodyError):
+                http.request(
+                    "PUT",
+                    f"{self.base_url}/redirect?target=/echo&status=307",
+                    body=BadTellObject(b"PAYLOAD-DATA"),
+                )
 
     def test_303_redirect_makes_request_lose_body(self) -> None:
         with PoolManager() as http:


### PR DESCRIPTION
Closes #5181.

## Summary

- capture the initial position of a seekable file-like body at the `PoolManager` boundary
- pass that position to recursive redirect requests so body-preserving 301, 302, 307, and 308 hops rewind before resending
- retain the first-request behavior for tell-only streams and keep 303 redirects bodyless

Non-seekable one-shot bodies remain an existing limitation and are outside this patch.

## Validation

- exact `main` reproducer: the redirected request sends an empty body; this branch sends the payload on both hops
- 107 `PoolManager` tests passed
- 7 proxy redirect tests passed
- 78 focused redirect, retry, cross-host, and file-body tests passed
- strict mypy passed across 83 files
- Black, isort, Flake8, compileall, lockfile, and diff checks passed

## AI assistance disclosure

OpenAI Codex assisted with implementation, tests, and review. The account owner explicitly authorized publication of this contribution.
