### PR TITLE
Rewind file-like request bodies across PoolManager redirects

### DIFF
--- a/changelog/5181.bugfix.rst
+++ b/changelog/5181.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed ``PoolManager`` sending an empty file-like request body after a redirect that preserves it.

--- a/src/urllib3/poolmanager.py
+++ b/src/urllib3/poolmanager.py
@@ -20,6 +20,7 @@ from .exceptions import (
 from .response import BaseHTTPResponse
 from .util.connection import _TYPE_SOCKET_OPTIONS
 from .util.proxy import connection_requires_http_tunnel
+from .util.request import set_file_position
 from .util.retry import Retry
 from .util.timeout import Timeout
 from .util.url import Url, parse_url
@@ -450,6 +451,12 @@ class PoolManager(RequestMethods):
         kw["assert_same_host"] = False
         kw["redirect"] = False
 
+        # HTTPConnectionPool records where a file-like body starts so that it can
+        # rewind it before a redirect. Its redirect handling is turned off just
+        # above, so record the position here as well, while the body is still
+        # unread, and hand it to the hops below.
+        body_pos = set_file_position(kw.get("body"), kw.get("body_pos"))
+
         if "headers" not in kw:
             kw["headers"] = self.headers
 
@@ -464,6 +471,10 @@ class PoolManager(RequestMethods):
 
         # Support relative URLs for redirecting.
         redirect_location = urljoin(url, redirect_location)
+
+        # The body has to be rewound before it is sent again, back to where it
+        # started rather than to wherever the hop just made left it.
+        kw["body_pos"] = body_pos
 
         if response.status == 303:
             # Change the method according to RFC 9110, Section 15.4.4.

--- a/test/with_dummyserver/test_poolmanager.py
+++ b/test/with_dummyserver/test_poolmanager.py
@@ -15,7 +15,11 @@ from dummyserver.testcase import (
 )
 from urllib3 import HTTPHeaderDict, HTTPResponse, request
 from urllib3.connectionpool import port_by_scheme
-from urllib3.exceptions import MaxRetryError, URLSchemeUnknown
+from urllib3.exceptions import (
+    MaxRetryError,
+    UnrewindableBodyError,
+    URLSchemeUnknown,
+)
 from urllib3.poolmanager import PoolManager
 from urllib3.util.retry import Retry
 
@@ -424,11 +428,55 @@ class TestPoolManager(HypercornDummyServerTestCase):
                 "POST",
                 f"{self.base_url}/redirect?target={self.base_url}/echo",
                 body=io.BytesIO(b"the data"),
-                headers={"Content-Length": "8"},
                 body_pos=0,
             )
         assert response.status == 200
         assert response.data == b""
+
+    def test_307_redirect_resends_file_like_body(self) -> None:
+        # The body is kept, so it has to be rewound to where it started rather
+        # than to wherever the first hop left it.
+        with PoolManager() as http:
+            response = http.urlopen(
+                "PUT",
+                f"{self.base_url}/redirect?target={self.base_url}/echo&status=307",
+                body=io.BytesIO(b"the data"),
+            )
+        assert response.status == 200
+        assert response.data == b"the data"
+
+    def test_307_redirect_with_failed_tell(self) -> None:
+        # A body whose position cannot be recorded cannot be rewound either,
+        # which has to be an error rather than a silently empty request.
+        class BadTellObject(io.BytesIO):
+            def tell(self) -> typing.NoReturn:
+                raise OSError
+
+        with PoolManager() as http:
+            with pytest.raises(
+                UnrewindableBodyError, match="Unable to record file position"
+            ):
+                http.urlopen(
+                    "PUT",
+                    f"{self.base_url}/redirect?target={self.base_url}/echo&status=307",
+                    body=BadTellObject(b"the data"),
+                )
+
+    def test_failed_tell_without_a_redirect(self) -> None:
+        # Recording the position is not the same as rewinding to it: a body
+        # that cannot do either is fine as long as it is sent only once.
+        class BadTellObject(io.BytesIO):
+            def tell(self) -> typing.NoReturn:
+                raise OSError
+
+        with PoolManager() as http:
+            response = http.urlopen(
+                "PUT",
+                f"{self.base_url}/echo",
+                body=BadTellObject(b"the data"),
+            )
+        assert response.status == 200
+        assert response.data == b"the data"
 
     def test_unknown_scheme(self) -> None:
         with PoolManager() as http:


### PR DESCRIPTION
Fixes #5181.

## The bug

`HTTPConnectionPool.urlopen` records where a file-like body starts, so that it can rewind the body before resending it on a redirect. `PoolManager.urlopen` turns that machinery off (`kw["redirect"] = False`) and runs its own cross-pool redirect loop, but never carried `body_pos` across hops. The second hop therefore recorded the position again, by then at EOF, and sent a well-formed **empty** body.

Nothing raises. The caller gets the redirect target's `200` and cannot tell that the upload was dropped. `urllib3.request()` goes through `PoolManager`, so the documented entry point is affected.

Against a raw-socket server that answers `PUT /start` with `307 Location: /echo`:

```
hop 1: PUT /start  Transfer-Encoding: chunked  body=b'PAYLOAD-DATA'
hop 2: PUT /echo   Transfer-Encoding: chunked  body=b''
status: 200
```

The identical request through a bare `HTTPConnectionPool` resends `b'PAYLOAD-DATA'` correctly, which puts the defect at the `PoolManager` layer.

## The fix

Record the position at the `PoolManager` boundary too, while the body is still unread, and attach it to the redirect hops:

```python
        # HTTPConnectionPool records where a file-like body starts so that it can
        # rewind it before a redirect. Its redirect handling is turned off just
        # above, so record the position here as well, while the body is still
        # unread, and hand it to the hops below.
        body_pos = set_file_position(kw.get("body"), kw.get("body_pos"))
```

and, once a redirect is known to be happening:

```python
        # The body has to be rewound before it is sent again, back to where it
        # started rather than to wherever the hop just made left it.
        kw["body_pos"] = body_pos
```

The 303 branch already clears `kw["body_pos"]` (from #5161) and keeps doing so, since that redirect drops the body entirely.

## Why not the shorter version

@waterWang proposed this in #5191, which was closed unmerged:

```python
        if "body_pos" not in kw:
            kw["body_pos"] = set_file_position(kw.get("body"), None)
```

That puts the recorded position into `kw` for the **first** request as well. `HTTPConnectionPool.urlopen` then calls `set_file_position(body, pos)`, and a non-`None` position means *rewind*, so the first request now seeks a body it never used to seek. For a body that cannot seek, a pipe, `stdin`, a socket file object, anything whose `tell()` raises, a plain `PUT` **with no redirect at all** starts raising `UnrewindableBodyError`.

Recording and rewinding have to stay separate, which is why the position is held in a local and injected only on the redirect path.

`test_failed_tell_without_a_redirect` pins that difference:

| | `main` | #5191's shape | this PR |
|---|---|---|---|
| `test_307_redirect_resends_file_like_body` | FAIL | pass | pass |
| `test_307_redirect_with_failed_tell` | FAIL | pass | pass |
| `test_failed_tell_without_a_redirect` | pass | **FAIL** | pass |

## Behaviour change

A 307/308 whose body cannot be rewound now raises `UnrewindableBodyError` instead of silently sending nothing. That is what a bare `HTTPConnectionPool` has always done for the same request, and the issue asks for exactly this: rewind, or say so.

## Verification

- `test/`: 1464 passed, 51 skipped.
- `test/with_dummyserver/`: same failure set before and after, 559 → 562 passed, the three new tests being the difference.
- black, flake8 and mypy clean on both changed files.
