### PR TITLE
Bump gh-action-pypi-publish to 1.14.2 to fix the publish job

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -84,7 +84,7 @@ jobs:
         gh release upload "$GITHUB_REF_NAME" dist/* --repo "$GITHUB_REPOSITORY"
 
     - name: "Publish dists to PyPI"
-      uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+      uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
       with:
         attestations: true
 
@@ -105,7 +105,7 @@ jobs:
         path: "dist/"
 
     - name: "Publish dists to Test PyPI"
-      uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+      uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
       with:
         repository-url: https://test.pypi.org/legacy/
         attestations: true


### PR DESCRIPTION
Our publish job has started to fail https://github.com/urllib3/urllib3/actions/runs/32984949786/job/98315680368

>   Checking dist/urllib3-2.7.1.dev41-py3-none-any.whl: ERROR    InvalidDistribution: Invalid distribution metadata: '2.5' is not a     
           valid metadata version            

gh-action-pypi-publish v1.14.2 should be able to handle v2.5 of the metadata because of Twine updated to v7.