### PR TITLE
fix: rewind file-like bodies across PoolManager redirects

### DIFF
--- a/changelog/5181.bugfix.rst
+++ b/changelog/5181.bugfix.rst
@@ -1,0 +1,4 @@
+Fixed ``PoolManager`` (and therefore ``urllib3.request()``) silently sending
+an empty body on 301/307/308 redirects when the request body is a file-like
+object. The original file position is now recorded and passed through redirect
+hops so the body can be rewound, matching ``HTTPConnectionPool`` behavior.

--- a/src/urllib3/poolmanager.py
+++ b/src/urllib3/poolmanager.py
@@ -20,6 +20,7 @@ from .exceptions import (
 from .response import BaseHTTPResponse
 from .util.connection import _TYPE_SOCKET_OPTIONS
 from .util.proxy import connection_requires_http_tunnel
+from .util.request import set_file_position
 from .util.retry import Retry
 from .util.timeout import Timeout
 from .util.url import Url, parse_url
@@ -453,6 +454,17 @@ class PoolManager(RequestMethods):
         if "headers" not in kw:
             kw["headers"] = self.headers
 
+        # PoolManager follows redirects itself (conn.urlopen gets redirect=False)
+        # and must carry body_pos the same way HTTPConnectionPool.urlopen does,
+        # otherwise a file-like body is re-recorded at EOF on hop 2 and resent
+        # empty. Capture the original position before the first request.
+        body_pos = kw.get("body_pos")
+        if body_pos is None:
+            body_pos = set_file_position(kw.get("body"), None)
+            # Don't inject a freshly recorded position into this hop: a failed
+            # tell() becomes _FAILEDTELL and would abort before any request.
+            kw.pop("body_pos", None)
+
         if self._proxy_requires_url_absolute_form(u):
             response = conn.urlopen(method, u._replace(fragment=None).url, **kw)
         else:
@@ -471,6 +483,7 @@ class PoolManager(RequestMethods):
             # And lose the body not to transfer anything sensitive.
             kw["body"] = None
             kw["headers"] = HTTPHeaderDict(kw["headers"])._prepare_for_method_change()
+            body_pos = None
 
         retries = kw.get("retries", response.retries)
         if not isinstance(retries, Retry):
@@ -498,6 +511,7 @@ class PoolManager(RequestMethods):
 
         kw["retries"] = retries
         kw["redirect"] = redirect
+        kw["body_pos"] = body_pos
 
         log.info("Redirecting %s -> %s", url, redirect_location)
 

--- a/test/with_dummyserver/test_poolmanager.py
+++ b/test/with_dummyserver/test_poolmanager.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import gzip
+import io
 import typing
 from test import LONG_TIMEOUT
 from unittest import mock
@@ -14,7 +15,7 @@ from dummyserver.testcase import (
 )
 from urllib3 import HTTPHeaderDict, HTTPResponse, request
 from urllib3.connectionpool import port_by_scheme
-from urllib3.exceptions import MaxRetryError, URLSchemeUnknown
+from urllib3.exceptions import MaxRetryError, UnrewindableBodyError, URLSchemeUnknown
 from urllib3.poolmanager import PoolManager
 from urllib3.util.retry import Retry
 
@@ -91,6 +92,97 @@ class TestPoolManager(HypercornDummyServerTestCase):
 
             assert r.status == 200
             assert r.data == b"Dummy server!"
+
+    @pytest.mark.parametrize("status", (301, 307, 308))
+    def test_redirect_put_file(self, status: int) -> None:
+        """PUT with a file-like body must be resent after a body-preserving redirect.
+
+        Twin of TestFileBodiesOnRetryOrRedirect.test_redirect_put_file covering
+        PoolManager's own redirect loop (inner pools are called with redirect=False).
+        """
+        # httplib reads in 8k chunks; use a larger content length
+        content_length = 65535
+        data = b"A" * content_length
+        uploaded_file = io.BytesIO(data)
+        headers = {
+            "test-name": "test_redirect_put_file",
+            "Content-Length": str(content_length),
+        }
+        url = f"{self.base_url}/redirect?target=/echo&status={status}"
+        with PoolManager() as http:
+            resp = http.request(
+                "PUT",
+                url,
+                headers=headers,
+                retries=Retry(total=3, redirect=3),
+                body=uploaded_file,
+                timeout=LONG_TIMEOUT,
+            )
+        assert resp.status == 200
+        assert resp.data == data
+
+    def test_top_level_request_redirect_put_file(self) -> None:
+        """urllib3.request() routes through PoolManager, so file bodies must rewind."""
+        content_length = 65535
+        data = b"A" * content_length
+        uploaded_file = io.BytesIO(data)
+        headers = {
+            "test-name": "test_top_level_request_redirect_put_file",
+            "Content-Length": str(content_length),
+        }
+        url = f"{self.base_url}/redirect?target=/echo&status=307"
+        resp = request(
+            "PUT",
+            url,
+            headers=headers,
+            retries=Retry(total=3, redirect=3),
+            body=uploaded_file,
+            timeout=LONG_TIMEOUT,
+        )
+        assert resp.status == 200
+        assert resp.data == data
+
+    def test_redirect_303_drops_file_body(self) -> None:
+        """303 must drop a file-like body (and not raise while clearing body_pos)."""
+        data = b"SENSITIVE"
+        uploaded_file = io.BytesIO(data)
+        headers = {"Content-Length": str(len(data))}
+        url = f"{self.base_url}/redirect?target=/echo&status=303"
+        with PoolManager() as http:
+            resp = http.request(
+                "PUT",
+                url,
+                headers=headers,
+                retries=Retry(total=3, redirect=3),
+                body=uploaded_file,
+                timeout=LONG_TIMEOUT,
+            )
+        assert resp.status == 200
+        # 303 becomes GET without a body; /echo on GET returns the query string.
+        assert resp.data == b""
+
+    def test_redirect_put_file_with_failed_tell(self) -> None:
+        """Abort a PoolManager redirect if tell() cannot record the body position."""
+
+        class BadTellObject(io.BytesIO):
+            def tell(self) -> typing.NoReturn:
+                raise OSError
+
+        body = BadTellObject(b"the data")
+        headers = {"Content-Length": "8"}
+        url = f"{self.base_url}/redirect?target=/echo&status=307"
+        with PoolManager() as http:
+            with pytest.raises(
+                UnrewindableBodyError, match="Unable to record file position for"
+            ):
+                http.request(
+                    "PUT",
+                    url,
+                    headers=headers,
+                    retries=Retry(total=3, redirect=3),
+                    body=body,
+                    timeout=LONG_TIMEOUT,
+                )
 
     @pytest.mark.parametrize(
         "retries",


### PR DESCRIPTION
## Summary

`PoolManager.urlopen()` implements its own redirect loop (it always calls the inner pool with `redirect=False`) but never carried `body_pos`. `HTTPConnectionPool.urlopen()` records the file position via `set_file_position()` before sending and rewinds on retries/redirects; PoolManager did not, so hop 2 re-recorded the position at EOF.

On 301/307/308 redirects that must preserve the request body, a file-like body was therefore resent empty. Callers still saw HTTP 200 (or a protocol/timeout error if `Content-Length` was set) with no exception — silent upload truncation. `urllib3.request()` routes through `PoolManager`, so the high-level API is affected.

Fixes #5181.

## Fix

Record the original body position once at the PoolManager boundary with `set_file_position(body, None)` *before* the first request, then pass `body_pos` into every subsequent `self.urlopen(...)` hop so the inner pool can rewind. The freshly recorded position is not injected into the first `conn.urlopen()` call so a failed `tell()` (`_FAILEDTELL`) does not abort before any request is sent.

303 responses still drop the body (RFC 9110 §15.4.4) and also clear `body_pos` so the discarded file is not rewound.

## Tests

Added PoolManager-level coverage in `test/with_dummyserver/test_poolmanager.py`:

- `test_redirect_put_file` — twin of the existing bare-pool `TestFileBodiesOnRetryOrRedirect.test_redirect_put_file`, parametrized over 301/307/308
- `test_top_level_request_redirect_put_file` — same path through `urllib3.request()`
- `test_redirect_303_drops_file_body` — 303 must not resend a file-like body
- `test_redirect_put_file_with_failed_tell` — unrewindable bodies raise `UnrewindableBodyError` on redirect, matching the pool

These tests fail on current main (hop 2 sends an empty body / incomplete `Content-Length`) and pass with this change.