### PR TITLE
Construct authentication headers from URL userinfo

### DIFF
--- a/changelog/1999.bugfix.rst
+++ b/changelog/1999.bugfix.rst
@@ -1,0 +1,2 @@
+Constructed ``Authorization`` and ``Proxy-Authorization`` headers from URL
+userinfo credentials, including percent-decoded credentials.

--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -42,7 +42,11 @@ from .exceptions import (
 from .response import BaseHTTPResponse
 from .util.connection import is_connection_dropped
 from .util.proxy import connection_requires_http_tunnel
-from .util.request import _TYPE_BODY_POSITION, set_file_position
+from .util.request import (
+    _TYPE_BODY_POSITION,
+    _set_header_from_auth,
+    set_file_position,
+)
 from .util.retry import Retry
 from .util.ssl_match_hostname import CertificateError
 from .util.timeout import _DEFAULT_TIMEOUT, _TYPE_DEFAULT, Timeout
@@ -709,6 +713,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
             auto-populate the value when needed.
         """
         # Ensure that the URL we're connecting to is properly encoded
+        parsed_url: Url | None = None
         if url.startswith("/"):
             # URLs starting with / are inherently schemeless.
             url = to_str(_encode_target(url))
@@ -716,10 +721,15 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         else:
             parsed_url = parse_url(url)
             destination_scheme = parsed_url.scheme
-            url = to_str(parsed_url._replace(fragment=None).url)
+            url = to_str(parsed_url._replace(auth=None, fragment=None).url)
 
         if headers is None:
             headers = self.headers
+
+        if parsed_url is not None and parsed_url.auth is not None:
+            headers = _set_header_from_auth(
+                parsed_url.auth_decoded_joined, headers, "authorization"
+            )
 
         if not isinstance(retries, Retry):
             retries = Retry.from_int(retries, redirect=redirect, default=self.retries)

--- a/src/urllib3/poolmanager.py
+++ b/src/urllib3/poolmanager.py
@@ -20,6 +20,7 @@ from .exceptions import (
 from .response import BaseHTTPResponse
 from .util.connection import _TYPE_SOCKET_OPTIONS
 from .util.proxy import connection_requires_http_tunnel
+from .util.request import _set_header_from_auth
 from .util.retry import Retry
 from .util.timeout import Timeout
 from .util.url import Url, parse_url
@@ -450,11 +451,20 @@ class PoolManager(RequestMethods):
         kw["assert_same_host"] = False
         kw["redirect"] = False
 
-        if "headers" not in kw:
-            kw["headers"] = self.headers
+        headers = kw.get("headers", self.headers)
+        if headers is None:
+            headers = self.headers
+        if u.auth is not None:
+            headers = _set_header_from_auth(
+                u.auth_decoded_joined, headers, "authorization"
+            )
+        kw["headers"] = headers
 
         if self._proxy_requires_url_absolute_form(u):
-            response = conn.urlopen(method, u._replace(fragment=None).url, **kw)
+            # Userinfo is used to construct the Authorization header and must
+            # not be sent in the absolute-form request target to a proxy.
+            request_url = u._replace(auth=None, fragment=None).url
+            response = conn.urlopen(method, request_url, **kw)
         else:
             response = conn.urlopen(method, u.request_uri, **kw)
 
@@ -611,7 +621,11 @@ class ProxyManager(PoolManager):
             proxy = proxy._replace(port=port)
 
         self.proxy = proxy
-        self.proxy_headers = proxy_headers or {}
+        self.proxy_headers = _set_header_from_auth(
+            proxy.auth_decoded_joined,
+            HTTPHeaderDict(proxy_headers or {}),
+            "proxy-authorization",
+        )
         self.proxy_config = ProxyConfig(
             proxy_ssl_context,
             use_forwarding_for_https,

--- a/src/urllib3/util/request.py
+++ b/src/urllib3/util/request.py
@@ -6,6 +6,7 @@ import typing
 from base64 import b64encode
 from enum import Enum
 
+from .._collections import HTTPHeaderDict
 from ..exceptions import UnrewindableBodyError
 from .util import to_bytes
 
@@ -171,6 +172,35 @@ def make_headers(
         headers["cache-control"] = "no-cache"
 
     return headers
+
+
+def _set_header_from_auth(
+    auth: str | None, headers: typing.Mapping[str, str], header_name: str
+) -> typing.Mapping[str, str]:
+    """Set a Basic auth header from URL userinfo without mutating ``headers``."""
+    if auth is None:
+        return headers
+
+    if header_name == "authorization":
+        auth_header = make_headers(basic_auth=auth)["authorization"]
+    else:
+        auth_header = make_headers(proxy_basic_auth=auth)["proxy-authorization"]
+
+    found_header = False
+    for header, value in headers.items():
+        if header.lower() == header_name:
+            found_header = True
+            if value != auth_header:
+                raise ValueError(
+                    f"URL credentials do not match the provided {header_name} header"
+                )
+
+    if found_header:
+        return headers
+
+    new_headers = HTTPHeaderDict(headers)
+    new_headers[header_name] = auth_header
+    return new_headers
 
 
 def set_file_position(

--- a/test/test_connectionpool.py
+++ b/test/test_connectionpool.py
@@ -37,6 +37,7 @@ from urllib3.exceptions import (
     UnrewindableBodyError,
 )
 from urllib3.response import HTTPResponse
+from urllib3.util.request import make_headers
 from urllib3.util.ssl_match_hostname import CertificateError
 from urllib3.util.timeout import _DEFAULT_TIMEOUT, Timeout
 
@@ -801,6 +802,20 @@ class TestConnectionPool:
 
             actual_url = mock_request.call_args[0][2]
             assert actual_url == expected_url
+
+    def test_absolute_url_userinfo_sets_authorization_and_is_removed_from_target(
+        self,
+    ) -> None:
+        with HTTPConnectionPool(host="localhost", port=80) as pool:
+            with patch.object(
+                pool, "_make_request", return_value=HTTPResponse(status=200)
+            ) as mock_request:
+                pool.urlopen("GET", "http://user%40name:pass%3Aword@localhost/path")
+
+        assert mock_request.call_args.args[2] == "http://localhost/path"
+        assert mock_request.call_args.kwargs["headers"]["authorization"] == (
+            make_headers(basic_auth="user@name:pass:word")["authorization"]
+        )
 
     def test_absolute_redirect_request_target_strips_fragment(self) -> None:
         redirect_response = HTTPResponse(

--- a/test/test_poolmanager.py
+++ b/test/test_poolmanager.py
@@ -18,10 +18,111 @@ from urllib3.poolmanager import (
     key_fn_by_scheme,
 )
 from urllib3.util import retry, timeout
+from urllib3.util.request import make_headers
 from urllib3.util.url import Url
 
 
 class TestPoolManager:
+    def test_url_auth_sets_authorization_without_mutating_headers(self) -> None:
+        pool = MagicMock()
+        response = MagicMock()
+        response.get_redirect_location.return_value = False
+        pool.urlopen.return_value = response
+        manager = PoolManager()
+        manager.connection_from_host = MagicMock(return_value=pool)  # type: ignore[method-assign]
+        headers = {"X-Test": "value"}
+
+        manager.urlopen(
+            "GET", "http://user%40name:pass%3Aword@example.com/path", headers=headers
+        )
+
+        assert headers == {"X-Test": "value"}
+        call_headers = pool.urlopen.call_args.kwargs["headers"]
+        assert (
+            call_headers["authorization"]
+            == make_headers(basic_auth="user@name:pass:word")["authorization"]
+        )
+        assert pool.urlopen.call_args.args[1] == "/path"
+
+    @pytest.mark.parametrize("header_name", ["Authorization", "authorization"])
+    def test_url_auth_accepts_matching_authorization_header(
+        self, header_name: str
+    ) -> None:
+        pool = MagicMock()
+        response = MagicMock()
+        response.get_redirect_location.return_value = False
+        pool.urlopen.return_value = response
+        manager = PoolManager()
+        manager.connection_from_host = MagicMock(return_value=pool)  # type: ignore[method-assign]
+        auth = make_headers(basic_auth="user:pass")["authorization"]
+
+        manager.urlopen(
+            "GET",
+            "http://user:pass@example.com/path",
+            headers={header_name: auth},
+        )
+
+        assert pool.urlopen.call_args.kwargs["headers"][header_name] == auth
+
+    def test_url_auth_rejects_mismatched_authorization_header(self) -> None:
+        manager = PoolManager()
+
+        with pytest.raises(ValueError, match="do not match"):
+            manager.urlopen(
+                "GET",
+                "http://user:pass@example.com/path",
+                headers={"Authorization": "Basic wrong"},
+            )
+
+        with pytest.raises(ValueError, match="do not match"):
+            manager.urlopen(
+                "GET",
+                "http://user:pass@example.com/path",
+                headers={
+                    "Authorization": make_headers(basic_auth="user:pass")[
+                        "authorization"
+                    ],
+                    "authorization": "Basic wrong",
+                },
+            )
+
+    def test_url_auth_does_not_persist_in_manager_headers(self) -> None:
+        pool = MagicMock()
+        pool.urlopen.return_value.get_redirect_location.return_value = False
+        defaults = {"X-Test": "value"}
+        manager = PoolManager(headers=defaults)
+        manager.connection_from_host = MagicMock(return_value=pool)  # type: ignore[method-assign]
+        manager.urlopen("GET", "http://user:pass@example.com/", headers=None)
+        manager.urlopen("GET", "http://example.com/")
+        assert defaults == {"X-Test": "value"}
+        assert "authorization" not in pool.urlopen.call_args.kwargs["headers"]
+
+    def test_url_auth_is_not_forwarded_to_cross_host_redirect(self) -> None:
+        pool = MagicMock()
+        redirect = MagicMock()
+        redirect.get_redirect_location.return_value = "http://new:pass@other.example/"
+        redirect.status = 302
+        redirect.retries = retry.Retry(total=1)
+        final = MagicMock()
+        final.get_redirect_location.return_value = False
+        pool.urlopen.side_effect = [redirect, final]
+        pool.is_same_host.return_value = False
+        manager = PoolManager()
+        manager.connection_from_host = MagicMock(return_value=pool)  # type: ignore[method-assign]
+
+        manager.urlopen("GET", "http://old:pass@example.com/")
+
+        first_headers = pool.urlopen.call_args_list[0].kwargs["headers"]
+        second_headers = pool.urlopen.call_args_list[1].kwargs["headers"]
+        assert (
+            first_headers["authorization"]
+            == make_headers(basic_auth="old:pass")["authorization"]
+        )
+        assert (
+            second_headers["authorization"]
+            == make_headers(basic_auth="new:pass")["authorization"]
+        )
+
     @resolvesLocalhostFQDN()
     def test_same_url(self) -> None:
         # Convince ourselves that normally we don't get the same object

--- a/test/test_proxymanager.py
+++ b/test/test_proxymanager.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from unittest.mock import MagicMock
+
 import pytest
 
 from urllib3.exceptions import (
@@ -10,6 +12,7 @@ from urllib3.exceptions import (
 )
 from urllib3.poolmanager import ProxyManager
 from urllib3.response import HTTPResponse
+from urllib3.util.request import make_headers
 from urllib3.util.retry import Retry
 from urllib3.util.url import parse_url
 
@@ -17,6 +20,54 @@ from .port_helpers import find_unused_port
 
 
 class TestProxyManager:
+    def test_proxy_url_auth_sets_proxy_authorization_without_leaking_to_origin(
+        self,
+    ) -> None:
+        pool = MagicMock()
+        response = MagicMock()
+        response.get_redirect_location.return_value = False
+        pool.urlopen.return_value = response
+        manager = ProxyManager("http://proxy-user:proxy-pass@proxy.example")
+        manager.connection_from_host = MagicMock(return_value=pool)  # type: ignore[method-assign]
+
+        manager.urlopen("GET", "http://origin-user:origin-pass@example.com/path")
+
+        call_url = pool.urlopen.call_args.args[1]
+        call_headers = pool.urlopen.call_args.kwargs["headers"]
+        assert call_url == "http://example.com/path"
+        assert (
+            call_headers["authorization"]
+            == make_headers(basic_auth="origin-user:origin-pass")["authorization"]
+        )
+        assert "proxy-authorization" not in call_headers
+        assert (
+            manager.proxy_headers["proxy-authorization"]
+            == make_headers(proxy_basic_auth="proxy-user:proxy-pass")[
+                "proxy-authorization"
+            ]
+        )
+
+    @pytest.mark.parametrize(
+        "header_name", ["Proxy-Authorization", "proxy-authorization"]
+    )
+    @pytest.mark.parametrize("scheme", ["http", "https"])
+    def test_proxy_url_auth_accepts_matching_proxy_header(
+        self, header_name: str, scheme: str
+    ) -> None:
+        auth = make_headers(proxy_basic_auth="user:pass")["proxy-authorization"]
+        manager = ProxyManager(
+            f"{scheme}://user:pass@proxy.example", proxy_headers={header_name: auth}
+        )
+
+        assert manager.proxy_headers[header_name] == auth
+
+    def test_proxy_url_auth_rejects_mismatched_proxy_header(self) -> None:
+        with pytest.raises(ValueError, match="do not match"):
+            ProxyManager(
+                "http://user:pass@proxy.example",
+                proxy_headers={"Proxy-Authorization": "Basic wrong"},
+            )
+
     @pytest.mark.parametrize("proxy_scheme", ["http", "https"])
     def test_proxy_headers(self, proxy_scheme: str) -> None:
         url = "http://pypi.org/project/urllib3/"

--- a/test/with_dummyserver/test_poolmanager.py
+++ b/test/with_dummyserver/test_poolmanager.py
@@ -17,6 +17,7 @@ from urllib3 import HTTPHeaderDict, HTTPResponse, request
 from urllib3.connectionpool import port_by_scheme
 from urllib3.exceptions import MaxRetryError, URLSchemeUnknown
 from urllib3.poolmanager import PoolManager
+from urllib3.util.request import make_headers
 from urllib3.util.retry import Retry
 
 
@@ -26,6 +27,44 @@ class TestPoolManager(HypercornDummyServerTestCase):
         super().setup_class()
         cls.base_url = f"http://{cls.host}:{cls.port}"
         cls.base_url_alt = f"http://{cls.host_alt}:{cls.port}"
+
+    @pytest.mark.parametrize(
+        "userinfo,decoded",
+        [
+            ("user:pass", "user:pass"),
+            ("user%40name:pass%3Aword", "user@name:pass:word"),
+            ("user", "user:"),
+            (":pass", ":pass"),
+            (":", ":"),
+            ("us%C3%A9r:pass", "usér:pass"),
+        ],
+    )
+    def test_url_credentials(self, userinfo: str, decoded: str) -> None:
+        with PoolManager() as http:
+            response = http.request(
+                "GET",
+                f"http://{userinfo}@{self.host}:{self.port}/headers",
+                headers=None,
+            )
+        assert (
+            response.json()["Authorization"]
+            == make_headers(basic_auth=decoded)["authorization"]
+        )
+
+    @pytest.mark.parametrize("cross_host", [False, True])
+    def test_url_credentials_redirect(self, cross_host: bool) -> None:
+        target = self.base_url_alt if cross_host else self.base_url
+        with PoolManager() as http:
+            response = http.request(
+                "GET",
+                f"http://user:pass@{self.host}:{self.port}/redirect",
+                fields={"target": f"{target}/headers"},
+            )
+        headers = response.json()
+        if cross_host:
+            assert "Authorization" not in headers
+        else:
+            assert headers["Authorization"] == "Basic dXNlcjpwYXNz"
 
     @pytest.mark.parametrize(
         "pool_manager_kwargs",

--- a/test/with_dummyserver/test_proxy_poolmanager.py
+++ b/test/with_dummyserver/test_proxy_poolmanager.py
@@ -450,6 +450,21 @@ class TestHTTPProxyManager(HypercornDummyProxyTestCase):
             assert r._pool is not None
             assert r._pool.host == self.https_host
 
+    @pytest.mark.parametrize("secure_proxy", [False, True])
+    @pytest.mark.parametrize("secure_origin", [False, True])
+    def test_url_credentials(self, secure_proxy: bool, secure_origin: bool) -> None:
+        proxy_url = self.https_proxy_url if secure_proxy else self.proxy_url
+        origin_url = self.https_url if secure_origin else self.http_url
+        proxy_url = proxy_url.replace("://", "://proxy:secret@", 1)
+        origin_url = origin_url.replace("://", "://user:pass@", 1)
+        with proxy_from_url(proxy_url, ca_certs=DEFAULT_CA) as http:
+            response = http.request("GET", f"{origin_url}/headers")
+            headers = response.json()
+            assert headers["Authorization"] == "Basic dXNlcjpwYXNz"
+            assert http.proxy_headers["proxy-authorization"] == "Basic cHJveHk6c2VjcmV0"
+            if secure_origin:
+                assert "Proxy-Authorization" not in headers
+
     def test_headers(self) -> None:
         with proxy_from_url(
             self.proxy_url,


### PR DESCRIPTION
Resolves #1999.

URLs containing userinfo now generate Basic `Authorization` headers for `PoolManager` and direct connection-pool requests. HTTP and HTTPS proxy URLs similarly generate `Proxy-Authorization`. Credentials are percent-decoded using the existing URL helpers and encoded with `make_headers`' existing Latin-1 default. Matching explicit headers are preserved; conflicting headers raise `ValueError` without including credentials in the error. Caller header mappings are not mutated, and userinfo is removed from absolute-form request targets.

Regression tests cover escaped and empty credentials, case-insensitive header conflicts, reuse of manager defaults, same-host and cross-host redirects, destination-specific credentials, and HTTP/HTTPS proxy/origin combinations. HTTPS tunneling tests check that proxy authorization is absent from the origin request.

Validation on this branch, rebased onto main at 3f587c6: the full suite passed (2372 passed, 288 skipped, 45 xfailed) on CPython 3.12 / macOS. All `pre-commit` hooks pass (pyupgrade, black, isort, flake8, uv-lock, zizmor, prettier, eslint). `mypy src/urllib3` reports only four pre-existing `brotli` stub errors that also reproduce on unmodified `main` in the same environment. Full cross-platform CI remains to run here.

I am aware there are several other open PRs against this issue. Happy to close this one, or to rework it toward whichever approach you prefer, if that is more useful to you.

Implementation and tests were prepared with AI assistance.
