### PR TITLE
Assert on the ALPN extension in test_tunnel_sets_http_11_alpn

### DIFF
--- a/changelog/5232.misc.rst
+++ b/changelog/5232.misc.rst
@@ -1,0 +1,1 @@
+Fixed a flaky proxy test that searched the whole TLS ClientHello for ALPN protocol names.

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -12,7 +12,6 @@ import select
 import shutil
 import socket
 import ssl
-import struct
 import tempfile
 import threading
 import time
@@ -1148,43 +1147,6 @@ class TestSocketClosing(SocketDummyServerTestCase):
         timed_out.set()
 
 
-def client_hello_alpn_protocols(data: bytes) -> list[bytes]:
-    """Return the ALPN protocols offered by the ClientHello in ``data``.
-
-    Looking for a protocol name in the record as a whole is not reliable:
-    the random bytes, the session id and the key shares spell one out by
-    accident often enough to make a test flaky.
-    """
-    if len(data) < 5 or data[0] != 0x16:
-        raise ValueError("not a TLS handshake record")
-    if len(data) < 5 + struct.unpack_from("!H", data, 3)[0]:
-        raise ValueError("truncated TLS record")
-    pos = 5
-    if data[pos] != 0x01:
-        raise ValueError("not a ClientHello")
-    pos += 4  # handshake type and length
-    pos += 2 + 32  # legacy_version and random
-    pos += 1 + data[pos]  # legacy_session_id
-    pos += 2 + struct.unpack_from("!H", data, pos)[0]  # cipher_suites
-    pos += 1 + data[pos]  # legacy_compression_methods
-    end = pos + 2 + struct.unpack_from("!H", data, pos)[0]
-    pos += 2
-    while pos < end:
-        extension_type, extension_length = struct.unpack_from("!HH", data, pos)
-        pos += 4
-        if extension_type != 16:  # application_layer_protocol_negotiation
-            pos += extension_length
-            continue
-        stop = pos + 2 + struct.unpack_from("!H", data, pos)[0]
-        pos += 2
-        protocols = []
-        while pos < stop:
-            protocols.append(data[pos + 1 : pos + 1 + data[pos]])
-            pos += 1 + data[pos]
-        return protocols
-    return []
-
-
 class TestProxyManager(SocketDummyServerTestCase):
     @pytest.mark.parametrize(
         ("target_url", "expected_request_line", "expected_host"),
@@ -1347,31 +1309,31 @@ class TestProxyManager(SocketDummyServerTestCase):
 
     def test_tunnel_sets_http_11_alpn(self) -> None:
         done_receiving = Event()
-        self.buf = b""
+        self.alpn_protocol: str | None = None
 
         def socket_handler(listener: socket.socket) -> None:
             sock = listener.accept()[0]
 
-            # A ClientHello does not necessarily arrive in a single packet,
-            # so read until the record announced by its header is complete.
-            buf = b""
-            while len(buf) < 5 or len(buf) < 5 + struct.unpack_from("!H", buf, 3)[0]:
-                chunk = sock.recv(65536)
-                if not chunk:
-                    break
-                buf += chunk
-            self.buf = buf
-            done_receiving.set()  # let the test know it can proceed
-            sock.close()
+            context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+            context.load_cert_chain(DEFAULT_CERTS["certfile"], DEFAULT_CERTS["keyfile"])
+            # The server picks the first protocol it prefers that the client
+            # also offered, so http/1.1 is negotiated only when the client
+            # offered nothing else.
+            context.set_alpn_protocols(DEFAULT_CERTS["alpn_protocols"])
+            try:
+                with context.wrap_socket(sock, server_side=True) as ssl_sock:
+                    self.alpn_protocol = ssl_sock.selected_alpn_protocol()
+            finally:
+                done_receiving.set()  # let the test know it can proceed
 
         self._start_server(socket_handler)
         base_url = f"https://{self.host}:{self.port}"
-        with proxy_from_url(base_url) as proxy:
+        with proxy_from_url(base_url, ca_certs=DEFAULT_CA) as proxy:
             with pytest.raises(MaxRetryError):
                 proxy.request("GET", "https://localhost/")
 
         done_receiving.wait()
-        assert client_hello_alpn_protocols(self.buf) == [b"http/1.1"]
+        assert self.alpn_protocol == "http/1.1"
 
     def test_connect_reconn(self) -> None:
         def proxy_ssl_one(listener: socket.socket) -> None:

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -1309,20 +1309,19 @@ class TestProxyManager(SocketDummyServerTestCase):
 
     def test_tunnel_sets_http_11_alpn(self) -> None:
         done_receiving = Event()
-        self.alpn_protocol: str | None = None
+        alpn_protocol: str | None = None
 
         def socket_handler(listener: socket.socket) -> None:
+            nonlocal alpn_protocol
             sock = listener.accept()[0]
 
             context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
             context.load_cert_chain(DEFAULT_CERTS["certfile"], DEFAULT_CERTS["keyfile"])
-            # The server picks the first protocol it prefers that the client
-            # also offered, so http/1.1 is negotiated only when the client
-            # offered nothing else.
-            context.set_alpn_protocols(DEFAULT_CERTS["alpn_protocols"])
+            # Prefer h2 so the assertion fails if the client offers it.
+            context.set_alpn_protocols(["h2", "http/1.1"])
             try:
                 with context.wrap_socket(sock, server_side=True) as ssl_sock:
-                    self.alpn_protocol = ssl_sock.selected_alpn_protocol()
+                    alpn_protocol = ssl_sock.selected_alpn_protocol()
             finally:
                 done_receiving.set()  # let the test know it can proceed
 
@@ -1333,7 +1332,7 @@ class TestProxyManager(SocketDummyServerTestCase):
                 proxy.request("GET", "https://localhost/")
 
         done_receiving.wait()
-        assert self.alpn_protocol == "http/1.1"
+        assert alpn_protocol == "http/1.1"
 
     def test_connect_reconn(self) -> None:
         def proxy_ssl_one(listener: socket.socket) -> None:

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -12,6 +12,7 @@ import select
 import shutil
 import socket
 import ssl
+import struct
 import tempfile
 import threading
 import time
@@ -1147,6 +1148,43 @@ class TestSocketClosing(SocketDummyServerTestCase):
         timed_out.set()
 
 
+def client_hello_alpn_protocols(data: bytes) -> list[bytes]:
+    """Return the ALPN protocols offered by the ClientHello in ``data``.
+
+    Looking for a protocol name in the record as a whole is not reliable:
+    the random bytes, the session id and the key shares spell one out by
+    accident often enough to make a test flaky.
+    """
+    if len(data) < 5 or data[0] != 0x16:
+        raise ValueError("not a TLS handshake record")
+    if len(data) < 5 + struct.unpack_from("!H", data, 3)[0]:
+        raise ValueError("truncated TLS record")
+    pos = 5
+    if data[pos] != 0x01:
+        raise ValueError("not a ClientHello")
+    pos += 4  # handshake type and length
+    pos += 2 + 32  # legacy_version and random
+    pos += 1 + data[pos]  # legacy_session_id
+    pos += 2 + struct.unpack_from("!H", data, pos)[0]  # cipher_suites
+    pos += 1 + data[pos]  # legacy_compression_methods
+    end = pos + 2 + struct.unpack_from("!H", data, pos)[0]
+    pos += 2
+    while pos < end:
+        extension_type, extension_length = struct.unpack_from("!HH", data, pos)
+        pos += 4
+        if extension_type != 16:  # application_layer_protocol_negotiation
+            pos += extension_length
+            continue
+        stop = pos + 2 + struct.unpack_from("!H", data, pos)[0]
+        pos += 2
+        protocols = []
+        while pos < stop:
+            protocols.append(data[pos + 1 : pos + 1 + data[pos]])
+            pos += 1 + data[pos]
+        return protocols
+    return []
+
+
 class TestProxyManager(SocketDummyServerTestCase):
     @pytest.mark.parametrize(
         ("target_url", "expected_request_line", "expected_host"),
@@ -1314,7 +1352,15 @@ class TestProxyManager(SocketDummyServerTestCase):
         def socket_handler(listener: socket.socket) -> None:
             sock = listener.accept()[0]
 
-            self.buf = sock.recv(65536)  # We only accept one packet
+            # A ClientHello does not necessarily arrive in a single packet,
+            # so read until the record announced by its header is complete.
+            buf = b""
+            while len(buf) < 5 or len(buf) < 5 + struct.unpack_from("!H", buf, 3)[0]:
+                chunk = sock.recv(65536)
+                if not chunk:
+                    break
+                buf += chunk
+            self.buf = buf
             done_receiving.set()  # let the test know it can proceed
             sock.close()
 
@@ -1325,8 +1371,7 @@ class TestProxyManager(SocketDummyServerTestCase):
                 proxy.request("GET", "https://localhost/")
 
         done_receiving.wait()
-        assert b"http/1.1" in self.buf
-        assert b"h2" not in self.buf
+        assert client_hello_alpn_protocols(self.buf) == [b"http/1.1"]
 
     def test_connect_reconn(self) -> None:
         def proxy_ssl_one(listener: socket.socket) -> None:


### PR DESCRIPTION
`test_tunnel_sets_http_11_alpn` asserted against the whole ClientHello:

```python
assert b"http/1.1" in self.buf
assert b"h2" not in self.buf
```

`self.buf` is the entire record, most of which is random, so `b"h2"` turns
up in it by chance. Measuring 3000 handshakes locally (OpenSSL 3.0.13, a
517-byte ClientHello), 7 of them contained `b"h2"` somewhere, about one in
430. CI is worse: newer OpenSSL sends a post-quantum key share, so the
record is several times larger and the odds scale with it. I hit it twice
in 300 local runs of the test and once on Windows CI.

This parses the ALPN extension out of the ClientHello and compares the
protocol list:

```python
assert client_hello_alpn_protocols(self.buf) == [b"http/1.1"]
```

That is stricter than what it replaces, it checks `http/1.1` is the *only*
protocol offered, instead of checking its bytes appear somewhere in the
packet, and the failure message becomes readable:

```
AssertionError: assert [b'h2', b'http/1.1'] == [b'http/1.1']
```

rather than a hex dump of the ClientHello.

The socket handler now also reads until the record announced by its header
is complete, instead of assuming one packet. A post-quantum ClientHello is
big enough that this is worth not relying on, and an incomplete read would
otherwise just trade one flake for another.

### Verification

- 500 consecutive runs of the test, no failures.
- Reverting `ALPN_PROTOCOLS` to `["h2", "http/1.1"]` makes it fail, so the
  assertion still catches the regression it is there to catch.
- The parser returns the right protocol list for `["http/1.1"]`,
  `["h2", "http/1.1"]` and no ALPN at all, over 3000 handshakes.
- Full `test_socketlevel.py`: 122 passed, 8 skipped.
