### PR TITLE
Add opt-in Retry-After limit errors with transport regression tests

### DIFF
--- a/changelog/1338.feature.rst
+++ b/changelog/1338.feature.rst
@@ -1,0 +1,1 @@
+Added ``Retry(raise_on_retry_after=True)`` to raise :class:`~urllib3.exceptions.RetryAfterError` when a parsed Retry-After delay exceeds ``retry_after_max``, retaining the server-requested delay for scheduling a later attempt. The default behavior continues to cap the delay.

--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -629,6 +629,40 @@ specify the retry at the :class:`~urllib3.poolmanager.PoolManager` level:
 You still override this pool-level retry policy by specifying ``retries`` to
 :meth:`~urllib3.PoolManager.request`.
 
+Limiting Retry-After delays
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A server can request a delay between attempts using the ``Retry-After`` header.
+Connect and read timeouts do not limit this delay. By default, urllib3 caps it
+at ``Retry.retry_after_max`` (six hours).
+
+To stop instead of waiting when a server requests more time than you allow,
+enable ``raise_on_retry_after``:
+
+.. code-block:: python
+
+    import urllib3
+    from urllib3.exceptions import RetryAfterError
+
+    retries = urllib3.Retry(retry_after_max=60, raise_on_retry_after=True)
+    try:
+        response = urllib3.request("GET", "https://example.com/", retries=retries)
+    except RetryAfterError as error:
+        print(f"Server requested {error.retry_after} seconds; limit is {error.retry_after_max}")
+        # Schedule another attempt in your application instead of waiting here.
+
+``RetryAfterError.retry_after`` contains the server-requested delay before
+capping. For an HTTP-date header, it is the remaining duration when the header
+was parsed. The exception preserves these attributes when pickled. A delay
+equal to the limit is allowed; a limit of zero rejects every positive delay.
+
+This option applies when urllib3 processes a Retry-After header for a retry,
+and to redirects handled directly by a connection pool. Redirects handled by
+``PoolManager`` currently do not process Retry-After headers. Disabling retries
+or disabling header handling with ``respect_retry_after_header=False`` in
+``Retry.sleep()`` does not enable a new delay check. This is not an overall
+request deadline and does not limit exponential backoff.
+
 Errors & Exceptions
 -------------------
 

--- a/dummyserver/app.py
+++ b/dummyserver/app.py
@@ -261,7 +261,9 @@ async def redirect_after() -> ResponseReturnValue:
         retry_after = "1"
     target = params.get("target", "/")
     headers = [("Location", target), ("Retry-After", retry_after)]
-    return await make_response("", 303, headers)
+    return await make_response(
+        params.get("body", ""), params.get("status", "303"), headers
+    )
 
 
 @hypercorn_app.route("/retry_after")

--- a/src/urllib3/exceptions.py
+++ b/src/urllib3/exceptions.py
@@ -213,6 +213,27 @@ class URLSchemeUnknown(LocationValueError):
         self.scheme = scheme
 
 
+class RetryAfterError(HTTPError):
+    """A Retry-After header requested a delay longer than the configured limit.
+
+    :param float retry_after: The server-requested delay in seconds, before
+        applying the limit. For an HTTP-date, this is relative to the time the
+        header was parsed.
+    :param int retry_after_max: The configured maximum delay in seconds.
+    """
+
+    def __init__(self, retry_after: float, retry_after_max: int) -> None:
+        self.retry_after = retry_after
+        self.retry_after_max = retry_after_max
+        super().__init__(
+            f"Retry-After delay of {retry_after} seconds exceeds "
+            f"the maximum of {retry_after_max} seconds"
+        )
+
+    def __reduce__(self) -> _TYPE_REDUCE_RESULT:
+        return type(self), (self.retry_after, self.retry_after_max)
+
+
 class ResponseError(HTTPError):
     """Used as a container for an error reason supplied in a MaxRetryError."""
 

--- a/src/urllib3/util/retry.py
+++ b/src/urllib3/util/retry.py
@@ -19,6 +19,7 @@ from ..exceptions import (
     ProxyError,
     ReadTimeoutError,
     ResponseError,
+    RetryAfterError,
 )
 from .util import reraise
 
@@ -192,7 +193,13 @@ class Retry:
     :param int retry_after_max: Number of seconds to allow as the maximum for
         Retry-After headers. Defaults to :attr:`Retry.DEFAULT_RETRY_AFTER_MAX`.
         Any Retry-After headers larger than this value will be limited to this
-        value.
+        value unless ``raise_on_retry_after`` is enabled.
+
+    :param bool raise_on_retry_after:
+        If True, raise :class:`~urllib3.exceptions.RetryAfterError` when parsing
+        a Retry-After header whose delay exceeds ``retry_after_max``. The
+        exception contains the uncapped delay so callers can schedule a later
+        attempt. If False (the default), the delay is capped instead.
     """
 
     #: Default methods to be used for ``allowed_methods``
@@ -240,6 +247,7 @@ class Retry:
         ] = DEFAULT_REMOVE_HEADERS_ON_REDIRECT,
         backoff_jitter: float = 0.0,
         retry_after_max: int = DEFAULT_RETRY_AFTER_MAX,
+        raise_on_retry_after: bool = False,
     ) -> None:
         self.total = total
         self.connect = connect
@@ -266,6 +274,7 @@ class Retry:
         self.backoff_factor = backoff_factor
         self.backoff_max = backoff_max
         self.retry_after_max = retry_after_max
+        self.raise_on_retry_after = raise_on_retry_after
         self.raise_on_redirect = raise_on_redirect
         self.raise_on_status = raise_on_status
         self.history = history or ()
@@ -288,6 +297,7 @@ class Retry:
             backoff_factor=self.backoff_factor,
             backoff_max=self.backoff_max,
             retry_after_max=self.retry_after_max,
+            raise_on_retry_after=self.raise_on_retry_after,
             raise_on_redirect=self.raise_on_redirect,
             raise_on_status=self.raise_on_status,
             history=self.history,
@@ -354,6 +364,8 @@ class Retry:
 
         # Check the seconds do not exceed the specified maximum
         if seconds > self.retry_after_max:
+            if self.raise_on_retry_after:
+                raise RetryAfterError(seconds, self.retry_after_max)
             seconds = self.retry_after_max
 
         return seconds

--- a/test/test_exceptions.py
+++ b/test/test_exceptions.py
@@ -21,10 +21,22 @@ from urllib3.exceptions import (
     NameResolutionError,
     NewConnectionError,
     ReadTimeoutError,
+    RetryAfterError,
 )
 
 
 class TestPickle:
+    @pytest.mark.parametrize("delay", [3600, 3599.5, 10**100])
+    def test_retry_after_error(self, delay: float) -> None:
+        exception = RetryAfterError(delay, 60)
+        restored = pickle.loads(pickle.dumps(exception))
+        assert isinstance(restored, RetryAfterError)
+        assert restored.retry_after == delay
+        assert restored.retry_after_max == 60
+        assert str(restored) == str(exception)
+        assert str(delay) in str(restored)
+        assert "60" in str(restored)
+
     @pytest.mark.parametrize(
         "exception",
         [

--- a/test/test_retry.py
+++ b/test/test_retry.py
@@ -12,6 +12,7 @@ from urllib3.exceptions import (
     MaxRetryError,
     ReadTimeoutError,
     ResponseError,
+    RetryAfterError,
     SSLError,
 )
 from urllib3.response import HTTPResponse
@@ -192,6 +193,74 @@ class TestRetry:
         retry = Retry(retry_after_max=1)
         assert retry.parse_retry_after(str(1)) == 1
         assert retry.parse_retry_after(str(2)) == 1
+
+    @pytest.mark.parametrize("delay", [61, 3600, 10**100])
+    def test_raise_on_retry_after(self, delay: int) -> None:
+        retry = Retry(retry_after_max=60, raise_on_retry_after=True)
+        response = HTTPResponse(status=503, headers={"Retry-After": str(delay)})
+        with mock.patch("time.sleep") as sleep:
+            with pytest.raises(RetryAfterError) as exc:
+                retry.sleep(response)
+        assert exc.value.retry_after == delay
+        assert exc.value.retry_after_max == 60
+        sleep.assert_not_called()
+
+    @pytest.mark.parametrize("limit, delay", [(0, 0), (60, 0), (60, 1), (60, 60)])
+    def test_raise_on_retry_after_within_limit(self, limit: int, delay: int) -> None:
+        retry = Retry(retry_after_max=limit, raise_on_retry_after=True)
+        with mock.patch("time.sleep") as sleep:
+            retry.sleep(HTTPResponse(status=503, headers={"Retry-After": str(delay)}))
+        if delay:
+            sleep.assert_called_once_with(delay)
+        else:
+            sleep.assert_not_called()
+
+    def test_raise_on_retry_after_zero_limit(self) -> None:
+        with pytest.raises(RetryAfterError) as exc:
+            Retry(retry_after_max=0, raise_on_retry_after=True).parse_retry_after("1")
+        assert exc.value.retry_after == 1
+        assert exc.value.retry_after_max == 0
+
+    def test_raise_on_retry_after_date(self) -> None:
+        retry = Retry(retry_after_max=60, raise_on_retry_after=True)
+        with mock.patch("time.time", return_value=0.5):
+            with pytest.raises(RetryAfterError) as exc:
+                retry.parse_retry_after("Thu, 01 Jan 1970 01:00:00 GMT")
+            assert retry.parse_retry_after("Thu, 01 Jan 1970 00:00:00 GMT") == 0
+        assert exc.value.retry_after == 3599.5
+        assert exc.value.retry_after_max == 60
+
+    def test_raise_on_retry_after_propagated(self) -> None:
+        class CustomRetry(Retry):
+            pass
+
+        retry = CustomRetry(retry_after_max=60, raise_on_retry_after=True)
+        updated = retry.increment(method="GET", response=HTTPResponse(status=503))
+        assert isinstance(updated, CustomRetry)
+        with pytest.raises(RetryAfterError):
+            updated.parse_retry_after("61")
+        assert updated.new(raise_on_retry_after=False).parse_retry_after("61") == 60
+
+    @pytest.mark.parametrize("headers", [{}, {"Retry-After": "3600"}])
+    def test_raise_on_retry_after_backoff(self, headers: dict[str, str]) -> None:
+        retry = (
+            Retry(
+                retry_after_max=60,
+                raise_on_retry_after=True,
+                respect_retry_after_header=False,
+                backoff_factor=1,
+            )
+            .increment()
+            .increment()
+        )
+        with mock.patch("time.sleep") as sleep:
+            retry.sleep(HTTPResponse(status=503, headers=headers))
+        sleep.assert_called_once_with(2)
+
+    @pytest.mark.parametrize("raise_on_retry_after", [False, True])
+    def test_retry_after_missing_header(self, raise_on_retry_after: bool) -> None:
+        retry = Retry(raise_on_retry_after=raise_on_retry_after)
+        assert retry.get_retry_after(HTTPResponse(status=503)) is None
 
     def test_backoff_jitter(self) -> None:
         """Backoff with jitter is computed correctly"""
@@ -376,8 +445,11 @@ class TestRetry:
         assert retry.remove_headers_on_redirect == {"x-api-secret"}
 
     @pytest.mark.parametrize("value", ["-1", "+1", "1.0", "\xb2"])  # \xb2 = ^2
-    def test_parse_retry_after_invalid(self, value: str) -> None:
-        retry = Retry()
+    @pytest.mark.parametrize("raise_on_retry_after", [False, True])
+    def test_parse_retry_after_invalid(
+        self, value: str, raise_on_retry_after: bool
+    ) -> None:
+        retry = Retry(raise_on_retry_after=raise_on_retry_after)
         with pytest.raises(InvalidHeader):
             retry.parse_retry_after(value)
 

--- a/test/with_dummyserver/test_connectionpool.py
+++ b/test/with_dummyserver/test_connectionpool.py
@@ -16,7 +16,7 @@ import pytest
 
 from dummyserver.socketserver import NoIPv6Warning
 from dummyserver.testcase import HypercornDummyServerTestCase, SocketDummyServerTestCase
-from urllib3 import HTTPConnectionPool, encode_multipart_formdata
+from urllib3 import HTTPConnectionPool, PoolManager, encode_multipart_formdata
 from urllib3._collections import HTTPHeaderDict
 from urllib3.connection import _get_default_user_agent
 from urllib3.exceptions import (
@@ -27,6 +27,7 @@ from urllib3.exceptions import (
     NameResolutionError,
     NewConnectionError,
     ReadTimeoutError,
+    RetryAfterError,
     UnrewindableBodyError,
 )
 from urllib3.fields import _TYPE_FIELD_VALUE_TUPLE
@@ -1324,6 +1325,80 @@ class TestRetry(HypercornDummyServerTestCase):
 
 
 class TestRetryAfter(HypercornDummyServerTestCase):
+    @pytest.mark.parametrize("use_manager", [False, True])
+    @pytest.mark.parametrize("preload_content", [False, True])
+    def test_excessive_delay_aborts_status_retry(
+        self, use_manager: bool, preload_content: bool
+    ) -> None:
+        retry = Retry(retry_after_max=0, raise_on_retry_after=True)
+        with PoolManager(maxsize=1, block=True) as manager:
+            pool = manager.connection_from_host(self.host, self.port)
+            client = manager if use_manager else pool
+            prefix = f"http://{self.host}:{self.port}" if use_manager else ""
+            with mock.patch("time.sleep") as sleep:
+                with pytest.raises(RetryAfterError) as exc:
+                    client.request(
+                        "GET",
+                        f"{prefix}/redirect_after?status=503&body=retry-later",
+                        retries=retry,
+                        preload_content=preload_content,
+                        timeout=LONG_TIMEOUT,
+                    )
+            assert exc.value.retry_after == 1
+            assert exc.value.retry_after_max == 0
+            sleep.assert_not_called()
+            assert pool.num_requests == 1
+
+            # The rejected response's body must be drained and the sole pool
+            # connection returned, including when preload_content=False.
+            response = client.request("GET", f"{prefix}/", pool_timeout=SHORT_TIMEOUT)
+            assert response.status == 200
+            assert response.data == b"Dummy server!"
+            assert pool.num_requests == 2
+            assert pool.num_connections == 1
+
+    @pytest.mark.parametrize("preload_content", [False, True])
+    def test_excessive_delay_aborts_redirect(self, preload_content: bool) -> None:
+        with HTTPConnectionPool(self.host, self.port, maxsize=1, block=True) as pool:
+            with mock.patch("time.sleep") as sleep:
+                with pytest.raises(RetryAfterError):
+                    pool.request(
+                        "GET",
+                        "/redirect_after?body=retry-later",
+                        retries=Retry(retry_after_max=0, raise_on_retry_after=True),
+                        preload_content=preload_content,
+                    )
+            sleep.assert_not_called()
+            assert pool.num_requests == 1
+            assert pool.request("GET", "/", pool_timeout=SHORT_TIMEOUT).status == 200
+            assert pool.num_connections == 1
+
+    @pytest.mark.parametrize(
+        "retry",
+        [
+            Retry(retry_after_max=0),
+            Retry(retry_after_max=0, raise_on_retry_after=False),
+        ],
+    )
+    def test_retry_after_default_still_caps(self, retry: Retry) -> None:
+        with HTTPConnectionPool(self.host, self.port) as pool:
+            with mock.patch("time.sleep") as sleep:
+                response = pool.request("GET", "/redirect_after", retries=retry)
+            assert response.status == 200
+            assert pool.num_requests == 2
+            sleep.assert_not_called()
+
+    def test_excessive_delay_ignored_when_headers_disabled(self) -> None:
+        retry = Retry(
+            retry_after_max=0,
+            raise_on_retry_after=True,
+            respect_retry_after_header=False,
+        )
+        with HTTPConnectionPool(self.host, self.port) as pool:
+            response = pool.request("GET", "/redirect_after?status=503", retries=retry)
+            assert response.status == 503
+            assert pool.num_requests == 1
+
     def test_retry_after(self) -> None:
         # Request twice in a second to get a 429 response.
         with HTTPConnectionPool(self.host, self.port) as pool:


### PR DESCRIPTION
When a server sends `Retry-After: 3600`, `Retry(retry_after_max=60)` currently waits 60 seconds and retries. This adds opt-in `raise_on_retry_after=True` to raise `RetryAfterError` before sleeping instead. The error preserves the uncapped delay and configured limit so callers can schedule a later attempt. Defaults continue to cap the delay, and connect/read timeouts keep their existing meaning.

Addresses #1338. I reviewed #3233, #5010, and #5227 before preparing this change. In particular, #5227 proposes the same core API; this is an overlapping implementation, not a claim of priority. This version adds deterministic real-503 tests with nonempty response bodies, request-count assertions, both `HTTPConnectionPool` and `PoolManager`, and a user-guide example. If you prefer consolidating those tests/docs into an existing PR, that would also resolve the issue.

The option survives `Retry.new()`/`increment()` and exception pickling. Tests cover numeric and HTTP-date delays, exact and zero boundaries, large integer delays, ignored/malformed headers, default behavior, and successful connection reuse after aborting, with and without response preloading. The existing dummy-server endpoint accepts optional status/body values to make the transport tests deterministic.

Scope: this checks the delay wherever `Retry` parses a `Retry-After` header. `PoolManager` redirects currently do not process that header; this PR documents that existing limitation and does not change redirect policy or add an overall request deadline.

Validation on Linux, CPython 3.11.15, against base `3f587c61a1a6c72c71c76193e5b863fb0c1180a1`:

- Full local suite: **2,398 passed, 288 skipped, 4 xfailed**. Optional integration-mode tests were not enabled; IPv6 is unavailable on this host. No Windows/macOS runtime tests were run locally.
- Focused retry/exception/transport tests after formatting: **115 passed**.
- Statement coverage: **100%** for `src/urllib3/util/retry.py` and `src/urllib3/exceptions.py`.
- All pre-commit hooks passed; wheel and sdist build passed.
- Mypy targeting Python 3.13 passed for all 83 source files. The standard Python 3.12 mypy session reports one `ClassVar[Final[...]]` error at `connection.py:146`; the untouched base reproduces the same error.
- Fresh Sphinx HTML build completes but fails `-W` on four existing unresolved-reference warnings (`connection._TYPE_SOCKET_OPTIONS` three times and `Retry.respect_retry_after_header` once). The untouched base reproduces exactly those four warnings; no new documentation warnings remain.

Reproduction commands:

```sh
uv sync --frozen --group dev --group mypy --group docs --all-extras
.venv/bin/python -m coverage run --parallel-mode -m pytest test/ -q --strict-config --strict-markers --disable-socket --allow-unix-socket --allow-hosts=localhost,127.0.0.1,::1,127.0.0.0,240.0.0.0
.venv/bin/python -m pytest test/test_retry.py test/test_exceptions.py test/with_dummyserver/test_connectionpool.py::TestRetryAfter -q --disable-socket --allow-unix-socket --allow-hosts=localhost,127.0.0.1,::1,127.0.0.0,240.0.0.0
uvx nox -s lint
uvx nox -s mypy
.nox/mypy/bin/mypy --python-version 3.13 -p dummyserver -m noxfile -p urllib3 -p test
.venv/bin/sphinx-build -E -b html -W docs docs/_build/review-html
.venv/bin/python -m build
```

`nox -s lint` includes mypy and therefore encounters the baseline error described above; its pre-commit stage passes. The full suite was run before the final formatting-only changes, followed by the focused suite afterward.

Implementation, review, tests, and this description were prepared with OpenAI Codex assistance. The reported commands were actually run locally; no separate human code review is claimed.
