### PR TITLE
Read the request body in dummyserver handlers that ignore it

### DIFF
--- a/changelog/5239.misc.rst
+++ b/changelog/5239.misc.rst
@@ -1,0 +1,1 @@
+Fixed dummyserver handlers that left an unread request body in the socket.

--- a/dummyserver/app.py
+++ b/dummyserver/app.py
@@ -60,6 +60,7 @@ async def certificate() -> ResponseReturnValue:
 @pyodide_testing_app.route("/specific_method", methods=["GET", "POST", "PUT"])
 async def specific_method() -> ResponseReturnValue:
     "Confirm that the request matches the desired method type"
+    await request.get_data(parse_form_data=True)
     method_param = (await request.values).get("method", "")
 
     if request.method.upper() == method_param.upper():
@@ -73,6 +74,7 @@ async def specific_method() -> ResponseReturnValue:
 @hypercorn_app.route("/upload", methods=["POST"])
 async def upload() -> ResponseReturnValue:
     "Confirm that the uploaded file conforms to specification"
+    await request.get_data(parse_form_data=True)
     params = await request.form
     param = params.get("upload_param")
     filename_param = params.get("upload_filename")
@@ -135,10 +137,11 @@ async def keepalive() -> ResponseReturnValue:
 @hypercorn_app.route("/echo", methods=["GET", "POST", "PUT"])
 async def echo() -> ResponseReturnValue:
     "Echo back the params"
+    data = await request.get_data()
     if request.method == "GET":
         return await make_response(request.query_string)
 
-    return await make_response(await request.get_data())
+    return await make_response(data)
 
 
 @hypercorn_app.route("/echo_json", methods=["POST"])
@@ -169,6 +172,7 @@ async def echo_params() -> ResponseReturnValue:
 
 @hypercorn_app.route("/headers", methods=["GET", "POST"])
 async def headers() -> ResponseReturnValue:
+    await request.get_data()
     return await make_response(dict(request.headers.items()))
 
 
@@ -184,6 +188,7 @@ async def headers_and_params() -> ResponseReturnValue:
 
 @hypercorn_app.route("/multi_headers", methods=["GET", "POST"])
 async def multi_headers() -> ResponseReturnValue:
+    await request.get_data()
     return await make_response({"headers": list(request.headers)})
 
 
@@ -299,6 +304,7 @@ async def successful_retry() -> ResponseReturnValue:
 
     It's not currently very flexible as the number of retries is hard-coded.
     """
+    await request.get_data()
     test_name = request.headers.get("test-name", None)
     if not test_name:
         return await make_response("test-name header not set", 400)

--- a/test/with_dummyserver/test_connectionpool.py
+++ b/test/with_dummyserver/test_connectionpool.py
@@ -677,6 +677,42 @@ class TestConnectionPool(HypercornDummyServerTestCase):
                 b"--boundary--\r\n",
             ]
 
+    @pytest.mark.parametrize(
+        "method,url",
+        [
+            ("GET", "/echo"),
+            ("POST", "/echo"),
+            ("POST", "/headers"),
+            ("POST", "/multi_headers"),
+            ("POST", "/redirect?target=/"),
+            ("POST", "/specific_method?method=POST"),
+            ("PUT", "/successful_retry"),
+            ("POST", "/upload"),
+        ],
+    )
+    def test_handler_reads_the_request_body(self, method: str, url: str) -> None:
+        """A body the handler has no use for still has to leave the socket.
+
+        Anything left behind is read as the start of the next request made on
+        that connection, which then never gets a response. The body has to be
+        larger than the socket buffers for that to happen.
+        """
+        with HTTPConnectionPool(self.host, self.port, maxsize=1) as pool:
+            pool.request(
+                method,
+                url,
+                body=b"x" * (2 * 1024 * 1024),
+                headers={"test-name": "test_handler_reads_the_request_body"},
+                redirect=False,
+                retries=False,
+            )
+
+            # A generous timeout, so that a handler that stops reading the
+            # body fails the test instead of hanging it.
+            response = pool.request("GET", "/", timeout=10, retries=False)
+            assert response.status == 200
+            assert pool.num_connections == 1, "the connection was not reused"
+
     def test_check_gzip(self) -> None:
         with HTTPConnectionPool(self.host, self.port) as pool:
             r = pool.request(

--- a/test/with_dummyserver/test_connectionpool.py
+++ b/test/with_dummyserver/test_connectionpool.py
@@ -677,42 +677,6 @@ class TestConnectionPool(HypercornDummyServerTestCase):
                 b"--boundary--\r\n",
             ]
 
-    @pytest.mark.parametrize(
-        "method,url",
-        [
-            ("GET", "/echo"),
-            ("POST", "/echo"),
-            ("POST", "/headers"),
-            ("POST", "/multi_headers"),
-            ("POST", "/redirect?target=/"),
-            ("POST", "/specific_method?method=POST"),
-            ("PUT", "/successful_retry"),
-            ("POST", "/upload"),
-        ],
-    )
-    def test_handler_reads_the_request_body(self, method: str, url: str) -> None:
-        """A body the handler has no use for still has to leave the socket.
-
-        Anything left behind is read as the start of the next request made on
-        that connection, which then never gets a response. The body has to be
-        larger than the socket buffers for that to happen.
-        """
-        with HTTPConnectionPool(self.host, self.port, maxsize=1) as pool:
-            pool.request(
-                method,
-                url,
-                body=b"x" * (2 * 1024 * 1024),
-                headers={"test-name": "test_handler_reads_the_request_body"},
-                redirect=False,
-                retries=False,
-            )
-
-            # A generous timeout, so that a handler that stops reading the
-            # body fails the test instead of hanging it.
-            response = pool.request("GET", "/", timeout=10, retries=False)
-            assert response.status == 200
-            assert pool.num_connections == 1, "the connection was not reused"
-
     def test_check_gzip(self) -> None:
         with HTTPConnectionPool(self.host, self.port) as pool:
             r = pool.request(


### PR DESCRIPTION
Follow-up to #5161, where @illia-v asked whether the body drain added to `/redirect` should go to the other dummyserver handlers as well.

## The problem

A handler that answers without reading the request body leaves it in the socket. Hypercorn then reads those leftover bytes as the start of the next request on that connection, and the next request never gets a response, a read timeout, or a hang for a client without one.

Six handlers left a body behind on at least one code path:

| Handler | Methods | Before |
|---|---|---|
| `/echo` | GET, POST, PUT | GET returns the query string without reading |
| `/headers` | GET, POST | never reads |
| `/multi_headers` | GET, POST | never reads |
| `/specific_method` | GET, POST, PUT | `request.values`, which parses a body only for form content types |
| `/successful_retry` | GET, PUT | never reads |
| `/upload` | POST | `request.form`, which reads nothing from a non-form body |

Each one now reads the body first, with `parse_form_data=True` where the handler goes on to use `request.form` or `request.values`, matching `/redirect` and the existing `pyodide_upload`.

## Why nothing noticed

A small body fits in the socket buffers and hypercorn discards it with the rest of the connection state. The desynchronization only shows up once the body is larger than those buffers, on this machine the threshold sits between 256 KiB and 512 KiB, which is well above anything the test suite sends.

## Verification

I checked each handler with a throwaway test that sent a 2 MiB body and then made a second request on the same connection, asserting the connection was reused. Six of its eight parametrizations failed on `main` and all eight passed with this change:

```
FAILED ...[GET-/echo]
FAILED ...[POST-/headers]
FAILED ...[POST-/multi_headers]
FAILED ...[POST-/specific_method?method=POST]
FAILED ...[PUT-/successful_retry]
FAILED ...[POST-/upload]
6 failed, 2 passed
```

The two that passed either way were `POST /echo`, which always read the body, and `POST /redirect`, which reads it since #5161.

That test is not part of this PR, per review, dummyserver is scaffolding rather than something to test in its own right.

`test/with_dummyserver/` is otherwise unchanged: same failure set and same pass count before and after.

## What I did not do

**A blanket `before_request` hook.** It is the obvious generalization, and I tried it first:

```python
@hypercorn_app.before_request
@pyodide_testing_app.before_request
async def read_request_body() -> None:
    await request.get_data(parse_form_data=True)
```

It breaks four tests. `parse_form_data=True` consumes a multipart body into `request.form`, so `/echo` then echoes back an empty body and `test_post_with_multipart` fails. Dropping `parse_form_data` instead breaks every handler that reads `request.form` or `request.values`, which is the original `/redirect` bug. The per-handler call lets each one ask for what it actually needs.

**`OPTIONS` paths.** `/echo_json` and `pyodide_upload` return early for `OPTIONS` without reading the body, but a CORS preflight does not carry one, and on the hypercorn app `/echo_json` is registered for `POST` only.
