### PR TITLE
Bump ossf/scorecard-action to v2.4.4 to fix CI

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -27,7 +27,7 @@ jobs:
           persist-credentials: false
 
       - name: "Run Scorecard"
-        uses: ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46 # v2.4.0
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
Scorecard runs have begun to fail
https://github.com/urllib3/urllib3/actions/runs/33508660484/job/99859063973
https://github.com/urllib3/urllib3/actions/runs/33508700282/job/99899375745

```
Pull down action image 'gcr.io/openssf/scorecard-action:v2.4.0'
  /usr/bin/docker pull gcr.io/openssf/scorecard-action:v2.4.0
  Error response from daemon: Head "https://gcr.io/v2/openssf/scorecard-action/manifests/v2.4.0": denied: Consumer 'projects/367732848534' is invalid: .
  Warning: Docker pull failed with exit code 1, back off 6.692 seconds before retry.
  /usr/bin/docker pull gcr.io/openssf/scorecard-action:v2.4.0
  Error response from daemon: Head "https://gcr.io/v2/openssf/scorecard-action/manifests/v2.4.0": denied: Consumer 'projects/367732848534' is invalid: .
  Warning: Docker pull failed with exit code 1, back off 7.401 seconds before retry.
  /usr/bin/docker pull gcr.io/openssf/scorecard-action:v2.4.0
  Error response from daemon: Head "https://gcr.io/v2/openssf/scorecard-action/manifests/v2.4.0": denied: Consumer 'projects/367732848534' is invalid: .
Error: Docker pull failed with exit code 1
```

This is likely related to their infrastructure changes and switching to GHCR in particular.
See https://github.com/ossf/scorecard/issues/5208#issuecomment-5497809202.