### PR TITLE
Construct Basic authentication from request and proxy URL userinfo

### DIFF
--- a/changelog/1999.feature.rst
+++ b/changelog/1999.feature.rst
@@ -1,0 +1,3 @@
+Added Basic authentication from request and HTTP(S) proxy URL userinfo,
+with percent decoding, conflicting-header checks, and removal of credentials
+from request targets and stored proxy URLs.

--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -657,3 +657,29 @@ standard logger interface to change the log level for urllib3's logger:
 .. code-block:: python
 
     logging.getLogger("urllib3").setLevel(logging.WARNING)
+
+
+Authentication in URLs
+----------------------
+
+Request URLs may contain ``username:password`` userinfo::
+
+    http.request("GET", "https://username:password@example.com/private")
+
+urllib3 percent-decodes the userinfo and generates a Basic ``Authorization``
+header using Latin-1, matching :func:`urllib3.util.make_headers`. A username
+without a password is treated as having an empty password. Credentials that
+cannot be represented in Latin-1 raise ``ValueError``. To choose another
+encoding or authentication scheme, omit URL userinfo and supply an explicit
+header instead.
+
+The userinfo is removed from the request target. Headers supplied by the
+caller are not mutated: matching authentication headers are accepted, while
+conflicting values raise ``ValueError`` before the request is sent. Generated
+origin authentication follows the configured redirect-header removal policy;
+by default it is removed when the target origin changes.
+
+HTTP and HTTPS proxy URLs accept userinfo in the same way, generating
+``Proxy-Authorization`` and removing userinfo from the stored proxy URL.
+For HTTPS tunneling the proxy authentication is sent on CONNECT, separately
+from the origin authentication inside the TLS tunnel.

--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -42,13 +42,18 @@ from .exceptions import (
 from .response import BaseHTTPResponse
 from .util.connection import is_connection_dropped
 from .util.proxy import connection_requires_http_tunnel
-from .util.request import _TYPE_BODY_POSITION, set_file_position
+from .util.request import (
+    _TYPE_BODY_POSITION,
+    _add_url_auth,
+    _check_auth_header,
+    set_file_position,
+)
 from .util.retry import Retry
 from .util.ssl_match_hostname import CertificateError
 from .util.timeout import _DEFAULT_TIMEOUT, _TYPE_DEFAULT, Timeout
 from .util.url import Url, _encode_target
 from .util.url import _normalize_host as normalize_host
-from .util.url import parse_url
+from .util.url import _url_origin, parse_url
 from .util.util import to_str
 
 if typing.TYPE_CHECKING:
@@ -708,6 +713,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
             redirect. Typically this won't need to be set because urllib3 will
             auto-populate the value when needed.
         """
+        url_auth = None
         # Ensure that the URL we're connecting to is properly encoded
         if url.startswith("/"):
             # URLs starting with / are inherently schemeless.
@@ -716,10 +722,12 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         else:
             parsed_url = parse_url(url)
             destination_scheme = parsed_url.scheme
-            url = to_str(parsed_url._replace(fragment=None).url)
+            url_auth = parsed_url.auth_decoded_joined
+            url = to_str(parsed_url._replace(auth=None, fragment=None).url)
 
         if headers is None:
             headers = self.headers
+        headers = _add_url_auth(url_auth, headers)
 
         if not isinstance(retries, Retry):
             retries = Retry.from_int(retries, redirect=redirect, default=self.retries)
@@ -751,8 +759,19 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         # Merge the proxy headers. Only done when not using HTTP CONNECT. We
         # have to copy the headers dict so we can safely change it without those
         # changes being reflected in anyone else's copy.
+        for key, value in self.proxy_headers.items():
+            if to_str(key).lower() == "proxy-authorization":
+                matched = _check_auth_header(
+                    headers, "Proxy-Authorization", to_str(value)
+                )
+                if http_tunnel_required and matched:
+                    headers = HTTPHeaderDict(headers)
+                    headers.discard("Proxy-Authorization")
         if not http_tunnel_required:
-            headers = headers.copy()  # type: ignore[attr-defined]
+            if self.proxy_headers:
+                headers = HTTPHeaderDict(headers)
+            else:
+                headers = headers.copy()  # type: ignore[attr-defined]
             headers.update(self.proxy_headers)  # type: ignore[union-attr]
 
         # Must keep the exception bound to a separate variable or else Python 3
@@ -917,11 +936,13 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
                 headers = HTTPHeaderDict(headers)._prepare_for_method_change()
 
             # Strip headers marked as unsafe to forward to the redirected location.
-            # Check remove_headers_on_redirect to avoid a potential network call within
-            # self.is_same_host() which may use socket.gethostbyname() in the future.
-            if retries.remove_headers_on_redirect and not self.is_same_host(
-                redirect_location
-            ):
+            # A forwarding proxy's connection host is not the target origin.
+            same_origin = (
+                _url_origin(parse_url(url)) == _url_origin(parse_url(redirect_location))
+                if self.proxy is not None and not redirect_location.startswith("/")
+                else self.is_same_host(redirect_location)
+            )
+            if retries.remove_headers_on_redirect and not same_origin:
                 new_headers = headers.copy()  # type: ignore[union-attr]
                 for header in headers:
                     if header.lower() in retries.remove_headers_on_redirect:
@@ -938,7 +959,11 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
 
             response.drain_conn()
             retries.sleep_for_retry(response)
-            log.debug("Redirecting %s -> %s", url, redirect_location)
+            log.debug(
+                "Redirecting %s -> %s",
+                url,
+                parse_url(redirect_location)._replace(auth=None).url,
+            )
             return self.urlopen(
                 method,
                 redirect_location,

--- a/src/urllib3/poolmanager.py
+++ b/src/urllib3/poolmanager.py
@@ -20,9 +20,10 @@ from .exceptions import (
 from .response import BaseHTTPResponse
 from .util.connection import _TYPE_SOCKET_OPTIONS
 from .util.proxy import connection_requires_http_tunnel
+from .util.request import _add_url_auth
 from .util.retry import Retry
 from .util.timeout import Timeout
-from .util.url import Url, parse_url
+from .util.url import Url, _url_origin, parse_url
 
 if typing.TYPE_CHECKING:
     import ssl
@@ -434,6 +435,12 @@ class PoolManager(RequestMethods):
         :class:`urllib3.connectionpool.ConnectionPool` can be chosen for it.
         """
         u = parse_url(url)
+        if u.auth is not None:
+            kw["headers"] = _add_url_auth(
+                u.auth_decoded_joined, kw.get("headers", self.headers) or {}
+            )
+            u = u._replace(auth=None)
+            url = u.url
 
         if u.scheme is None:
             warnings.warn(
@@ -482,10 +489,9 @@ class PoolManager(RequestMethods):
             retries = Retry.from_int(retries, redirect=redirect)
 
         # Strip headers marked as unsafe to forward to the redirected location.
-        # Check remove_headers_on_redirect to avoid a potential network call within
-        # conn.is_same_host() which may use socket.gethostbyname() in the future.
-        if retries.remove_headers_on_redirect and not conn.is_same_host(
-            redirect_location
+        # Compare target origins, not the proxy connection's host.
+        if retries.remove_headers_on_redirect and _url_origin(u) != _url_origin(
+            parse_url(redirect_location)
         ):
             new_headers = kw["headers"].copy()
             for header in kw["headers"]:
@@ -504,7 +510,11 @@ class PoolManager(RequestMethods):
         kw["retries"] = retries
         kw["redirect"] = redirect
 
-        log.info("Redirecting %s -> %s", url, redirect_location)
+        log.info(
+            "Redirecting %s -> %s",
+            url,
+            parse_url(redirect_location)._replace(auth=None).url,
+        )
 
         response.drain_conn()
         return self.urlopen(method, redirect_location, **kw)
@@ -516,7 +526,10 @@ class ProxyManager(PoolManager):
     the defined proxy, using the CONNECT method for HTTPS URLs.
 
     :param proxy_url:
-        The URL of the proxy to be used.
+        The URL of the proxy to be used. URL userinfo is percent-decoded and
+        converted to a Basic Proxy-Authorization header using Latin-1, then
+        removed from the stored proxy URL. Conflicting explicit authentication
+        headers raise ValueError.
 
     :param proxy_headers:
         A dictionary containing headers that will be sent to the proxy. In case
@@ -610,8 +623,10 @@ class ProxyManager(PoolManager):
             port = port_by_scheme.get(proxy.scheme, 80)
             proxy = proxy._replace(port=port)
 
-        self.proxy = proxy
-        self.proxy_headers = proxy_headers or {}
+        self.proxy_headers = _add_url_auth(
+            proxy.auth_decoded_joined, proxy_headers or {}, "Proxy-Authorization"
+        )
+        self.proxy = proxy._replace(auth=None)
         self.proxy_config = ProxyConfig(
             proxy_ssl_context,
             use_forwarding_for_https,

--- a/src/urllib3/util/request.py
+++ b/src/urllib3/util/request.py
@@ -6,6 +6,7 @@ import typing
 from base64 import b64encode
 from enum import Enum
 
+from .._collections import HTTPHeaderDict
 from ..exceptions import UnrewindableBodyError
 from .util import to_bytes
 
@@ -171,6 +172,46 @@ def make_headers(
         headers["cache-control"] = "no-cache"
 
     return headers
+
+
+def _check_auth_header(
+    headers: typing.Mapping[str, str], header_name: str, expected: str
+) -> bool:
+    found = False
+    expected_scheme, _, expected_token = expected.partition(" ")
+    for key, value in headers.items():
+        if isinstance(key, bytes):
+            key = key.decode("latin-1")
+        if key.lower() != header_name.lower():
+            continue
+        if isinstance(value, bytes):
+            value = value.decode("latin-1")
+        scheme, _, token = value.partition(" ")
+        if scheme.lower() != expected_scheme.lower() or token.strip() != expected_token:
+            raise ValueError(f"URL userinfo conflicts with {header_name} header")
+        found = True
+    return found
+
+
+def _add_url_auth(
+    auth: str | None,
+    headers: typing.Mapping[str, str],
+    header_name: str = "Authorization",
+) -> typing.Mapping[str, str]:
+    """Add URL credentials without mutating or overriding caller headers."""
+    if auth is None:
+        return headers
+    try:
+        generated = make_headers(basic_auth=auth)["authorization"]
+    except UnicodeEncodeError:
+        raise ValueError("URL credentials must be encodable as Latin-1") from None
+
+    found = _check_auth_header(headers, header_name, generated)
+    if found:
+        return headers
+    updated = HTTPHeaderDict(headers)
+    updated[header_name] = generated
+    return updated
 
 
 def set_file_position(

--- a/src/urllib3/util/url.py
+++ b/src/urllib3/util/url.py
@@ -575,3 +575,9 @@ def parse_url(url: str) -> Url:
         query=query,
         fragment=fragment,
     )
+
+
+def _url_origin(url: Url) -> tuple[str, str | None, int | None]:
+    scheme = url.scheme or "http"
+    port = url.port if url.port is not None else {"http": 80, "https": 443}.get(scheme)
+    return scheme, url.host, port

--- a/test/test_url_auth.py
+++ b/test/test_url_auth.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+import typing
+from unittest import mock
+
+import pytest
+
+from urllib3 import HTTPConnectionPool, HTTPSConnectionPool, PoolManager, ProxyManager
+from urllib3.response import HTTPResponse
+from urllib3.util import make_headers
+
+
+@pytest.mark.parametrize(
+    "userinfo,decoded",
+    [
+        ("alice:secret", "alice:secret"),
+        ("alice", "alice:"),
+        ("al%69ce:p%40ss%3Aword", "alice:p@ss:word"),
+        ("us%C3%A9r:pass", "usér:pass"),
+    ],
+)
+def test_manager_generates_auth_without_mutating_defaults(
+    userinfo: str, decoded: str
+) -> None:
+    headers = {"X-Trace": "synthetic"}
+    with (
+        PoolManager(headers=headers) as manager,
+        mock.patch.object(
+            HTTPConnectionPool, "urlopen", return_value=HTTPResponse(status=200)
+        ) as send,
+    ):
+        manager.urlopen("GET", f"http://{userinfo}@localhost/resource")
+    assert send.call_args.args[1] == "/resource"
+    assert (
+        send.call_args.kwargs["headers"]["Authorization"]
+        == make_headers(basic_auth=decoded)["authorization"]
+    )
+    assert headers == {"X-Trace": "synthetic"}
+
+
+def test_conflicting_origin_auth_fails_before_io() -> None:
+    with (
+        PoolManager() as manager,
+        mock.patch.object(
+            HTTPConnectionPool, "urlopen", return_value=HTTPResponse(status=200)
+        ) as send,
+    ):
+        with pytest.raises(ValueError, match="conflicts"):
+            manager.urlopen(
+                "GET",
+                "http://alice:secret@localhost/",
+                headers={"aUtHoRiZaTiOn": "Bearer other"},
+            )
+    send.assert_not_called()
+
+
+def test_matching_origin_auth_is_accepted() -> None:
+    auth = make_headers(basic_auth="alice:secret")["authorization"]
+    with (
+        PoolManager() as manager,
+        mock.patch.object(
+            HTTPConnectionPool, "urlopen", return_value=HTTPResponse(status=200)
+        ) as send,
+    ):
+        manager.urlopen(
+            "GET", "http://alice:secret@localhost/", headers={"authorization": auth}
+        )
+    assert list(send.call_args.kwargs["headers"].values()) == [auth]
+
+
+def test_proxy_url_is_sanitized_and_auth_is_separate() -> None:
+    headers = {"X-Proxy": "synthetic"}
+    with ProxyManager(
+        "http://proxyuser:proxypass@localhost:8080", proxy_headers=headers
+    ) as manager:
+        assert manager.proxy is not None
+        assert manager.proxy.auth is None
+        assert (
+            manager.proxy_headers["Proxy-Authorization"]
+            == make_headers(proxy_basic_auth="proxyuser:proxypass")[
+                "proxy-authorization"
+            ]
+        )
+        assert "proxypass" not in manager.proxy.url
+    assert headers == {"X-Proxy": "synthetic"}
+
+
+def test_conflicting_proxy_auth_fails() -> None:
+    with pytest.raises(ValueError, match="conflicts"):
+        ProxyManager(
+            "http://proxyuser:proxypass@localhost:8080",
+            proxy_headers={"proxy-authorization": "Bearer other"},
+        )
+
+
+def test_pool_absolute_target_strips_userinfo() -> None:
+    with (
+        HTTPConnectionPool("localhost") as pool,
+        mock.patch.object(
+            pool, "_make_request", return_value=HTTPResponse(status=200)
+        ) as send,
+    ):
+        pool.urlopen("GET", "http://alice:secret@localhost/resource", retries=False)
+    assert send.call_args.args[2] == "http://localhost/resource"
+    assert (
+        send.call_args.kwargs["headers"]["Authorization"]
+        == make_headers(basic_auth="alice:secret")["authorization"]
+    )
+
+
+def test_redirect_credentials_are_not_logged(caplog: pytest.LogCaptureFixture) -> None:
+    response = HTTPResponse(
+        status=302, headers={"Location": "http://bob:newsecret@localhost/next"}
+    )
+    with (
+        PoolManager() as manager,
+        mock.patch.object(HTTPConnectionPool, "urlopen", return_value=response),
+    ):
+        with pytest.raises(ValueError, match="conflicts"):
+            manager.urlopen("GET", "http://alice:secret@localhost/", retries=1)
+    assert "newsecret" not in caplog.text
+
+
+def test_forwarded_proxy_auth_conflict_fails_before_io() -> None:
+    with (
+        ProxyManager("http://proxyuser:proxypass@localhost:8080") as manager,
+        mock.patch.object(
+            HTTPConnectionPool, "_make_request", return_value=HTTPResponse(status=200)
+        ) as send,
+    ):
+        with pytest.raises(ValueError, match="conflicts"):
+            manager.urlopen(
+                "GET",
+                "http://localhost/",
+                headers={"proxy-authorization": "Basic b3RoZXI="},
+                retries=False,
+            )
+    send.assert_not_called()
+
+
+def test_matching_forwarded_proxy_auth_is_not_duplicated() -> None:
+    auth = make_headers(proxy_basic_auth="proxyuser:proxypass")["proxy-authorization"]
+    with (
+        ProxyManager("http://proxyuser:proxypass@localhost:8080") as manager,
+        mock.patch.object(
+            HTTPConnectionPool, "_make_request", return_value=HTTPResponse(status=200)
+        ) as send,
+    ):
+        manager.urlopen(
+            "GET",
+            "http://localhost/",
+            headers={"proxy-authorization": auth},
+            retries=False,
+        )
+    values = [
+        value
+        for key, value in send.call_args.kwargs["headers"].items()
+        if key.lower() == "proxy-authorization"
+    ]
+    assert values == [auth]
+
+
+def test_unencodable_credentials_have_a_safe_error() -> None:
+    with (
+        PoolManager() as manager,
+        mock.patch.object(HTTPConnectionPool, "urlopen") as send,
+    ):
+        with pytest.raises(ValueError) as caught:
+            manager.urlopen("GET", "http://alice:%E4%B8%ADsecret@localhost/")
+    assert "secret" not in str(caught.value)
+    send.assert_not_called()
+
+
+def test_manager_does_not_reuse_url_credentials() -> None:
+    with (
+        PoolManager() as manager,
+        mock.patch.object(
+            HTTPConnectionPool, "urlopen", return_value=HTTPResponse(status=200)
+        ) as send,
+    ):
+        manager.urlopen("GET", "http://alice:secret@localhost/")
+        manager.urlopen("GET", "http://localhost/")
+    assert all(
+        key.lower() != "authorization" for key in send.call_args.kwargs["headers"]
+    )
+
+
+def test_matching_byte_auth_header_is_accepted() -> None:
+    auth = make_headers(basic_auth="alice:secret")["authorization"].encode()
+    headers = typing.cast("typing.Mapping[str, str]", {b"Authorization": auth})
+    with (
+        PoolManager() as manager,
+        mock.patch.object(
+            HTTPConnectionPool, "urlopen", return_value=HTTPResponse(status=200)
+        ) as send,
+    ):
+        manager.urlopen("GET", "http://alice:secret@localhost/", headers=headers)
+    assert send.call_args.kwargs["headers"] is headers
+
+
+def test_connect_proxy_auth_conflict_fails_before_connect() -> None:
+    with (
+        ProxyManager("http://proxyuser:proxypass@localhost:8080") as manager,
+        mock.patch.object(HTTPSConnectionPool, "_prepare_proxy") as connect,
+        mock.patch.object(
+            HTTPConnectionPool, "_make_request", return_value=HTTPResponse(status=200)
+        ) as send,
+    ):
+        with pytest.raises(ValueError, match="conflicts"):
+            manager.urlopen(
+                "GET",
+                "https://localhost/",
+                headers={"proxy-authorization": "Basic b3RoZXI="},
+                retries=False,
+            )
+    connect.assert_not_called()
+    send.assert_not_called()

--- a/test/with_dummyserver/test_url_auth.py
+++ b/test/with_dummyserver/test_url_auth.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+import socket
+import ssl
+
+import pytest
+import trustme
+
+from dummyserver.socketserver import SocketServerThread
+from dummyserver.testcase import SocketDummyServerTestCase
+from urllib3 import HTTPConnectionPool, PoolManager, ProxyManager
+from urllib3.util import make_headers
+
+
+def read_request(sock: socket.socket) -> bytes:
+    sock.settimeout(5)
+    request = b""
+    while not request.endswith(b"\r\n\r\n"):
+        chunk = sock.recv(65536)
+        if not chunk:
+            raise RuntimeError("Incomplete request")
+        request += chunk
+    return request
+
+
+class TestURLAuthWire(SocketDummyServerTestCase):
+    @pytest.mark.parametrize("mode", ["pool", "manager", "proxy"])
+    def test_wire_headers_and_target(
+        self, mode: str, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        requests: list[bytes] = []
+
+        def serve(listener: socket.socket) -> None:
+            listener.settimeout(5)
+            with listener.accept()[0] as sock:
+                requests.append(read_request(sock))
+                sock.sendall(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok")
+
+        self._start_server(serve)
+        client = (
+            ProxyManager(f"http://proxyuser:proxypass@{self.host}:{self.port}")
+            if mode == "proxy"
+            else (
+                PoolManager()
+                if mode == "manager"
+                else HTTPConnectionPool(self.host, self.port)
+            )
+        )
+        with client:
+            response = client.request(
+                "GET",
+                f"http://alice:s%65cret@{self.host}:{self.port}/resource",
+                retries=False,
+                timeout=2,
+            )
+            assert response.data == b"ok"
+        raw = requests[0]
+        assert b"@" not in raw.split(b"\r\n", 1)[0]
+        assert (
+            b"Authorization: "
+            + make_headers(basic_auth="alice:secret")["authorization"].encode()
+            + b"\r\n"
+            in raw
+        )
+        proxy_header = (
+            b"Proxy-Authorization: "
+            + make_headers(proxy_basic_auth="proxyuser:proxypass")[
+                "proxy-authorization"
+            ].encode()
+            + b"\r\n"
+        )
+        assert (proxy_header in raw) is (mode == "proxy")
+        assert "secret" not in caplog.text
+        assert "proxypass" not in caplog.text
+
+    @pytest.mark.parametrize("cross_host", [False, True])
+    @pytest.mark.parametrize("proxy", [False, True])
+    def test_redirect_does_not_reintroduce_url_credentials(
+        self, cross_host: bool, proxy: bool
+    ) -> None:
+        requests: list[bytes] = []
+        origin_host = "origin.invalid" if proxy else self.host
+        target_host = (
+            (
+                "other.invalid"
+                if proxy
+                else "[::1]" if SocketServerThread.USE_IPV6 else "127.0.0.1"
+            )
+            if cross_host
+            else origin_host
+        )
+
+        def serve(listener: socket.socket) -> None:
+            listener.settimeout(5)
+            for index in range(2):
+                with listener.accept()[0] as sock:
+                    requests.append(read_request(sock))
+                    if index == 0:
+                        response = f"HTTP/1.1 302 Found\r\nLocation: http://{target_host}:{self.port}/next\r\nContent-Length: 0\r\nConnection: close\r\n\r\n".encode()
+                    else:
+                        response = b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok"
+                    sock.sendall(response)
+
+        self._start_server(serve)
+        with (
+            ProxyManager(f"http://{self.host}:{self.port}") if proxy else PoolManager()
+        ) as client:
+            response = client.request(
+                "GET",
+                f"http://alice:secret@{origin_host}:{self.port}/first",
+                retries=1,
+                timeout=2,
+            )
+            assert response.data == b"ok"
+        assert b"Authorization:" in requests[0]
+        assert (b"Authorization:" in requests[1]) is not cross_host
+        assert all(b"@" not in request.split(b"\r\n", 1)[0] for request in requests)
+
+    @pytest.mark.parametrize("request_proxy_auth", [False, True])
+    def test_connect_keeps_proxy_credentials_out_of_origin_request(
+        self, request_proxy_auth: bool
+    ) -> None:
+        ca = trustme.CA()
+        certificate = ca.issue_cert("localhost")
+        server_context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+        certificate.configure_cert(server_context)
+        client_context = ssl.create_default_context()
+        ca.configure_trust(client_context)
+        requests: list[bytes] = []
+
+        def serve(listener: socket.socket) -> None:
+            listener.settimeout(5)
+            with listener.accept()[0] as sock:
+                requests.append(read_request(sock))
+                sock.sendall(b"HTTP/1.1 200 Connection established\r\n\r\n")
+                with server_context.wrap_socket(sock, server_side=True) as tls:
+                    requests.append(read_request(tls))
+                    tls.sendall(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok")
+
+        self._start_server(serve)
+        with ProxyManager(
+            f"http://proxyuser:proxypass@{self.host}:{self.port}",
+            ssl_context=client_context,
+        ) as client:
+            response = client.request(
+                "GET",
+                "https://alice:secret@localhost:443/resource",
+                headers=(
+                    make_headers(proxy_basic_auth="proxyuser:proxypass")
+                    if request_proxy_auth
+                    else {}
+                ),
+                retries=False,
+                timeout=2,
+            )
+            assert response.data == b"ok"
+        assert requests[0].startswith(b"CONNECT localhost:443 ")
+        assert (
+            b"Proxy-Authorization: "
+            + make_headers(proxy_basic_auth="proxyuser:proxypass")[
+                "proxy-authorization"
+            ].encode()
+            + b"\r\n"
+            in requests[0]
+        )
+        assert (
+            b"Authorization: "
+            + make_headers(basic_auth="alice:secret")["authorization"].encode()
+            + b"\r\n"
+            not in requests[0]
+        )
+        assert requests[1].startswith(b"GET /resource ")
+        assert b"proxy-authorization:" not in requests[1].lower()
+        assert (
+            b"Authorization: "
+            + make_headers(basic_auth="alice:secret")["authorization"].encode()
+            + b"\r\n"
+            in requests[1]
+        )


### PR DESCRIPTION
Fixes #1999.

Request URL userinfo now generates Basic Authorization, and HTTP(S) proxy URL userinfo generates Proxy-Authorization. Credentials are percent-decoded using the existing URL API and encoded with the existing Latin-1 Basic-auth convention. Userinfo is removed from request targets and stored proxy URLs. Matching explicit authentication headers are accepted; conflicting values fail before sending the request, without including credentials in the error.

Caller header mappings remain unchanged. Redirect handling uses the target origin rather than the proxy connection's host, preserving authentication for same-origin forwarding and removing it on cross-origin redirects under the default Retry policy. Redirect log messages omit userinfo. Forwarded proxy headers are merged case-insensitively so matching credentials aren't duplicated.

Regression coverage includes:
- Ordinary, percent-encoded, username-only, Latin-1 and unsupported-encoding credentials; explicit matches/conflicts and caller mapping reuse.
- Actual HTTP request bytes for direct pools, PoolManager and forwarding proxies, with no userinfo in the request target.
- Same-origin and cross-origin redirects, both directly and through a forwarding proxy.
- A real verified TLS connection through HTTP CONNECT: proxy credentials occur only in CONNECT and origin credentials only in the tunneled request.
- Credential-free redirect logs and conflict errors, plus matching byte-valued headers.

Local verification on Windows/Python 3.13.3:
- Original manager/proxy-manager baseline: 52 passed; initial new regressions: 8 failed, 1 passed before implementation.
- Final 25 specialized unit/socket/TLS cases passed. The expanded proxy suite also passed 116 tests before the last two CONNECT cases were added.
- Final full `test/` suite with the project socket restrictions: **2327 passed, 329 skipped, 45 xfailed**.
- The four changed source modules report 885 statements, two missed (both unchanged lines), 99% combined statement coverage. The complete merged platform coverage remains for hosted CI.
- Linux-target mypy passed 85 files. Changed Python files passed Black (py310), isort, flake8 and pyupgrade; `git diff --check` passed.

Hosted verification now reports 37 successful checks and one failed Ubuntu 3.13 job. [Requests and botocore downstream tests](https://github.com/urllib3/urllib3/actions/runs/34345866889) pass. [Combined coverage from the available 28 artifacts](https://github.com/urllib3/urllib3/actions/runs/34345866881/job/102449184560) reports 3,949 statements, zero missed, 100%. The remaining matrix failure is documented in [this diagnosis and rerun request](https://github.com/urllib3/urllib3/pull/5245#issuecomment-5601216595): an unchanged test finds `h2` inside ClientHello random bytes even though the actual ALPN list is only `http/1.1`. A maintainer rerun is still needed; this is not a claim that the full matrix passed. CONNECT validation also checks that a matching Proxy-Authorization supplied in request headers is removed from the tunneled origin request, and a conflicting value is rejected before connecting.

Implemented and self-reviewed with OpenAI Codex; no independent human review is claimed.
