### PR TITLE
Don't decode unhandled content-codings as deflate

### DIFF
--- a/changelog/5189.bugfix.rst
+++ b/changelog/5189.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed decoding of a comma-separated ``Content-Encoding`` response header so that an ``identity`` or otherwise unhandled coding is treated as a pass-through instead of being run through a fallback DEFLATE decoder, which previously raised ``DecodeError`` on an otherwise valid body (e.g. ``Content-Encoding: gzip, identity``).

--- a/src/urllib3/response.py
+++ b/src/urllib3/response.py
@@ -300,6 +300,20 @@ else:
             return b""
 
 
+class IdentityDecoder(ContentDecoder):
+    """A no-op decoder for the "identity" and other unhandled content codings."""
+
+    def decompress(self, data: bytes, max_length: int = -1) -> bytes:
+        return data
+
+    @property
+    def has_unconsumed_tail(self) -> bool:
+        return False
+
+    def flush(self) -> bytes:
+        return b""
+
+
 class MultiDecoder(ContentDecoder):
     """
     From RFC7231:
@@ -371,7 +385,15 @@ def _get_decoder(mode: str) -> ContentDecoder:
     if HAS_ZSTD and mode == "zstd":
         return ZstdDecoder()
 
-    return DeflateDecoder()
+    if mode == "deflate":
+        return DeflateDecoder()
+
+    # A coding we can't handle (e.g. "identity" or an unknown token) is left
+    # untouched. A single such coding never reaches here because
+    # `_init_decoder` only builds a decoder for known codings, but one can
+    # appear alongside a known coding in a comma-separated list, where it must
+    # be a pass-through rather than a spurious DEFLATE decode.
+    return IdentityDecoder()
 
 
 class BytesQueueBuffer:

--- a/test/test_response.py
+++ b/test/test_response.py
@@ -933,6 +933,24 @@ class TestResponse:
 
         assert r.data == b"foo"
 
+    @pytest.mark.parametrize(
+        "content_encoding",
+        ["gzip, identity", "identity, gzip", "gzip, x-unknown-coding"],
+    )
+    def test_multi_decoding_ignores_unhandled_codings(
+        self, content_encoding: str
+    ) -> None:
+        # A comma-separated content-encoding whose only decodable coding is
+        # gzip must decode with gzip. Unhandled codings such as identity or
+        # an unknown token were previously passed to a fallback DEFLATE
+        # decoder, which made a valid gzip body fail to decode.
+        data = gzip.compress(b"foo")
+
+        fp = BytesIO(data)
+        r = HTTPResponse(fp, headers={"content-encoding": content_encoding})
+
+        assert r.data == b"foo"
+
     def test_read_multi_decoding_deflate_deflate(self) -> None:
         msg = b"foobarbaz" * 42
         data = zlib.compress(zlib.compress(msg))


### PR DESCRIPTION
A comma-separated Content-Encoding whose only decodable coding is gzip fails to decode because _get_decoder falls back to a DEFLATE decoder for every token it doesn't recognize, so a server response such as `Content-Encoding: gzip, identity` runs zlib inflate over the identity token and raises DecodeError on otherwise valid content. A single unhandled coding is already left as a pass-through, so this makes the comma-separated path match by adding an explicit deflate branch and returning a no-op IdentityDecoder for anything else. Known codings still decode and the decode-chain limit is unchanged.