### PR TITLE
fix: preserve file-like body position across PoolManager redirects

### DIFF
--- a/changelog/5181.bugfix.rst
+++ b/changelog/5181.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed ``PoolManager`` silently sending an empty seekable file-like request body after a body-preserving redirect (301/307/308).

--- a/src/urllib3/poolmanager.py
+++ b/src/urllib3/poolmanager.py
@@ -20,6 +20,7 @@ from .exceptions import (
 from .response import BaseHTTPResponse
 from .util.connection import _TYPE_SOCKET_OPTIONS
 from .util.proxy import connection_requires_http_tunnel
+from .util.request import set_file_position
 from .util.retry import Retry
 from .util.timeout import Timeout
 from .util.url import Url, parse_url
@@ -447,6 +448,13 @@ class PoolManager(RequestMethods):
 
         conn = self.connection_from_host(u.host, port=u.port, scheme=u.scheme)
 
+        # Record the initial position of a seekable file-like body so it can be
+        # rewound before a body-preserving redirect (301/307/308). Without this,
+        # the connection pool records the position at EOF on the first hop and
+        # resends an empty body on the redirected request (see #5181).
+        if "body_pos" not in kw:
+            kw["body_pos"] = set_file_position(kw.get("body"), None)
+
         kw["assert_same_host"] = False
         kw["redirect"] = False
 
@@ -470,6 +478,7 @@ class PoolManager(RequestMethods):
             method = "GET"
             # And lose the body not to transfer anything sensitive.
             kw["body"] = None
+            kw["body_pos"] = None
             kw["headers"] = HTTPHeaderDict(kw["headers"])._prepare_for_method_change()
 
         retries = kw.get("retries", response.retries)

--- a/test/with_dummyserver/test_poolmanager.py
+++ b/test/with_dummyserver/test_poolmanager.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import gzip
+import io
 import typing
 from test import LONG_TIMEOUT
 from unittest import mock
@@ -662,6 +663,48 @@ class TestPoolManager(HypercornDummyServerTestCase):
         r = request("POST", f"{self.base_url}/echo", body=b"test")
         assert r.status == 200
         assert r.data == b"test"
+
+    def test_redirect_resends_file_like_body(self) -> None:
+        # Issue #5181: a file-like body was sent empty on a body-preserving
+        # redirect (301/307/308) because PoolManager did not preserve the
+        # recorded body position across redirect hops.
+        data = b"PAYLOAD-DATA"
+        body = io.BytesIO(data)
+        url = (
+            f"{self.base_url}/redirect"
+            f"?target={self.base_url}/echo&status=307"
+        )
+        with PoolManager() as http:
+            response = http.request(
+                "PUT",
+                url,
+                body=body,
+                headers={"Content-Length": str(len(data))},
+                retries=Retry(total=1, redirect=1),
+            )
+        assert response.status == 200
+        assert response.data == data
+
+    def test_redirect_303_drops_file_like_body(self) -> None:
+        # A 303 redirect must not resend the request body (RFC 9110 15.4.4),
+        # even when the body is a seekable file-like object.
+        data = b"PAYLOAD-DATA"
+        body = io.BytesIO(data)
+        url = (
+            f"{self.base_url}/redirect"
+            f"?target={self.base_url}/echo&status=303"
+        )
+        with PoolManager() as http:
+            response = http.request(
+                "PUT",
+                url,
+                body=body,
+                headers={"Content-Length": str(len(data))},
+                retries=Retry(total=1, redirect=1),
+            )
+        assert response.status == 200
+        # 303 changes the method to GET, which does not carry a body.
+        assert response.data == b""
 
     def test_top_level_request_with_preload_content(self) -> None:
         r = request("GET", f"{self.base_url}/echo", preload_content=False)


### PR DESCRIPTION
## Summary

Closes #5181

`PoolManager.urlopen` implements its own cross-pool redirect loop but never carries `body_pos` (the file-position bookkeeping that `HTTPConnectionPool.urlopen` uses to rewind file-like bodies before resending). On any body-preserving redirect (301/307/308), hop 2 re-records the body position at EOF and delivers a well-formed but empty request body — reporting HTTP success to the client while the upstream receives no payload.

This PR records the initial position of a seekable file-like body at the `PoolManager` boundary and passes it through redirect hops, so body-preserving redirects rewind before resending. A 303 redirect clears the position (RFC 9110 15.4.4 discards the body).

## Validation

- Local reproducer: a `PUT /start -> 307 /echo` round trip previously sent an empty body; with the fix the payload is resent correctly on both hops.
- Added regression tests: `test_redirect_resends_file_like_body` (307 preserves body) and `test_redirect_303_drops_file_like_body` (303 drops body).