### PR TITLE
Avoid repeated response decoder initialization

### DIFF
--- a/changelog/5209.misc.rst
+++ b/changelog/5209.misc.rst
@@ -1,0 +1,1 @@
+Improved streamed response decoding performance.

--- a/src/urllib3/response.py
+++ b/src/urllib3/response.py
@@ -499,6 +499,8 @@ class BaseHTTPResponse(io.IOBase):
             self.chunked = True
 
         self._decoder: ContentDecoder | None = None
+        # Distinguish an uninitialized decoder from a response needing no decoder.
+        self._decoder_initialized = False
         self.length_remaining: int | None
 
     def get_redirect_location(self) -> str | None | typing.Literal[False]:
@@ -604,10 +606,13 @@ class BaseHTTPResponse(io.IOBase):
         """
         Set-up the _decoder attribute if necessary.
         """
-        # Note: content-encoding value should be case-insensitive, per RFC 7230
-        # Section 3.2
-        content_encoding = self.headers.get("content-encoding", "").lower()
+        if self._decoder_initialized:
+            return
+
         if self._decoder is None:
+            # Note: content-encoding value should be case-insensitive, per RFC 7230
+            # Section 3.2
+            content_encoding = self.headers.get("content-encoding", "").lower()
             if content_encoding in self.CONTENT_DECODERS:
                 self._decoder = _get_decoder(content_encoding)
             elif "," in content_encoding:
@@ -618,6 +623,8 @@ class BaseHTTPResponse(io.IOBase):
                 ]
                 if encodings:
                     self._decoder = _get_decoder(content_encoding)
+
+        self._decoder_initialized = True
 
     def _decode(
         self,

--- a/test/test_response.py
+++ b/test/test_response.py
@@ -300,6 +300,40 @@ class TestResponse:
         with pytest.raises(DecodeError):
             HTTPResponse(fp, headers={"content-encoding": "deflate"})
 
+    @pytest.mark.parametrize("content_encoding", (None, "gzip"))
+    def test_content_encoding_is_inspected_once(
+        self, content_encoding: str | None
+    ) -> None:
+        headers = {"content-encoding": content_encoding} if content_encoding else None
+        r = HTTPResponse(BytesIO(), headers=headers, preload_content=False)
+
+        with mock.patch.object(r.headers, "get", wraps=r.headers.get) as get_header:
+            r._init_decoder()
+            r._init_decoder()
+
+        assert get_header.call_count == 1
+        if content_encoding is None:
+            assert r._decoder is None
+        else:
+            assert r._decoder is not None
+
+    def test_decoder_initialization_is_retried_after_failure(self) -> None:
+        r = HTTPResponse(
+            BytesIO(), headers={"content-encoding": "gzip"}, preload_content=False
+        )
+        decoder = mock.Mock()
+
+        with mock.patch(
+            "urllib3.response._get_decoder", side_effect=(RuntimeError, decoder)
+        ) as get_decoder:
+            with pytest.raises(RuntimeError):
+                r._init_decoder()
+            r._init_decoder()
+            r._init_decoder()
+
+        assert r._decoder is decoder
+        assert get_decoder.call_count == 2
+
     def test_reference_read(self) -> None:
         fp = BytesIO(b"foo")
         r = HTTPResponse(fp, preload_content=False)


### PR DESCRIPTION
I discovered this low-hanging fruit during a short research effort into potential urllib3 optimizations.
It avoids repeated `Content-Encoding` lookups after decoder initialization.

I benchmarked the way Requests uses urllib3 by reading responses in 10 KiB chunks.
Median CPU times, excluding socket I/O:

| Decoded response | Encoding | Before | After | Saving |
|---:|---|---:|---:|---:|
| 10 KiB | none | 0.0168 ms | 0.0166 ms | ~0 (noise) |
| 10 KiB | gzip | 0.0349 ms | 0.0350 ms | ~0 (noise) |
| 50 KiB | none | 0.0370 ms | 0.0349 ms | 0.0020 ms (5.5%) |
| 50 KiB | gzip | 0.1088 ms | 0.1078 ms | 0.0010 ms (0.9%) |
| 1 MiB | none | 0.433 ms | 0.379 ms | 0.055 ms (12.6%) |
| 1 MiB | gzip | 0.590 ms | 0.562 ms | 0.029 ms (4.8%) |
| 10 MiB | none | 4.499 ms | 3.969 ms | 0.530 ms (11.8%) |
| 10 MiB | gzip | 5.314 ms | 4.761 ms | 0.552 ms (10.4%) |
| 1 GiB | none | 1,050.1 ms | 979.4 ms | 70.7 ms (6.7%) |
| 1 GiB | gzip | 700.4 ms | 643.2 ms | 57.3 ms (8.2%) |

The 10 KiB case needs one read; every multi-read case improved.