### PR TITLE
Fix 1338 retry after max

### DIFF
--- a/changelog/1338.feature.rst
+++ b/changelog/1338.feature.rst
@@ -1,0 +1,2 @@
+Added ``raise_on_retry_after_max`` to ``Retry`` to raise an informative exception
+instead of capping ``Retry-After`` values that exceed ``retry_after_max``.

--- a/src/urllib3/exceptions.py
+++ b/src/urllib3/exceptions.py
@@ -81,6 +81,22 @@ ConnectionError = ProtocolError
 # Leaf Exceptions
 
 
+class RetryAfterMaxExceededError(HTTPError):
+    """Raised when ``Retry-After`` exceeds the configured maximum wait time.
+
+    :param float retry_after: The server-requested delay in seconds.
+    :param int max_wait: The configured maximum delay in seconds.
+    """
+
+    def __init__(self, retry_after: float, max_wait: int) -> None:
+        self.retry_after = retry_after
+        self.max_wait = max_wait
+        super().__init__(
+            f"Retry-After requested {retry_after} seconds, exceeding "
+            f"the configured maximum of {max_wait} seconds"
+        )
+
+
 class MaxRetryError(RequestError):
     """Raised when the maximum number of retries is exceeded.
 

--- a/src/urllib3/util/retry.py
+++ b/src/urllib3/util/retry.py
@@ -17,6 +17,7 @@ from ..exceptions import (
     ProxyError,
     ReadTimeoutError,
     ResponseError,
+    RetryAfterMaxExceededError,
 )
 from .util import reraise
 
@@ -191,6 +192,11 @@ class Retry:
         Retry-After headers. Defaults to :attr:`Retry.DEFAULT_RETRY_AFTER_MAX`.
         Any Retry-After headers larger than this value will be limited to this
         value.
+
+    :param bool raise_on_retry_after_max:
+        Whether to raise :class:`~urllib3.exceptions.RetryAfterMaxExceededError`
+        instead of limiting the value when a ``Retry-After`` header exceeds
+        ``retry_after_max``. Defaults to ``False``.
     """
 
     #: Default methods to be used for ``allowed_methods``
@@ -238,6 +244,7 @@ class Retry:
         ] = DEFAULT_REMOVE_HEADERS_ON_REDIRECT,
         backoff_jitter: float = 0.0,
         retry_after_max: int = DEFAULT_RETRY_AFTER_MAX,
+        raise_on_retry_after_max: bool = False,
     ) -> None:
         self.total = total
         self.connect = connect
@@ -255,6 +262,7 @@ class Retry:
         self.backoff_factor = backoff_factor
         self.backoff_max = backoff_max
         self.retry_after_max = retry_after_max
+        self.raise_on_retry_after_max = raise_on_retry_after_max
         self.raise_on_redirect = raise_on_redirect
         self.raise_on_status = raise_on_status
         self.history = history or ()
@@ -277,6 +285,7 @@ class Retry:
             backoff_factor=self.backoff_factor,
             backoff_max=self.backoff_max,
             retry_after_max=self.retry_after_max,
+            raise_on_retry_after_max=self.raise_on_retry_after_max,
             raise_on_redirect=self.raise_on_redirect,
             raise_on_status=self.raise_on_status,
             history=self.history,
@@ -343,6 +352,8 @@ class Retry:
 
         # Check the seconds do not exceed the specified maximum
         if seconds > self.retry_after_max:
+            if self.raise_on_retry_after_max:
+                raise RetryAfterMaxExceededError(seconds, self.retry_after_max)
             seconds = self.retry_after_max
 
         return seconds

--- a/test/test_retry_after_max.py
+++ b/test/test_retry_after_max.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import datetime
+from unittest import mock
+
+import pytest
+
+from urllib3.exceptions import RetryAfterMaxExceededError
+from urllib3.response import HTTPResponse
+from urllib3.util.retry import Retry
+
+
+def test_default_retry_after_max_still_caps() -> None:
+    retry = Retry(retry_after_max=60)
+    assert retry.parse_retry_after("3600") == 60
+
+
+def test_raise_on_retry_after_max() -> None:
+    retry = Retry(retry_after_max=60, raise_on_retry_after_max=True)
+
+    with pytest.raises(RetryAfterMaxExceededError) as exc_info:
+        retry.parse_retry_after("3600")
+
+    assert exc_info.value.retry_after == 3600
+    assert exc_info.value.max_wait == 60
+
+
+def test_raise_on_retry_after_max_boundary() -> None:
+    retry = Retry(retry_after_max=60, raise_on_retry_after_max=True)
+    assert retry.parse_retry_after("60") == 60
+
+
+def test_raise_on_retry_after_max_http_date() -> None:
+    retry = Retry(retry_after_max=60, raise_on_retry_after_max=True)
+    now = datetime.datetime(
+        2019, 6, 3, 11, tzinfo=datetime.timezone.utc
+    ).timestamp()
+
+    with mock.patch("time.time", return_value=now):
+        with pytest.raises(RetryAfterMaxExceededError) as exc_info:
+            retry.parse_retry_after("Mon, 3 Jun 2019 12:00:00 UTC")
+
+    assert exc_info.value.retry_after == 3600
+    assert exc_info.value.max_wait == 60
+
+
+def test_raise_on_retry_after_max_propagated() -> None:
+    retry = Retry(retry_after_max=60, raise_on_retry_after_max=True)
+    new_retry = retry.new()
+
+    assert new_retry.retry_after_max == 60
+    assert new_retry.raise_on_retry_after_max is True
+
+    with pytest.raises(RetryAfterMaxExceededError):
+        new_retry.parse_retry_after("61")
+
+
+def test_raise_on_retry_after_max_sleep() -> None:
+    retry = Retry(retry_after_max=60, raise_on_retry_after_max=True)
+    response = HTTPResponse(status=503, headers={"Retry-After": "3600"})
+
+    with mock.patch("time.sleep") as sleep_mock:
+        with pytest.raises(RetryAfterMaxExceededError):
+            retry.sleep_for_retry(response)
+
+    sleep_mock.assert_not_called()

--- a/test/test_retry_after_max.py
+++ b/test/test_retry_after_max.py
@@ -32,9 +32,7 @@ def test_raise_on_retry_after_max_boundary() -> None:
 
 def test_raise_on_retry_after_max_http_date() -> None:
     retry = Retry(retry_after_max=60, raise_on_retry_after_max=True)
-    now = datetime.datetime(
-        2019, 6, 3, 11, tzinfo=datetime.timezone.utc
-    ).timestamp()
+    now = datetime.datetime(2019, 6, 3, 11, tzinfo=datetime.timezone.utc).timestamp()
 
     with mock.patch("time.time", return_value=now):
         with pytest.raises(RetryAfterMaxExceededError) as exc_info:


### PR DESCRIPTION
<!---
Thanks for your contribution! ♥️

If this is your first PR to urllib3 please review the Contributing Guide:
https://urllib3.readthedocs.io/en/latest/contributing.html

Adhering to the Contributing Guide means we can review, merge, and release your change faster! :)
--->

## Summary

Fixes #1338 by making it possible to detect when a server asks for an
unreasonably long `Retry-After` delay instead of silently waiting (or silently
capping the wait).

The issue reports a real-world case: a server returning `Retry-After: 3600`
made retry tasks sleep for an hour. Discussion in the issue converged on
opt-in behavior rather than changing defaults.

## Changes

- New `raise_on_retry_after_max: bool = False` kwarg on `Retry` (opt-in,
  existing behavior unchanged by default).
- New `RetryAfterMaxExceededError(HTTPError)` carrying `retry_after` and
  `max_wait`, raised from `parse_retry_after()` when the header exceeds
  `retry_after_max` and the opt-in is enabled.
- Tests in `test/test_retry_after_max.py` covering: raise on exceed, no raise
  by default (cap preserved), boundary value, and both parsed formats
  (seconds + HTTP-date).
- Changelog fragment `changelog/1338.feature.rst`.

## Why opt-in

`retry_after_max` (capping) remains the default so no existing caller sees a
new exception. Callers who want the issue's "fail fast on absurd delays"
semantics pass `raise_on_retry_after_max=True` and catch
`RetryAfterMaxExceededError` (or `HTTPError`).

## Checklist

- [x] Changes are locally tested and test suite passes (`test_retry_after_max.py`)
- [x] CI: all checks green (Analyze, CodeQL, Ubuntu 3.10/3.11/3.12, emscripten)
- [x] Changelog fragment added
- [x] Type hints follow the existing style in `util/retry.py`

Closes #1338
