### PR TITLE
Deprecate using an empty collection to indicate retries on all verbs for Retry's allowed_methods option

### DIFF
--- a/changelog/5044.removal.rst
+++ b/changelog/5044.removal.rst
@@ -1,0 +1,1 @@
+Deprecated using an empty collection as ``Retry`` option ``allowed_methods`` to retry any verb.

--- a/src/urllib3/util/retry.py
+++ b/src/urllib3/util/retry.py
@@ -6,6 +6,8 @@ import random
 import re
 import time
 import typing
+import warnings
+from collections.abc import Collection
 from itertools import takewhile
 from types import TracebackType
 
@@ -251,6 +253,15 @@ class Retry:
 
         self.redirect = redirect
         self.status_forcelist = status_forcelist or set()
+        if not allowed_methods and isinstance(allowed_methods, Collection):
+            warnings.warn(
+                "Using an empty collection for 'allowed_methods' option to "
+                "retry on any verb is deprecated and will skip retries for "
+                "all verbs in urllib3 v3.0. Instead use "
+                "Retry(..., allowed_methods=None).",
+                FutureWarning,
+                stacklevel=2,
+            )
         self.allowed_methods = allowed_methods
         self.backoff_factor = backoff_factor
         self.backoff_max = backoff_max

--- a/test/test_retry.py
+++ b/test/test_retry.py
@@ -263,7 +263,7 @@ class TestRetry:
         assert not retry.is_retry("GET", status_code=418)
 
     def test_allowed_methods_with_status_forcelist(self) -> None:
-        # Falsey allowed_methods means to retry on any method.
+        # None allowed_methods means to retry on any method.
         retry = Retry(status_forcelist=[500], allowed_methods=None)
         assert retry.is_retry("GET", status_code=500)
         assert retry.is_retry("POST", status_code=500)
@@ -272,6 +272,24 @@ class TestRetry:
         retry = Retry(status_forcelist=[500], allowed_methods=["POST"])
         assert not retry.is_retry("GET", status_code=500)
         assert retry.is_retry("POST", status_code=500)
+
+    def test_false_allowed_methods(self) -> None:
+        # False is also accepted to mean retry on any method, since 1.26.x
+        retry = Retry(status_forcelist=[500], allowed_methods=False)  # type: ignore[arg-type]
+        assert retry.is_retry("POST", status_code=500)
+
+    def test_empty_allowed_methods(self) -> None:
+        with pytest.warns(FutureWarning) as records:
+            retry = Retry(status_forcelist=[500], allowed_methods=[])
+        assert retry.is_retry("GET", status_code=500)
+        msg = (
+            "Using an empty collection for 'allowed_methods' option to retry "
+            "on any verb is deprecated and will skip retries for all verbs "
+            "in urllib3 v3.0. Instead use Retry(..., allowed_methods=None)."
+        )
+        record = records[0]
+        assert isinstance(record.message, Warning)
+        assert record.message.args[0] == msg
 
     def test_exhausted(self) -> None:
         assert not Retry(0).is_exhausted()


### PR DESCRIPTION
- Deprecate use of an empty collection to indicate "retry any verb"
- Add explicit test for `allowed_methods=False` as an alternative to `allowed_methods=None`

A first step towards resolving #5044 