### PR TITLE
Construct Basic authentication headers from request and proxy URLs

### DIFF
--- a/changelog/1999.feature.rst
+++ b/changelog/1999.feature.rst
@@ -1,0 +1,4 @@
+Added HTTP Basic authentication from percent-encoded credentials in request and
+HTTP/HTTPS proxy URLs. Conflicting explicit authentication headers raise
+``ValueError``. URL credentials are removed from request targets and stored proxy
+URLs.

--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -173,6 +173,26 @@ to ``False``. By default HTTP responses are closed after reading all bytes, this
     # </body>
     # </html>
 
+HTTP Basic authentication
+-------------------------
+
+Credentials in a request URL are percent-decoded and sent in an
+``Authorization: Basic ...`` header. For example,
+``https://user:password@example.com/`` authenticates as ``user`` with password
+``password``. A username without a colon uses an empty password. URL credentials
+are removed from the request target.
+
+An explicit ``Authorization`` header must match the generated header; conflicting
+values raise ``ValueError`` before sending the request. Header names are compared
+case-insensitively. By default, authentication headers are removed when following
+a redirect to another host, port, or scheme.
+
+HTTP and HTTPS proxy URLs support credentials in the same way, using
+``Proxy-Authorization`` instead. Pass explicit proxy authentication headers in
+``ProxyManager(proxy_headers=...)``. When tunneling HTTPS, proxy credentials are
+sent on the CONNECT request, not on the request to the destination server.
+
+
 .. _request_data:
 
 Request Data

--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -42,7 +42,7 @@ from .exceptions import (
 from .response import BaseHTTPResponse
 from .util.connection import is_connection_dropped
 from .util.proxy import connection_requires_http_tunnel
-from .util.request import _TYPE_BODY_POSITION, set_file_position
+from .util.request import _TYPE_BODY_POSITION, _headers_from_userinfo, set_file_position
 from .util.retry import Retry
 from .util.ssl_match_hostname import CertificateError
 from .util.timeout import _DEFAULT_TIMEOUT, _TYPE_DEFAULT, Timeout
@@ -708,6 +708,9 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
             redirect. Typically this won't need to be set because urllib3 will
             auto-populate the value when needed.
         """
+        if headers is None:
+            headers = self.headers
+
         # Ensure that the URL we're connecting to is properly encoded
         if url.startswith("/"):
             # URLs starting with / are inherently schemeless.
@@ -716,10 +719,9 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         else:
             parsed_url = parse_url(url)
             destination_scheme = parsed_url.scheme
-            url = to_str(parsed_url._replace(fragment=None).url)
-
-        if headers is None:
-            headers = self.headers
+            if parsed_url.auth is not None:
+                headers = _headers_from_userinfo(parsed_url.auth, headers)
+            url = to_str(parsed_url._replace(auth=None, fragment=None).url)
 
         if not isinstance(retries, Retry):
             retries = Retry.from_int(retries, redirect=redirect, default=self.retries)

--- a/src/urllib3/poolmanager.py
+++ b/src/urllib3/poolmanager.py
@@ -20,6 +20,7 @@ from .exceptions import (
 from .response import BaseHTTPResponse
 from .util.connection import _TYPE_SOCKET_OPTIONS
 from .util.proxy import connection_requires_http_tunnel
+from .util.request import _headers_from_userinfo
 from .util.retry import Retry
 from .util.timeout import Timeout
 from .util.url import Url, parse_url
@@ -453,6 +454,13 @@ class PoolManager(RequestMethods):
         if "headers" not in kw:
             kw["headers"] = self.headers
 
+        if u.auth is not None:
+            kw["headers"] = _headers_from_userinfo(u.auth, kw["headers"])
+            u = u._replace(auth=None)
+            # Resolve redirects against the sanitized URL, so relative redirects
+            # cannot reintroduce credentials which were removed from headers.
+            url = u.url
+
         if self._proxy_requires_url_absolute_form(u):
             response = conn.urlopen(method, u._replace(fragment=None).url, **kw)
         else:
@@ -604,6 +612,12 @@ class ProxyManager(PoolManager):
         if proxy.port is None:
             port = port_by_scheme.get(proxy.scheme, 80)
             proxy = proxy._replace(port=port)
+
+        if proxy.auth is not None:
+            proxy_headers = _headers_from_userinfo(
+                proxy.auth, proxy_headers, "Proxy-Authorization"
+            )
+            proxy = proxy._replace(auth=None)
 
         self.proxy = proxy
         self.proxy_headers = proxy_headers or {}

--- a/src/urllib3/util/request.py
+++ b/src/urllib3/util/request.py
@@ -5,7 +5,9 @@ import sys
 import typing
 from base64 import b64encode
 from enum import Enum
+from urllib.parse import unquote_to_bytes
 
+from .._collections import HTTPHeaderDict
 from ..exceptions import UnrewindableBodyError
 from .util import to_bytes
 
@@ -55,6 +57,25 @@ _TYPE_BODY_POSITION = typing.Union[int, _TYPE_FAILEDTELL]
 # which 'should' have a body is because unknown methods should be
 # treated as if they were 'POST' which *does* expect a body.
 _METHODS_NOT_EXPECTING_BODY = {"GET", "HEAD", "DELETE", "TRACE", "OPTIONS", "CONNECT"}
+
+
+def _headers_from_userinfo(
+    userinfo: str,
+    headers: typing.Mapping[str, str] | None,
+    header_name: str = "Authorization",
+) -> HTTPHeaderDict:
+    """Add URL credentials without mutating headers or overriding explicit auth."""
+    username, _, password = userinfo.partition(":")
+    credentials = unquote_to_bytes(username) + b":" + unquote_to_bytes(password)
+    authorization = "Basic " + b64encode(credentials).decode("ascii")
+    result = HTTPHeaderDict(headers)
+    existing = result.getlist(header_name)
+    if any(value != authorization for value in existing):
+        # Neither the URL credentials nor the supplied header should reach logs.
+        raise ValueError(f"URL credentials conflict with {header_name} header")
+    if not existing:
+        result[header_name] = authorization
+    return result
 
 
 def make_headers(

--- a/test/test_url_auth.py
+++ b/test/test_url_auth.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from urllib3 import HTTPConnectionPool, PoolManager, ProxyManager
+from urllib3._collections import HTTPHeaderDict
+from urllib3.response import HTTPResponse
+
+
+@pytest.mark.parametrize("use_manager", [False, True])
+@pytest.mark.parametrize(
+    "userinfo,expected",
+    [
+        ("user:pass", "Basic dXNlcjpwYXNz"),
+        ("user", "Basic dXNlcjo="),
+        (":", "Basic Og=="),
+        ("user%40example.com:p%3Ass", "Basic dXNlckBleGFtcGxlLmNvbTpwOnNz"),
+        ("user:%FF", "Basic dXNlcjr/"),
+    ],
+)
+def test_origin_userinfo(use_manager: bool, userinfo: str, expected: str) -> None:
+    client = PoolManager() if use_manager else HTTPConnectionPool("example.com")
+    original = {"X-Test": "preserved"}
+    with patch.object(
+        HTTPConnectionPool, "_make_request", return_value=HTTPResponse()
+    ) as request:
+        client.urlopen("GET", f"http://{userinfo}@example.com/path", headers=original)
+    assert request.call_args.kwargs["headers"]["Authorization"] == expected
+    assert "@" not in request.call_args.args[2]
+    assert original == {"X-Test": "preserved"}
+    client.close() if isinstance(client, HTTPConnectionPool) else client.clear()
+
+
+@pytest.mark.parametrize("scheme", ["http", "https"])
+def test_proxy_userinfo(scheme: str) -> None:
+    original = {"X-Proxy": "preserved"}
+    manager = ProxyManager(
+        f"{scheme}://user:p%3Ass@proxy.example:8080", proxy_headers=original
+    )
+    assert manager.proxy_headers["Proxy-Authorization"] == "Basic dXNlcjpwOnNz"
+    assert manager.proxy is not None
+    assert manager.proxy.auth is None
+    assert original == {"X-Proxy": "preserved"}
+    manager.clear()
+
+
+@pytest.mark.parametrize("use_manager", [False, True])
+def test_conflicting_origin_header(use_manager: bool) -> None:
+    client = PoolManager() if use_manager else HTTPConnectionPool("example.com")
+    with patch.object(
+        HTTPConnectionPool, "_make_request", return_value=HTTPResponse()
+    ) as request:
+        with pytest.raises(ValueError, match="Authorization") as error:
+            client.urlopen(
+                "GET",
+                "http://user:secret@example.com/",
+                headers={"authorization": "Bearer token"},
+            )
+    request.assert_not_called()
+    assert "secret" not in str(error.value)
+
+
+def test_matching_header_preserves_other_repeated_headers() -> None:
+    headers = HTTPHeaderDict({"aUtHoRiZaTiOn": "Basic dXNlcjpwYXNz"})
+    headers.add("X-Test", "one")
+    headers.add("X-Test", "two")
+    with patch.object(
+        HTTPConnectionPool, "_make_request", return_value=HTTPResponse()
+    ) as request:
+        PoolManager().urlopen("GET", "http://user:pass@example.com/", headers=headers)
+    assert request.call_args.kwargs["headers"].getlist("X-Test") == ["one", "two"]
+    assert headers.getlist("X-Test") == ["one", "two"]
+
+
+def test_conflicting_proxy_header() -> None:
+    with pytest.raises(ValueError, match="Proxy-Authorization"):
+        ProxyManager(
+            "http://user:pass@proxy.example",
+            proxy_headers={"proxy-authorization": "Basic different"},
+        )
+
+
+def test_absolute_form_never_contains_credentials() -> None:
+    with patch.object(
+        HTTPConnectionPool, "_make_request", return_value=HTTPResponse()
+    ) as request:
+        ProxyManager("http://proxy:password@proxy.example").urlopen(
+            "GET", "http://user:pass@example.com/path"
+        )
+    assert request.call_args.args[2] == "http://example.com/path"
+    headers = request.call_args.kwargs["headers"]
+    assert headers["Authorization"] == "Basic dXNlcjpwYXNz"
+    assert headers["Proxy-Authorization"] == "Basic cHJveHk6cGFzc3dvcmQ="
+
+
+def test_conflicting_duplicate_authorization_header() -> None:
+    headers = HTTPHeaderDict({"Authorization": "Basic dXNlcjpwYXNz"})
+    headers.add("authorization", "Bearer different")
+    with pytest.raises(ValueError, match="Authorization"):
+        PoolManager().urlopen("GET", "http://user:pass@example.com/", headers=headers)
+    assert headers.getlist("Authorization") == [
+        "Basic dXNlcjpwYXNz",
+        "Bearer different",
+    ]
+
+
+def test_default_headers_not_modified() -> None:
+    defaults = {"X-Test": "default"}
+    with PoolManager(headers=defaults) as manager:
+        with patch.object(
+            HTTPConnectionPool, "_make_request", return_value=HTTPResponse()
+        ) as request:
+            manager.request("GET", "http://user:pass@example.com/")
+        assert (
+            request.call_args.kwargs["headers"]["Authorization"] == "Basic dXNlcjpwYXNz"
+        )
+        assert defaults == {"X-Test": "default"}
+        assert manager.headers == defaults
+
+
+def test_matching_proxy_authorization_header() -> None:
+    headers = {"pRoXy-AuThOrIzAtIoN": "Basic dXNlcjpwYXNz"}
+    with ProxyManager(
+        "http://user:pass@proxy.example", proxy_headers=headers
+    ) as manager:
+        assert manager.proxy_headers["Proxy-Authorization"] == "Basic dXNlcjpwYXNz"
+        assert headers == {"pRoXy-AuThOrIzAtIoN": "Basic dXNlcjpwYXNz"}

--- a/test/with_dummyserver/test_url_auth.py
+++ b/test/with_dummyserver/test_url_auth.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import pytest
+
+from dummyserver.socketserver import DEFAULT_CA
+from dummyserver.testcase import (
+    HypercornDummyProxyTestCase,
+    HypercornDummyServerTestCase,
+)
+from urllib3 import HTTPConnectionPool, PoolManager, ProxyManager
+
+
+class TestURLAuthentication(HypercornDummyServerTestCase):
+    @pytest.mark.parametrize("use_manager", [False, True])
+    def test_origin_credentials_on_wire(self, use_manager: bool) -> None:
+        url = f"http://user:pass@{self.host}:{self.port}/headers"
+        client = (
+            PoolManager() if use_manager else HTTPConnectionPool(self.host, self.port)
+        )
+        with client:
+            response = client.request("GET", url)
+            assert response.json()["Authorization"] == "Basic dXNlcjpwYXNz"
+            assert response.url is not None
+            assert "user:pass" not in response.url
+            response = client.request("GET", f"http://{self.host}:{self.port}/headers")
+            assert "Authorization" not in response.json()
+
+    @pytest.mark.parametrize("same_host", [False, True])
+    @pytest.mark.parametrize("use_manager", [False, True])
+    def test_redirect_credentials(self, same_host: bool, use_manager: bool) -> None:
+        target = (
+            "/headers" if same_host else f"http://{self.host_alt}:{self.port}/headers"
+        )
+        url = f"http://user:pass@{self.host}:{self.port}/redirect"
+        client = (
+            PoolManager() if use_manager else HTTPConnectionPool(self.host, self.port)
+        )
+        with client:
+            response = client.request(
+                "GET", url, fields={"target": target}, assert_same_host=False
+            )
+            assert response.json().get("Authorization") == (
+                "Basic dXNlcjpwYXNz" if same_host else None
+            )
+
+
+class TestProxyURLAuthentication(HypercornDummyProxyTestCase):
+    @pytest.mark.parametrize("proxy_scheme", ["http", "https"])
+    @pytest.mark.parametrize("target_scheme", ["http", "https"])
+    def test_origin_and_proxy_credentials(
+        self, proxy_scheme: str, target_scheme: str
+    ) -> None:
+        proxy_port = (
+            self.proxy_port if proxy_scheme == "http" else self.https_proxy_port
+        )
+        target_host = self.http_host if target_scheme == "http" else self.https_host
+        target_port = self.http_port if target_scheme == "http" else self.https_port
+        with ProxyManager(
+            f"{proxy_scheme}://proxy:password@{self.proxy_host}:{proxy_port}",
+            ca_certs=DEFAULT_CA,
+        ) as manager:
+            response = manager.request(
+                "GET",
+                f"{target_scheme}://user:pass@{target_host}:{target_port}/headers",
+            )
+            headers = response.json()
+            assert headers["Authorization"] == "Basic dXNlcjpwYXNz"
+            # CONNECT credentials must never appear in the tunneled origin request.
+            assert headers.get("Proxy-Authorization") == (
+                "Basic cHJveHk6cGFzc3dvcmQ=" if target_scheme == "http" else None
+            )


### PR DESCRIPTION
Fixes #1999.

URL credentials now generate authentication headers and are removed from request targets and stored proxy URLs. Conflicting explicit headers raise ValueError without exposing credentials.

Tests cover encoded credentials, direct connections, HTTP/HTTPS proxies, redirects, and preservation of caller headers.

Validation: 913 passed, 6 skipped. Twenty-seven new regression cases fail on unchanged main and pass with this patch. Formatting and lint passed. Mypy reports one identical pre-existing error on baseline and patch.

This implementation was AI-assisted.
