### PR TITLE
Preserve dot segments in the absolute-form request target

### DIFF
--- a/changelog/4965.bugfix.rst
+++ b/changelog/4965.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed ``HTTPConnectionPool.urlopen()`` collapsing ``.``/``..`` path segments when given an absolute-form URL (the proxy request path), which sent a different resource than the one requested. The non-absolute-form path already left such segments alone; the two now agree.

--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -714,7 +714,13 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
             url = to_str(_encode_target(url))
             destination_scheme = None
         else:
-            parsed_url = parse_url(url)
+            # normalize_path=False: this url is going straight onto the
+            # wire as an absolute-form request target (the proxy branch),
+            # so it must match what the caller asked for byte for byte,
+            # the same as the schemeless branch above leaves a path alone.
+            # Collapsing ".."/"." here would silently change which
+            # resource gets requested.
+            parsed_url = parse_url(url, normalize_path=False)
             destination_scheme = parsed_url.scheme
             url = to_str(parsed_url._replace(fragment=None).url)
 

--- a/src/urllib3/util/url.py
+++ b/src/urllib3/util/url.py
@@ -458,7 +458,7 @@ def _encode_target(target: str) -> str:
     return encoded_target
 
 
-def parse_url(url: str) -> Url:
+def parse_url(url: str, *, normalize_path: bool = True) -> Url:
     """
     Given a url, return a parsed :class:`.Url` namedtuple. Best-effort is
     performed to parse incomplete urls. Fields not provided will be None.
@@ -468,6 +468,12 @@ def parse_url(url: str) -> Url:
     work done in the ``rfc3986`` module.
 
     :param str url: URL to parse into a :class:`.Url` namedtuple.
+    :param bool normalize_path:
+        Whether to collapse ``.``/``..`` path segments per RFC 3986 Section
+        6.2.2.3. Callers that need to send a path exactly as given, such as
+        forwarding a request line to a proxy, should pass ``False``;
+        percent-encoding of otherwise-invalid characters still happens
+        either way.
 
     Partly backwards-compatible with :mod:`urllib.parse`.
 
@@ -539,7 +545,8 @@ def parse_url(url: str) -> Url:
     host = _normalize_host(host, scheme)
 
     if normalize_uri and path:
-        path = _remove_path_dot_segments(path)
+        if normalize_path:
+            path = _remove_path_dot_segments(path)
         path = _encode_invalid_chars(path, _PATH_CHARS)
     if normalize_uri and query:
         query = _encode_invalid_chars(query, _QUERY_CHARS)

--- a/test/test_connectionpool.py
+++ b/test/test_connectionpool.py
@@ -776,7 +776,7 @@ class TestConnectionPool:
 
         The non-absolute-form branch above never collapses ../. segments
         in a path, so the absolute-form branch used for proxied requests
-        must not either -- otherwise the request sent on the wire no
+        must not either, since otherwise the request sent on the wire no
         longer matches the URL the caller asked for.
         """
         with HTTPConnectionPool(host="localhost", port=80) as pool:

--- a/test/test_connectionpool.py
+++ b/test/test_connectionpool.py
@@ -754,6 +754,40 @@ class TestConnectionPool:
             actual_url = mock_request.call_args[0][2]
             assert actual_url == expected_url
 
+    @pytest.mark.parametrize(
+        ("target_url", "expected_url"),
+        [
+            pytest.param(
+                "http://localhost/../secret",
+                "http://localhost/../secret",
+                id="parent-dir-segment",
+            ),
+            pytest.param(
+                "http://localhost/a/./b/../c",
+                "http://localhost/a/./b/../c",
+                id="current-and-parent-dir-segments",
+            ),
+        ],
+    )
+    def test_absolute_url_request_target_preserves_dot_segments(
+        self, target_url: str, expected_url: str
+    ) -> None:
+        """See https://github.com/urllib3/urllib3/issues/4965.
+
+        The non-absolute-form branch above never collapses ../. segments
+        in a path, so the absolute-form branch used for proxied requests
+        must not either -- otherwise the request sent on the wire no
+        longer matches the URL the caller asked for.
+        """
+        with HTTPConnectionPool(host="localhost", port=80) as pool:
+            with patch.object(
+                pool, "_make_request", return_value=HTTPResponse(status=200)
+            ) as mock_request:
+                pool.urlopen("GET", target_url)
+
+            actual_url = mock_request.call_args[0][2]
+            assert actual_url == expected_url
+
     def test_absolute_redirect_request_target_strips_fragment(self) -> None:
         redirect_response = HTTPResponse(
             status=302,

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -465,6 +465,30 @@ class TestUtil:
         assert actual_url == expected_url
         assert actual_url.url == expected_url.url
 
+    @pytest.mark.parametrize(
+        "url",
+        [
+            # Same inputs as test_parse_and_normalize_url_paths, but with
+            # normalize_path=False none of them should be touched.
+            "/abc/../def",
+            "/..",
+            "/./abc/./def/",
+            "/.",
+            "/./",
+            "/abc/./.././d/././e/.././f/./../../ghi",
+        ],
+    )
+    def test_parse_url_without_normalizing_path(self, url: str) -> None:
+        assert parse_url(url, normalize_path=False).path == url
+
+    def test_parse_url_without_normalizing_path_still_encodes_invalid_chars(
+        self,
+    ) -> None:
+        # Dot segments are left alone, but characters that aren't valid in a
+        # path still get percent-encoded either way.
+        actual_url = parse_url("http://example.com/../foo bar<>", normalize_path=False)
+        assert actual_url.path == "/../foo%20bar%3C%3E"
+
     def test_parse_url_invalid_IPv6(self) -> None:
         with pytest.raises(LocationParseError):
             parse_url("[::1")


### PR DESCRIPTION
Fixes #4965.

`urlopen()`'s absolute-form branch (used when going through a proxy) rebuilds the target from `parse_url(url)._replace(fragment=None).url`. `parse_url()` collapses `.`/`..` path segments by default, so a caller asking for `http://example.com/../something.txt` had that silently turned into `http://example.com/something.txt` on the wire — a different resource than the one requested. The non-absolute-form branch right above it never does this: it only percent-encodes invalid characters through `_encode_target()` and otherwise sends the path exactly as given.

`parse_url()` gets a new `normalize_path` keyword, defaulting to `True` so every existing caller keeps its current behavior. The proxy branch in `connectionpool.py` passes `normalize_path=False`, which brings it in line with the non-absolute-form branch: invalid characters still get percent-encoded, but `.`/`..` segments pass through untouched.

Added test coverage at both levels: `parse_url(url, normalize_path=False)` directly in `test_util.py` (including confirming percent-encoding of invalid characters still happens), and an end-to-end check in `test_connectionpool.py` that patches `_make_request` to inspect the actual URL `urlopen()` builds for a proxied absolute-form request.

Changelog entry added at `changelog/4965.bugfix.rst`.
