### PR TITLE
Support byte-valued HTTPHeaderDict inputs with Latin-1 normalization

### DIFF
--- a/changelog/3072.bugfix.rst
+++ b/changelog/3072.bugfix.rst
@@ -1,0 +1,1 @@
+Added support for byte-valued headers in ``HTTPHeaderDict``, decoding them with Latin-1 on insertion so lookups and duplicate-header merging consistently return strings.

--- a/src/urllib3/_collections.py
+++ b/src/urllib3/_collections.py
@@ -15,7 +15,7 @@ if typing.TYPE_CHECKING:
     class HasGettableStringKeys(Protocol):
         def keys(self) -> typing.Iterator[str]: ...
 
-        def __getitem__(self, key: str) -> str: ...
+        def __getitem__(self, key: str) -> str | bytes: ...
 
 
 __all__ = ["RecentlyUsedContainer", "HTTPHeaderDict"]
@@ -30,8 +30,8 @@ _DT = typing.TypeVar("_DT")
 
 ValidHTTPHeaderSource = typing.Union[
     "HTTPHeaderDict",
-    typing.Mapping[str, str],
-    typing.Iterable[tuple[str, str]],
+    typing.Mapping[str, str | bytes],
+    typing.Iterable[tuple[str, str | bytes]],
     "HasGettableStringKeys",
 ]
 
@@ -48,12 +48,12 @@ def ensure_can_construct_http_header_dict(
     elif isinstance(potential, typing.Mapping):
         # Full runtime checking of the contents of a Mapping is expensive, so for the
         # purposes of typechecking, we assume that any Mapping is the right shape.
-        return typing.cast(typing.Mapping[str, str], potential)
+        return typing.cast(typing.Mapping[str, str | bytes], potential)
     elif isinstance(potential, typing.Iterable):
         # Similarly to Mapping, full runtime checking of the contents of an Iterable is
         # expensive, so for the purposes of typechecking, we assume that any Iterable
         # is the right shape.
-        return typing.cast(typing.Iterable[tuple[str, str]], potential)
+        return typing.cast(typing.Iterable[tuple[str, str | bytes]], potential)
     elif hasattr(potential, "keys") and hasattr(potential, "__getitem__"):
         return typing.cast("HasGettableStringKeys", potential)
     else:
@@ -212,6 +212,9 @@ class HTTPHeaderDict(typing.MutableMapping[str, str]):
 
     A ``dict`` like container for storing HTTP Headers.
 
+    Byte-valued headers are decoded with Latin-1 when inserted. Reading values
+    always returns strings; encoding them as Latin-1 recovers the original bytes.
+
     Field names are stored and compared case-insensitively in compliance with
     RFC 7230. Iteration provides the first case-sensitive key seen for each
     case-insensitive pair.
@@ -237,7 +240,7 @@ class HTTPHeaderDict(typing.MutableMapping[str, str]):
 
     _container: typing.MutableMapping[str, list[str]]
 
-    def __init__(self, headers: ValidHTTPHeaderSource | None = None, **kwargs: str):
+    def __init__(self, headers: ValidHTTPHeaderSource | None = None, **kwargs: str | bytes):
         super().__init__()
         self._container = {}  # 'dict' is insert-ordered
         if headers is not None:
@@ -248,10 +251,12 @@ class HTTPHeaderDict(typing.MutableMapping[str, str]):
         if kwargs:
             self.extend(kwargs)
 
-    def __setitem__(self, key: str, val: str) -> None:
+    def __setitem__(self, key: str, val: str | bytes) -> None:
         # avoid a bytes/str comparison by decoding before httplib
         if isinstance(key, bytes):
             key = key.decode("latin-1")
+        if isinstance(val, bytes):
+            val = val.decode("latin-1")
         self._container[key.lower()] = [key, val]
 
     def __getitem__(self, key: str) -> str:
@@ -272,7 +277,9 @@ class HTTPHeaderDict(typing.MutableMapping[str, str]):
             return key.lower() in self._container
         return False
 
-    def setdefault(self, key: str, default: str = "") -> str:
+    def setdefault(self, key: str, default: str | bytes = "") -> str:
+        if isinstance(default, bytes):
+            default = default.decode("latin-1")
         return super().setdefault(key, default)
 
     def __eq__(self, other: object) -> bool:
@@ -303,7 +310,7 @@ class HTTPHeaderDict(typing.MutableMapping[str, str]):
         except KeyError:
             pass
 
-    def add(self, key: str, val: str, *, combine: bool = False) -> None:
+    def add(self, key: str, val: str | bytes, *, combine: bool = False) -> None:
         """Adds a (name, value) pair, doesn't overwrite the value if it already
         exists.
 
@@ -326,6 +333,8 @@ class HTTPHeaderDict(typing.MutableMapping[str, str]):
         if isinstance(key, bytes):
             key = key.decode("latin-1")
         key_lower = key.lower()
+        if isinstance(val, bytes):
+            val = val.decode("latin-1")
         new_vals = [key, val]
         # Keep the common case aka no item present as fast as possible
         vals = self._container.setdefault(key_lower, new_vals)
@@ -338,7 +347,7 @@ class HTTPHeaderDict(typing.MutableMapping[str, str]):
             else:
                 vals.append(val)
 
-    def extend(self, *args: ValidHTTPHeaderSource, **kwargs: str) -> None:
+    def extend(self, *args: ValidHTTPHeaderSource, **kwargs: str | bytes) -> None:
         """Generic import function for any type of header-like object.
         Adapted version of MutableMapping.update in order to insert items
         with self.add instead of self.__setitem__
@@ -349,6 +358,7 @@ class HTTPHeaderDict(typing.MutableMapping[str, str]):
             )
         other = args[0] if len(args) >= 1 else ()
 
+        val: str | bytes
         if isinstance(other, HTTPHeaderDict):
             for key, val in other.iteritems():
                 self.add(key, val)

--- a/src/urllib3/_collections.py
+++ b/src/urllib3/_collections.py
@@ -240,7 +240,9 @@ class HTTPHeaderDict(typing.MutableMapping[str, str]):
 
     _container: typing.MutableMapping[str, list[str]]
 
-    def __init__(self, headers: ValidHTTPHeaderSource | None = None, **kwargs: str | bytes):
+    def __init__(
+        self, headers: ValidHTTPHeaderSource | None = None, **kwargs: str | bytes
+    ):
         super().__init__()
         self._container = {}  # 'dict' is insert-ordered
         if headers is not None:

--- a/test/test_collections.py
+++ b/test/test_collections.py
@@ -1,11 +1,57 @@
 from __future__ import annotations
 
 import typing
+from http.client import HTTPConnection
+from unittest.mock import Mock
 
 import pytest
 
 from urllib3._collections import HTTPHeaderDict
 from urllib3._collections import RecentlyUsedContainer as Container
+
+
+class TestHTTPHeaderBytesValues:
+    def test_setitem_and_roundtrip(self) -> None:
+        headers = HTTPHeaderDict()
+        value = bytes(range(256))
+        headers["X-Value"] = value
+        assert headers["x-value"].encode("latin-1") == value
+        assert headers.getlist("X-Value") == [value.decode("latin-1")]
+
+    @pytest.mark.parametrize("combine", [False, True])
+    def test_add_mixed_values(self, combine: bool) -> None:
+        headers = HTTPHeaderDict({"X-Value": b"caf\xe9"})
+        headers.add("x-value", "text", combine=combine)
+        headers.add("X-VALUE", b"\xff", combine=combine)
+        assert headers["x-value"] == "caf\xe9, text, \xff"
+        assert list(headers.itermerged()) == [("X-Value", "caf\xe9, text, \xff")]
+        expected = ["caf\xe9, text, \xff"] if combine else ["caf\xe9", "text", "\xff"]
+        assert headers.getlist("x-value") == expected
+        assert list(headers.items()) == [("X-Value", value) for value in expected]
+        assert headers.copy() == headers
+
+    def test_import_and_default_paths(self) -> None:
+        headers = HTTPHeaderDict([("X-Value", b"one"), ("x-value", "two")])
+        headers.extend({"Other": b"three"})
+        headers.extend(Last=b"four")
+        assert headers.setdefault("Empty", b"") == ""
+        assert headers.setdefault("Other", b"ignored") == "three"
+        assert dict(headers.itermerged()) == {
+            "X-Value": "one, two", "Other": "three", "Last": "four", "Empty": "",
+        }
+        assert (headers | {"Other": b"five"})["other"] == "three, five"
+        assert (HTTPHeaderDict(Agent=b"caf\xe9"))["agent"] == "caf\xe9"
+
+    def test_http11_preserves_non_ascii_octets(self) -> None:
+        headers = HTTPHeaderDict({"User-Agent": b"Sch\xf6nefeld/1.18.0"})
+        connection = HTTPConnection("example.invalid")
+        connection.sock = Mock()
+        connection.putrequest("GET", "/")
+        for key, value in headers.items():
+            connection.putheader(key, value)
+        connection.endheaders()
+        wire = connection.sock.sendall.call_args.args[0]
+        assert b"User-Agent: Sch\xf6nefeld/1.18.0\r\n" in wire
 
 
 class TestLRUContainer:

--- a/test/test_collections.py
+++ b/test/test_collections.py
@@ -37,7 +37,10 @@ class TestHTTPHeaderBytesValues:
         assert headers.setdefault("Empty", b"") == ""
         assert headers.setdefault("Other", b"ignored") == "three"
         assert dict(headers.itermerged()) == {
-            "X-Value": "one, two", "Other": "three", "Last": "four", "Empty": "",
+            "X-Value": "one, two",
+            "Other": "three",
+            "Last": "four",
+            "Empty": "",
         }
         assert (headers | {"Other": b"five"})["other"] == "three, five"
         assert (HTTPHeaderDict(Agent=b"caf\xe9"))["agent"] == "caf\xe9"


### PR DESCRIPTION
Fixes #3072.

HTTPHeaderDict accepts byte values into storage, then raises TypeError when lookups or duplicate merging join them with strings. Normalize byte values using Latin-1 in insertion paths and setdefault, retaining the string-valued read interface. Widen corresponding input annotations and document the conversion.

Tests cover all 256 byte values round-tripping, mixed byte/string duplicates with both combine modes, constructor/extend/default/union paths, copy and item iteration, and non-ASCII octet preservation through HTTP/1.1 serialization. Four new regression cases fail before the fix; the serialization control already passes. HTTP/2 behavior and project-wide request-header typing are outside this change.

Validation on Windows / Python 3.12:
- Collection tests: 54 passed.
- Connection, connection-pool and response tests: 585 passed, 15 skipped.
- Mypy for the two changed Python files: passed.
- Full-project mypy: 27 errors in three unchanged files; the same 27 errors reproduce on upstream HEAD.
- All pre-commit hooks pass after applying Black formatting. The complete nox -rs lint command then fails only on the same 27 baseline mypy errors documented above.

Prepared with AI assistance and tested locally. Includes the required changelog entry.