### PR TITLE
Treat empty allowed_methods as allowing no methods

### DIFF
--- a/changelog/5044.bugfix.rst
+++ b/changelog/5044.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed ``Retry`` to treat an empty ``allowed_methods`` collection as allowing no HTTP methods.

--- a/src/urllib3/util/retry.py
+++ b/src/urllib3/util/retry.py
@@ -405,8 +405,8 @@ class Retry:
         """Checks if a given HTTP method should be retried upon, depending if
         it is included in the allowed_methods
         """
-        if self.allowed_methods and method.upper() not in self.allowed_methods:
-            return False
+        if self.allowed_methods is not None and self.allowed_methods is not False:  # type: ignore[comparison-overlap]
+            return method.upper() in self.allowed_methods
         return True
 
     def is_retry(

--- a/test/test_retry.py
+++ b/test/test_retry.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 import datetime
-from test import DUMMY_POOL
+import typing
 from unittest import mock
 
 import pytest
 
+from test import DUMMY_POOL
 from urllib3.exceptions import (
     ConnectTimeoutError,
     InvalidHeader,
@@ -263,7 +264,7 @@ class TestRetry:
         assert not retry.is_retry("GET", status_code=418)
 
     def test_allowed_methods_with_status_forcelist(self) -> None:
-        # Falsey allowed_methods means to retry on any method.
+        # None allowed_methods means to retry on any method.
         retry = Retry(status_forcelist=[500], allowed_methods=None)
         assert retry.is_retry("GET", status_code=500)
         assert retry.is_retry("POST", status_code=500)
@@ -271,6 +272,20 @@ class TestRetry:
         # Criteria of allowed_methods and status_forcelist are ANDed.
         retry = Retry(status_forcelist=[500], allowed_methods=["POST"])
         assert not retry.is_retry("GET", status_code=500)
+        assert retry.is_retry("POST", status_code=500)
+
+    @pytest.mark.parametrize("empty_collection", [set(), [], (), frozenset()])
+    def test_empty_allowed_methods(self, empty_collection: typing.Collection[str]) -> None:
+        # Empty collection means to retry on no methods.
+        retry = Retry(status_forcelist=[500], allowed_methods=empty_collection)
+        assert not retry.is_retry("GET", status_code=500)
+        assert not retry.is_retry("POST", status_code=500)
+
+    def test_allowed_methods_false_backwards_compat(self) -> None:
+        # False allowed_methods is supported for backwards compatibility and means
+        # to retry on any method.
+        retry = Retry(status_forcelist=[500], allowed_methods=False)  # type: ignore[arg-type]
+        assert retry.is_retry("GET", status_code=500)
         assert retry.is_retry("POST", status_code=500)
 
     def test_exhausted(self) -> None:

--- a/test/test_retry.py
+++ b/test/test_retry.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 import datetime
 import typing
+from test import DUMMY_POOL
 from unittest import mock
 
 import pytest
 
-from test import DUMMY_POOL
 from urllib3.exceptions import (
     ConnectTimeoutError,
     InvalidHeader,
@@ -275,7 +275,9 @@ class TestRetry:
         assert retry.is_retry("POST", status_code=500)
 
     @pytest.mark.parametrize("empty_collection", [set(), [], (), frozenset()])
-    def test_empty_allowed_methods(self, empty_collection: typing.Collection[str]) -> None:
+    def test_empty_allowed_methods(
+        self, empty_collection: typing.Collection[str]
+    ) -> None:
         # Empty collection means to retry on no methods.
         retry = Retry(status_forcelist=[500], allowed_methods=empty_collection)
         assert not retry.is_retry("GET", status_code=500)


### PR DESCRIPTION
Fixes #5044

### Summary of Changes

Previously, `_is_method_retryable` checked `if self.allowed_methods and method.upper() not in self.allowed_methods:`. When `allowed_methods` was passed an empty collection (such as `set()`, `[]`, or `()`), the falsy check evaluated to `False`, causing `_is_method_retryable` to return `True` (allowing retries for all HTTP verbs).

As discussed in #5044:
1. An empty collection for `allowed_methods` now treats all HTTP methods as not retryable (`_is_method_retryable` returns `False`).
2. Backwards compatibility for `allowed_methods=False` (and `None`), which allows retrying on any verb, is preserved.
3. Added parameterized unit tests covering empty collections (`set`, `list`, `tuple`, `frozenset`) and `False`.
4. Added towncrier changelog fragment `changelog/5044.bugfix.rst`.