### PR TITLE
Treat empty allowed_methods collection as retrying on no methods

### DIFF
--- a/changelog/5044.bugfix.rst
+++ b/changelog/5044.bugfix.rst
@@ -1,0 +1,5 @@
+Fixed ``Retry`` to treat an explicitly empty ``allowed_methods`` collection
+(``set()``, ``frozenset()``, ``[]``, ``()``, ``{}``) as "retry on no methods"
+instead of falling back to the ``None`` behavior of retrying on any method.
+Passing ``None`` (or the legacy ``False`` from urllib3 1.26.x) still retries
+on every method.

--- a/src/urllib3/util/retry.py
+++ b/src/urllib3/util/retry.py
@@ -131,7 +131,8 @@ class Retry:
         idempotent (multiple requests with the same parameters end with the
         same state). See :attr:`Retry.DEFAULT_ALLOWED_METHODS`.
 
-        Set to a ``None`` value to retry on any verb.
+        Set to a ``None`` value to retry on any verb. Passing an empty
+        collection (e.g. ``set()``) disables retries on all methods.
 
     :param Collection status_forcelist:
         A set of integer HTTP status codes that we should force a retry on.
@@ -405,9 +406,14 @@ class Retry:
         """Checks if a given HTTP method should be retried upon, depending if
         it is included in the allowed_methods
         """
-        if self.allowed_methods and method.upper() not in self.allowed_methods:
-            return False
-        return True
+        # ``allowed_methods=False`` was documented in urllib3 1.26.x as
+        # retrying on any verb, so it is preserved here for backward
+        # compatibility even though the type hint does not advertise it.
+        # An explicitly empty collection, on the other hand, means "retry
+        # on no methods".
+        if self.allowed_methods is None or isinstance(self.allowed_methods, bool):
+            return True
+        return method.upper() in self.allowed_methods
 
     def is_retry(
         self, method: str, status_code: int, has_retry_after: bool = False

--- a/test/test_retry.py
+++ b/test/test_retry.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import datetime
+import typing
 from test import DUMMY_POOL
 from unittest import mock
 
@@ -263,7 +264,7 @@ class TestRetry:
         assert not retry.is_retry("GET", status_code=418)
 
     def test_allowed_methods_with_status_forcelist(self) -> None:
-        # Falsey allowed_methods means to retry on any method.
+        # ``None`` allowed_methods means to retry on any method.
         retry = Retry(status_forcelist=[500], allowed_methods=None)
         assert retry.is_retry("GET", status_code=500)
         assert retry.is_retry("POST", status_code=500)
@@ -271,6 +272,28 @@ class TestRetry:
         # Criteria of allowed_methods and status_forcelist are ANDed.
         retry = Retry(status_forcelist=[500], allowed_methods=["POST"])
         assert not retry.is_retry("GET", status_code=500)
+        assert retry.is_retry("POST", status_code=500)
+
+    @pytest.mark.parametrize("empty_methods", [set(), frozenset(), [], (), {}])
+    def test_empty_allowed_methods_retries_no_method(
+        self, empty_methods: typing.Collection[str]
+    ) -> None:
+        # An explicitly empty ``allowed_methods`` collection means "retry
+        # on no methods". This differs from ``None``, which retries on any
+        # method, and it protects users who make mistakes like
+        # ``allowed_methods=DEFAULT_ALLOWED_METHODS & {"POST"}`` (intersection
+        # instead of union) from silently retrying on every method.
+        retry = Retry(status_forcelist=[500], allowed_methods=empty_methods)
+        assert not retry.is_retry("GET", status_code=500)
+        assert not retry.is_retry("POST", status_code=500)
+
+    def test_allowed_methods_false_retries_any_method(self) -> None:
+        # urllib3 1.26.x documented ``allowed_methods=False`` as meaning
+        # "retry on any verb", so it is treated identically to ``None`` for
+        # backward compatibility. The type hint does not advertise this, but
+        # code still passing ``False`` must not silently regress.
+        retry = Retry(status_forcelist=[500], allowed_methods=False)  # type: ignore[arg-type]
+        assert retry.is_retry("GET", status_code=500)
         assert retry.is_retry("POST", status_code=500)
 
     def test_exhausted(self) -> None:


### PR DESCRIPTION
Fixes #5044.

## Problem

`Retry._is_method_retryable` uses a truthiness check on `allowed_methods`:

```python
if self.allowed_methods and method.upper() not in self.allowed_methods:
    return False
return True
```

An empty collection is falsy in Python, so an explicitly empty `allowed_methods`
(`set()`, `frozenset()`, `[]`, `()`, `{}`) is indistinguishable from `None`
and silently retries on **every** method. The user in #5044 hit this the way
the mistake shows up in the wild:

```python
Retry(allowed_methods=Retry.DEFAULT_ALLOWED_METHODS & {HTTPMethod.POST})
```

`&` gives the intersection (empty) rather than the intended union, and instead
of being scoped down the retry rule opens up to every verb — the opposite of
what the caller asked for.

## Fix

Distinguish the two states in `_is_method_retryable`:

- `None` — retry on any verb (unchanged).
- `False` — retry on any verb. urllib3 1.26.x [documented `allowed_methods=False`
  as meaning "retry on any verb"](https://github.com/urllib3/urllib3/blob/6f2ad7ca0cdde53751bab29cbc10bcc965bb4387/src/urllib3/util/retry.py#L172-L179);
  the type hint doesn't advertise it, but code that still passes `False` must
  not silently regress. `isinstance(self.allowed_methods, bool)` matches this
  without widening the type as @illia-v [asked in the issue thread](https://github.com/urllib3/urllib3/issues/5044#issuecomment-5552655479).
- Empty collection — retry on **no** method. This is the corrected reading of
  the plain value.
- Non-empty collection — membership check (unchanged).

An inline comment on the `isinstance` branch names the 1.26.x compatibility
reason so it's obvious next time someone reads it.

## Tests

- `test_empty_allowed_methods_retries_no_method` — parametrized over `set()`,
  `frozenset()`, `[]`, `()`, `{}`; asserts neither `GET` nor `POST` retries
  when combined with `status_forcelist=[500]`, pinning the fix for the
  reported failure mode. The existing suite would have accepted the buggy
  behavior — [`test_allowed_methods_with_status_forcelist`](https://github.com/urllib3/urllib3/blob/main/test/test_retry.py#L265-L268)
  describes the case as "falsey allowed_methods means to retry on any method"
  but only tests `None`, which is why an empty collection slipped through.
- `test_allowed_methods_false_retries_any_method` — asserts `allowed_methods=False`
  still retries on any verb, guarding the 1.26.x backward-compat leg.
- Retouched the docstring comment on the existing test to say "`None`" rather
  than "falsey", so no reader is misled about which values are the "retry any
  verb" ones after the fix lands.

Ran `test/test_retry.py`, `test/test_connectionpool.py`, `test/test_poolmanager.py`
(all 209 pass), and `nox -s mypy` (my change no longer errors — the remaining
`src/urllib3/connection.py:146` error is pre-existing on `main` and unrelated).

## Docs

Extended the `allowed_methods` parameter docstring on `Retry` to note that an
empty collection disables retries on all methods, so the distinction between
`None` and `set()` is visible without reading the source.

## Changelog

`changelog/5044.bugfix.rst` added.