### PR TITLE
Test serialized request targets without server normalization

### DIFF
--- a/test/test_request_target.py
+++ b/test/test_request_target.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import io
+import socket
+from collections.abc import Iterator
+from unittest import mock
+
+import pytest
+
+from urllib3 import HTTPConnectionPool, PoolManager, ProxyManager
+from urllib3.connection import HTTPConnection
+
+
+@pytest.fixture
+def request_socket() -> Iterator[mock.MagicMock]:
+    # Keep request serialization and response parsing real; replace only the
+    # transport so no server can normalize the request target before we see it.
+    sock = mock.MagicMock(spec=socket.socket)
+    with io.BytesIO(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n") as response:
+        sock.makefile.return_value = response
+        with mock.patch.object(HTTPConnection, "_new_conn", return_value=sock):
+            yield sock
+
+
+class TestRequestTarget:
+    @pytest.mark.parametrize("client", ["pool", "manager", "proxy"])
+    @pytest.mark.parametrize(
+        ["target", "expected_target"],
+        [
+            ("/echo_uri", b"/echo_uri"),
+            ("/echo_uri?", b"/echo_uri?"),
+            ("/echo_uri?q=1#fragment", b"/echo_uri?q=1"),
+            ("/echo_uri?#", b"/echo_uri?"),
+            ("/echo_uri#?", b"/echo_uri"),
+            ("/echo_uri#?#", b"/echo_uri"),
+            ("/echo_uri#!", b"/echo_uri"),
+            ("/echo_uri#!#", b"/echo_uri"),
+            ("/echo_uri??#", b"/echo_uri??"),
+            ("/echo_uri?%3f#", b"/echo_uri?%3F"),
+            ("/echo_uri?%3F#", b"/echo_uri?%3F"),
+            ("/echo_uri?[]", b"/echo_uri?%5B%5D"),
+            ("/a%2fb?q=%23%26%3d", b"/a%2Fb?q=%23%26%3D"),
+            ("/a%23b%3fc?q=%23%3f#fragment", b"/a%23b%3Fc?q=%23%3F"),
+            ("/a%252Fb?q=%253F", b"/a%252Fb?q=%253F"),
+            ("/echo_uri?q=1&q=2&empty=", b"/echo_uri?q=1&q=2&empty="),
+            ("/echo_uri?q=a+b%20c", b"/echo_uri?q=a+b%20c"),
+            ("/echo_uri?q=/a?b", b"/echo_uri?q=/a?b"),
+            ("/echo_params?q=\r&k=\n \n", b"/echo_params?q=%0D&k=%0A%20%0A"),
+            ("/a b?q=c d", b"/a%20b?q=c%20d"),
+            ("/café?q=雪", b"/caf%C3%A9?q=%E9%9B%AA"),
+            ("/a;b:c@d?q=$!,'()*;:@", b"/a;b:c@d?q=$!,'()*;:@"),
+        ],
+    )
+    def test_encoded_target(
+        self,
+        request_socket: mock.MagicMock,
+        client: str,
+        target: str,
+        expected_target: bytes,
+    ) -> None:
+        if client == "pool":
+            with HTTPConnectionPool("example.com") as pool:
+                response = pool.request("GET", target, retries=False)
+        else:
+            manager = (
+                ProxyManager("http://proxy.example:8080")
+                if client == "proxy"
+                else PoolManager()
+            )
+            with manager:
+                response = manager.request(
+                    "GET", "http://example.com" + target, retries=False
+                )
+            if client == "proxy":
+                expected_target = b"http://example.com" + expected_target
+
+        assert response.status == 200
+        sent = b"".join(call.args[0] for call in request_socket.sendall.call_args_list)
+        assert sent.partition(b"\r\n")[0] == b"GET " + expected_target + b" HTTP/1.1"
+        assert sent.count(b"\r\n\r\n") == 1
+
+    def test_pool_preserves_path_dot_segments(
+        self, request_socket: mock.MagicMock
+    ) -> None:
+        with HTTPConnectionPool("example.com") as pool:
+            response = pool.request("GET", "/echo_uri/seg0/../seg2", retries=False)
+
+        assert response.status == 200
+        sent = b"".join(call.args[0] for call in request_socket.sendall.call_args_list)
+        assert sent.partition(b"\r\n")[0] == b"GET /echo_uri/seg0/../seg2 HTTP/1.1"

--- a/test/with_dummyserver/test_connectionpool.py
+++ b/test/with_dummyserver/test_connectionpool.py
@@ -820,11 +820,6 @@ class TestConnectionPool(HypercornDummyServerTestCase):
             with HTTPConnectionPool(self.host, self.port) as pool:
                 pool.request("GET" + char, "/")
 
-    def test_percent_encode_invalid_target_chars(self) -> None:
-        with HTTPConnectionPool(self.host, self.port) as pool:
-            r = pool.request("GET", "/echo_params?q=\r&k=\n \n")
-            assert r.data == b"[('k', '\\n \\n'), ('q', '\\r')]"
-
     def test_source_address(self) -> None:
         for addr, is_ipv6 in VALID_SOURCE_ADDRESSES:
             if is_ipv6:
@@ -947,12 +942,6 @@ class TestConnectionPool(HypercornDummyServerTestCase):
         with HTTPConnectionPool("LoCaLhOsT", self.port) as pool:
             response = pool.request("GET", f"http://LoCaLhOsT:{self.port}/")
             assert response.status == 200
-
-    def test_preserves_path_dot_segments(self) -> None:
-        """ConnectionPool preserves dot segments in the URI"""
-        with HTTPConnectionPool(self.host, self.port) as pool:
-            response = pool.request("GET", "/echo_uri/seg0/../seg2")
-            assert response.data == b"/echo_uri/seg0/../seg2?"
 
     def test_default_user_agent_header(self) -> None:
         """ConnectionPool has a default user agent"""

--- a/test/with_dummyserver/test_poolmanager.py
+++ b/test/with_dummyserver/test_poolmanager.py
@@ -627,27 +627,6 @@ class TestPoolManager(HypercornDummyServerTestCase):
             r = http.request("GET", f"http://{self.host}:{self.port}/")
             assert r.status == 200
 
-    @pytest.mark.parametrize(
-        ["target", "expected_target"],
-        [
-            # annoyingly quart.request.full_path adds a stray `?`
-            ("/echo_uri", b"/echo_uri?"),
-            ("/echo_uri?q=1#fragment", b"/echo_uri?q=1"),
-            ("/echo_uri?#", b"/echo_uri?"),
-            ("/echo_uri#!", b"/echo_uri?"),
-            ("/echo_uri#!#", b"/echo_uri?"),
-            ("/echo_uri??#", b"/echo_uri??"),
-            ("/echo_uri?%3f#", b"/echo_uri?%3F"),
-            ("/echo_uri?%3F#", b"/echo_uri?%3F"),
-            ("/echo_uri?[]", b"/echo_uri?%5B%5D"),
-        ],
-    )
-    def test_encode_http_target(self, target: str, expected_target: bytes) -> None:
-        with PoolManager() as http:
-            url = f"http://{self.host}:{self.port}{target}"
-            r = http.request("GET", url)
-            assert r.data == expected_target
-
     def test_top_level_request(self) -> None:
         r = request("GET", f"{self.base_url}/")
         assert r.status == 200


### PR DESCRIPTION
Addresses https://github.com/urllib3/urllib3/issues/3199.

The existing URI echo tests assert on Quart's parsed `full_path`, which adds a trailing `?` for requests without a query. Move these checks to a test that captures bytes passed to the socket, retaining real request serialization and HTTP response parsing. `/echo_uri` now expects that exact target, while `/echo_uri?` retains its empty query; the original fragment cases containing `?` can also be tested directly.

The 67 cases cover HTTPConnectionPool, PoolManager and HTTP ProxyManager, including absolute-form proxy targets, percent-encoded delimiters, UTF-8, query ordering, controls and the existing direct-pool dot-segment behavior. All nine existing target cases and the two adjacent encoding/path cases are preserved. This changes tests only. It does not decide the separately discussed proxy dot-segment behavior in #4965/#5192.

Validation on Linux, CPython 3.14.7:

- `python -m pytest -q test/test_connection.py test/test_connectionpool.py test/test_poolmanager.py test/test_request_target.py --disable-socket --timeout=15`: 492 passed.
- New module separately reviewed and run: 67 passed with sockets disabled.
- Both modified dummyserver modules: 174 tests collected successfully; their server-based tests were not executed in this verification run.
- Black 26.5.1 (`--target-version py310`), isort 9.0.1, flake8 7.3.0 and `git diff --check` passed.
- Six isolated deliberate regressions each caused the new suite to fail: adding/dropping empty query separators, leaking fragments, decoding escaped delimiters, normalizing direct-pool dot segments, and using origin-form for an HTTP proxy. Baseline passes. These local mutation checks are not added to the project.

The complete cross-platform/nox matrix has not been run. The isolated environment uses Quart 0.20.0 from the lockfile but is not a complete `uv.lock` recreation. Tests still load the shared dummyserver dependencies through `conftest.py`; they do not execute a web server or make network connections.

AI disclosure: this patch was prepared and tested using Codex, with a separate agent reviewing the changes and independently running the new tests. Human maintainer review is pending. No assertion of human-only authorship or upstream acceptance is made.

Suggested label: `Skip Changelog` (test-only change).
