### PR TITLE
Raise SSLError for non-hex fingerprints

### DIFF
--- a/changelog/5211.bugfix.rst
+++ b/changelog/5211.bugfix.rst
@@ -1,0 +1,3 @@
+Fixed ``assert_fingerprint()`` raising ``binascii.Error`` instead of
+``urllib3.exceptions.SSLError`` when given a fingerprint containing
+non-hexadecimal characters.

--- a/src/urllib3/util/ssl_.py
+++ b/src/urllib3/util/ssl_.py
@@ -7,6 +7,7 @@ import socket
 import sys
 import typing
 import warnings
+from binascii import Error as BinasciiError
 from binascii import unhexlify
 
 from ..exceptions import ProxySchemeUnsupported, SSLError
@@ -128,7 +129,10 @@ def assert_fingerprint(cert: bytes | None, fingerprint: str) -> None:
         )
 
     # We need encode() here for py32; works on py2 and p33.
-    fingerprint_bytes = unhexlify(fingerprint.encode())
+    try:
+        fingerprint_bytes = unhexlify(fingerprint.encode())
+    except BinasciiError as e:
+        raise SSLError(e) from e
 
     cert_digest = hashfunc(cert).digest()
 

--- a/test/test_ssl.py
+++ b/test/test_ssl.py
@@ -255,3 +255,7 @@ class TestSSL:
             ssl_.assert_fingerprint(
                 cert=None, fingerprint="55:39:BF:70:05:12:43:FA:1F:D1:BF:4E:E8:1B:07:1D"
             )
+
+    def test_assert_fingerprint_raises_ssl_error_on_non_hex_fingerprint(self) -> None:
+        with pytest.raises(SSLError):
+            ssl_.assert_fingerprint(cert=b"certificate", fingerprint="g" * 40)


### PR DESCRIPTION
Fixes #5211.

`assert_fingerprint()` can raise `binascii.Error` for a supported-length fingerprint containing non-hexadecimal characters. This converts that error to `SSLError`, consistent with the function's other invalid-fingerprint paths.

Adds a regression test and changelog entry.