### PR TITLE
docs: document that enabling a backoff is recommended for retries

### DIFF
--- a/changelog/3677.misc.rst
+++ b/changelog/3677.misc.rst
@@ -1,0 +1,1 @@
+Documented that enabling a backoff (``backoff_factor``) is recommended when retrying requests.

--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -629,6 +629,31 @@ specify the retry at the :class:`~urllib3.poolmanager.PoolManager` level:
 You still override this pool-level retry policy by specifying ``retries`` to
 :meth:`~urllib3.PoolManager.request`.
 
+By default, :class:`~util.retry.Retry` does not wait between attempts
+(``backoff_factor=0``). For anything beyond quick, best-effort requests, it's
+best practice to enable a backoff so retries don't hammer a server that's
+already struggling:
+
+.. code-block:: python
+
+    import urllib3
+
+    resp = urllib3.request(
+        "GET",
+        "https://httpbin.org/ip",
+        retries=urllib3.Retry(
+            total=3,
+            backoff_factor=0.5,
+            backoff_jitter=0.5,
+        )
+    )
+
+With ``backoff_factor=0.5``, urllib3 sleeps for ``[0.5s, 1.0s, 2.0s, ...]``
+between attempts (see :class:`~util.retry.Retry` for the exact formula).
+Adding ``backoff_jitter`` spreads out retries from multiple clients so they
+don't all land on the server at once, and ``backoff_max`` caps how long any
+single sleep can be.
+
 Errors & Exceptions
 -------------------
 


### PR DESCRIPTION
Closes #3677.

 The docs didn't explain that retries have no delay by default, which could hurt users retrying against real servers. I added a short explanation and example to the User Guide showing how to enable a sensible backoff.