### PR TITLE
Add opt-in errors for excessive Retry-After intervals

### DIFF
--- a/changelog/1338.feature.rst
+++ b/changelog/1338.feature.rst
@@ -1,0 +1,3 @@
+Added an opt-in ``Retry.raise_on_retry_after_max`` option that raises
+``RetryAfterMaxExceededError`` with the requested delay and configured maximum
+when a Retry-After interval exceeds the limit.

--- a/src/urllib3/exceptions.py
+++ b/src/urllib3/exceptions.py
@@ -333,3 +333,21 @@ class HeaderParsingError(HTTPError):
 
 class UnrewindableBodyError(HTTPError):
     """urllib3 encountered an error when trying to rewind a body"""
+
+
+class RetryAfterMaxExceededError(HTTPError):
+    """A Retry-After interval exceeded the caller's configured maximum.
+
+    ``retry_after`` is the server-requested delay in seconds and ``max_wait``
+    is the configured limit. Raised only when explicitly enabled on Retry.
+    """
+
+    def __init__(self, retry_after: float, max_wait: int) -> None:
+        self.retry_after = retry_after
+        self.max_wait = max_wait
+        super().__init__(
+            f"Retry-After interval {retry_after} exceeds maximum wait {max_wait}"
+        )
+
+    def __reduce__(self) -> tuple[type[RetryAfterMaxExceededError], tuple[float, int]]:
+        return type(self), (self.retry_after, self.max_wait)

--- a/src/urllib3/util/retry.py
+++ b/src/urllib3/util/retry.py
@@ -19,6 +19,7 @@ from ..exceptions import (
     ProxyError,
     ReadTimeoutError,
     ResponseError,
+    RetryAfterMaxExceededError,
 )
 from .util import reraise
 
@@ -192,7 +193,14 @@ class Retry:
     :param int retry_after_max: Number of seconds to allow as the maximum for
         Retry-After headers. Defaults to :attr:`Retry.DEFAULT_RETRY_AFTER_MAX`.
         Any Retry-After headers larger than this value will be limited to this
-        value.
+        value unless ``raise_on_retry_after_max`` is enabled.
+
+    :param bool raise_on_retry_after_max:
+        If True, raise :class:`~urllib3.exceptions.RetryAfterMaxExceededError`
+        when a Retry-After interval exceeds ``retry_after_max``, instead of
+        shortening the wait. The exception exposes the requested interval and
+        configured maximum so callers can schedule a later attempt. Defaults
+        to False. This does not change connection/read timeout semantics.
     """
 
     #: Default methods to be used for ``allowed_methods``
@@ -240,6 +248,7 @@ class Retry:
         ] = DEFAULT_REMOVE_HEADERS_ON_REDIRECT,
         backoff_jitter: float = 0.0,
         retry_after_max: int = DEFAULT_RETRY_AFTER_MAX,
+        raise_on_retry_after_max: bool = False,
     ) -> None:
         self.total = total
         self.connect = connect
@@ -266,6 +275,7 @@ class Retry:
         self.backoff_factor = backoff_factor
         self.backoff_max = backoff_max
         self.retry_after_max = retry_after_max
+        self.raise_on_retry_after_max = raise_on_retry_after_max
         self.raise_on_redirect = raise_on_redirect
         self.raise_on_status = raise_on_status
         self.history = history or ()
@@ -288,6 +298,7 @@ class Retry:
             backoff_factor=self.backoff_factor,
             backoff_max=self.backoff_max,
             retry_after_max=self.retry_after_max,
+            raise_on_retry_after_max=self.raise_on_retry_after_max,
             raise_on_redirect=self.raise_on_redirect,
             raise_on_status=self.raise_on_status,
             history=self.history,
@@ -354,6 +365,8 @@ class Retry:
 
         # Check the seconds do not exceed the specified maximum
         if seconds > self.retry_after_max:
+            if self.raise_on_retry_after_max:
+                raise RetryAfterMaxExceededError(seconds, self.retry_after_max)
             seconds = self.retry_after_max
 
         return seconds

--- a/test/test_retry_after_limit.py
+++ b/test/test_retry_after_limit.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import pickle
+from unittest import mock
+
+import pytest
+
+from urllib3 import exceptions
+from urllib3.response import HTTPResponse
+from urllib3.util.retry import Retry
+
+
+@pytest.mark.parametrize("header", ["61", " 61 ", "Thu, 01 Jan 1970 00:02:01 GMT"])
+def test_excessive_delay_preserves_requested_interval(header: str) -> None:
+    retry = Retry(retry_after_max=60, raise_on_retry_after_max=True)
+    with mock.patch("time.time", return_value=60), mock.patch("time.sleep") as sleep:
+        with pytest.raises(exceptions.RetryAfterMaxExceededError) as caught:
+            retry.sleep(HTTPResponse(headers={"Retry-After": header}))
+    assert caught.value.retry_after == 61
+    assert caught.value.max_wait == 60
+    sleep.assert_not_called()
+
+
+@pytest.mark.parametrize("seconds", [0, 59, 60])
+def test_limit_is_inclusive(seconds: int) -> None:
+    retry = Retry(retry_after_max=60, raise_on_retry_after_max=True)
+    assert retry.parse_retry_after(str(seconds)) == seconds
+
+
+def test_default_still_caps_delay() -> None:
+    assert Retry(retry_after_max=60).parse_retry_after("3600") == 60
+
+
+def test_limit_policy_survives_retry_cloning() -> None:
+    retry = Retry(total=2, retry_after_max=60, raise_on_retry_after_max=True)
+    assert retry.increment().raise_on_retry_after_max is True
+    assert retry.new(raise_on_retry_after_max=False).raise_on_retry_after_max is False
+
+
+def test_ignored_header_does_not_raise_or_sleep() -> None:
+    retry = Retry(
+        retry_after_max=60,
+        raise_on_retry_after_max=True,
+        respect_retry_after_header=False,
+    )
+    with mock.patch("time.sleep") as sleep:
+        retry.sleep(HTTPResponse(headers={"Retry-After": "3600"}))
+    sleep.assert_not_called()
+
+
+def test_exception_pickle_round_trip() -> None:
+    error = exceptions.RetryAfterMaxExceededError(3600, 60)
+    restored = pickle.loads(pickle.dumps(error))
+    assert type(restored) is type(error)
+    assert restored.retry_after == 3600
+    assert restored.max_wait == 60
+    assert str(restored) == str(error)

--- a/test/with_dummyserver/test_retry_after_limit.py
+++ b/test/with_dummyserver/test_retry_after_limit.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import socket
+from unittest import mock
+
+import pytest
+
+from dummyserver.testcase import SocketDummyServerTestCase
+from urllib3 import HTTPConnectionPool, PoolManager
+from urllib3.exceptions import RetryAfterMaxExceededError
+from urllib3.util.retry import Retry
+
+
+class TestRetryAfterConnectionRelease(SocketDummyServerTestCase):
+    @pytest.mark.parametrize(
+        "manager,status", [(False, 503), (False, 302), (True, 503)]
+    )
+    def test_excessive_wait_releases_streamed_response(
+        self, manager: bool, status: int
+    ) -> None:
+        requests: list[bytes] = []
+
+        def serve(listener: socket.socket) -> None:
+            with listener.accept()[0] as sock:
+                sock.settimeout(5)
+                for index in range(2):
+                    request = b""
+                    while not request.endswith(b"\r\n\r\n"):
+                        chunk = sock.recv(65536)
+                        if not chunk:
+                            raise RuntimeError("Connection closed before next request")
+                        request += chunk
+                    requests.append(request)
+                    if index == 0:
+                        response = (
+                            f"HTTP/1.1 {status} Retry\r\n"
+                            "Retry-After: 3600\r\nLocation: /redirected\r\n"
+                            "Content-Length: 4\r\n\r\nbusy"
+                        ).encode("ascii")
+                    else:
+                        response = b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok"
+                    sock.sendall(response)
+
+        self._start_server(serve)
+        retry = Retry(total=1, retry_after_max=60, raise_on_retry_after_max=True)
+        client = (
+            PoolManager(maxsize=1, block=True)
+            if manager
+            else HTTPConnectionPool(self.host, self.port, maxsize=1, block=True)
+        )
+        prefix = f"http://{self.host}:{self.port}" if manager else ""
+        with client, mock.patch("time.sleep") as sleep:
+            with pytest.raises(RetryAfterMaxExceededError) as caught:
+                client.request(
+                    "GET",
+                    prefix + "/first",
+                    retries=retry,
+                    preload_content=False,
+                    timeout=2,
+                    pool_timeout=1,
+                )
+            assert caught.value.retry_after == 3600
+            assert caught.value.max_wait == 60
+            assert len(requests) == 1
+            sleep.assert_not_called()
+            response = client.request(
+                "GET",
+                prefix + "/next",
+                retries=False,
+                timeout=2,
+                pool_timeout=1,
+            )
+            assert response.data == b"ok"
+        assert len(requests) == 2
+        assert requests[0].startswith(b"GET /first ")
+        assert requests[1].startswith(b"GET /next ")


### PR DESCRIPTION
Fixes #1338.

Add `Retry(raise_on_retry_after_max=True)` as an opt-in alternative to capping an excessive Retry-After interval. When the parsed interval exceeds `retry_after_max`, `RetryAfterMaxExceededError` exposes both the original `retry_after` and configured `max_wait`, allowing callers to schedule a later attempt. The option survives retry cloning; its default is false, preserving existing capping behavior and connect/read timeout semantics.

The exception supports pickle round trips. Regression tests cover numeric and HTTP-date values, the inclusive boundary, unchanged default behavior, retry cloning, ignored headers and no sleep on error. Three socket tests exercise pool-level status retries, pool-level redirects and PoolManager status retries with a streamed response and a single blocking connection. They verify that the exception occurs without a second request and that a subsequent explicit request succeeds on the same connection.

Validation:
- Original retry/exception suite: 65 passed, 18 Windows timezone skips.
- New tests before implementation: 9 failed because the requested API was absent; the default-capping regression already passed.
- Updated retry/exception tests: 75 passed, 18 skips; socket tests: 3 passed.
- Linux-target mypy: 85 files passed. Black (py310 target), isort, flake8 and pyupgrade checks passed for changed Python files.

Full local `test/` suite on Windows/Python 3.13.3 with the project socket restrictions: **2315 passed, 329 skipped, 45 xfailed**. [Upstream CI](https://github.com/urllib3/urllib3/actions/runs/34343292169) now passes all 38 reported checks at `6bf8120`, including the configured cross-platform/interpreter matrix and Emscripten environments. [Merged coverage](https://github.com/urllib3/urllib3/actions/runs/34343292169/job/102441034495) reports 3,911 statements, zero missed, 100%. [Requests and botocore downstream tests](https://github.com/urllib3/urllib3/actions/runs/34343292224), lint, CodeQL and documentation also pass. No change is made to PoolManager's existing redirect wait behavior, which does not invoke Retry-After sleeping.

Implemented and self-reviewed with OpenAI Codex; no independent human review is claimed.
