### PR TITLE
Fix file body redirects in PoolManager

### DIFF
--- a/changelog/5181.bugfix.rst
+++ b/changelog/5181.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed ``PoolManager`` redirects to resend file-like request bodies.

--- a/src/urllib3/poolmanager.py
+++ b/src/urllib3/poolmanager.py
@@ -20,6 +20,7 @@ from .exceptions import (
 from .response import BaseHTTPResponse
 from .util.connection import _TYPE_SOCKET_OPTIONS
 from .util.proxy import connection_requires_http_tunnel
+from .util.request import set_file_position
 from .util.retry import Retry
 from .util.timeout import Timeout
 from .util.url import Url, parse_url
@@ -447,6 +448,7 @@ class PoolManager(RequestMethods):
 
         conn = self.connection_from_host(u.host, port=u.port, scheme=u.scheme)
 
+        kw["body_pos"] = set_file_position(kw.get("body"), kw.get("body_pos"))
         kw["assert_same_host"] = False
         kw["redirect"] = False
 
@@ -470,6 +472,7 @@ class PoolManager(RequestMethods):
             method = "GET"
             # And lose the body not to transfer anything sensitive.
             kw["body"] = None
+            kw["body_pos"] = None
             kw["headers"] = HTTPHeaderDict(kw["headers"])._prepare_for_method_change()
 
         retries = kw.get("retries", response.retries)

--- a/test/with_dummyserver/test_poolmanager.py
+++ b/test/with_dummyserver/test_poolmanager.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import gzip
+import io
 import typing
 from test import LONG_TIMEOUT
 from unittest import mock
@@ -662,6 +663,23 @@ class TestPoolManager(HypercornDummyServerTestCase):
         r = request("POST", f"{self.base_url}/echo", body=b"test")
         assert r.status == 200
         assert r.data == b"test"
+
+    def test_file_body_is_rewound_on_redirect(self) -> None:
+        data = b"PAYLOAD-DATA"
+        body = io.BytesIO(data)
+        url = f"{self.base_url}/redirect?target={self.base_url}/echo&status=307"
+
+        with PoolManager() as http:
+            response = http.urlopen(
+                "PUT",
+                url,
+                body=body,
+                headers={"Content-Length": str(len(data))},
+                retries=Retry(total=1, redirect=1),
+            )
+
+        assert response.status == 200
+        assert response.data == data
 
     def test_top_level_request_with_preload_content(self) -> None:
         r = request("GET", f"{self.base_url}/echo", preload_content=False)


### PR DESCRIPTION
Fixes #5181

## Summary

`PoolManager.urlopen` did not preserve the file position recorded by the underlying connection pool when following redirects. As a result, file-like request bodies could be sent empty on a subsequent 307/308 redirect.

Record and carry the body position through `PoolManager` redirect hops, while clearing it when a 303 redirect intentionally discards the body. Add a PoolManager-level regression test and a bugfix changelog entry.

## Testing

- `python -m pytest -q test/with_dummyserver/test_poolmanager.py`
- `python -m pytest -q test/with_dummyserver/test_connectionpool.py -k redirect`
- `ruff check src/urllib3/poolmanager.py test/with_dummyserver/test_poolmanager.py`
