### PR TITLE
Support Basic authentication from URL userinfo

### DIFF
--- a/changelog/1999.feature.rst
+++ b/changelog/1999.feature.rst
@@ -1,0 +1,2 @@
+Add Basic authentication from userinfo in HTTP and HTTPS URLs and proxy URLs.
+Explicit conflicting authorization headers now raise ``ValueError``.

--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -42,7 +42,12 @@ from .exceptions import (
 from .response import BaseHTTPResponse
 from .util.connection import is_connection_dropped
 from .util.proxy import connection_requires_http_tunnel
-from .util.request import _TYPE_BODY_POSITION, set_file_position
+from .util.request import (
+    _TYPE_BODY_POSITION,
+    _add_url_auth,
+    make_headers,
+    set_file_position,
+)
 from .util.retry import Retry
 from .util.ssl_match_hostname import CertificateError
 from .util.timeout import _DEFAULT_TIMEOUT, _TYPE_DEFAULT, Timeout
@@ -611,6 +616,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         body_pos: _TYPE_BODY_POSITION | None = None,
         preload_content: bool = True,
         decode_content: bool = True,
+        _url_auth_generated: str | None = None,
         **response_kw: typing.Any,
     ) -> BaseHTTPResponse:
         """
@@ -709,6 +715,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
             auto-populate the value when needed.
         """
         # Ensure that the URL we're connecting to is properly encoded
+        parsed_url = None
         if url.startswith("/"):
             # URLs starting with / are inherently schemeless.
             url = to_str(_encode_target(url))
@@ -716,10 +723,27 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         else:
             parsed_url = parse_url(url)
             destination_scheme = parsed_url.scheme
-            url = to_str(parsed_url._replace(fragment=None).url)
+            url = to_str(parsed_url._replace(auth=None, fragment=None).url)
 
         if headers is None:
             headers = self.headers
+
+        generated_auth = _url_auth_generated
+        if (
+            generated_auth is not None
+            and parsed_url is not None
+            and parsed_url.auth is not None
+        ):
+            headers = HTTPHeaderDict(headers)
+            if headers.get("Authorization") == generated_auth:
+                headers.pop("Authorization", None)
+        had_authorization = bool(HTTPHeaderDict(headers).getlist("Authorization"))
+        if parsed_url is not None:
+            headers = _add_url_auth(headers, parsed_url.auth_decoded_joined)
+            if parsed_url.auth_decoded_joined is not None and not had_authorization:
+                generated_auth = make_headers(
+                    basic_auth=parsed_url.auth_decoded_joined
+                )["authorization"]
 
         if not isinstance(retries, Retry):
             retries = Retry.from_int(retries, redirect=redirect, default=self.retries)
@@ -896,6 +920,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
                 release_conn=release_conn,
                 chunked=chunked,
                 body_pos=body_pos,
+                _url_auth_generated=generated_auth,
                 preload_content=preload_content,
                 decode_content=decode_content,
                 **response_kw,
@@ -947,6 +972,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
                 release_conn=release_conn,
                 chunked=chunked,
                 body_pos=body_pos,
+                _url_auth_generated=generated_auth,
                 preload_content=preload_content,
                 decode_content=decode_content,
                 **response_kw,
@@ -979,6 +1005,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
                 release_conn=release_conn,
                 chunked=chunked,
                 body_pos=body_pos,
+                _url_auth_generated=generated_auth,
                 preload_content=preload_content,
                 decode_content=decode_content,
                 **response_kw,
@@ -1152,10 +1179,16 @@ def connection_from_url(url: str, **kw: typing.Any) -> HTTPConnectionPool:
         >>> conn = connection_from_url('http://google.com/')
         >>> r = conn.request('GET', '/')
     """
-    scheme, _, host, port, *_ = parse_url(url)
+    parsed_url = parse_url(url)
+    scheme, _, host, port, *_ = parsed_url
     scheme = scheme or "http"
     if port is None:
         port = port_by_scheme.get(scheme, 80)
+    if parsed_url.auth_decoded_joined is not None:
+        headers = kw.get("headers")
+        kw["headers"] = _add_url_auth(
+            headers if headers is not None else {}, parsed_url.auth_decoded_joined
+        )
     if scheme == "https":
         return HTTPSConnectionPool(host, port=port, **kw)  # type: ignore[arg-type]
     else:

--- a/src/urllib3/poolmanager.py
+++ b/src/urllib3/poolmanager.py
@@ -20,6 +20,7 @@ from .exceptions import (
 from .response import BaseHTTPResponse
 from .util.connection import _TYPE_SOCKET_OPTIONS
 from .util.proxy import connection_requires_http_tunnel
+from .util.request import _add_url_auth, make_headers
 from .util.retry import Retry
 from .util.timeout import Timeout
 from .util.url import Url, parse_url
@@ -124,7 +125,9 @@ def _default_key_normalizer(
     # These are both dictionaries and need to be transformed into frozensets
     for key in ("headers", "_proxy_headers", "_socks_options"):
         if key in context and context[key] is not None:
-            context[key] = frozenset(context[key].items())
+            # Force iteration: HTTPHeaderDict's item view subclasses set but
+            # stores its values in the header mapping, not the underlying set.
+            context[key] = frozenset(item for item in context[key].items())
 
     # The socket_options key may be a list and needs to be transformed into a
     # tuple.
@@ -383,6 +386,11 @@ class PoolManager(RequestMethods):
         not used.
         """
         u = parse_url(url)
+        if u.auth_decoded_joined is not None:
+            pool_kwargs = self._merge_pool_kwargs(pool_kwargs)
+            pool_kwargs["headers"] = _add_url_auth(
+                pool_kwargs.get("headers") or {}, u.auth_decoded_joined
+            )
         return self.connection_from_host(
             u.host, port=u.port, scheme=u.scheme, pool_kwargs=pool_kwargs
         )
@@ -445,6 +453,7 @@ class PoolManager(RequestMethods):
                 stacklevel=2,
             )
 
+        generated_auth = kw.pop("_url_auth_generated", None)
         conn = self.connection_from_host(u.host, port=u.port, scheme=u.scheme)
 
         kw["assert_same_host"] = False
@@ -453,10 +462,30 @@ class PoolManager(RequestMethods):
         if "headers" not in kw:
             kw["headers"] = self.headers
 
+        if generated_auth is not None and u.auth_decoded_joined is not None:
+            headers = HTTPHeaderDict(kw["headers"])
+            if headers.get("Authorization") == generated_auth:
+                headers.pop("Authorization", None)
+            kw["headers"] = headers
+        had_authorization = bool(HTTPHeaderDict(kw["headers"]).getlist("Authorization"))
+        kw["headers"] = _add_url_auth(kw["headers"], u.auth_decoded_joined)
+        if u.auth_decoded_joined is not None and not had_authorization:
+            generated_auth = make_headers(basic_auth=u.auth_decoded_joined)[
+                "authorization"
+            ]
+        if generated_auth is not None:
+            kw["_url_auth_generated"] = generated_auth
+
         if self._proxy_requires_url_absolute_form(u):
-            response = conn.urlopen(method, u._replace(fragment=None).url, **kw)
+            call_kw = kw.copy()
+            call_kw.pop("_url_auth_generated", None)
+            response = conn.urlopen(
+                method, u._replace(auth=None, fragment=None).url, **call_kw
+            )
         else:
-            response = conn.urlopen(method, u.request_uri, **kw)
+            call_kw = kw.copy()
+            call_kw.pop("_url_auth_generated", None)
+            response = conn.urlopen(method, u.request_uri, **call_kw)
 
         redirect_location = redirect and response.get_redirect_location()
         if not redirect_location:
@@ -502,6 +531,8 @@ class PoolManager(RequestMethods):
         log.info("Redirecting %s -> %s", url, redirect_location)
 
         response.drain_conn()
+        if generated_auth is not None:
+            kw["_url_auth_generated"] = generated_auth
         return self.urlopen(method, redirect_location, **kw)
 
 
@@ -605,8 +636,10 @@ class ProxyManager(PoolManager):
             port = port_by_scheme.get(proxy.scheme, 80)
             proxy = proxy._replace(port=port)
 
-        self.proxy = proxy
-        self.proxy_headers = proxy_headers or {}
+        self.proxy = proxy._replace(auth=None)
+        self.proxy_headers = _add_url_auth(
+            proxy_headers or {}, proxy.auth_decoded_joined, "Proxy-Authorization"
+        )
         self.proxy_config = ProxyConfig(
             proxy_ssl_context,
             use_forwarding_for_https,

--- a/src/urllib3/util/request.py
+++ b/src/urllib3/util/request.py
@@ -6,6 +6,7 @@ import typing
 from base64 import b64encode
 from enum import Enum
 
+from .._collections import HTTPHeaderDict
 from ..exceptions import UnrewindableBodyError
 from .util import to_bytes
 
@@ -55,6 +56,27 @@ _TYPE_BODY_POSITION = typing.Union[int, _TYPE_FAILEDTELL]
 # which 'should' have a body is because unknown methods should be
 # treated as if they were 'POST' which *does* expect a body.
 _METHODS_NOT_EXPECTING_BODY = {"GET", "HEAD", "DELETE", "TRACE", "OPTIONS", "CONNECT"}
+
+
+def _add_url_auth(
+    headers: typing.Mapping[str, str],
+    auth: str | None,
+    header: str = "Authorization",
+) -> typing.Mapping[str, str]:
+    """Add Basic authentication from URL userinfo without mutating headers."""
+    if auth is None:
+        return headers
+
+    value = make_headers(basic_auth=auth)["authorization"]
+    result = HTTPHeaderDict(headers)
+    if any(
+        (existing.decode("latin-1") if isinstance(existing, bytes) else existing)
+        != value
+        for existing in result.getlist(header)
+    ):
+        raise ValueError(f"{header} header conflicts with URL credentials")
+    result[header] = value
+    return result
 
 
 def make_headers(

--- a/test/test_connectionpool.py
+++ b/test/test_connectionpool.py
@@ -802,6 +802,22 @@ class TestConnectionPool:
             actual_url = mock_request.call_args[0][2]
             assert actual_url == expected_url
 
+    def test_absolute_url_credentials_are_added_and_removed_from_target(self) -> None:
+        headers = {"X-Test": "value"}
+        with HTTPConnectionPool(host="localhost", port=80) as pool:
+            with patch.object(
+                pool, "_make_request", return_value=HTTPResponse(status=200)
+            ) as mock_request:
+                pool.urlopen(
+                    "GET", "http://user:p%40ss@localhost/private", headers=headers
+                )
+
+            assert mock_request.call_args.args[2] == "http://localhost/private"
+            assert mock_request.call_args.kwargs["headers"]["Authorization"] == (
+                "Basic dXNlcjpwQHNz"
+            )
+            assert headers == {"X-Test": "value"}
+
     def test_absolute_redirect_request_target_strips_fragment(self) -> None:
         redirect_response = HTTPResponse(
             status=302,
@@ -821,3 +837,35 @@ class TestConnectionPool:
 
         assert response.status == 200
         assert requested_urls == ["/", "http://localhost/next?x=1"]
+
+    def test_redirect_url_credentials_replace_generated_credentials(self) -> None:
+        redirect_response = HTTPResponse(
+            status=302,
+            headers={"location": "http://bob:two@localhost/next"},
+        )
+        final_response = HTTPResponse(status=200)
+
+        with HTTPConnectionPool(host="localhost", port=80) as pool:
+            with patch.object(
+                pool,
+                "_make_request",
+                side_effect=[redirect_response, final_response],
+            ) as mock_request:
+                response = pool.urlopen(
+                    "GET", "http://alice:one@localhost/start", retries=1
+                )
+
+        assert response.status == 200
+        assert [
+            call.kwargs["headers"]["Authorization"]
+            for call in mock_request.call_args_list
+        ] == ["Basic YWxpY2U6b25l", "Basic Ym9iOnR3bw=="]
+
+    def test_absolute_url_credentials_conflict_with_explicit_header(self) -> None:
+        with HTTPConnectionPool(host="localhost", port=80) as pool:
+            with pytest.raises(ValueError, match="Authorization header conflicts"):
+                pool.urlopen(
+                    "GET",
+                    "http://alice:one@localhost/start",
+                    headers={"Authorization": "Basic different"},
+                )

--- a/test/test_poolmanager.py
+++ b/test/test_poolmanager.py
@@ -22,6 +22,126 @@ from urllib3.util.url import Url
 
 
 class TestPoolManager:
+    def test_url_credentials_are_added_without_mutating_headers(self) -> None:
+        headers = {"X-Test": "value"}
+        manager = PoolManager()
+        response = mock.Mock(get_redirect_location=lambda: None)
+        response.status = 200
+        response.retries = retry.Retry()
+        pool = mock.Mock()
+        pool.urlopen.return_value = response
+        manager.connection_from_host = mock.Mock(return_value=pool)
+
+        manager.urlopen("GET", "http://user:p%40ss@example.com/path", headers=headers)
+
+        assert headers == {"X-Test": "value"}
+        sent_headers = pool.urlopen.call_args.kwargs["headers"]
+        assert sent_headers["Authorization"] == "Basic dXNlcjpwQHNz"
+        assert pool.urlopen.call_args.args[1] == "/path"
+
+    def test_url_credentials_conflict_with_explicit_header(self) -> None:
+        manager = PoolManager()
+        with pytest.raises(ValueError, match="Authorization header conflicts"):
+            manager.urlopen(
+                "GET",
+                "http://user:pass@example.com/",
+                headers={"Authorization": "Basic different"},
+            )
+
+    def test_connection_from_url_adds_url_credentials(self) -> None:
+        headers = {"X-Test": "value"}
+        pool = connection_from_url("http://user:p%40ss@example.com/", headers=headers)
+
+        assert pool.headers["Authorization"] == "Basic dXNlcjpwQHNz"
+        assert headers == {"X-Test": "value"}
+
+    def test_connection_from_url_credentials_are_pool_scoped(self) -> None:
+        manager = PoolManager()
+
+        first = manager.connection_from_url("http://alice:one@example.com/")
+        second = manager.connection_from_url("http://bob:two@example.com/")
+        plain = manager.connection_from_url("http://example.com/")
+
+        assert first is not second
+        assert first is not plain
+        assert second is not plain
+        assert first.headers["Authorization"] != second.headers["Authorization"]
+        assert "Authorization" not in plain.headers
+
+    def test_connection_from_url_pool_kwargs_conflict_and_immutability(self) -> None:
+        headers = {"X-Test": "value", "Authorization": "Basic different"}
+        manager = PoolManager()
+        with pytest.raises(ValueError, match="Authorization header conflicts"):
+            manager.connection_from_url(
+                "http://user:pass@example.com/", pool_kwargs={"headers": headers}
+            )
+        assert headers == {
+            "X-Test": "value",
+            "Authorization": "Basic different",
+        }
+
+    def test_connection_from_url_accepts_matching_bytes_header(self) -> None:
+        manager = PoolManager()
+        pool = manager.connection_from_url(
+            "http://user:pass@example.com/",
+            pool_kwargs={"headers": {"Authorization": b"Basic dXNlcjpwYXNz"}},
+        )
+
+        assert pool.headers["Authorization"] == "Basic dXNlcjpwYXNz"
+
+    def test_redirect_to_other_host_removes_generated_credentials(self) -> None:
+        first = mock.Mock(status=302, retries=retry.Retry())
+        first.get_redirect_location.return_value = "http://other.example/next"
+        second = mock.Mock(status=200, retries=retry.Retry())
+        second.get_redirect_location.return_value = None
+        pool = mock.Mock()
+        pool.urlopen.side_effect = [first, second]
+        pool.is_same_host.return_value = False
+        manager = PoolManager()
+        manager.connection_from_host = mock.Mock(return_value=pool)
+
+        manager.urlopen("GET", "http://user:pass@example.com/start")
+
+        assert "Authorization" in pool.urlopen.call_args_list[0].kwargs["headers"]
+        assert "Authorization" not in pool.urlopen.call_args_list[1].kwargs["headers"]
+
+    def test_relative_redirect_keeps_same_origin_generated_credentials(self) -> None:
+        first = mock.Mock(status=302, retries=retry.Retry())
+        first.get_redirect_location.return_value = "/next"
+        second = mock.Mock(status=200, retries=retry.Retry())
+        second.get_redirect_location.return_value = None
+        pool = mock.Mock()
+        pool.urlopen.side_effect = [first, second]
+        pool.is_same_host.return_value = True
+        manager = PoolManager()
+        manager.connection_from_host = mock.Mock(return_value=pool)
+
+        manager.urlopen("GET", "http://user:pass@example.com/start")
+
+        assert pool.urlopen.call_args_list[1].kwargs["headers"]["Authorization"] == (
+            "Basic dXNlcjpwYXNz"
+        )
+
+    def test_same_origin_redirect_replaces_generated_credentials(self) -> None:
+        first = mock.Mock(status=302, retries=retry.Retry())
+        first.get_redirect_location.return_value = "http://bob:two@example.com/next"
+        second = mock.Mock(status=200, retries=retry.Retry())
+        second.get_redirect_location.return_value = None
+        pool = mock.Mock()
+        pool.urlopen.side_effect = [first, second]
+        pool.is_same_host.return_value = True
+        manager = PoolManager()
+        manager.connection_from_host = mock.Mock(return_value=pool)
+
+        manager.urlopen("GET", "http://alice:one@example.com/start")
+
+        assert pool.urlopen.call_args_list[0].kwargs["headers"]["Authorization"] == (
+            "Basic YWxpY2U6b25l"
+        )
+        assert pool.urlopen.call_args_list[1].kwargs["headers"]["Authorization"] == (
+            "Basic Ym9iOnR3bw=="
+        )
+
     @resolvesLocalhostFQDN()
     def test_same_url(self) -> None:
         # Convince ourselves that normally we don't get the same object

--- a/test/test_poolmanager.py
+++ b/test/test_poolmanager.py
@@ -30,9 +30,10 @@ class TestPoolManager:
         response.retries = retry.Retry()
         pool = mock.Mock()
         pool.urlopen.return_value = response
-        manager.connection_from_host = mock.Mock(return_value=pool)
-
-        manager.urlopen("GET", "http://user:p%40ss@example.com/path", headers=headers)
+        with mock.patch.object(manager, "connection_from_host", return_value=pool):
+            manager.urlopen(
+                "GET", "http://user:p%40ss@example.com/path", headers=headers
+            )
 
         assert headers == {"X-Test": "value"}
         sent_headers = pool.urlopen.call_args.kwargs["headers"]
@@ -98,9 +99,8 @@ class TestPoolManager:
         pool.urlopen.side_effect = [first, second]
         pool.is_same_host.return_value = False
         manager = PoolManager()
-        manager.connection_from_host = mock.Mock(return_value=pool)
-
-        manager.urlopen("GET", "http://user:pass@example.com/start")
+        with mock.patch.object(manager, "connection_from_host", return_value=pool):
+            manager.urlopen("GET", "http://user:pass@example.com/start")
 
         assert "Authorization" in pool.urlopen.call_args_list[0].kwargs["headers"]
         assert "Authorization" not in pool.urlopen.call_args_list[1].kwargs["headers"]
@@ -114,9 +114,8 @@ class TestPoolManager:
         pool.urlopen.side_effect = [first, second]
         pool.is_same_host.return_value = True
         manager = PoolManager()
-        manager.connection_from_host = mock.Mock(return_value=pool)
-
-        manager.urlopen("GET", "http://user:pass@example.com/start")
+        with mock.patch.object(manager, "connection_from_host", return_value=pool):
+            manager.urlopen("GET", "http://user:pass@example.com/start")
 
         assert pool.urlopen.call_args_list[1].kwargs["headers"]["Authorization"] == (
             "Basic dXNlcjpwYXNz"
@@ -131,9 +130,8 @@ class TestPoolManager:
         pool.urlopen.side_effect = [first, second]
         pool.is_same_host.return_value = True
         manager = PoolManager()
-        manager.connection_from_host = mock.Mock(return_value=pool)
-
-        manager.urlopen("GET", "http://alice:one@example.com/start")
+        with mock.patch.object(manager, "connection_from_host", return_value=pool):
+            manager.urlopen("GET", "http://alice:one@example.com/start")
 
         assert pool.urlopen.call_args_list[0].kwargs["headers"]["Authorization"] == (
             "Basic YWxpY2U6b25l"

--- a/test/test_poolmanager.py
+++ b/test/test_poolmanager.py
@@ -105,6 +105,32 @@ class TestPoolManager:
         assert "Authorization" in pool.urlopen.call_args_list[0].kwargs["headers"]
         assert "Authorization" not in pool.urlopen.call_args_list[1].kwargs["headers"]
 
+    def test_303_redirect_drops_body_state_and_generated_credentials(self) -> None:
+        first = mock.Mock(status=303, retries=retry.Retry())
+        first.get_redirect_location.return_value = "http://other.example/next"
+        second = mock.Mock(status=200, retries=retry.Retry())
+        second.get_redirect_location.return_value = None
+        pool = mock.Mock()
+        pool.urlopen.side_effect = [first, second]
+        pool.is_same_host.return_value = False
+        manager = PoolManager()
+
+        with mock.patch.object(manager, "connection_from_host", return_value=pool):
+            manager.urlopen(
+                "POST",
+                "http://user:pass@example.com/start",
+                body=iter([b"the data"]),
+                chunked=True,
+            )
+
+        first_call, second_call = pool.urlopen.call_args_list
+        assert first_call.kwargs["headers"]["Authorization"] == "Basic dXNlcjpwYXNz"
+        assert "Authorization" not in second_call.kwargs["headers"]
+        assert second_call.args[0] == "GET"
+        assert second_call.kwargs["body"] is None
+        assert second_call.kwargs["chunked"] is False
+        assert second_call.kwargs["body_pos"] is None
+
     def test_relative_redirect_keeps_same_origin_generated_credentials(self) -> None:
         first = mock.Mock(status=302, retries=retry.Retry())
         first.get_redirect_location.return_value = "/next"

--- a/test/test_proxymanager.py
+++ b/test/test_proxymanager.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from unittest import mock
+
 import pytest
 
 from urllib3.exceptions import (
@@ -17,6 +19,46 @@ from .port_helpers import find_unused_port
 
 
 class TestProxyManager:
+    @pytest.mark.parametrize("proxy_scheme", ["http", "https"])
+    def test_origin_and_proxy_credentials_stay_separate(
+        self, proxy_scheme: str
+    ) -> None:
+        response = mock.Mock(status=200, retries=Retry())
+        response.get_redirect_location.return_value = None
+        pool = mock.Mock()
+        pool.urlopen.return_value = response
+
+        with ProxyManager(
+            f"{proxy_scheme}://proxy-user:proxy-pass@proxy.example"
+        ) as manager:
+            manager.connection_from_host = mock.Mock(return_value=pool)
+            manager.urlopen("GET", "http://origin-user:origin-pass@example/target")
+
+            sent_headers = pool.urlopen.call_args.kwargs["headers"]
+            assert sent_headers["Authorization"] == (
+                "Basic b3JpZ2luLXVzZXI6b3JpZ2luLXBhc3M="
+            )
+            assert "Proxy-Authorization" not in sent_headers
+            assert manager.proxy_headers["Proxy-Authorization"] == (
+                "Basic cHJveHktdXNlcjpwcm94eS1wYXNz"
+            )
+
+    def test_proxy_url_credentials_are_stored_as_proxy_authorization(self) -> None:
+        headers = {"X-Test": "value"}
+        with ProxyManager(
+            "http://user:p%40ss@proxy.example", proxy_headers=headers
+        ) as p:
+            assert p.proxy.auth is None
+            assert p.proxy_headers["Proxy-Authorization"] == "Basic dXNlcjpwQHNz"
+            assert headers == {"X-Test": "value"}
+
+    def test_proxy_url_credentials_conflict_with_explicit_header(self) -> None:
+        with pytest.raises(ValueError, match="Proxy-Authorization header conflicts"):
+            ProxyManager(
+                "http://user:pass@proxy.example",
+                proxy_headers={"Proxy-Authorization": "Basic different"},
+            )
+
     @pytest.mark.parametrize("proxy_scheme", ["http", "https"])
     def test_proxy_headers(self, proxy_scheme: str) -> None:
         url = "http://pypi.org/project/urllib3/"

--- a/test/test_proxymanager.py
+++ b/test/test_proxymanager.py
@@ -31,8 +31,8 @@ class TestProxyManager:
         with ProxyManager(
             f"{proxy_scheme}://proxy-user:proxy-pass@proxy.example"
         ) as manager:
-            manager.connection_from_host = mock.Mock(return_value=pool)
-            manager.urlopen("GET", "http://origin-user:origin-pass@example/target")
+            with mock.patch.object(manager, "connection_from_host", return_value=pool):
+                manager.urlopen("GET", "http://origin-user:origin-pass@example/target")
 
             sent_headers = pool.urlopen.call_args.kwargs["headers"]
             assert sent_headers["Authorization"] == (
@@ -48,6 +48,7 @@ class TestProxyManager:
         with ProxyManager(
             "http://user:p%40ss@proxy.example", proxy_headers=headers
         ) as p:
+            assert p.proxy is not None
             assert p.proxy.auth is None
             assert p.proxy_headers["Proxy-Authorization"] == "Basic dXNlcjpwQHNz"
             assert headers == {"X-Test": "value"}

--- a/test/with_dummyserver/test_url_auth.py
+++ b/test/with_dummyserver/test_url_auth.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import socket
+import ssl
+from threading import Event
+
+from dummyserver.socketserver import DEFAULT_CA, DEFAULT_CERTS
+from dummyserver.testcase import SocketDummyServerTestCase
+from urllib3 import proxy_from_url
+
+
+class TestURLAuthOnWire(SocketDummyServerTestCase):
+    def test_http_forward_separates_proxy_credential_name(self) -> None:
+        captured: dict[str, bytes] = {}
+        done = Event()
+
+        def proxy_handler(listener: socket.socket) -> None:
+            sock = listener.accept()[0]
+            sock.settimeout(5)
+            try:
+                request = b""
+                while not request.endswith(b"\r\n\r\n"):
+                    chunk = sock.recv(65536)
+                    assert chunk, "connection closed before request headers"
+                    request += chunk
+                captured["request"] = request
+                sock.sendall(
+                    b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n"
+                    b"Connection: close\r\n\r\nOK"
+                )
+            finally:
+                sock.close()
+                done.set()
+
+        self._start_server(proxy_handler)
+        proxy_url = f"http://proxy-user:proxy-pass@{self.host}:{self.port}"
+        origin_url = "http://origin-user:origin-pass@example.com/path"
+
+        with proxy_from_url(proxy_url) as manager:
+            response = manager.request("GET", origin_url, timeout=5, retries=False)
+            assert response.status == 200
+
+        assert done.wait(5)
+        assert b"GET http://example.com/path HTTP/1.1" in captured["request"]
+        assert (
+            b"Proxy-Authorization: Basic cHJveHktdXNlcjpwcm94eS1wYXNz"
+            in captured["request"]
+        )
+        assert (
+            b"Authorization: Basic b3JpZ2luLXVzZXI6b3JpZ2luLXBhc3M="
+            in captured["request"]
+        )
+
+    def test_connect_separates_proxy_and_origin_credentials(self) -> None:
+        captured: dict[str, bytes] = {}
+        done = Event()
+
+        def proxy_handler(listener: socket.socket) -> None:
+            sock = listener.accept()[0]
+            sock.settimeout(5)
+            try:
+                request = b""
+                while not request.endswith(b"\r\n\r\n"):
+                    chunk = sock.recv(65536)
+                    assert chunk, "connection closed before CONNECT headers"
+                    request += chunk
+                captured["connect"] = request
+                sock.sendall(b"HTTP/1.1 200 Connection Established\r\n\r\n")
+
+                context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+                context.load_cert_chain(
+                    DEFAULT_CERTS["certfile"], DEFAULT_CERTS["keyfile"]
+                )
+                tls_sock = context.wrap_socket(sock, server_side=True)
+                request = b""
+                while not request.endswith(b"\r\n\r\n"):
+                    chunk = tls_sock.recv(65536)
+                    assert chunk, "connection closed before origin headers"
+                    request += chunk
+                captured["origin"] = request
+                tls_sock.sendall(
+                    b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n"
+                    b"Connection: close\r\n\r\nOK"
+                )
+                tls_sock.close()
+            finally:
+                done.set()
+
+        self._start_server(proxy_handler)
+        proxy_url = f"http://proxy-user:proxy-pass@{self.host}:{self.port}"
+        origin_url = f"https://origin-user:origin-pass@{self.host}:443/"
+
+        with proxy_from_url(proxy_url, ca_certs=DEFAULT_CA) as manager:
+            response = manager.request("GET", origin_url, timeout=5, retries=False)
+            assert response.status == 200
+
+        assert done.wait(5)
+        assert (
+            b"Proxy-Authorization: Basic cHJveHktdXNlcjpwcm94eS1wYXNz"
+            in captured["connect"]
+        )
+        assert b"\r\nAuthorization:" not in captured["connect"]
+        assert (
+            b"Authorization: Basic b3JpZ2luLXVzZXI6b3JpZ2luLXBhc3M="
+            in captured["origin"]
+        )
+        assert b"Proxy-Authorization:" not in captured["origin"]


### PR DESCRIPTION
Fixes #1999.

URL userinfo now produces Basic `Authorization` headers for requests and `Proxy-Authorization` headers for HTTP/HTTPS proxies. Userinfo is removed from request targets and stored proxy URLs. Conflicting explicit headers raise `ValueError` without modifying the caller's headers.

The change also handles `connection_from_url()` defaults, separates credentialed connection pools, and carries URL-generated authorization through retries and redirects. New URL credentials can replace previously generated credentials; caller-supplied conflicting authorization is still rejected. Cross-host redirects retain the existing `Retry.remove_headers_on_redirect` policy.

Tests cover percent-encoded credentials, explicit/duplicate/bytes-valued headers, pool separation, redirects, and real local HTTP forwarding and CONNECT-to-TLS traffic. The CONNECT test verifies that origin authorization is absent from CONNECT and proxy authorization is absent from the tunneled origin request.

Validation on Linux / CPython 3.14.4:

- Top-level unit tests plus `test/with_dummyserver/test_url_auth.py`: **1490 passed, 22 skipped**.
- Black, isort, flake8, and `git diff --check` passed.
- Mypy 1.20.2 (the CI-pinned version): no issues in the 36 library modules and four changed test modules. The initial CI test-mocking errors are corrected in the follow-up commit; affected tests pass (171 passed, 1 skipped).
- Local full `test/` coverage runs hit a PyOpenSSL timeout on both unchanged upstream and this branch in the isolated local-socket environment. Upstream CI subsequently completed successfully on commit `217ba4e`: all 37 reported checks passed, including the Linux/macOS/Windows matrix, integration and browser checks, downstream Requests/Botocore tests, and coverage. The combined coverage report is 3941 statements, 0 missed (100%). [CI run](https://github.com/urllib3/urllib3/actions/runs/34244266572).

This contribution was developed with AI assistance, including implementation, review, and local test execution.


Updated against upstream main `3f587c6`, including the 303 body-framing fix, retry-method deprecation and URL-encoding changes. A new regression verifies that a cross-host 303 redirect from a credentialed URL drops generated authorization, switches to GET and clears body/chunked/rewind state.

Validation of the updated branch: 172 authentication/pool/proxy/local-wire tests passed (1 skipped) in an isolated Linux environment; Black, isort, flake8 and mypy (40 files) passed. Additional Windows checks passed 637 retry/URL tests (24 skipped) and 8 local-server 303 tests. Upstream CI for commit `b409865` completed successfully: all 31 CI jobs passed, including combined coverage. All 38 reported PR checks/statuses passed, including Requests/Botocore downstream tests, lint, CodeQL and documentation. [Updated CI run](https://github.com/urllib3/urllib3/actions/runs/34297148981).

