### PR TITLE
fix(poolmanager): preserve body_pos across cross-pool redirects

### DIFF
--- a/src/urllib3/poolmanager.py
+++ b/src/urllib3/poolmanager.py
@@ -20,6 +20,7 @@ from .exceptions import (
 from .response import BaseHTTPResponse
 from .util.connection import _TYPE_SOCKET_OPTIONS
 from .util.proxy import connection_requires_http_tunnel
+from .util.request import set_file_position
 from .util.retry import Retry
 from .util.timeout import Timeout
 from .util.url import Url, parse_url
@@ -453,6 +454,9 @@ class PoolManager(RequestMethods):
         if "headers" not in kw:
             kw["headers"] = self.headers
 
+        if "body_pos" not in kw:
+            kw["body_pos"] = set_file_position(kw.get("body"), None)
+
         if self._proxy_requires_url_absolute_form(u):
             response = conn.urlopen(method, u._replace(fragment=None).url, **kw)
         else:
@@ -470,6 +474,7 @@ class PoolManager(RequestMethods):
             method = "GET"
             # And lose the body not to transfer anything sensitive.
             kw["body"] = None
+            kw["body_pos"] = None
             kw["headers"] = HTTPHeaderDict(kw["headers"])._prepare_for_method_change()
 
         retries = kw.get("retries", response.retries)

--- a/test/test_poolmanager.py
+++ b/test/test_poolmanager.py
@@ -514,3 +514,51 @@ class TestPoolManager:
 
         # Connection should be closed, because reference to pool_1 is gone.
         assert conn_queue.qsize() == 0
+
+    def test_redirect_file_like_body_pos_preserved(self) -> None:
+        """Verify that PoolManager preserves body_pos across cross-pool redirects (issue #5181)."""
+        import io
+        from urllib3.response import HTTPResponse
+
+        p = PoolManager()
+        body = io.BytesIO(b"PAYLOAD-DATA")
+
+        pool1 = MagicMock()
+        resp1 = HTTPResponse(
+            status=307,
+            headers={"Location": "http://host2/target"},
+            preload_content=False,
+        )
+
+        def fake_urlopen1(*args: typing.Any, **kwargs: typing.Any) -> HTTPResponse:
+            assert kwargs.get("body_pos") == 0
+            body.read()  # advances stream to EOF
+            return resp1
+
+        pool1.urlopen.side_effect = fake_urlopen1
+        pool1.is_same_host.return_value = False
+
+        pool2 = MagicMock()
+        resp2 = HTTPResponse(status=200, body=b"OK", preload_content=False)
+        received_body_pos = None
+        received_stream_pos = None
+
+        def fake_urlopen2(*args: typing.Any, **kwargs: typing.Any) -> HTTPResponse:
+            nonlocal received_body_pos, received_stream_pos
+            received_body_pos = kwargs.get("body_pos")
+            from urllib3.util.request import set_file_position
+
+            set_file_position(kwargs.get("body"), kwargs.get("body_pos"))
+            received_stream_pos = body.tell()
+            return resp2
+
+        pool2.urlopen.side_effect = fake_urlopen2
+
+        with patch.object(p, "connection_from_host") as mock_conn:
+            mock_conn.side_effect = [pool1, pool2]
+            res = p.urlopen("PUT", "http://host1/start", body=body)
+
+        assert res.status == 200
+        assert received_body_pos == 0
+        assert received_stream_pos == 0
+


### PR DESCRIPTION
## Summary

Fixes #5181

PoolManager.urlopen() implements its own redirect loop for cross-host redirects, but did not record or pass ody_pos across request hops.

On any 307/308 (or body-preserving 301) redirect with a file-like body, the first hop read the stream to EOF. The second hop called conn.urlopen() without ody_pos, which recorded the stream position at EOF and delivered an empty body while returning HTTP 200 to the caller (silent upload truncation).

## Changes

- In src/urllib3/poolmanager.py, initialize kw["body_pos"] = set_file_position(kw.get("body"), None) if not already set, ensuring the initial file position is recorded and threaded through recursive self.urlopen(method, redirect_location, **kw) calls.
- On HTTP 303 (where method changes to GET and body is discarded), also reset kw["body_pos"] = None.
- Added unit test 	est_redirect_file_like_body_pos_preserved in 	est/test_poolmanager.py verifying that file-like streams are rewound before the redirected request is sent.
