### PR TITLE
Add an opt-in error for excessive Retry-After delays

### DIFF
--- a/changelog/1338.feature.rst
+++ b/changelog/1338.feature.rst
@@ -1,0 +1,1 @@
+Added ``Retry(raise_on_retry_after=True)`` to raise ``RetryAfterError`` when a server's Retry-After delay exceeds ``retry_after_max``. The exception preserves the requested delay and configured limit. The default behavior continues to cap the delay.

--- a/src/urllib3/exceptions.py
+++ b/src/urllib3/exceptions.py
@@ -213,6 +213,25 @@ class URLSchemeUnknown(LocationValueError):
         self.scheme = scheme
 
 
+class RetryAfterError(HTTPError):
+    """A server requested a delay exceeding the configured Retry-After limit.
+
+    :param float retry_after: The requested delay in seconds, before capping.
+    :param int retry_after_max: The configured maximum delay in seconds.
+    """
+
+    def __init__(self, retry_after: float, retry_after_max: int) -> None:
+        self.retry_after = retry_after
+        self.retry_after_max = retry_after_max
+        super().__init__(
+            f"Retry-After delay of {retry_after} seconds exceeds "
+            f"the maximum of {retry_after_max} seconds"
+        )
+
+    def __reduce__(self) -> _TYPE_REDUCE_RESULT:
+        return self.__class__, (self.retry_after, self.retry_after_max)
+
+
 class ResponseError(HTTPError):
     """Used as a container for an error reason supplied in a MaxRetryError."""
 

--- a/src/urllib3/util/retry.py
+++ b/src/urllib3/util/retry.py
@@ -17,6 +17,7 @@ from ..exceptions import (
     ProxyError,
     ReadTimeoutError,
     ResponseError,
+    RetryAfterError,
 )
 from .util import reraise
 
@@ -190,7 +191,12 @@ class Retry:
     :param int retry_after_max: Number of seconds to allow as the maximum for
         Retry-After headers. Defaults to :attr:`Retry.DEFAULT_RETRY_AFTER_MAX`.
         Any Retry-After headers larger than this value will be limited to this
-        value.
+        value unless ``raise_on_retry_after`` is enabled.
+
+    :param bool raise_on_retry_after:
+        Raise :class:`~urllib3.exceptions.RetryAfterError` when a Retry-After
+        header exceeds ``retry_after_max``, preserving the requested delay in
+        the exception. Defaults to ``False``, which caps the delay instead.
     """
 
     #: Default methods to be used for ``allowed_methods``
@@ -238,6 +244,7 @@ class Retry:
         ] = DEFAULT_REMOVE_HEADERS_ON_REDIRECT,
         backoff_jitter: float = 0.0,
         retry_after_max: int = DEFAULT_RETRY_AFTER_MAX,
+        raise_on_retry_after: bool = False,
     ) -> None:
         self.total = total
         self.connect = connect
@@ -255,6 +262,7 @@ class Retry:
         self.backoff_factor = backoff_factor
         self.backoff_max = backoff_max
         self.retry_after_max = retry_after_max
+        self.raise_on_retry_after = raise_on_retry_after
         self.raise_on_redirect = raise_on_redirect
         self.raise_on_status = raise_on_status
         self.history = history or ()
@@ -277,6 +285,7 @@ class Retry:
             backoff_factor=self.backoff_factor,
             backoff_max=self.backoff_max,
             retry_after_max=self.retry_after_max,
+            raise_on_retry_after=self.raise_on_retry_after,
             raise_on_redirect=self.raise_on_redirect,
             raise_on_status=self.raise_on_status,
             history=self.history,
@@ -343,6 +352,8 @@ class Retry:
 
         # Check the seconds do not exceed the specified maximum
         if seconds > self.retry_after_max:
+            if self.raise_on_retry_after:
+                raise RetryAfterError(seconds, self.retry_after_max)
             seconds = self.retry_after_max
 
         return seconds

--- a/test/test_exceptions.py
+++ b/test/test_exceptions.py
@@ -21,10 +21,19 @@ from urllib3.exceptions import (
     NameResolutionError,
     NewConnectionError,
     ReadTimeoutError,
+    RetryAfterError,
 )
 
 
 class TestPickle:
+    def test_retry_after_error(self) -> None:
+        exception = RetryAfterError(3600.5, 60)
+        result = pickle.loads(pickle.dumps(exception))
+        assert isinstance(result, RetryAfterError)
+        assert result.retry_after == 3600.5
+        assert result.retry_after_max == 60
+        assert str(result) == str(exception)
+
     @pytest.mark.parametrize(
         "exception",
         [

--- a/test/test_retry.py
+++ b/test/test_retry.py
@@ -12,6 +12,7 @@ from urllib3.exceptions import (
     MaxRetryError,
     ReadTimeoutError,
     ResponseError,
+    RetryAfterError,
     SSLError,
 )
 from urllib3.response import HTTPResponse
@@ -192,6 +193,44 @@ class TestRetry:
         retry = Retry(retry_after_max=1)
         assert retry.parse_retry_after(str(1)) == 1
         assert retry.parse_retry_after(str(2)) == 1
+
+    def test_raise_on_retry_after(self) -> None:
+        retry = Retry(retry_after_max=60, raise_on_retry_after=True)
+        response = HTTPResponse(status=503, headers={"Retry-After": "3600"})
+        with mock.patch("time.sleep") as sleep:
+            with pytest.raises(RetryAfterError, match="3600.*60") as exc:
+                retry.sleep(response)
+        assert exc.value.retry_after == 3600
+        assert exc.value.retry_after_max == 60
+        sleep.assert_not_called()
+
+    @pytest.mark.parametrize("delay", [0, 1, 60])
+    def test_raise_on_retry_after_within_limit(self, delay: int) -> None:
+        retry = Retry(retry_after_max=60, raise_on_retry_after=True)
+        assert retry.parse_retry_after(str(delay)) == delay
+
+    def test_raise_on_retry_after_date(self) -> None:
+        retry = Retry(retry_after_max=60, raise_on_retry_after=True)
+        with mock.patch("time.time", return_value=0):
+            with pytest.raises(RetryAfterError) as exc:
+                retry.parse_retry_after("Thu, 01 Jan 1970 01:00:00 GMT")
+        assert exc.value.retry_after == 3600
+
+    def test_raise_on_retry_after_increment(self) -> None:
+        retry = Retry(retry_after_max=60, raise_on_retry_after=True).increment()
+        with pytest.raises(RetryAfterError):
+            retry.parse_retry_after("61")
+        assert retry.new(raise_on_retry_after=False).parse_retry_after("61") == 60
+
+    def test_raise_on_retry_after_ignored_header(self) -> None:
+        retry = Retry(
+            retry_after_max=60,
+            raise_on_retry_after=True,
+            respect_retry_after_header=False,
+        )
+        with mock.patch("time.sleep") as sleep:
+            retry.sleep(HTTPResponse(status=503, headers={"Retry-After": "3600"}))
+        sleep.assert_not_called()
 
     def test_backoff_jitter(self) -> None:
         """Backoff with jitter is computed correctly"""

--- a/test/with_dummyserver/test_connectionpool.py
+++ b/test/with_dummyserver/test_connectionpool.py
@@ -27,6 +27,7 @@ from urllib3.exceptions import (
     NameResolutionError,
     NewConnectionError,
     ReadTimeoutError,
+    RetryAfterError,
     UnrewindableBodyError,
 )
 from urllib3.fields import _TYPE_FIELD_VALUE_TUPLE
@@ -1300,6 +1301,30 @@ class TestRetry(HypercornDummyServerTestCase):
 
 
 class TestRetryAfter(HypercornDummyServerTestCase):
+    @pytest.mark.parametrize("redirect", [False, True])
+    @pytest.mark.parametrize("preload_content", [False, True])
+    def test_raise_on_retry_after(self, redirect: bool, preload_content: bool) -> None:
+        retry = Retry(
+            retry_after_max=0, raise_on_retry_after=True, status_forcelist=[303]
+        )
+        with HTTPConnectionPool(self.host, self.port, maxsize=1, block=True) as pool:
+            with mock.patch("time.sleep") as sleep:
+                with pytest.raises(RetryAfterError) as exc:
+                    pool.request(
+                        "GET",
+                        "/redirect_after",
+                        retries=retry,
+                        redirect=redirect,
+                        preload_content=preload_content,
+                    )
+            assert exc.value.retry_after == 1
+            assert exc.value.retry_after_max == 0
+            sleep.assert_not_called()
+            # Aborting the retry must return the connection to the pool.
+            response = pool.request("GET", "/", pool_timeout=SHORT_TIMEOUT)
+            assert response.status == 200
+            assert pool.num_connections == 1
+
     def test_retry_after(self) -> None:
         # Request twice in a second to get a 429 response.
         with HTTPConnectionPool(self.host, self.port) as pool:


### PR DESCRIPTION
When a server requests a delay above `retry_after_max`, urllib3 currently caps it and retries early. This adds `Retry(raise_on_retry_after=True)` to abort instead, exposing the uncapped delay and configured limit through `RetryAfterError.retry_after` and `.retry_after_max`. Default behavior remains unchanged.

The option survives retry increments. Tests cover numeric and HTTP-date headers, the limit boundary, ignored headers, exception pickling, and actual HTTP status retries and redirects with both response preload modes. They also verify that aborting releases the connection for reuse.

Addresses #1338. Prepared with AI assistance and tested locally; API naming and acceptance remain subject to maintainer review.

Validation on Windows, Python 3.14.7:

- Retry, exception, connection pool and pool manager suites: 338 passed, 18 skipped; IPv6 unavailable warning.
- After formatting: focused retry/exception/HTTP integration suite, 77 passed, 18 skipped.
- All pre-commit hooks passed.
- Mypy targeting Linux/Python 3.14: no issues in 83 source files.
- Native Windows `nox -s mypy` reports 27 errors in three unchanged files. An untouched worktree of the base commit reproduces all 27; the native check is not green.

Reproduction commands:

```powershell
uv sync --frozen --group dev --group mypy --all-extras
.venv\Scripts\python.exe -m pytest test/test_retry.py test/test_exceptions.py test/test_connectionpool.py test/test_poolmanager.py test/with_dummyserver/test_connectionpool.py -q --disable-socket --allow-unix-socket --allow-hosts=localhost,127.0.0.1,::1,127.0.0.0,240.0.0.0
.nox\lint\Scripts\pre-commit.exe run --all-files
.nox\mypy\Scripts\python.exe -m mypy --platform linux --python-version 3.14 -p dummyserver -m noxfile -p urllib3 -p test
```

The final two commands use environments created by `nox -s lint` and `nox -s mypy` respectively. The first lint run formats files and stops; rerun the hooks after formatting. No Linux runtime test suite was run.
