### PR TITLE
Include scheme and host in the Retrying warning

### DIFF
--- a/changelog/3583.bugfix.rst
+++ b/changelog/3583.bugfix.rst
@@ -1,0 +1,3 @@
+The "Retrying" warning raised by connection pools now includes the scheme and
+host of the failed request, so the full URL is visible without additional
+debugging.

--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -872,9 +872,11 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         if not conn:
             # Try again
             log.warning(
-                "Retrying (%r) after connection broken by '%r': %s",
+                "Retrying (%r) after connection broken by '%r': %s://%s%s",
                 retries,
                 err,
+                self.scheme,
+                self.host,
                 url,
                 # Provide an unique attribute with the host needed by pip to
                 # rewrite this warning. Ideally, we'd go with a better solution,

--- a/test/test_connectionpool.py
+++ b/test/test_connectionpool.py
@@ -25,6 +25,7 @@ from urllib3.connectionpool import (
 )
 from urllib3.exceptions import (
     ClosedPoolError,
+    ConnectTimeoutError,
     EmptyPoolError,
     FullPoolError,
     HostChangedError,

--- a/test/test_connectionpool.py
+++ b/test/test_connectionpool.py
@@ -25,7 +25,6 @@ from urllib3.connectionpool import (
 )
 from urllib3.exceptions import (
     ClosedPoolError,
-    ConnectTimeoutError,
     EmptyPoolError,
     FullPoolError,
     HostChangedError,
@@ -834,8 +833,16 @@ class TestRetryWarningIncludesHost:
         failed request is visible, not just the (usually relative) path.
         """
         caplog.set_level(logging.WARNING, logger="urllib3.connectionpool")
-        with HTTPConnectionPool(host="example.com", port=1) as pool:
-            with pytest.raises(ConnectTimeoutError):
-                pool.urlopen("GET", "/", retries=1, timeout=SHORT_TIMEOUT)
+        with HTTPConnectionPool(host="example.com", port=80) as pool:
+            with patch.object(
+                pool,
+                "_make_request",
+                side_effect=[
+                    ProtocolError("Connection aborted.", OSError("boom")),
+                    HTTPResponse(status=200),
+                ],
+            ):
+                response = pool.urlopen("GET", "/", retries=1)
+        assert response.status == 200
         assert "Retrying" in caplog.text
-        assert "example.com" in caplog.text
+        assert "http://example.com/" in caplog.text

--- a/test/test_connectionpool.py
+++ b/test/test_connectionpool.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import http.client as httplib
+import logging
 import queue
 import ssl
 import typing
@@ -821,3 +822,19 @@ class TestConnectionPool:
 
         assert response.status == 200
         assert requested_urls == ["/", "http://localhost/next?x=1"]
+
+
+class TestRetryWarningIncludesHost:
+    def test_retry_warning_includes_host(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """
+        The "Retrying" warning should include the host so the full URL of the
+        failed request is visible, not just the (usually relative) path.
+        """
+        caplog.set_level(logging.WARNING, logger="urllib3.connectionpool")
+        with HTTPConnectionPool(host="example.com", port=1) as pool:
+            with pytest.raises(ConnectTimeoutError):
+                pool.urlopen("GET", "/", retries=1, timeout=SHORT_TIMEOUT)
+        assert "Retrying" in caplog.text
+        assert "example.com" in caplog.text


### PR DESCRIPTION
## Summary

Fixes #3583.

The `Retrying (...) after connection broken by ...` warning only printed the `url` argument, which is usually a relative path like `/simple/virtualenv/` — for a connection pool bound to `https://pypi.org/` the log line never says *which* host was failing. The pool already carries `self.scheme` and `self.host`, so the warning now logs the full `scheme://host` prefix followed by the path.

Before:
```
Retrying (Retry(...)) after connection broken by '...': /simple/virtualenv/
```
After:
```
Retrying (Retry(...)) after connection broken by '...': https://pypi.org/simple/virtualenv/
```

The `__urllib3-retry-warning` extra attribute (pip's rewrite contract, #2580) is unchanged.

## Changes

- `src/urllib3/connectionpool.py`: include `self.scheme` / `self.host` in the retry warning format
- `test/test_connectionpool.py`: `TestRetryWarningIncludesHost` — asserts the warning contains the pool's host
- `changelog/3583.bugfix.rst`: towncrier changelog fragment

## Validation

- [x] Direct script against the change: forced a connection failure on `example.invalid:1` and captured the log — message now reads `... : http://example.invalid/some/path`
- [x] `python -m py_compile` on both changed files; `Retry.increment()` unit path exercised
- [x] The existing `test_debug_log` exact-match assertion is unaffected (it doesn't trigger a retry)
- [x] The new pytest test could not run fully locally (conftest imports the dummyserver stack, which needs quart-trio not yet available on Python 3.14 here); it follows the existing `caplog` pattern in the same file and urllib3 CI will exercise it

## Notes

Only the log text changes — no exception type, behavior, or the pip contract changes.