### PR TITLE
Give the memory-limited response tests room for allocation noise

### DIFF
--- a/changelog/5234.misc.rst
+++ b/changelog/5234.misc.rst
@@ -1,1 +1,1 @@
-Fixed a memory-limited response test that failed intermittently on allocation noise.
+Fixed memory-limited response tests that failed intermittently on allocation noise.

--- a/changelog/5234.misc.rst
+++ b/changelog/5234.misc.rst
@@ -1,0 +1,1 @@
+Fixed a memory-limited response test that failed intermittently on allocation noise.

--- a/test/test_response.py
+++ b/test/test_response.py
@@ -148,6 +148,7 @@ class TestBytesQueueBuffer:
     )
     # Copying the chunk instead of handing it back would take this to 20 MiB;
     # the peak is 10 MiB and the identity assertion below is the real check.
+    # The margin is deliberately wide so that allocation noise cannot fail it.
     @pytest.mark.limit_memory("12 MB", current_thread_only=True)
     def test_memory_usage_single_chunk(
         self, get_func: typing.Callable[[BytesQueueBuffer], bytes]
@@ -164,6 +165,7 @@ class TestBytesQueueBuffer:
     )
     # Duplicating the chunk while splitting it would take this to 20 MiB;
     # the peak is 11 MiB.
+    # The margin is deliberately wide so that allocation noise cannot fail it.
     @pytest.mark.limit_memory("13 MB", current_thread_only=True)
     def test_memory_usage_splitting_chunk(self, finish_with_get_all: bool) -> None:
         # Allocate a single 10MiB chunk, then read it in two parts.
@@ -1604,8 +1606,8 @@ class TestResponse:
         ],
     )
     # The body is 10 MiB and reading it must not buffer a second copy, which
-    # would take the peak to 20 MiB. Leaving only 0.5 MiB of headroom to catch
-    # that made the test fail intermittently on CI at 11.0 MiB.
+    # would take the peak to 20 MiB.
+    # The margin is deliberately wide so that allocation noise cannot fail it.
     @pytest.mark.limit_memory("13 MB", current_thread_only=True)
     def test_buffer_memory_usage_no_decoding(
         self, preload_content: bool, amt: int, read_meth: str

--- a/test/test_response.py
+++ b/test/test_response.py
@@ -125,9 +125,9 @@ class TestBytesQueueBuffer:
         (lambda b: b.get(len(b)), lambda b: b.get_all()),
         ids=("get", "get_all"),
     )
-    @pytest.mark.limit_memory(
-        "12.5 MB", current_thread_only=True
-    )  # assert that we're not doubling memory usagelimit_mem
+    # Doubling memory usage would take this past 20 MiB; the peak is 12.1 MiB.
+    # The margin is deliberately wide so that allocation noise cannot fail it.
+    @pytest.mark.limit_memory("15 MB", current_thread_only=True)
     def test_memory_usage(
         self, get_func: typing.Callable[[BytesQueueBuffer], bytes]
     ) -> None:
@@ -146,7 +146,9 @@ class TestBytesQueueBuffer:
         (lambda b: b.get(len(b)), lambda b: b.get_all()),
         ids=("get", "get_all"),
     )
-    @pytest.mark.limit_memory("10.01 MB", current_thread_only=True)
+    # Copying the chunk instead of handing it back would take this to 20 MiB;
+    # the peak is 10 MiB and the identity assertion below is the real check.
+    @pytest.mark.limit_memory("12 MB", current_thread_only=True)
     def test_memory_usage_single_chunk(
         self, get_func: typing.Callable[[BytesQueueBuffer], bytes]
     ) -> None:
@@ -160,7 +162,9 @@ class TestBytesQueueBuffer:
         (True, False),
         ids=("finish_with_get_all", "finish_with_get"),
     )
-    @pytest.mark.limit_memory("11.01 MB", current_thread_only=True)
+    # Duplicating the chunk while splitting it would take this to 20 MiB;
+    # the peak is 11 MiB.
+    @pytest.mark.limit_memory("13 MB", current_thread_only=True)
     def test_memory_usage_splitting_chunk(self, finish_with_get_all: bool) -> None:
         # Allocate a single 10MiB chunk, then read it in two parts.
         # Verifies that splitting a chunk doesn't cause additional memory allocation.

--- a/test/test_response.py
+++ b/test/test_response.py
@@ -1599,7 +1599,10 @@ class TestResponse:
             (False, 10 * 2**20, "read1"),
         ],
     )
-    @pytest.mark.limit_memory("10.5 MB", current_thread_only=True)
+    # The body is 10 MiB and reading it must not buffer a second copy, which
+    # would take the peak to 20 MiB. Leaving only 0.5 MiB of headroom to catch
+    # that made the test fail intermittently on CI at 11.0 MiB.
+    @pytest.mark.limit_memory("13 MB", current_thread_only=True)
     def test_buffer_memory_usage_no_decoding(
         self, preload_content: bool, amt: int, read_meth: str
     ) -> None:


### PR DESCRIPTION
Several `limit_memory` marks in `test/test_response.py` sit within a rounding error of their measured peak, so ordinary allocation noise fails them. Two have failed on CI in the past day:

```
MEMORY PROBLEMS test/test_response.py::TestResponse::test_buffer_memory_usage_no_decoding[False-None-read1]
  - Test was limited to 10.5MiB but allocated 11.0MiB

MEMORY PROBLEMS test/test_response.py::TestBytesQueueBuffer::test_memory_usage_splitting_chunk[finish_with_get_all]
  - Test was limited to 11.0MiB but allocated 12.0MiB
```

Measured with `memray` on Python 3.13:

| test | peak | old limit | headroom | new limit |
| --- | --- | --- | --- | --- |
| `test_memory_usage` | 12.13 MiB | 12.5 MB | +0.37 MiB | 15 MB |
| `test_memory_usage_single_chunk` | 10.00 MiB | 10.01 MB | +0.01 MiB | 12 MB |
| `test_memory_usage_splitting_chunk` | 11.00 MiB | 11.01 MB | +0.01 MiB | 13 MB |
| `test_buffer_memory_usage_no_decoding` | 10.00 MiB | 10.5 MB | +0.50 MiB | 13 MB |

Three of them allow 10 KiB of slack on a 10 MiB allocation. That is not a memory bound, it is an assertion that the allocator behaves exactly as it did when the number was written.

Each of these tests guards against the body being retained a second time, which takes the peak to roughly 20 MiB, so there is a wide gap between the real peak and the regression being caught. The new limits keep at least a 5 MiB margin below a doubled body while giving noise 2-3 MiB instead of 0.01 MiB.

`test_memory_usage_decode_with_max_length` (10 MB) and `test_buffer_memory_usage_decode_one_chunk` (25 MB) are left alone: neither has failed, and I did not measure them.

### Verification

- `test/test_response.py` passes on 3.12 and 3.13: 169 passed, 45 skipped.
- 15 consecutive runs of the whole `memory_usage` family under
  `coverage run --parallel-mode`, as the CI session runs them: clean.
- Adding a genuine extra copy of the body to each test makes all six
  parametrizations fail at the new limits, so they still catch what they
  are for.

One caveat stated plainly: I could not reproduce the CI overshoot locally on either 3.12 or 3.13, with or without coverage. The case rests on the measured margins and the observed failures rather than on a local reproduction. If you would rather see the extra megabyte accounted for before widening anything, I am happy to dig into that instead.
