### PR TITLE
Speed up URL percent encoding with an ASCII fast path

### DIFF
--- a/src/urllib3/util/url.py
+++ b/src/urllib3/util/url.py
@@ -285,6 +285,18 @@ def _encode_invalid_chars(
 
     component = to_str(component)
 
+    # Fast path: an ASCII component that consists only of allowed characters
+    # and contains no '%' needs neither encoding nor percent-normalization.
+    # Components containing '%' always take the general path below because
+    # how '%' is treated depends on whether the whole component is already
+    # percent-encoded.
+    if (
+        "%" not in component
+        and component.isascii()
+        and all(map(allowed_chars.__contains__, component))
+    ):
+        return component
+
     # Normalize existing percent-encoded bytes.
     # Try to see if the component we're encoding is already percent-encoded
     # so we can skip all '%' characters but still encode all others.
@@ -296,16 +308,14 @@ def _encode_invalid_chars(
     is_percent_encoded = percent_encodings == uri_bytes.count(b"%")
     encoded_component = bytearray()
 
-    for i in range(0, len(uri_bytes)):
-        # Will return a single character bytestring
-        byte = uri_bytes[i : i + 1]
-        byte_ord = ord(byte)
-        if (is_percent_encoded and byte == b"%") or (
-            byte_ord < 128 and byte.decode() in allowed_chars
+    # Iterating over bytes yields integers; 0x25 is '%'.
+    for byte_ord in uri_bytes:
+        if (is_percent_encoded and byte_ord == 0x25) or (
+            byte_ord < 128 and chr(byte_ord) in allowed_chars
         ):
-            encoded_component += byte
-            continue
-        encoded_component.extend(b"%" + (hex(byte_ord)[2:].encode().zfill(2).upper()))
+            encoded_component.append(byte_ord)
+        else:
+            encoded_component += b"%%%02X" % byte_ord
 
     return encoded_component.decode()
 

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -34,7 +34,7 @@ from urllib3.util.ssl_ import (
     ssl_wrap_socket,
 )
 from urllib3.util.timeout import _DEFAULT_TIMEOUT, Timeout
-from urllib3.util.url import Url, _encode_invalid_chars, parse_url
+from urllib3.util.url import _PATH_CHARS, Url, _encode_invalid_chars, parse_url
 from urllib3.util.util import to_bytes, to_str
 
 from . import clear_warnings
@@ -149,6 +149,56 @@ class TestUtil:
 
     def test_encode_invalid_chars_none(self) -> None:
         assert _encode_invalid_chars(None, set()) is None
+
+    @pytest.mark.parametrize(
+        "component, expected",
+        [
+            # Already valid components are returned unchanged.
+            ("", ""),
+            ("/", "/"),
+            ("/path/to/resource", "/path/to/resource"),
+            (b"/bytes/path", "/bytes/path"),
+            # Invalid ASCII characters are percent-encoded (uppercase hex).
+            ("/a b|c", "/a%20b%7Cc"),
+            (b"/a b", "/a%20b"),
+            # Non-ASCII characters are encoded as UTF-8 bytes.
+            ("/caf\xe9", "/caf%C3%A9"),
+            ("/日本/\U0001f600", "/%E6%97%A5%E6%9C%AC/%F0%9F%98%80"),
+            # Lone surrogates are encoded with 'surrogatepass' (3 bytes).
+            ("/a\udc80b", "/a%ED%B2%80b"),
+            ("\ud800", "%ED%A0%80"),
+            # Fully percent-encoded components keep their '%' and get their
+            # hex digits normalized to uppercase.
+            ("/%2f%2F", "/%2F%2F"),
+            ("/a%20b c", "/a%20b%20c"),
+            ("%C3%A9\xe9", "%C3%A9%C3%A9"),
+            # A single bare '%' makes every '%' get encoded, even valid ones.
+            ("%", "%25"),
+            ("%2", "%252"),
+            ("%%20", "%25%2520"),
+            ("/%2F%", "/%252F%25"),
+            ("/%2f%2F%zz", "/%252F%252F%25zz"),
+        ],
+    )
+    def test_encode_invalid_chars(self, component: str | bytes, expected: str) -> None:
+        assert _encode_invalid_chars(component, _PATH_CHARS) == expected  # type: ignore[arg-type]
+
+    def test_encode_invalid_chars_respects_allowed_chars(self) -> None:
+        # Only characters in ``allowed_chars`` are kept, and any container
+        # type works, not only the module's own sets.
+        assert _encode_invalid_chars("abc", {"a", "b"}) == "ab%63"
+        assert _encode_invalid_chars("abc", "ab") == "ab%63"
+        assert _encode_invalid_chars("abc", ["a", "b"]) == "ab%63"
+        assert _encode_invalid_chars("abc", frozenset()) == "%61%62%63"
+        assert _encode_invalid_chars("abc", set()) == "%61%62%63"
+        # Non-ASCII characters are always encoded, even if "allowed".
+        assert _encode_invalid_chars("\xe9", {"\xe9"}) == "%C3%A9"
+        # '%' is only kept when the whole component is percent-encoded,
+        # or when it is explicitly allowed.
+        assert _encode_invalid_chars("a%", {"a"}) == "a%25"
+        assert _encode_invalid_chars("a%", {"a", "%"}) == "a%"
+        assert _encode_invalid_chars("a%41%", {"a"}) == "a%25%34%31%25"
+        assert _encode_invalid_chars("a%41%", {"a", "%"}) == "a%%34%31%"
 
     @pytest.mark.parametrize(
         "url",


### PR DESCRIPTION
Already-valid ASCII URL components currently go through percent normalization and a byte-by-byte encoding loop. Return them directly when every character is allowed and the component contains no `%`.

Components containing `%` continue through the general path, preserving escape normalization and the handling of bare percent signs. The general loop iterates UTF-8 bytes as integers and formats each `%XX` escape only when needed. UTF-8 and `surrogatepass` handling are preserved.

Related to #3454. The changelog entry is omitted because the underlying changes have not been released.

Validation on the revised patch:

- URL utility, connection-pool, and pool-manager suites: **732 passed, 6 skipped**.
- Fresh differential runs against base `278d98d7bf6c`: **245,312** comparisons with seed `20260906` and **245,473** with seed `424242`, all identical.
- Black, isort, flake8, and scoped mypy (`--follow-imports=silent`) passed for both changed files.

The existing tests cover valid ASCII, bytes input, Unicode, lone surrogates, valid and bare percent signs, and allowed-character containers. For direct private-helper calls, the fast path preserves a `str` subclass instance and requires `allowed_chars.__contains__`; production URL paths supply plain strings and the module's sets.

Fresh measurements for `ff7b286f1eb8`, with the lookup table removed, versus base `278d98d7bf6c`: CPython 3.11.15, Windows, i5-12600KF. Both variants ran in alternating fresh processes pinned to logical CPU 0 (`0x1`). Five samples per variant, a discarded warmup pair, and the median of each process's best of three timings:

| Case | Baseline (µs/call) | Revised patch (µs/call) | Speedup |
| --- | ---: | ---: | ---: |
| Already-valid short path helper | 3.416 | 0.462 | 7.40× |
| Already-percent-encoded path helper | 5.081 | 3.240 | 1.57× |
| Unicode path helper | 4.892 | 3.073 | 1.59× |
| `parse_url`, API URL | 12.925 | 6.636 | 1.95× |
| `parse_url`, simple URL | 5.471 | 4.681 | 1.17× |
| `requests.PreparedRequest.prepare_url` | 40.416 | 25.659 | 1.58× |

All 14 measured workload medians improved. Background applications were active and some later samples varied substantially, especially request preparation; these are local URL-processing measurements, not network-latency or cross-platform guarantees.

<details>
<summary>Small standalone benchmark for checking the direction</summary>

Run this on the baseline and revised checkout in alternating fresh processes pinned to the same CPU. It reproduces three workloads; the table above uses the broader harness and timings will vary.

```python
import statistics
import timeit
import urllib3
from urllib3.util.url import _PATH_CHARS, _encode_invalid_chars, parse_url

print(urllib3.__file__)
cases = {
    "valid_path": lambda: _encode_invalid_chars("/path/to/resource123", _PATH_CHARS),
    "encoded_path": lambda: _encode_invalid_chars("/path/with%20space/and%2Fslash", _PATH_CHARS),
    "parse_api": lambda: parse_url("https://api.example.com/v1/users/12345/repos?page=2&per_page=100"),
}
for name, operation in cases.items():
    timer = timeit.Timer(operation)
    timer.timeit(10_000)
    samples = timer.repeat(repeat=5, number=100_000)
    print(name, statistics.median(samples) * 1e6 / 100_000, "us/call")
```

</details>

AI assistance: Claude and Codex were used during implementation and review.
