### PR TITLE
Raise SSLError for non-hex fingerprints in assert_fingerprint

### DIFF
--- a/changelog/5211.bugfix.rst
+++ b/changelog/5211.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed ``assert_fingerprint()`` to raise ``SSLError`` instead of ``binascii.Error`` when a fingerprint has a supported length but contains non-hexadecimal characters.

--- a/src/urllib3/util/ssl_.py
+++ b/src/urllib3/util/ssl_.py
@@ -7,6 +7,7 @@ import socket
 import sys
 import typing
 import warnings
+from binascii import Error as BinasciiError
 from binascii import unhexlify
 
 from ..exceptions import ProxySchemeUnsupported, SSLError
@@ -128,7 +129,10 @@ def assert_fingerprint(cert: bytes | None, fingerprint: str) -> None:
         )
 
     # We need encode() here for py32; works on py2 and p33.
-    fingerprint_bytes = unhexlify(fingerprint.encode())
+    try:
+        fingerprint_bytes = unhexlify(fingerprint.encode())
+    except BinasciiError as e:
+        raise SSLError(e) from e
 
     cert_digest = hashfunc(cert).digest()
 

--- a/test/test_ssl.py
+++ b/test/test_ssl.py
@@ -255,3 +255,19 @@ class TestSSL:
             ssl_.assert_fingerprint(
                 cert=None, fingerprint="55:39:BF:70:05:12:43:FA:1F:D1:BF:4E:E8:1B:07:1D"
             )
+
+    @pytest.mark.parametrize(
+        "fingerprint",
+        [
+            "g" * 32,
+            "g" * 40,
+            "g" * 64,
+            "a" * 39 + "g",
+            "GG:" * 19 + "GG",
+        ],
+    )
+    def test_assert_fingerprint_raises_sslerror_on_non_hexadecimal(
+        self, fingerprint: str
+    ) -> None:
+        with pytest.raises(SSLError):
+            ssl_.assert_fingerprint(b"certificate", fingerprint)


### PR DESCRIPTION
## Summary

`assert_fingerprint()` already raises `SSLError` for unsupported fingerprint lengths and digest mismatches. When a fingerprint has a supported length (32/40/64) but contains a non-hexadecimal character, `unhexlify()` raised `binascii.Error` instead.

Wrap that failure as `SSLError` (same pattern as the existing `OSError` handling in this module) so callers that catch `SSLError` for verification failures see a consistent exception type.

## Test plan

- [x] Parametrized unit tests for non-hex fingerprints of lengths 32/40/64 (plain and colon-separated)
- [x] Existing `test_assert_fingerprint_*` cases still pass (`test/test_ssl.py`: 56 passed)

Fixes #5211