### PR TITLE
Make Dependabot open grouped PRs for Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,15 +3,15 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
+    # Combine all Actions updates into one pull request.
+    groups:
+      github-actions:
+        patterns:
+          - "*"
     labels:
       - "dependencies"
       - "Skip Changelog"
-    ignore:
-      # Ignore all patch releases as we can manually
-      # upgrade if we run into a bug and need a fix.
-      - dependency-name: "*"
-        update-types: ["version-update:semver-patch"]
     cooldown:
       default-days: 7
   - package-ecosystem: "pre-commit"


### PR DESCRIPTION
I recently had to upgrade two broken actions manually: #5187 and #5194.

Both upgrades involved patch releases, which Dependabot was configured to ignore.

I propose updating the Dependabot configuration to include patch releases while grouping all action updates into a single PR. I'm also changing the schedule to monthly to avoid weekly PRs, while retaining the option to trigger Dependabot manually when needed.

I hope this will reduce the need for manual upgrades.