### PR TITLE
Align header input typing and normalize binary request headers

### DIFF
--- a/changelog/3047.bugfix.rst
+++ b/changelog/3047.bugfix.rst
@@ -1,0 +1,1 @@
+Aligned header input annotations across request and response APIs to accept string, byte, and mixed mappings without widening response header values. Fixed binary header handling for JSON requests and proxy defaults.

--- a/changelog/3072.bugfix.rst
+++ b/changelog/3072.bugfix.rst
@@ -1,0 +1,1 @@
+Added support for byte-valued headers in ``HTTPHeaderDict``, decoding them with Latin-1 on insertion so lookups and duplicate-header merging consistently return strings.

--- a/src/urllib3/__init__.py
+++ b/src/urllib3/__init__.py
@@ -13,7 +13,7 @@ from logging import NullHandler
 
 from . import exceptions
 from ._base_connection import _TYPE_BODY
-from ._collections import HTTPHeaderDict
+from ._collections import _TYPE_HEADERS, HTTPHeaderDict
 from ._version import __version__
 from .connectionpool import HTTPConnectionPool, HTTPSConnectionPool, connection_from_url
 from .filepost import _TYPE_FIELDS, encode_multipart_formdata
@@ -120,7 +120,7 @@ def request(
     *,
     body: _TYPE_BODY | None = None,
     fields: _TYPE_FIELDS | None = None,
-    headers: typing.Mapping[str, str] | None = None,
+    headers: _TYPE_HEADERS | None = None,
     preload_content: bool | None = True,
     decode_content: bool | None = True,
     redirect: bool | None = True,

--- a/src/urllib3/_base_connection.py
+++ b/src/urllib3/_base_connection.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import typing
 
+from ._collections import _TYPE_HEADERS
 from .util.connection import _TYPE_SOCKET_OPTIONS
 from .util.timeout import _DEFAULT_TIMEOUT, _TYPE_TIMEOUT
 from .util.url import Url
@@ -70,7 +71,7 @@ if typing.TYPE_CHECKING:
             self,
             host: str,
             port: int | None = None,
-            headers: typing.Mapping[str, str] | None = None,
+            headers: _TYPE_HEADERS | None = None,
             scheme: str = "http",
         ) -> None: ...
 
@@ -81,7 +82,7 @@ if typing.TYPE_CHECKING:
             method: str,
             url: str,
             body: _TYPE_BODY | None = None,
-            headers: typing.Mapping[str, str] | None = None,
+            headers: _TYPE_HEADERS | None = None,
             # We know *at least* botocore is depending on the order of the
             # first 3 parameters so to be safe we only mark the later ones
             # as keyword-only to ensure we have space to extend.

--- a/src/urllib3/_collections.py
+++ b/src/urllib3/_collections.py
@@ -28,10 +28,18 @@ _VT = typing.TypeVar("_VT")
 # Default type
 _DT = typing.TypeVar("_DT")
 
+# Mapping keys are invariant: keep the homogeneous alternatives so ordinary
+# dict[str, str] and HTTPHeaderDict remain valid header inputs.
+_TYPE_HEADERS = typing.Union[
+    typing.Mapping[str, str | bytes],
+    typing.Mapping[bytes, str | bytes],
+    typing.Mapping[str | bytes, str | bytes],
+]
+
 ValidHTTPHeaderSource = typing.Union[
     "HTTPHeaderDict",
-    typing.Mapping[str, str | bytes],
-    typing.Iterable[tuple[str, str | bytes]],
+    _TYPE_HEADERS,
+    typing.Iterable[tuple[str | bytes, str | bytes]],
     "HasGettableStringKeys",
 ]
 
@@ -253,7 +261,7 @@ class HTTPHeaderDict(typing.MutableMapping[str, str]):
         if kwargs:
             self.extend(kwargs)
 
-    def __setitem__(self, key: str, val: str | bytes) -> None:
+    def __setitem__(self, key: str | bytes, val: str | bytes) -> None:
         # avoid a bytes/str comparison by decoding before httplib
         if isinstance(key, bytes):
             key = key.decode("latin-1")
@@ -261,13 +269,13 @@ class HTTPHeaderDict(typing.MutableMapping[str, str]):
             val = val.decode("latin-1")
         self._container[key.lower()] = [key, val]
 
-    def __getitem__(self, key: str) -> str:
+    def __getitem__(self, key: str | bytes) -> str:
         if isinstance(key, bytes):
             key = key.decode("latin-1")
         val = self._container[key.lower()]
         return ", ".join(val[1:])
 
-    def __delitem__(self, key: str) -> None:
+    def __delitem__(self, key: str | bytes) -> None:
         if isinstance(key, bytes):
             key = key.decode("latin-1")
         del self._container[key.lower()]
@@ -279,9 +287,11 @@ class HTTPHeaderDict(typing.MutableMapping[str, str]):
             return key.lower() in self._container
         return False
 
-    def setdefault(self, key: str, default: str | bytes = "") -> str:
+    def setdefault(self, key: str | bytes, default: str | bytes = "") -> str:
         if isinstance(default, bytes):
             default = default.decode("latin-1")
+        if isinstance(key, bytes):
+            key = key.decode("latin-1")
         return super().setdefault(key, default)
 
     def __eq__(self, other: object) -> bool:
@@ -306,13 +316,13 @@ class HTTPHeaderDict(typing.MutableMapping[str, str]):
         for vals in self._container.values():
             yield vals[0]
 
-    def discard(self, key: str) -> None:
+    def discard(self, key: str | bytes) -> None:
         try:
             del self[key]
         except KeyError:
             pass
 
-    def add(self, key: str, val: str | bytes, *, combine: bool = False) -> None:
+    def add(self, key: str | bytes, val: str | bytes, *, combine: bool = False) -> None:
         """Adds a (name, value) pair, doesn't overwrite the value if it already
         exists.
 
@@ -360,6 +370,7 @@ class HTTPHeaderDict(typing.MutableMapping[str, str]):
             )
         other = args[0] if len(args) >= 1 else ()
 
+        key: str | bytes
         val: str | bytes
         if isinstance(other, HTTPHeaderDict):
             for key, val in other.iteritems():
@@ -383,13 +394,13 @@ class HTTPHeaderDict(typing.MutableMapping[str, str]):
             self.add(key, value)
 
     @typing.overload
-    def getlist(self, key: str) -> list[str]: ...
+    def getlist(self, key: str | bytes) -> list[str]: ...
 
     @typing.overload
-    def getlist(self, key: str, default: _DT) -> list[str] | _DT: ...
+    def getlist(self, key: str | bytes, default: _DT) -> list[str] | _DT: ...
 
     def getlist(
-        self, key: str, default: _Sentinel | _DT = _Sentinel.not_passed
+        self, key: str | bytes, default: _Sentinel | _DT = _Sentinel.not_passed
     ) -> list[str] | _DT:
         """Returns a list of all the values for the named field. Returns an
         empty list if the key doesn't exist."""

--- a/src/urllib3/_collections.py
+++ b/src/urllib3/_collections.py
@@ -15,7 +15,7 @@ if typing.TYPE_CHECKING:
     class HasGettableStringKeys(Protocol):
         def keys(self) -> typing.Iterator[str]: ...
 
-        def __getitem__(self, key: str) -> str: ...
+        def __getitem__(self, key: str) -> str | bytes: ...
 
 
 __all__ = ["RecentlyUsedContainer", "HTTPHeaderDict"]
@@ -30,8 +30,8 @@ _DT = typing.TypeVar("_DT")
 
 ValidHTTPHeaderSource = typing.Union[
     "HTTPHeaderDict",
-    typing.Mapping[str, str],
-    typing.Iterable[tuple[str, str]],
+    typing.Mapping[str, str | bytes],
+    typing.Iterable[tuple[str, str | bytes]],
     "HasGettableStringKeys",
 ]
 
@@ -48,12 +48,12 @@ def ensure_can_construct_http_header_dict(
     elif isinstance(potential, typing.Mapping):
         # Full runtime checking of the contents of a Mapping is expensive, so for the
         # purposes of typechecking, we assume that any Mapping is the right shape.
-        return typing.cast(typing.Mapping[str, str], potential)
+        return typing.cast(typing.Mapping[str, str | bytes], potential)
     elif isinstance(potential, typing.Iterable):
         # Similarly to Mapping, full runtime checking of the contents of an Iterable is
         # expensive, so for the purposes of typechecking, we assume that any Iterable
         # is the right shape.
-        return typing.cast(typing.Iterable[tuple[str, str]], potential)
+        return typing.cast(typing.Iterable[tuple[str, str | bytes]], potential)
     elif hasattr(potential, "keys") and hasattr(potential, "__getitem__"):
         return typing.cast("HasGettableStringKeys", potential)
     else:
@@ -212,6 +212,9 @@ class HTTPHeaderDict(typing.MutableMapping[str, str]):
 
     A ``dict`` like container for storing HTTP Headers.
 
+    Byte-valued headers are decoded with Latin-1 when inserted. Reading values
+    always returns strings; encoding them as Latin-1 recovers the original bytes.
+
     Field names are stored and compared case-insensitively in compliance with
     RFC 7230. Iteration provides the first case-sensitive key seen for each
     case-insensitive pair.
@@ -237,7 +240,7 @@ class HTTPHeaderDict(typing.MutableMapping[str, str]):
 
     _container: typing.MutableMapping[str, list[str]]
 
-    def __init__(self, headers: ValidHTTPHeaderSource | None = None, **kwargs: str):
+    def __init__(self, headers: ValidHTTPHeaderSource | None = None, **kwargs: str | bytes):
         super().__init__()
         self._container = {}  # 'dict' is insert-ordered
         if headers is not None:
@@ -248,10 +251,12 @@ class HTTPHeaderDict(typing.MutableMapping[str, str]):
         if kwargs:
             self.extend(kwargs)
 
-    def __setitem__(self, key: str, val: str) -> None:
+    def __setitem__(self, key: str, val: str | bytes) -> None:
         # avoid a bytes/str comparison by decoding before httplib
         if isinstance(key, bytes):
             key = key.decode("latin-1")
+        if isinstance(val, bytes):
+            val = val.decode("latin-1")
         self._container[key.lower()] = [key, val]
 
     def __getitem__(self, key: str) -> str:
@@ -272,7 +277,9 @@ class HTTPHeaderDict(typing.MutableMapping[str, str]):
             return key.lower() in self._container
         return False
 
-    def setdefault(self, key: str, default: str = "") -> str:
+    def setdefault(self, key: str, default: str | bytes = "") -> str:
+        if isinstance(default, bytes):
+            default = default.decode("latin-1")
         return super().setdefault(key, default)
 
     def __eq__(self, other: object) -> bool:
@@ -303,7 +310,7 @@ class HTTPHeaderDict(typing.MutableMapping[str, str]):
         except KeyError:
             pass
 
-    def add(self, key: str, val: str, *, combine: bool = False) -> None:
+    def add(self, key: str, val: str | bytes, *, combine: bool = False) -> None:
         """Adds a (name, value) pair, doesn't overwrite the value if it already
         exists.
 
@@ -326,6 +333,8 @@ class HTTPHeaderDict(typing.MutableMapping[str, str]):
         if isinstance(key, bytes):
             key = key.decode("latin-1")
         key_lower = key.lower()
+        if isinstance(val, bytes):
+            val = val.decode("latin-1")
         new_vals = [key, val]
         # Keep the common case aka no item present as fast as possible
         vals = self._container.setdefault(key_lower, new_vals)
@@ -338,7 +347,7 @@ class HTTPHeaderDict(typing.MutableMapping[str, str]):
             else:
                 vals.append(val)
 
-    def extend(self, *args: ValidHTTPHeaderSource, **kwargs: str) -> None:
+    def extend(self, *args: ValidHTTPHeaderSource, **kwargs: str | bytes) -> None:
         """Generic import function for any type of header-like object.
         Adapted version of MutableMapping.update in order to insert items
         with self.add instead of self.__setitem__
@@ -349,6 +358,7 @@ class HTTPHeaderDict(typing.MutableMapping[str, str]):
             )
         other = args[0] if len(args) >= 1 else ()
 
+        val: str | bytes
         if isinstance(other, HTTPHeaderDict):
             for key, val in other.iteritems():
                 self.add(key, val)

--- a/src/urllib3/_collections.py
+++ b/src/urllib3/_collections.py
@@ -240,7 +240,9 @@ class HTTPHeaderDict(typing.MutableMapping[str, str]):
 
     _container: typing.MutableMapping[str, list[str]]
 
-    def __init__(self, headers: ValidHTTPHeaderSource | None = None, **kwargs: str | bytes):
+    def __init__(
+        self, headers: ValidHTTPHeaderSource | None = None, **kwargs: str | bytes
+    ):
         super().__init__()
         self._container = {}  # 'dict' is insert-ordered
         if headers is not None:

--- a/src/urllib3/_request_methods.py
+++ b/src/urllib3/_request_methods.py
@@ -5,7 +5,7 @@ import typing
 from urllib.parse import urlencode
 
 from ._base_connection import _TYPE_BODY
-from ._collections import HTTPHeaderDict
+from ._collections import _TYPE_HEADERS, HTTPHeaderDict
 from .filepost import _TYPE_FIELDS, encode_multipart_formdata
 from .response import BaseHTTPResponse
 
@@ -48,7 +48,7 @@ class RequestMethods:
 
     _encode_url_methods = {"DELETE", "GET", "HEAD", "OPTIONS"}
 
-    def __init__(self, headers: typing.Mapping[str, str] | None = None) -> None:
+    def __init__(self, headers: _TYPE_HEADERS | None = None) -> None:
         self.headers = headers or {}
 
     def urlopen(
@@ -56,7 +56,7 @@ class RequestMethods:
         method: str,
         url: str,
         body: _TYPE_BODY | None = None,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADERS | None = None,
         encode_multipart: bool = True,
         multipart_boundary: str | None = None,
         **kw: typing.Any,
@@ -72,7 +72,7 @@ class RequestMethods:
         url: str,
         body: _TYPE_BODY | None = None,
         fields: _TYPE_FIELDS | None = None,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADERS | None = None,
         json: typing.Any | None = None,
         **urlopen_kw: typing.Any,
     ) -> BaseHTTPResponse:
@@ -120,7 +120,7 @@ class RequestMethods:
             if headers is None:
                 headers = self.headers
 
-            if not ("content-type" in map(str.lower, headers.keys())):
+            if "content-type" not in HTTPHeaderDict(headers):
                 headers = HTTPHeaderDict(headers)
                 headers["Content-Type"] = "application/json"
 
@@ -149,7 +149,7 @@ class RequestMethods:
         method: str,
         url: str,
         fields: _TYPE_ENCODE_URL_FIELDS | None = None,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADERS | None = None,
         **urlopen_kw: str,
     ) -> BaseHTTPResponse:
         """
@@ -186,7 +186,7 @@ class RequestMethods:
         method: str,
         url: str,
         fields: _TYPE_FIELDS | None = None,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADERS | None = None,
         encode_multipart: bool = True,
         multipart_boundary: str | None = None,
         **urlopen_kw: str,

--- a/src/urllib3/connection.py
+++ b/src/urllib3/connection.py
@@ -20,7 +20,7 @@ if typing.TYPE_CHECKING:
     from .util.ssl_ import _TYPE_PEER_CERT_RET_DICT
     from .util.ssltransport import SSLTransport
 
-from ._collections import HTTPHeaderDict
+from ._collections import _TYPE_HEADERS, HTTPHeaderDict
 from .http2 import probe as http2_probe
 from .util.response import assert_header_parsing
 from .util.timeout import _DEFAULT_TIMEOUT, _TYPE_TIMEOUT, Timeout
@@ -263,14 +263,18 @@ class HTTPConnection(_HTTPConnection):
         self,
         host: str,
         port: int | None = None,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADERS | None = None,
         scheme: str = "http",
     ) -> None:
         if scheme not in ("http", "https"):
             raise ValueError(
                 f"Invalid proxy scheme for tunneling: {scheme!r}, must be either 'http' or 'https'"
             )
-        super().set_tunnel(host, port=port, headers=headers)
+        super().set_tunnel(
+            host,
+            port=port,
+            headers=HTTPHeaderDict(headers) if headers is not None else None,
+        )
         self._tunnel_scheme = scheme
 
     if sys.version_info < (3, 11, 16) or ((3, 12) <= sys.version_info < (3, 12, 14)):
@@ -474,7 +478,7 @@ class HTTPConnection(_HTTPConnection):
             method, url, skip_host=skip_host, skip_accept_encoding=skip_accept_encoding
         )
 
-    def putheader(self, header: str, *values: str) -> None:  # type: ignore[override]
+    def putheader(self, header: str | bytes, *values: str | bytes) -> None:  # type: ignore[override]
         """"""
         if not any(isinstance(v, str) and v == SKIP_HEADER for v in values):
             super().putheader(header, *values)
@@ -493,7 +497,7 @@ class HTTPConnection(_HTTPConnection):
         method: str,
         url: str,
         body: _TYPE_BODY | None = None,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADERS | None = None,
         *,
         chunked: bool = False,
         preload_content: bool = True,
@@ -590,7 +594,7 @@ class HTTPConnection(_HTTPConnection):
         method: str,
         url: str,
         body: _TYPE_BODY | None = None,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADERS | None = None,
     ) -> None:
         """
         Alternative to the common request method, which sends the

--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -11,7 +11,7 @@ from socket import timeout as SocketTimeout
 from types import TracebackType
 
 from ._base_connection import _TYPE_BODY
-from ._collections import HTTPHeaderDict
+from ._collections import _TYPE_HEADERS, HTTPHeaderDict
 from ._request_methods import RequestMethods
 from .connection import (
     BaseSSLError,
@@ -185,10 +185,10 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         timeout: _TYPE_TIMEOUT | None = _DEFAULT_TIMEOUT,
         maxsize: int = 1,
         block: bool = False,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADERS | None = None,
         retries: Retry | bool | int | None = None,
         _proxy: Url | None = None,
-        _proxy_headers: typing.Mapping[str, str] | None = None,
+        _proxy_headers: _TYPE_HEADERS | None = None,
         _proxy_config: ProxyConfig | None = None,
         **conn_kw: typing.Any,
     ):
@@ -386,7 +386,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         method: str,
         url: str,
         body: _TYPE_BODY | None = None,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADERS | None = None,
         retries: Retry | None = None,
         timeout: _TYPE_TIMEOUT = _DEFAULT_TIMEOUT,
         chunked: bool = False,
@@ -600,7 +600,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         method: str,
         url: str,
         body: _TYPE_BODY | None = None,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADERS | None = None,
         retries: Retry | bool | int | None = None,
         redirect: bool = True,
         assert_same_host: bool = True,
@@ -752,8 +752,9 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         # have to copy the headers dict so we can safely change it without those
         # changes being reflected in anyone else's copy.
         if not http_tunnel_required:
-            headers = headers.copy()  # type: ignore[attr-defined]
-            headers.update(self.proxy_headers)  # type: ignore[union-attr]
+            headers = HTTPHeaderDict(headers)
+            for key, value in self.proxy_headers.items():
+                headers[key] = value
 
         # Must keep the exception bound to a separate variable or else Python 3
         # complains about UnboundLocalError.
@@ -1011,10 +1012,10 @@ class HTTPSConnectionPool(HTTPConnectionPool):
         timeout: _TYPE_TIMEOUT | None = _DEFAULT_TIMEOUT,
         maxsize: int = 1,
         block: bool = False,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADERS | None = None,
         retries: Retry | bool | int | None = None,
         _proxy: Url | None = None,
-        _proxy_headers: typing.Mapping[str, str] | None = None,
+        _proxy_headers: _TYPE_HEADERS | None = None,
         key_file: str | None = None,
         cert_file: str | None = None,
         cert_reqs: int | str | None = None,

--- a/src/urllib3/contrib/emscripten/connection.py
+++ b/src/urllib3/contrib/emscripten/connection.py
@@ -8,6 +8,7 @@ from http.client import HTTPException as HTTPException  # noqa: F401
 from http.client import ResponseNotReady
 
 from ..._base_connection import _TYPE_BODY
+from ..._collections import _TYPE_HEADERS, HTTPHeaderDict
 from ...connection import HTTPConnection, ProxyConfig, port_by_scheme
 from ...exceptions import TimeoutError
 from ...response import BaseHTTPResponse
@@ -74,7 +75,7 @@ class EmscriptenHTTPConnection:
         self,
         host: str,
         port: int | None = 0,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADERS | None = None,
         scheme: str = "http",
     ) -> None:
         pass
@@ -87,7 +88,7 @@ class EmscriptenHTTPConnection:
         method: str,
         url: str,
         body: _TYPE_BODY | None = None,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADERS | None = None,
         # We know *at least* botocore is depending on the order of the
         # first 3 parameters so to be safe we only mark the later ones
         # as keyword-only to ensure we have space to extend.
@@ -113,7 +114,7 @@ class EmscriptenHTTPConnection:
         )
         request.set_body(body)
         if headers:
-            for k, v in headers.items():
+            for k, v in HTTPHeaderDict(headers).items():
                 request.set_header(k, v)
         self._response = None
         try:

--- a/src/urllib3/http2/connection.py
+++ b/src/urllib3/http2/connection.py
@@ -11,7 +11,7 @@ import h2.connection
 import h2.events
 
 from .._base_connection import _TYPE_BODY
-from .._collections import HTTPHeaderDict
+from .._collections import _TYPE_HEADERS, HTTPHeaderDict
 from ..connection import HTTPSConnection, _get_default_user_agent
 from ..exceptions import ConnectionError
 from ..response import BaseHTTPResponse
@@ -217,7 +217,7 @@ class HTTP2Connection(HTTPSConnection):
         self,
         host: str,
         port: int | None = None,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADERS | None = None,
         scheme: str = "http",
     ) -> None:
         raise NotImplementedError(
@@ -271,7 +271,7 @@ class HTTP2Connection(HTTPSConnection):
         method: str,
         url: str,
         body: _TYPE_BODY | None = None,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADERS | None = None,
         *,
         preload_content: bool = True,
         decode_content: bool = True,

--- a/src/urllib3/poolmanager.py
+++ b/src/urllib3/poolmanager.py
@@ -7,7 +7,7 @@ import warnings
 from types import TracebackType
 from urllib.parse import urljoin
 
-from ._collections import HTTPHeaderDict, RecentlyUsedContainer
+from ._collections import _TYPE_HEADERS, HTTPHeaderDict, RecentlyUsedContainer
 from ._request_methods import RequestMethods
 from .connection import ProxyConfig
 from .connectionpool import HTTPConnectionPool, HTTPSConnectionPool, port_by_scheme
@@ -82,9 +82,9 @@ class PoolKey(typing.NamedTuple):
     key_ca_cert_dir: str | None
     key_ssl_context: ssl.SSLContext | None
     key_maxsize: int | None
-    key_headers: frozenset[tuple[str, str]] | None
+    key_headers: frozenset[tuple[str | bytes, str | bytes]] | None
     key__proxy: Url | None
-    key__proxy_headers: frozenset[tuple[str, str]] | None
+    key__proxy_headers: frozenset[tuple[str | bytes, str | bytes]] | None
     key__proxy_config: ProxyConfig | None
     key_socket_options: _TYPE_SOCKET_OPTIONS | None
     key__socks_options: frozenset[tuple[str, str]] | None
@@ -201,7 +201,7 @@ class PoolManager(RequestMethods):
     def __init__(
         self,
         num_pools: int = 10,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADERS | None = None,
         **connection_pool_kw: typing.Any,
     ) -> None:
         super().__init__(headers)
@@ -566,8 +566,8 @@ class ProxyManager(PoolManager):
         self,
         proxy_url: str,
         num_pools: int = 10,
-        headers: typing.Mapping[str, str] | None = None,
-        proxy_headers: typing.Mapping[str, str] | None = None,
+        headers: _TYPE_HEADERS | None = None,
+        proxy_headers: _TYPE_HEADERS | None = None,
         proxy_ssl_context: ssl.SSLContext | None = None,
         use_forwarding_for_https: bool = False,
         proxy_assert_hostname: None | str | typing.Literal[False] = None,
@@ -637,20 +637,20 @@ class ProxyManager(PoolManager):
         )
 
     def _set_proxy_headers(
-        self, url: str, headers: typing.Mapping[str, str] | None = None
-    ) -> typing.Mapping[str, str]:
+        self, url: str, headers: _TYPE_HEADERS | None = None
+    ) -> _TYPE_HEADERS:
         """
         Sets headers needed by proxies: specifically, the Accept and Host
         headers. Only sets headers not provided by the user.
         """
-        headers_ = {"Accept": "*/*"}
+        headers_ = HTTPHeaderDict({"Accept": "*/*"})
 
         netloc = parse_url(url).netloc
         if netloc:
             headers_["Host"] = netloc
 
         if headers:
-            headers_.update(headers)
+            headers_.update(HTTPHeaderDict(headers))
         return headers_
 
     def urlopen(  # type: ignore[override]

--- a/src/urllib3/response.py
+++ b/src/urllib3/response.py
@@ -27,7 +27,7 @@ except ImportError:
 
 from . import util
 from ._base_connection import _TYPE_BODY
-from ._collections import HTTPHeaderDict
+from ._collections import _TYPE_HEADERS, HTTPHeaderDict
 from .connection import BaseSSLError, HTTPConnection, HTTPException
 from .exceptions import (
     BodyNotHttplibCompatible,
@@ -469,7 +469,7 @@ class BaseHTTPResponse(io.IOBase):
     def __init__(
         self,
         *,
-        headers: typing.Mapping[str, str] | typing.Mapping[bytes, bytes] | None = None,
+        headers: _TYPE_HEADERS | None = None,
         status: int,
         version: int,
         version_string: str,
@@ -481,7 +481,7 @@ class BaseHTTPResponse(io.IOBase):
         if isinstance(headers, HTTPHeaderDict):
             self.headers = headers
         else:
-            self.headers = HTTPHeaderDict(headers)  # type: ignore[arg-type]
+            self.headers = HTTPHeaderDict(headers)
         self.status = status
         self.version = version
         self.version_string = version_string
@@ -732,7 +732,7 @@ class HTTPResponse(BaseHTTPResponse):
     def __init__(
         self,
         body: _TYPE_BODY = "",
-        headers: typing.Mapping[str, str] | typing.Mapping[bytes, bytes] | None = None,
+        headers: _TYPE_HEADERS | None = None,
         status: int = 0,
         version: int = 0,
         version_string: str = "HTTP/?",

--- a/test/test_collections.py
+++ b/test/test_collections.py
@@ -1,11 +1,57 @@
 from __future__ import annotations
 
 import typing
+from http.client import HTTPConnection
+from unittest.mock import Mock
 
 import pytest
 
 from urllib3._collections import HTTPHeaderDict
 from urllib3._collections import RecentlyUsedContainer as Container
+
+
+class TestHTTPHeaderBytesValues:
+    def test_setitem_and_roundtrip(self) -> None:
+        headers = HTTPHeaderDict()
+        value = bytes(range(256))
+        headers["X-Value"] = value
+        assert headers["x-value"].encode("latin-1") == value
+        assert headers.getlist("X-Value") == [value.decode("latin-1")]
+
+    @pytest.mark.parametrize("combine", [False, True])
+    def test_add_mixed_values(self, combine: bool) -> None:
+        headers = HTTPHeaderDict({"X-Value": b"caf\xe9"})
+        headers.add("x-value", "text", combine=combine)
+        headers.add("X-VALUE", b"\xff", combine=combine)
+        assert headers["x-value"] == "caf\xe9, text, \xff"
+        assert list(headers.itermerged()) == [("X-Value", "caf\xe9, text, \xff")]
+        expected = ["caf\xe9, text, \xff"] if combine else ["caf\xe9", "text", "\xff"]
+        assert headers.getlist("x-value") == expected
+        assert list(headers.items()) == [("X-Value", value) for value in expected]
+        assert headers.copy() == headers
+
+    def test_import_and_default_paths(self) -> None:
+        headers = HTTPHeaderDict([("X-Value", b"one"), ("x-value", "two")])
+        headers.extend({"Other": b"three"})
+        headers.extend(Last=b"four")
+        assert headers.setdefault("Empty", b"") == ""
+        assert headers.setdefault("Other", b"ignored") == "three"
+        assert dict(headers.itermerged()) == {
+            "X-Value": "one, two", "Other": "three", "Last": "four", "Empty": "",
+        }
+        assert (headers | {"Other": b"five"})["other"] == "three, five"
+        assert (HTTPHeaderDict(Agent=b"caf\xe9"))["agent"] == "caf\xe9"
+
+    def test_http11_preserves_non_ascii_octets(self) -> None:
+        headers = HTTPHeaderDict({"User-Agent": b"Sch\xf6nefeld/1.18.0"})
+        connection = HTTPConnection("example.invalid")
+        connection.sock = Mock()
+        connection.putrequest("GET", "/")
+        for key, value in headers.items():
+            connection.putheader(key, value)
+        connection.endheaders()
+        wire = connection.sock.sendall.call_args.args[0]
+        assert b"User-Agent: Sch\xf6nefeld/1.18.0\r\n" in wire
 
 
 class TestLRUContainer:

--- a/test/test_collections.py
+++ b/test/test_collections.py
@@ -37,7 +37,10 @@ class TestHTTPHeaderBytesValues:
         assert headers.setdefault("Empty", b"") == ""
         assert headers.setdefault("Other", b"ignored") == "three"
         assert dict(headers.itermerged()) == {
-            "X-Value": "one, two", "Other": "three", "Last": "four", "Empty": "",
+            "X-Value": "one, two",
+            "Other": "three",
+            "Last": "four",
+            "Empty": "",
         }
         assert (headers | {"Other": b"five"})["other"] == "three, five"
         assert (HTTPHeaderDict(Agent=b"caf\xe9"))["agent"] == "caf\xe9"

--- a/test/test_collections.py
+++ b/test/test_collections.py
@@ -261,9 +261,8 @@ class TestHTTPHeaderDict:
 
     def test_setitem(self, d: HTTPHeaderDict) -> None:
         d["Cookie"] = "foo"
-        # The bytes value gets converted to str. The API is typed for str only,
-        # but the implementation continues supports bytes.
-        d[b"Cookie"] = "bar"  # type: ignore[index]
+        # Byte header names are normalized to strings.
+        d[b"Cookie"] = "bar"
         assert d["cookie"] == "bar"
         d["cookie"] = "with, comma"
         assert d.getlist("cookie") == ["with, comma"]
@@ -280,7 +279,7 @@ class TestHTTPHeaderDict:
         assert "COOKIE" not in d
 
     def test_delitem_with_bytes_key(self, d: HTTPHeaderDict) -> None:
-        del d[b"cookie"]  # type: ignore[arg-type]
+        del d[b"cookie"]
         assert "cookie" not in d
 
     def test_add_well_known_multiheader(self, d: HTTPHeaderDict) -> None:
@@ -290,9 +289,8 @@ class TestHTTPHeaderDict:
 
     def test_add_comma_separated_multiheader(self, d: HTTPHeaderDict) -> None:
         d.add("bar", "foo")
-        # The bytes value gets converted to str. The API is typed for str only,
-        # but the implementation continues supports bytes.
-        d.add(b"BAR", "bar")  # type: ignore[arg-type]
+        # Byte header names are normalized to strings.
+        d.add(b"BAR", "bar")
         d.add("Bar", "asdf")
         assert d.getlist("bar") == ["foo", "bar", "asdf"]
         assert d["bar"] == "foo, bar, asdf"
@@ -372,12 +370,12 @@ class TestHTTPHeaderDict:
         assert d.getlist("b") == ["asdf"]
 
     def test_getlist_with_bytes_key(self, d: HTTPHeaderDict) -> None:
-        assert d.getlist(b"cookie") == ["foo", "bar"]  # type: ignore[call-overload]
+        assert d.getlist(b"cookie") == ["foo", "bar"]
 
     def test_getitem_with_bytes(self, d: HTTPHeaderDict) -> None:
         d["Content-Type"] = "application/json"
         d.add("Content-Type", "charset=utf-8")
-        result = d[b"Content-Type"]  # type: ignore[index]
+        result = d[b"Content-Type"]
         assert result == "application/json, charset=utf-8"
 
     def test_contains_with_bytes(self, d: HTTPHeaderDict) -> None:

--- a/test/test_collections.py
+++ b/test/test_collections.py
@@ -267,6 +267,11 @@ class TestHTTPHeaderDict:
         d["cookie"] = "with, comma"
         assert d.getlist("cookie") == ["with, comma"]
 
+    def test_setdefault_with_bytes_key(self, d: HTTPHeaderDict) -> None:
+        assert d.setdefault(b"COOKIE", b"ignored") == "foo, bar"
+        assert d.setdefault(b"X-New", b"caf\xe9") == "caf\xe9"
+        assert d["x-new"] == "caf\xe9"
+
     def test_update(self, d: HTTPHeaderDict) -> None:
         d.update(dict(Cookie="foo"))
         assert d["cookie"] == "foo"

--- a/test/test_header_typing.py
+++ b/test/test_header_typing.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import typing
+from unittest import mock
+
+import pytest
+from typing_extensions import assert_type
+
+import urllib3
+from urllib3 import HTTPConnectionPool, HTTPResponse, PoolManager, ProxyManager
+from urllib3._collections import HTTPHeaderDict
+from urllib3._request_methods import RequestMethods
+from urllib3.connection import HTTPConnection
+
+
+@pytest.mark.parametrize(
+    "headers",
+    [
+        {"Content-Type": "application/custom"},
+        {b"Content-Type": b"application/custom"},
+        {b"Content-Type": "application/custom", "X-Value": b"caf\xe9"},
+    ],
+)
+def test_json_preserves_binary_header_inputs(
+    headers: (
+        typing.Mapping[str, str | bytes]
+        | typing.Mapping[bytes, str | bytes]
+        | typing.Mapping[str | bytes, str | bytes]
+    ),
+) -> None:
+    request = RequestMethods()
+    with mock.patch.object(request, "urlopen", return_value=HTTPResponse()) as urlopen:
+        request.request("POST", "/", headers=headers, json={"hello": "world"})
+    sent = HTTPHeaderDict(urlopen.call_args.kwargs["headers"])
+    assert sent["Content-Type"] == "application/custom"
+    assert len(sent.getlist("Content-Type")) == 1
+    assert urlopen.call_args.kwargs["body"] == b'{"hello":"world"}'
+
+
+@pytest.mark.parametrize(
+    "headers",
+    [
+        {b"Host": b"example.test", b"Accept": b"application/json"},
+        {"hOsT": "example.test", "aCcEpT": "application/json"},
+    ],
+)
+def test_proxy_defaults_do_not_duplicate_binary_or_mixed_case_headers(
+    headers: typing.Mapping[str, str | bytes] | typing.Mapping[bytes, str | bytes],
+) -> None:
+    proxy = ProxyManager("http://localhost:8080")
+    sent = HTTPHeaderDict(proxy._set_proxy_headers("http://destination.test/", headers))
+    assert sent.getlist("Host") == ["example.test"]
+    assert sent.getlist("Accept") == ["application/json"]
+
+
+def test_json_adds_content_type_to_readonly_binary_headers() -> None:
+    from types import MappingProxyType
+
+    headers = MappingProxyType({b"X-Value": b"caf\xe9"})
+    request = RequestMethods()
+    with mock.patch.object(request, "urlopen", return_value=HTTPResponse()) as urlopen:
+        request.request("POST", "/", headers=headers, json={})
+    sent = HTTPHeaderDict(urlopen.call_args.kwargs["headers"])
+    assert sent["Content-Type"] == "application/json"
+    assert sent["X-Value"] == "caf\xe9"
+    assert list(headers) == [b"X-Value"]
+
+
+if typing.TYPE_CHECKING:
+
+    def check_public_header_inputs(
+        strings: dict[str, str],
+        byte_keys: dict[bytes, bytes],
+        byte_values: dict[str, bytes],
+        mixed: dict[str | bytes, str | bytes],
+        readonly: typing.Mapping[str, str],
+        header_dict: HTTPHeaderDict,
+    ) -> None:
+        # Preserve ordinary string mappings and HTTPHeaderDict despite Mapping's
+        # invariant key parameter, while allowing binary and mixed inputs.
+        for headers in (strings, byte_keys, byte_values, mixed, readonly, header_dict):
+            pool = HTTPConnectionPool("localhost", headers=headers)
+            manager = PoolManager(headers=headers)
+            ProxyManager("http://localhost", headers=headers, proxy_headers=headers)
+            urllib3.request("GET", "http://localhost", headers=headers)
+            manager.request("POST", "http://localhost", headers=headers, json={})
+            pool.urlopen("GET", "/", headers=headers)
+            HTTPConnection("localhost").request("GET", "/", headers=headers)
+            HTTPConnection("localhost").set_tunnel("localhost", headers=headers)
+            response = HTTPResponse(headers=headers)
+            assert_type(response.headers["Content-Type"], str)
+            assert_type(HTTPHeaderDict(headers)["Content-Type"], str)

--- a/test/test_header_typing.py
+++ b/test/test_header_typing.py
@@ -4,7 +4,6 @@ import typing
 from unittest import mock
 
 import pytest
-from typing_extensions import assert_type
 
 import urllib3
 from urllib3 import HTTPConnectionPool, HTTPResponse, PoolManager, ProxyManager
@@ -67,6 +66,7 @@ def test_json_adds_content_type_to_readonly_binary_headers() -> None:
 
 
 if typing.TYPE_CHECKING:
+    from typing_extensions import assert_type
 
     def check_public_header_inputs(
         strings: dict[str, str],


### PR DESCRIPTION
Public header annotations reject byte-keyed, byte-valued, and mixed mappings even where the implementation accepts them. This introduces a shared input alias with separate homogeneous and mixed `Mapping` alternatives, preserving ordinary `dict[str, str]` and `HTTPHeaderDict` compatibility despite invariant mapping keys. Response header reads remain `str`.

The new checks also exposed runtime gaps: JSON requests with byte header names raised `TypeError` in `str.lower`, and byte or mixed-case proxy `Host`/`Accept` headers could coexist with defaults. Header normalization fixes those paths, supports read-only mappings without assuming `.copy()`, and normalizes tunnel/browser header boundaries. HTTP/2 changes are annotation-only.

**Dependency:** this is based on #5228's byte-value normalization for #3072. The additional work for #3047 is isolated in commit `287d2db`; the earlier commits are included until #5228 merges.

Validation:

- Before the change, the new public-API typing fixture produced 12 errors; the original JSON path reproduced two byte-key `TypeError` cases while the string control passed.
- 482 collection, connection, pool, manager, and initial regression tests passed.
- 100 proxy/new regression tests passed, including all six final new runtime cases.
- 218 response and HTTP/2 regression tests passed; 15 skipped.
- All repository pre-commit hooks passed.
- Full repository mypy: the same 27 diagnostics in three unchanged/problematic upstream locations as the upstream baseline, compared programmatically with line numbers removed. No added diagnostics; the existing Windows `poll`/signal and `Final` issues remain.

The typing fixture covers top-level requests, pools, managers, proxies, connections, tunnels, response construction, mixed dictionaries, read-only mappings, and string-valued response access. Browser/Emscripten execution was not run locally.

Related to #3047. Submitted for bounty consideration, contingent on maintainer acceptance. AI-assisted implementation with executed regression checks.


Upstream validation update: all 37 checks pass on revision b58d23c, including coverage, platform matrices, browser/Emscripten tests, and downstream compatibility checks. This revision also keeps the test-only typing_extensions import under TYPE_CHECKING and covers byte-key setdefault behavior.


Additional header compatibility review is in progress. Keeping this as a draft until that review is resolved; the previously reported 37-check CI result remains valid for b58d23c.