### PR TITLE
Generate Basic authentication from request and proxy URLs

### DIFF
--- a/changelog/1999.feature.rst
+++ b/changelog/1999.feature.rst
@@ -1,0 +1,1 @@
+Generate Basic authentication headers from credentials in request and HTTP(S) proxy URLs. Conflicting explicit authentication headers raise ``ValueError``. URL credentials are percent-decoded and encoded as Latin-1, matching :func:`urllib3.util.make_headers`.

--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -76,6 +76,26 @@ including JSON, files, and binary data.
     In addition, the method does not accept the low-level ``**urlopen_kw`` keyword arguments.
     System CA certificates are loaded on default.
 
+Basic authentication from URLs
+------------------------------
+
+Credentials in request URLs generate an ``Authorization`` header. Credentials
+in an HTTP or HTTPS :class:`~urllib3.ProxyManager` URL generate a
+``Proxy-Authorization`` header instead. Percent escapes are decoded before
+encoding credentials as Latin-1, as with :func:`urllib3.util.make_headers`.
+An explicit authentication header must match the generated header; otherwise
+the request raises ``ValueError``. Caller-owned header dictionaries are not
+modified.
+
+.. code-block:: python
+
+    http = urllib3.PoolManager()
+    resp = http.request("GET", "https://user:password@example.com/private")
+
+The default redirect policy removes ``Authorization`` when redirecting to a
+different host, port, or scheme. For other credential encodings, pass a header
+generated with :func:`urllib3.util.make_headers` and omit credentials from the URL.
+
 .. _response_content:
 
 Response Content

--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -42,7 +42,7 @@ from .exceptions import (
 from .response import BaseHTTPResponse
 from .util.connection import is_connection_dropped
 from .util.proxy import connection_requires_http_tunnel
-from .util.request import _TYPE_BODY_POSITION, set_file_position
+from .util.request import _TYPE_BODY_POSITION, _add_url_auth, set_file_position
 from .util.retry import Retry
 from .util.ssl_match_hostname import CertificateError
 from .util.timeout import _DEFAULT_TIMEOUT, _TYPE_DEFAULT, Timeout
@@ -708,6 +708,9 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
             redirect. Typically this won't need to be set because urllib3 will
             auto-populate the value when needed.
         """
+        if headers is None:
+            headers = self.headers
+
         # Ensure that the URL we're connecting to is properly encoded
         if url.startswith("/"):
             # URLs starting with / are inherently schemeless.
@@ -716,10 +719,8 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         else:
             parsed_url = parse_url(url)
             destination_scheme = parsed_url.scheme
-            url = to_str(parsed_url._replace(fragment=None).url)
-
-        if headers is None:
-            headers = self.headers
+            headers = _add_url_auth(headers, parsed_url.auth_decoded_joined)
+            url = to_str(parsed_url._replace(auth=None, fragment=None).url)
 
         if not isinstance(retries, Retry):
             retries = Retry.from_int(retries, redirect=redirect, default=self.retries)

--- a/src/urllib3/poolmanager.py
+++ b/src/urllib3/poolmanager.py
@@ -20,6 +20,7 @@ from .exceptions import (
 from .response import BaseHTTPResponse
 from .util.connection import _TYPE_SOCKET_OPTIONS
 from .util.proxy import connection_requires_http_tunnel
+from .util.request import _add_url_auth
 from .util.retry import Retry
 from .util.timeout import Timeout
 from .util.url import Url, parse_url
@@ -453,6 +454,14 @@ class PoolManager(RequestMethods):
         if "headers" not in kw:
             kw["headers"] = self.headers
 
+        kw["headers"] = _add_url_auth(
+            kw["headers"] if kw["headers"] is not None else self.headers,
+            u.auth_decoded_joined,
+        )
+        if u.auth is not None:
+            u = u._replace(auth=None)
+            url = u.url
+
         if self._proxy_requires_url_absolute_form(u):
             response = conn.urlopen(method, u._replace(fragment=None).url, **kw)
         else:
@@ -605,8 +614,10 @@ class ProxyManager(PoolManager):
             port = port_by_scheme.get(proxy.scheme, 80)
             proxy = proxy._replace(port=port)
 
-        self.proxy = proxy
-        self.proxy_headers = proxy_headers or {}
+        self.proxy_headers = _add_url_auth(
+            proxy_headers or {}, proxy.auth_decoded_joined, "Proxy-Authorization"
+        )
+        self.proxy = proxy._replace(auth=None)
         self.proxy_config = ProxyConfig(
             proxy_ssl_context,
             use_forwarding_for_https,

--- a/src/urllib3/util/request.py
+++ b/src/urllib3/util/request.py
@@ -6,6 +6,7 @@ import typing
 from base64 import b64encode
 from enum import Enum
 
+from .._collections import HTTPHeaderDict
 from ..exceptions import UnrewindableBodyError
 from .util import to_bytes
 
@@ -55,6 +56,22 @@ _TYPE_BODY_POSITION = typing.Union[int, _TYPE_FAILEDTELL]
 # which 'should' have a body is because unknown methods should be
 # treated as if they were 'POST' which *does* expect a body.
 _METHODS_NOT_EXPECTING_BODY = {"GET", "HEAD", "DELETE", "TRACE", "OPTIONS", "CONNECT"}
+
+
+def _add_url_auth(
+    headers: typing.Mapping[str, str],
+    auth: str | None,
+    header: str = "Authorization",
+) -> typing.Mapping[str, str]:
+    """Add decoded URL credentials without mutating caller-owned headers."""
+    if auth is None:
+        return headers
+    value = make_headers(basic_auth=auth)["authorization"]
+    result = HTTPHeaderDict(headers)
+    if any(existing != value for existing in result.getlist(header)):
+        raise ValueError(f"{header} header conflicts with URL credentials")
+    result[header] = value
+    return result
 
 
 def make_headers(

--- a/test/test_url_auth.py
+++ b/test/test_url_auth.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from urllib3 import HTTPHeaderDict, HTTPResponse, PoolManager, ProxyManager
+from urllib3.connectionpool import HTTPConnectionPool
+
+
+@pytest.mark.parametrize(
+    "userinfo,expected",
+    [
+        ("user:pass", "Basic dXNlcjpwYXNz"),
+        ("user", "Basic dXNlcjo="),
+        (":", "Basic Og=="),
+        ("user:p%40ss", "Basic dXNlcjpwQHNz"),
+        ("user:p%C3%A4ss", "Basic dXNlcjpw5HNz"),
+    ],
+)
+@pytest.mark.parametrize("proxy", [False, True])
+def test_request_url_auth(userinfo: str, expected: str, proxy: bool) -> None:
+    headers = {"X-Test": "value"}
+    manager = ProxyManager("http://proxy.test") if proxy else PoolManager()
+    with manager, patch.object(HTTPConnectionPool, "urlopen") as urlopen:
+        urlopen.return_value = HTTPResponse(status=200)
+        manager.urlopen(
+            "GET", f"http://{userinfo}@example.test/path#fragment", headers=headers
+        )
+        assert urlopen.call_args.args[1] == (
+            "http://example.test/path" if proxy else "/path"
+        )
+        assert urlopen.call_args.kwargs["headers"]["Authorization"] == expected
+        assert headers == {"X-Test": "value"}
+
+
+@pytest.mark.parametrize("header", ["authorization", "Authorization", "AUTHORIZATION"])
+@pytest.mark.parametrize("matches", [False, True])
+def test_explicit_auth(header: str, matches: bool) -> None:
+    headers = {header: "Basic dXNlcjpwYXNz" if matches else "Bearer other"}
+    with (
+        PoolManager(headers=headers) as manager,
+        patch.object(HTTPConnectionPool, "urlopen") as urlopen,
+    ):
+        urlopen.return_value = HTTPResponse(status=200)
+        if matches:
+            manager.urlopen("GET", "http://user:pass@example.test/")
+            assert len(urlopen.call_args.kwargs["headers"]) == 1
+        else:
+            with pytest.raises(ValueError, match="Authorization"):
+                manager.urlopen("GET", "http://user:pass@example.test/")
+            urlopen.assert_not_called()
+
+
+def test_duplicate_auth_conflict() -> None:
+    headers = HTTPHeaderDict()
+    headers.add("Authorization", "Basic dXNlcjpwYXNz")
+    headers.add("authorization", "Bearer other")
+    with PoolManager() as manager, pytest.raises(ValueError, match="Authorization"):
+        manager.urlopen("GET", "http://user:pass@example.test/", headers=headers)
+
+
+@pytest.mark.parametrize("scheme", ["http", "https"])
+def test_proxy_url_auth(scheme: str) -> None:
+    headers = {"X-Proxy": "value"}
+    with ProxyManager(
+        f"{scheme}://user:p%40ss@proxy.test", proxy_headers=headers
+    ) as manager:
+        assert manager.proxy is not None
+        assert manager.proxy.auth is None
+        assert manager.proxy_headers["Proxy-Authorization"] == "Basic dXNlcjpwQHNz"
+        assert headers == {"X-Proxy": "value"}
+        pool = manager.connection_from_url("https://example.test/")
+        assert pool.proxy_headers == manager.proxy_headers
+
+
+@pytest.mark.parametrize("matches", [False, True])
+def test_explicit_proxy_auth(matches: bool) -> None:
+    headers = {
+        "proxy-authorization": "Basic dXNlcjpwYXNz" if matches else "Bearer other"
+    }
+    if matches:
+        with ProxyManager(
+            "http://user:pass@proxy.test", proxy_headers=headers
+        ) as manager:
+            assert len(manager.proxy_headers) == 1
+    else:
+        with pytest.raises(ValueError, match="Proxy-Authorization"):
+            ProxyManager("http://user:pass@proxy.test", proxy_headers=headers)
+
+
+def test_direct_pool_url_auth() -> None:
+    with (
+        HTTPConnectionPool("example.test") as pool,
+        patch.object(pool, "_make_request") as request,
+    ):
+        request.return_value = HTTPResponse(status=200)
+        pool.urlopen("GET", "http://user:pass@example.test/path", retries=False)
+        assert request.call_args.args[2] == "http://example.test/path"
+        assert (
+            request.call_args.kwargs["headers"]["Authorization"] == "Basic dXNlcjpwYXNz"
+        )

--- a/test/with_dummyserver/test_poolmanager.py
+++ b/test/with_dummyserver/test_poolmanager.py
@@ -20,6 +20,33 @@ from urllib3.util.retry import Retry
 
 
 class TestPoolManager(HypercornDummyServerTestCase):
+    @pytest.mark.parametrize("cross_host", [False, True])
+    def test_url_auth_redirect(self, cross_host: bool) -> None:
+        target = f"{self.base_url_alt if cross_host else self.base_url}/headers"
+        authenticated_url = self.base_url.replace("://", "://user:pass@")
+        with PoolManager() as manager:
+            response = manager.request(
+                "GET", f"{authenticated_url}/redirect", fields={"target": target}
+            )
+            headers = response.json()
+            if cross_host:
+                assert "Authorization" not in headers
+            else:
+                assert headers["Authorization"] == "Basic dXNlcjpwYXNz"
+            # A later request using the same manager must not inherit credentials.
+            assert (
+                "Authorization"
+                not in manager.request("GET", f"{self.base_url}/headers").json()
+            )
+
+    def test_url_auth_relative_redirect(self) -> None:
+        authenticated_url = self.base_url.replace("://", "://user:pass@")
+        with PoolManager() as manager:
+            response = manager.request(
+                "GET", f"{authenticated_url}/redirect", fields={"target": "/headers"}
+            )
+            assert response.json()["Authorization"] == "Basic dXNlcjpwYXNz"
+
     @classmethod
     def setup_class(cls) -> None:
         super().setup_class()

--- a/test/with_dummyserver/test_proxy_poolmanager.py
+++ b/test/with_dummyserver/test_proxy_poolmanager.py
@@ -57,6 +57,24 @@ def assert_is_verified(pm: ProxyManager, *, proxy: bool, target: bool) -> None:
 
 
 class TestHTTPProxyManager(HypercornDummyProxyTestCase):
+    @pytest.mark.parametrize("secure_proxy", [False, True])
+    @pytest.mark.parametrize("secure_target", [False, True])
+    def test_url_credentials(self, secure_proxy: bool, secure_target: bool) -> None:
+        proxy_url = self.https_proxy_url if secure_proxy else self.proxy_url
+        target_url = self.https_url if secure_target else self.http_url
+        with proxy_from_url(
+            proxy_url.replace("://", "://proxy:password@"), ca_certs=DEFAULT_CA
+        ) as manager:
+            response = manager.request(
+                "GET", target_url.replace("://", "://user:pass@") + "/headers"
+            )
+            headers = response.json()
+            assert headers["Authorization"] == "Basic dXNlcjpwYXNz"
+            if secure_target:
+                assert "Proxy-Authorization" not in headers
+            else:
+                assert headers["Proxy-Authorization"] == "Basic cHJveHk6cGFzc3dvcmQ="
+
     @classmethod
     def setup_class(cls) -> None:
         super().setup_class()


### PR DESCRIPTION
URLs such as `https://user:pass@example.com/` currently lose their credentials. This generates Basic authentication for request URLs and HTTP(S) proxy URLs, using the existing percent-decoding and Latin-1 encoding helpers.

Explicit authentication headers are checked case-insensitively and conflicting values raise `ValueError` before sending a request. Header mappings are copied when adding credentials, userinfo is removed from the request target and stored proxy URL, and generated origin credentials follow the existing redirect policy.

Closes #1999.

Validation:
- The initial regression suite reproduced the missing behavior: 18 failures before implementation.
- 327 tests passed with Python 3.14 on Windows, including live HTTP/HTTPS proxy and origin combinations, relative redirects, cross-host credential removal, duplicate/conflicting headers, and caller-header immutability.
- Changed-file pre-commit hooks passed.
- Mypy passed on 84 files using the isolated mypy dependency group, `--no-incremental --platform linux --python-version 3.14`.

Commands:
```
python -bb -m pytest test/test_url_auth.py test/test_poolmanager.py test/test_connectionpool.py test/with_dummyserver/test_poolmanager.py test/with_dummyserver/test_proxy_poolmanager.py -q --disable-socket --allow-unix-socket --allow-hosts=localhost,127.0.0.1,::1,127.0.0.0,240.0.0.0
python -m mypy --no-incremental --platform linux --python-version 3.14 -p dummyserver -m noxfile -p urllib3 -p test
```

This contribution was developed with AI assistance.
