### PR TITLE
Build Basic auth headers from request and proxy URL credentials

### DIFF
--- a/changelog/1999.feature.rst
+++ b/changelog/1999.feature.rst
@@ -1,0 +1,1 @@
+Added support for Basic authorization from userinfo in request and proxy URLs.

--- a/src/urllib3/poolmanager.py
+++ b/src/urllib3/poolmanager.py
@@ -20,6 +20,7 @@ from .exceptions import (
 from .response import BaseHTTPResponse
 from .util.connection import _TYPE_SOCKET_OPTIONS
 from .util.proxy import connection_requires_http_tunnel
+from .util.request import make_headers
 from .util.retry import Retry
 from .util.timeout import Timeout
 from .util.url import Url, parse_url
@@ -452,9 +453,23 @@ class PoolManager(RequestMethods):
 
         if "headers" not in kw:
             kw["headers"] = self.headers
+        url_auth = u.auth_decoded_joined
+        generated_auth = False
+        if url_auth:
+            expected_auth = make_headers(basic_auth=url_auth)["authorization"]
+            header_dict = HTTPHeaderDict(kw["headers"])
+            explicit_auth = header_dict.get("authorization")
+            if explicit_auth is not None and explicit_auth != expected_auth:
+                raise ValueError("URL credentials conflict with Authorization header")
+            if explicit_auth is None:
+                header_dict["authorization"] = expected_auth
+                kw["headers"] = header_dict
+                generated_auth = True
 
         if self._proxy_requires_url_absolute_form(u):
-            response = conn.urlopen(method, u._replace(fragment=None).url, **kw)
+            response = conn.urlopen(
+                method, u._replace(auth=None, fragment=None).url, **kw
+            )
         else:
             response = conn.urlopen(method, u.request_uri, **kw)
 
@@ -498,6 +513,10 @@ class PoolManager(RequestMethods):
 
         kw["retries"] = retries
         kw["redirect"] = redirect
+        if generated_auth:
+            headers = HTTPHeaderDict(kw["headers"])
+            headers.pop("authorization", None)
+            kw["headers"] = headers
 
         log.info("Redirecting %s -> %s", url, redirect_location)
 
@@ -605,8 +624,23 @@ class ProxyManager(PoolManager):
             port = port_by_scheme.get(proxy.scheme, 80)
             proxy = proxy._replace(port=port)
 
-        self.proxy = proxy
-        self.proxy_headers = proxy_headers or {}
+        proxy_auth = proxy.auth_decoded_joined
+        self.proxy = proxy._replace(auth=None)
+        self.proxy_headers = HTTPHeaderDict(proxy_headers or {})
+        if proxy_auth:
+            expected_proxy_auth = make_headers(proxy_basic_auth=proxy_auth)[
+                "proxy-authorization"
+            ]
+            explicit_proxy_auth = self.proxy_headers.get("proxy-authorization")
+            if (
+                explicit_proxy_auth is not None
+                and explicit_proxy_auth != expected_proxy_auth
+            ):
+                raise ValueError(
+                    "Proxy URL credentials conflict with Proxy-Authorization header"
+                )
+            if explicit_proxy_auth is None:
+                self.proxy_headers["proxy-authorization"] = expected_proxy_auth
         self.proxy_config = ProxyConfig(
             proxy_ssl_context,
             use_forwarding_for_https,

--- a/test/test_poolmanager.py
+++ b/test/test_poolmanager.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from urllib3 import connection_from_url
+from urllib3 import HTTPHeaderDict, connection_from_url
 from urllib3.connectionpool import HTTPSConnectionPool
 from urllib3.exceptions import LocationValueError
 from urllib3.poolmanager import (
@@ -17,11 +17,49 @@ from urllib3.poolmanager import (
     PoolManager,
     key_fn_by_scheme,
 )
+from urllib3.response import HTTPResponse
 from urllib3.util import retry, timeout
 from urllib3.util.url import Url
 
 
 class TestPoolManager:
+    @pytest.mark.parametrize("userinfo", ["user:pass", "%75ser:pa%73s"])
+    @pytest.mark.parametrize("headers", [None, {"Authorization": "Basic dXNlcjpwYXNz"}])
+    @patch("urllib3.poolmanager.PoolManager.connection_from_host")
+    def test_url_credentials_create_authorization_header(
+        self,
+        connection_from_host: MagicMock,
+        userinfo: str,
+        headers: dict[str, str] | None,
+    ) -> None:
+        connection = MagicMock()
+        connection.urlopen.return_value = HTTPResponse(status=200)
+        connection_from_host.return_value = connection
+
+        with PoolManager() as manager:
+            manager.urlopen(
+                "GET", f"http://{userinfo}@example.com/path", headers=headers
+            )
+            assert manager.headers == {}
+
+        _, kwargs = connection.urlopen.call_args
+        assert (
+            HTTPHeaderDict(kwargs["headers"])["authorization"] == "Basic dXNlcjpwYXNz"
+        )
+        assert connection.urlopen.call_args.args[1] == "/path"
+        assert headers is None or headers == {"Authorization": "Basic dXNlcjpwYXNz"}
+
+    @pytest.mark.parametrize("header", ["Authorization", "authorization"])
+    def test_url_credentials_reject_conflicting_authorization(
+        self, header: str
+    ) -> None:
+        with pytest.raises(ValueError, match="conflict"):
+            PoolManager().request(
+                "GET",
+                "http://user:pass@example.com/path",
+                headers={header: "Basic d3Jvbmc6cGFzcw=="},
+            )
+
     @resolvesLocalhostFQDN()
     def test_same_url(self) -> None:
         # Convince ourselves that normally we don't get the same object

--- a/test/test_proxymanager.py
+++ b/test/test_proxymanager.py
@@ -17,6 +17,36 @@ from .port_helpers import find_unused_port
 
 
 class TestProxyManager:
+    @pytest.mark.parametrize("scheme", ["http", "https"])
+    @pytest.mark.parametrize("userinfo", ["user:pass", "%75ser:pa%73s"])
+    @pytest.mark.parametrize(
+        "headers", [None, {"Proxy-Authorization": "Basic dXNlcjpwYXNz"}]
+    )
+    def test_proxy_url_credentials_create_proxy_authorization_header(
+        self, scheme: str, userinfo: str, headers: dict[str, str] | None
+    ) -> None:
+        with ProxyManager(
+            f"{scheme}://{userinfo}@proxy:8080", proxy_headers=headers
+        ) as manager:
+            assert manager.proxy_headers == {
+                "proxy-authorization": "Basic dXNlcjpwYXNz"
+            }
+            assert manager.proxy is not None
+            assert manager.proxy.auth is None
+        assert headers is None or headers == {
+            "Proxy-Authorization": "Basic dXNlcjpwYXNz"
+        }
+
+    @pytest.mark.parametrize("header", ["Proxy-Authorization", "proxy-authorization"])
+    def test_proxy_url_credentials_reject_conflicting_proxy_authorization(
+        self, header: str
+    ) -> None:
+        with pytest.raises(ValueError, match="conflict"):
+            ProxyManager(
+                "http://user:pass@proxy:8080",
+                proxy_headers={header: "Basic d3Jvbmc6cGFzcw=="},
+            )
+
     @pytest.mark.parametrize("proxy_scheme", ["http", "https"])
     def test_proxy_headers(self, proxy_scheme: str) -> None:
         url = "http://pypi.org/project/urllib3/"
@@ -82,8 +112,9 @@ class TestProxyManager:
             assert p._proxy_requires_url_absolute_form(https_url)
 
     @pytest.mark.parametrize("proxy_scheme", ["http", "https"])
+    @pytest.mark.parametrize("userinfo", ["", "user:pass@"])
     def test_absolute_form_request_target_strips_fragment_for_custom_pool(
-        self, proxy_scheme: str
+        self, proxy_scheme: str, userinfo: str
     ) -> None:
         class CustomConnectionPool:
             requested_urls: list[str] = []
@@ -100,7 +131,7 @@ class TestProxyManager:
             p.pool_classes_by_scheme[proxy_scheme] = CustomConnectionPool
             response = p.urlopen(
                 "GET",
-                "http://example.com/path?x=1#marker=value",
+                f"http://{userinfo}example.com/path?x=1#marker=value",
             )
 
         assert response.status == 200

--- a/test/with_dummyserver/test_poolmanager.py
+++ b/test/with_dummyserver/test_poolmanager.py
@@ -20,6 +20,41 @@ from urllib3.util.retry import Retry
 
 
 class TestPoolManager(HypercornDummyServerTestCase):
+    @pytest.mark.parametrize(
+        "target, expected_auth",
+        [
+            ("/headers", "Basic dXNlcjpwYXNz"),
+            ("http://{host}:{port}/headers", None),
+            ("http://{host_alt}:{port}/headers", None),
+            ("http://next:pass@{host}:{port}/headers", "Basic bmV4dDpwYXNz"),
+        ],
+    )
+    @pytest.mark.parametrize("remove_headers", [[], ["Authorization", "Cookie"]])
+    def test_url_credentials_on_redirect(
+        self, target: str, expected_auth: str | None, remove_headers: list[str]
+    ) -> None:
+        headers = {"Cookie": "private", "X-Test": "retained"}
+        with PoolManager() as manager:
+            response = manager.request(
+                "GET",
+                f"http://user:pass@{self.host}:{self.port}/redirect",
+                fields={
+                    "target": target.format(
+                        host=self.host, host_alt=self.host_alt, port=self.port
+                    )
+                },
+                headers=headers,
+                retries=Retry(total=1, remove_headers_on_redirect=remove_headers),
+            )
+        assert response.status == 200
+        received = response.json()
+        assert received.get("Authorization") == expected_auth
+        assert received["X-Test"] == "retained"
+        assert received.get("Cookie") == (
+            None if "{host_alt}" in target and "Cookie" in remove_headers else "private"
+        )
+        assert headers == {"Cookie": "private", "X-Test": "retained"}
+
     @classmethod
     def setup_class(cls) -> None:
         super().setup_class()

--- a/test/with_dummyserver/test_proxy_poolmanager.py
+++ b/test/with_dummyserver/test_proxy_poolmanager.py
@@ -57,6 +57,22 @@ def assert_is_verified(pm: ProxyManager, *, proxy: bool, target: bool) -> None:
 
 
 class TestHTTPProxyManager(HypercornDummyProxyTestCase):
+    @pytest.mark.parametrize("proxy_attribute", ["proxy_url", "https_proxy_url"])
+    @pytest.mark.parametrize("target_attribute", ["http_url", "https_url"])
+    def test_url_credentials_through_proxy(
+        self, proxy_attribute: str, target_attribute: str
+    ) -> None:
+        proxy = getattr(self, proxy_attribute).replace("://", "://proxy:pass@", 1)
+        target = getattr(self, target_attribute).replace("://", "://user:pass@", 1)
+        with ProxyManager(proxy, ca_certs=DEFAULT_CA) as manager:
+            response = manager.request("GET", f"{target}/headers")
+        assert response.status == 200
+        received = response.json()
+        assert received["Authorization"] == "Basic dXNlcjpwYXNz"
+        assert received.get("Proxy-Authorization") == (
+            "Basic cHJveHk6cGFzcw==" if target_attribute == "http_url" else None
+        )
+
     @classmethod
     def setup_class(cls) -> None:
         super().setup_class()


### PR DESCRIPTION
URLs such as `http://user:pass@host/path` currently discard the credentials. This change builds Basic `Authorization` headers from request URL userinfo and `Proxy-Authorization` headers from HTTP/HTTPS proxy URL userinfo, using the existing decoded-userinfo and header helpers. Conflicting explicit headers raise `ValueError`; matching explicit headers remain valid.

Generated auth is removed before following a redirect and rebuilt from the resolved destination URL. Relative redirects retain inherited userinfo; absolute destinations without userinfo receive no generated auth. Existing redirect header removal still applies. Proxy URLs and absolute request targets omit userinfo, and caller header mappings are preserved.

Fixes #1999.

Validation:

- Full `nox -rs test-3.12`: 2,371 passed, 288 skipped, 4 expected failures.
- Focused pool/proxy modules: 239 passed, including real local HTTP/HTTPS proxy requests and redirects.
- New credential tests against unchanged upstream source: 22 failed and 6 passed; all pass with this change.
- `nox -s lint` on Python 3.14: all pre-commit checks and mypy passed (83 source files), matching the CI lint interpreter range. Python 3.12 mypy reports an existing `ClassVar[Final[...]]` annotation error in unchanged `connection.py`; the same error was reproduced on upstream source.
- Independent correctness and simplification review passed.

Prepared with OpenAI Codex and independently reviewed. Local validation was on Linux; other platforms and Python versions remain for CI. This is a contribution to the listed bounty task, not a claim that a reward has been approved or paid.
