### PR TITLE
Add streaming multipart encoder, decoder, and buffered parts

### DIFF
--- a/changelog/624.feature.rst
+++ b/changelog/624.feature.rst
@@ -1,0 +1,1 @@
+Added streaming multipart encoding and decoding with buffered parts and support for rewinding file bodies.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -106,6 +106,8 @@ nitpick_ignore = [
     ("py:class", "_TYPE_SOCKET_OPTIONS"),
     ("py:class", "_TYPE_TIMEOUT"),
     ("py:class", "_TYPE_FIELD_VALUE"),
+    ("py:class", "_TYPE_FIELD_BODY"),
+    ("py:class", "_TYPE_FIELDS"),
     ("py:class", "_TYPE_BODY"),
     ("py:class", "_HttplibHTTPResponse"),
     ("py:class", "_HttplibHTTPMessage"),

--- a/docs/reference/urllib3.fields.rst
+++ b/docs/reference/urllib3.fields.rst
@@ -16,3 +16,73 @@ Multipart Forms
 .. autofunction:: urllib3.encode_multipart_formdata
 .. autofunction:: urllib3.filepost.choose_boundary
 .. autofunction:: urllib3.filepost.iter_field_objects
+
+
+Streaming multipart bodies
+--------------------------
+
+:class:`~urllib3.multipart.MultipartEncoder` accepts file objects without reading
+an entire file into memory. Pass the encoder as ``body`` and use its
+``content_type`` as the request's ``Content-Type``::
+
+    from urllib3 import PoolManager
+    from urllib3.multipart import MultipartEncoder
+
+    with open("report.csv", "rb") as source:
+        body = MultipartEncoder.from_fields({
+            "description": "Monthly report",
+            "file": ("report.csv", source, "text/csv"),
+        })
+        with PoolManager() as http:
+            response = http.request(
+                "POST",
+                "https://example.com/upload",
+                body=body,
+                headers={"Content-Type": body.content_type},
+            )
+
+The request uses chunked transfer encoding unless a content length is supplied
+separately. Keep the files open until the request finishes. Closing an encoder
+or a :class:`~urllib3.multipart.Part` does not close caller-owned input files.
+Files start at their current position. ``seek(0, 0)`` rewinds every part to that
+starting position, including attempts after an earlier part fails. If any part
+cannot rewind, the encoder raises ``io.UnsupportedOperation`` and cannot be
+read again until a successful rewind. Other encoder seek positions are not
+supported. Use seekable inputs when a request might need to be resent.
+
+Bounded positive ``read(size)`` calls stream the body. Calling ``read()`` without
+a size materializes the remaining output. The legacy
+:func:`~urllib3.encode_multipart_formdata` still returns the complete body as
+``bytes``, so it necessarily allocates memory proportional to that body.
+Encoder metadata scales with the number of parts and their headers. Text and
+bytes-like values are buffered in memory when constructing a part; use binary
+file objects to avoid loading large inputs into memory.
+
+:class:`~urllib3.multipart.MultipartDecoder` reads a multipart stream one part
+at a time. Supply the boundary value without the leading ``--`` delimiter::
+
+    from urllib3.multipart import MultipartDecoder
+
+    decoder = MultipartDecoder(source, boundary="example-boundary")
+    for part in decoder:
+        print(part.headers)
+        while chunk := part.read(8192):
+            destination.write(chunk)
+
+Consume each part before advancing the iterator. Advancing discards unread
+source bytes for the previous part; previously buffered bytes may remain
+readable from that old part, but it will never read into a subsequent part.
+Decoded parts do not support seeking. The decoder leaves its source open.
+It raises ``ValueError`` for malformed headers or truncated framing. Header
+blocks and boundary padding are bounded by ``max_header_size``; the source is
+read in chunks of ``buffer_size``. ``Part.peek()`` has the same buffering
+semantics as ``io.BufferedReader.peek()`` and may return more or fewer bytes
+than requested.
+
+.. autoclass:: urllib3.multipart.Part
+    :members: from_field
+
+.. autoclass:: urllib3.multipart.MultipartEncoder
+    :members: from_fields, read, readinto, seek, tell
+
+.. autoclass:: urllib3.multipart.MultipartDecoder

--- a/src/urllib3/fields.py
+++ b/src/urllib3/fields.py
@@ -5,10 +5,11 @@ import mimetypes
 import typing
 
 _TYPE_FIELD_VALUE = typing.Union[str, bytes]
+_TYPE_FIELD_BODY = typing.Union[str, bytes, bytearray, memoryview, typing.BinaryIO]
 _TYPE_FIELD_VALUE_TUPLE = typing.Union[
-    _TYPE_FIELD_VALUE,
-    tuple[str, _TYPE_FIELD_VALUE],
-    tuple[str, _TYPE_FIELD_VALUE, str],
+    _TYPE_FIELD_BODY,
+    tuple[str, _TYPE_FIELD_BODY],
+    tuple[str, _TYPE_FIELD_BODY, str],
 ]
 
 
@@ -171,7 +172,7 @@ class RequestField:
     def __init__(
         self,
         name: str,
-        data: _TYPE_FIELD_VALUE,
+        data: _TYPE_FIELD_BODY,
         filename: str | None = None,
         headers: typing.Mapping[str, str] | None = None,
         header_formatter: typing.Callable[[str, _TYPE_FIELD_VALUE], str] | None = None,
@@ -221,7 +222,7 @@ class RequestField:
         """
         filename: str | None
         content_type: str | None
-        data: _TYPE_FIELD_VALUE
+        data: _TYPE_FIELD_BODY
 
         if isinstance(value, tuple):
             if len(value) == 3:

--- a/src/urllib3/filepost.py
+++ b/src/urllib3/filepost.py
@@ -1,14 +1,10 @@
 from __future__ import annotations
 
 import binascii
-import codecs
 import os
 import typing
-from io import BytesIO
 
 from .fields import _TYPE_FIELD_VALUE_TUPLE, RequestField
-
-writer = codecs.lookup("utf-8")[3]
 
 _TYPE_FIELDS_SEQUENCE = typing.Sequence[
     typing.Union[tuple[str, _TYPE_FIELD_VALUE_TUPLE], RequestField]
@@ -62,28 +58,7 @@ def encode_multipart_formdata(
         If not specified, then a random boundary will be generated using
         :func:`urllib3.filepost.choose_boundary`.
     """
-    body = BytesIO()
-    if boundary is None:
-        boundary = choose_boundary()
+    from .multipart import MultipartEncoder
 
-    for field in iter_field_objects(fields):
-        body.write(f"--{boundary}\r\n".encode("latin-1"))
-
-        writer(body).write(field.render_headers())
-        data = field.data
-
-        if isinstance(data, int):
-            data = str(data)  # Backwards compatibility
-
-        if isinstance(data, str):
-            writer(body).write(data)
-        else:
-            body.write(data)
-
-        body.write(b"\r\n")
-
-    body.write(f"--{boundary}--\r\n".encode("latin-1"))
-
-    content_type = f"multipart/form-data; boundary={boundary}"
-
-    return body.getvalue(), content_type
+    encoder = MultipartEncoder.from_fields(fields, boundary)
+    return encoder.read(), encoder.content_type

--- a/src/urllib3/multipart.py
+++ b/src/urllib3/multipart.py
@@ -1,0 +1,430 @@
+from __future__ import annotations
+
+import io
+import operator
+import typing
+
+from ._collections import HTTPHeaderDict
+from .fields import RequestField
+
+
+class _BodyReader(io.RawIOBase):
+    """Adapt a caller-owned binary stream without taking ownership of it."""
+
+    def __init__(
+        self, stream: typing.BinaryIO | io.BufferedIOBase | io.RawIOBase
+    ) -> None:
+        super().__init__()
+        self.stream = stream
+        self.start: int | None
+        try:
+            self.start = stream.tell()
+        except (OSError, AttributeError):
+            self.start = None
+
+    def readable(self) -> bool:
+        return self.stream.readable()
+
+    def seekable(self) -> bool:
+        return self.start is not None and self.stream.seekable()
+
+    def tell(self) -> int:
+        if self.start is None:
+            raise io.UnsupportedOperation("Body position is unavailable")
+        return self.stream.tell() - self.start
+
+    def seek(self, offset: int, whence: int = io.SEEK_SET) -> int:
+        if self.start is None:
+            raise io.UnsupportedOperation("Body cannot be rewound")
+        if whence == io.SEEK_SET:
+            offset += self.start
+        return self.stream.seek(offset, whence) - self.start
+
+    def readinto(self, buffer: typing.Any) -> int:
+        data = self.stream.read(len(buffer))
+        if not isinstance(data, bytes):
+            raise TypeError("Multipart body streams must return bytes")
+        if len(data) > len(buffer):
+            raise ValueError("Multipart body returned more bytes than requested")
+        buffer[: len(data)] = data
+        return len(data)
+
+
+class Part(io.BufferedReader):
+    """A buffered multipart body with headers, leaving its input stream open.
+
+    ``read()`` and ``peek()`` follow :class:`io.BufferedReader`. Seeking to zero
+    returns to the position the input stream had when the part was created.
+    A nonseekable input remains nonseekable.
+    """
+
+    def __init__(
+        self,
+        body: (
+            bytes
+            | bytearray
+            | memoryview
+            | str
+            | typing.BinaryIO
+            | io.BufferedIOBase
+            | io.RawIOBase
+        ),
+        headers: typing.Mapping[str, str] | None = None,
+        *,
+        buffer_size: int = io.DEFAULT_BUFFER_SIZE,
+    ) -> None:
+        if isinstance(body, str):
+            body = body.encode("utf-8")
+        if isinstance(body, (bytes, bytearray, memoryview)):
+            body = io.BytesIO(body)
+        super().__init__(_BodyReader(body), buffer_size=buffer_size)
+        self.headers = HTTPHeaderDict(headers)
+        self._encoded_headers: bytes | None = None
+        self._header_snapshot: tuple[tuple[str, str], ...] = ()
+
+    @classmethod
+    def from_field(cls, field: RequestField) -> Part:
+        """Wrap a request field body and preserve its formatted headers."""
+        data = field.data
+        if isinstance(data, int):
+            data = str(data)
+        part = cls(data)
+        part._encoded_headers = field.render_headers().encode("utf-8")
+        part.headers = HTTPHeaderDict(
+            (name, value) for name, value in field.headers.items() if value
+        )
+        part._header_snapshot = tuple(part.headers.items())
+        return part
+
+    def _render_headers(self) -> bytes:
+        if (
+            self._encoded_headers is not None
+            and tuple(self.headers.items()) == self._header_snapshot
+        ):
+            return self._encoded_headers
+        lines = []
+        for name, value in self.headers.items():
+            if not name or any(c in name for c in "\r\n:"):
+                raise ValueError("Invalid multipart header name")
+            if "\r" in value or "\n" in value:
+                raise ValueError("Invalid multipart header value")
+            lines.append(f"{name}: {value}\r\n".encode("utf-8"))
+        return b"".join(lines) + b"\r\n"
+
+
+class MultipartEncoder(io.BufferedIOBase):
+    """Read a sequence of parts as a multipart/form-data body in bounded chunks.
+
+    Caller-owned parts and their underlying streams stay open when the encoder
+    closes. ``seek(0, 0)`` attempts to rewind every part; other seek positions
+    are unsupported. A failed rewind invalidates reading until a rewind succeeds.
+    """
+
+    def __init__(
+        self, parts: typing.Iterable[Part], boundary: str | None = None
+    ) -> None:
+        super().__init__()
+        # Import locally so the legacy filepost helper can use this class.
+        from .filepost import choose_boundary
+
+        self.boundary = choose_boundary() if boundary is None else boundary
+        if not self.boundary or "\r" in self.boundary or "\n" in self.boundary:
+            raise ValueError("Invalid multipart boundary")
+        self._boundary = self.boundary.encode("latin-1")
+        self.parts = tuple(parts)
+        self.content_type = f"multipart/form-data; boundary={self.boundary}"
+        self._segments: list[typing.BinaryIO] = []
+        for part in self.parts:
+            self._segments.extend(
+                (
+                    io.BytesIO(
+                        b"--" + self._boundary + b"\r\n" + part._render_headers()
+                    ),
+                    part,
+                    io.BytesIO(b"\r\n"),
+                )
+            )
+        self._segments.append(io.BytesIO(b"--" + self._boundary + b"--\r\n"))
+        self._index = 0
+        self._position = 0
+        self._valid = True
+
+    @classmethod
+    def from_fields(
+        cls, fields: _TYPE_FIELDS, boundary: str | None = None
+    ) -> MultipartEncoder:
+        """Build an encoder from the fields accepted by the legacy helper."""
+        from .filepost import iter_field_objects
+
+        return cls(
+            (Part.from_field(field) for field in iter_field_objects(fields)), boundary
+        )
+
+    def readable(self) -> bool:
+        return True
+
+    def seekable(self) -> bool:
+        return all(part.seekable() for part in self.parts)
+
+    def tell(self) -> int:
+        """Return the number of bytes read since creation or the last rewind."""
+        self._checkClosed()
+        return self._position
+
+    def seek(self, offset: int, whence: int = io.SEEK_SET) -> int:
+        """Rewind every part with ``seek(0, 0)`` or raise after all attempts."""
+        self._checkClosed()
+        if offset != 0 or whence != io.SEEK_SET:
+            raise io.UnsupportedOperation("MultipartEncoder only supports seek(0, 0)")
+        error: Exception | None = None
+        for segment in self._segments:
+            try:
+                segment.seek(0)
+            except Exception as exc:
+                # A custom part may raise errors other than OSError. Rewinding
+                # later parts must still be attempted before reporting failure.
+                if error is None:
+                    error = exc
+        self._valid = error is None
+        if error is not None:
+            raise io.UnsupportedOperation(
+                "One or more multipart bodies cannot rewind"
+            ) from error
+        self._index = 0
+        self._position = 0
+        return 0
+
+    def read(self, size: int | None = -1) -> bytes:
+        """Read at most ``size`` bytes, or all remaining bytes for a negative size.
+
+        ``None`` also reads all remaining bytes. Bounded positive sizes keep
+        body data buffered independently of the total length of each part.
+        """
+        self._checkClosed()
+        if not self._valid:
+            raise OSError("Multipart body is invalid after a failed rewind")
+        if size is not None:
+            size = operator.index(size)
+        if size == 0:
+            return b""
+        unlimited = size is None or size < 0
+        remaining = io.DEFAULT_BUFFER_SIZE if unlimited else size
+        assert remaining is not None
+        output = bytearray()
+        while self._index < len(self._segments):
+            data = self._segments[self._index].read(remaining)
+            if not data:
+                self._index += 1
+                continue
+            output.extend(data)
+            self._position += len(data)
+            if not unlimited:
+                remaining -= len(data)
+                if remaining == 0:
+                    break
+        return bytes(output)
+
+    def readinto(self, buffer: typing.Any) -> int:
+        """Fill a writable bytes-like buffer and return the byte count."""
+        view = memoryview(buffer).cast("B")
+        if view.readonly:
+            raise TypeError("readinto() requires a writable buffer")
+        data = self.read(len(view))
+        view[: len(data)] = data
+        return len(data)
+
+
+class _DecodedBody(io.RawIOBase):
+    def __init__(self, decoder: MultipartDecoder) -> None:
+        super().__init__()
+        self.decoder = decoder
+        self.done = False
+
+    def readable(self) -> bool:
+        return True
+
+    def readinto(self, buffer: typing.Any) -> int:
+        if self.done:
+            return 0
+        data = self.decoder._read_body(len(buffer))
+        if not data:
+            self.done = True
+        buffer[: len(data)] = data
+        return len(data)
+
+
+class MultipartDecoder(typing.Iterator[Part]):
+    """Iterate over multipart bodies without buffering entire parts.
+
+    Consume each returned :class:`Part` before requesting the next one. Moving
+    to the next part discards unread bytes of the previous part. Decoded parts
+    are forward-only; the caller's input stream is never closed by the decoder.
+    Header blocks are limited to ``max_header_size`` bytes.
+    """
+
+    def __init__(
+        self,
+        body: bytes | typing.BinaryIO | io.BufferedIOBase | io.RawIOBase,
+        boundary: str,
+        *,
+        buffer_size: int = io.DEFAULT_BUFFER_SIZE,
+        max_header_size: int = 65536,
+    ) -> None:
+        if not boundary or "\r" in boundary or "\n" in boundary:
+            raise ValueError("Invalid multipart boundary")
+        if buffer_size <= 0 or max_header_size <= 0:
+            raise ValueError("Multipart buffer and header limits must be positive")
+        self._stream = io.BytesIO(body) if isinstance(body, bytes) else body
+        self._delimiter = b"--" + boundary.encode("latin-1")
+        self._marker = b"\r\n" + self._delimiter
+        self._buffer_size = buffer_size
+        self._max_header_size = max_header_size
+        self._buffer = bytearray()
+        self._eof = False
+        self._started = False
+        self._finished = False
+        self._part_ended = False
+        self._current: Part | None = None
+        self._current_raw: _DecodedBody | None = None
+
+    def _fill(self) -> None:
+        data = self._stream.read(self._buffer_size)
+        if not isinstance(data, bytes):
+            raise TypeError("Multipart body streams must return bytes")
+        if len(data) > self._buffer_size:
+            raise ValueError("Multipart body returned more bytes than requested")
+        self._buffer.extend(data)
+        self._eof = not data
+
+    def _readline(self) -> bytes:
+        while True:
+            end = self._buffer.find(b"\r\n")
+            if end >= 0:
+                if end + 2 > self._max_header_size:
+                    raise ValueError("Multipart header line is too long")
+                line = bytes(self._buffer[: end + 2])
+                del self._buffer[: end + 2]
+                return line
+            if len(self._buffer) > self._max_header_size:
+                raise ValueError("Multipart header line is too long")
+            if self._eof:
+                line = bytes(self._buffer)
+                self._buffer.clear()
+                return line
+            self._fill()
+
+    def __next__(self) -> Part:
+        if self._current is not None:
+            # The previous Part may already have buffered bytes. They belong to
+            # that old Part, while this drains the remainder from the source.
+            while self._read_body(self._buffer_size):
+                pass
+            assert self._current_raw is not None
+            self._current_raw.done = True
+            self._current = None
+        if not self._started:
+            while True:
+                line = self._readline()
+                if not line:
+                    raise ValueError("Multipart opening boundary was not found")
+                marker = line.removesuffix(b"\r\n").rstrip(b" \t")
+                if marker == self._delimiter:
+                    break
+                if marker == self._delimiter + b"--":
+                    self._finished = True
+                    break
+            self._started = True
+        if self._finished:
+            raise StopIteration
+
+        headers = HTTPHeaderDict()
+        encoded_headers = bytearray()
+        current_name: str | None = None
+        current_value = ""
+        while True:
+            line = self._readline()
+            if not line.endswith(b"\r\n"):
+                raise ValueError("Truncated multipart headers")
+            encoded_headers.extend(line)
+            if len(encoded_headers) > self._max_header_size:
+                raise ValueError("Multipart header block is too long")
+            if line == b"\r\n":
+                if current_name is not None:
+                    headers.add(current_name, current_value)
+                break
+            if line[:1] in (b" ", b"\t"):
+                if current_name is None:
+                    raise ValueError("Multipart header continuation has no field")
+                current_value += " " + line.strip().decode("latin-1")
+                continue
+            if current_name is not None:
+                headers.add(current_name, current_value)
+            name, separator, value = line[:-2].partition(b":")
+            if not separator or not name or name.strip() != name:
+                raise ValueError("Invalid multipart header")
+            current_name = name.decode("latin-1")
+            current_value = value.strip().decode("latin-1")
+
+        self._part_ended = False
+        raw = _DecodedBody(self)
+        part = Part(typing.cast("typing.BinaryIO", raw), headers)
+        part._encoded_headers = bytes(encoded_headers)
+        part._header_snapshot = tuple(part.headers.items())
+        self._current_raw = raw
+        self._current = part
+        return part
+
+    def _read_body(self, size: int) -> bytes:
+        if self._part_ended or size == 0:
+            return b""
+        while True:
+            index = self._buffer.find(self._marker)
+            if index >= 0:
+                after = index + len(self._marker)
+                while len(self._buffer) < after + 2 and not self._eof:
+                    self._fill()
+                closing = self._buffer[after : after + 2] == b"--"
+                if closing:
+                    after += 2
+                padding_start = after
+                while True:
+                    while after < len(self._buffer) and self._buffer[after] in (32, 9):
+                        after += 1
+                    if after - padding_start > self._max_header_size:
+                        raise ValueError("Multipart boundary padding is too long")
+                    if len(self._buffer) >= after + 2 or self._eof:
+                        break
+                    self._fill()
+                terminated = self._buffer[after : after + 2] == b"\r\n"
+                if terminated or (closing and self._eof and after == len(self._buffer)):
+                    if index:
+                        count = min(index, size)
+                        data = bytes(self._buffer[:count])
+                        del self._buffer[:count]
+                        return data
+                    del self._buffer[: after + (2 if terminated else 0)]
+                    self._part_ended = True
+                    self._finished = closing
+                    return b""
+                # A boundary prefix followed by other body bytes is ordinary
+                # data. Return the leading CRLF and look for the next candidate.
+                count = min(index + 2, size)
+                data = bytes(self._buffer[:count])
+                del self._buffer[:count]
+                return data
+
+            available = len(self._buffer) - len(self._marker) - 2
+            if available > 0:
+                count = min(available, size)
+                data = bytes(self._buffer[:count])
+                del self._buffer[:count]
+                return data
+            if self._eof:
+                raise ValueError(
+                    "Truncated multipart body: closing boundary is missing"
+                )
+            self._fill()
+
+
+if typing.TYPE_CHECKING:
+    from .filepost import _TYPE_FIELDS

--- a/src/urllib3/multipart.py
+++ b/src/urllib3/multipart.py
@@ -108,7 +108,7 @@ class Part(io.BufferedReader):
                 raise ValueError("Invalid multipart header name")
             if "\r" in value or "\n" in value:
                 raise ValueError("Invalid multipart header value")
-            lines.append(f"{name}: {value}\r\n".encode("utf-8"))
+            lines.append(f"{name}: {value}\r\n".encode())
         return b"".join(lines) + b"\r\n"
 
 

--- a/test/test_multipart.py
+++ b/test/test_multipart.py
@@ -1,0 +1,367 @@
+from __future__ import annotations
+
+import io
+from array import array
+
+import pytest
+
+from urllib3.fields import RequestField
+from urllib3.filepost import encode_multipart_formdata
+from urllib3.multipart import MultipartDecoder, MultipartEncoder, Part
+
+
+class ShortReader(io.BytesIO):
+    def __init__(self, data: bytes, chunk_size: int = 3) -> None:
+        super().__init__(data)
+        self.chunk_size = chunk_size
+        self.requests: list[int] = []
+
+    def read(self, size: int | None = -1) -> bytes:
+        assert size is not None and size >= 0, "Unbounded source read"
+        self.requests.append(size)
+        return super().read(min(size, self.chunk_size))
+
+
+def read_chunks(stream: io.BufferedIOBase, size: int) -> bytes:
+    chunks = []
+    while chunk := stream.read(size):
+        assert len(chunk) <= size
+        chunks.append(chunk)
+    return b"".join(chunks)
+
+
+class TestPart:
+    def test_buffering_original_offset_and_ownership(self) -> None:
+        source = ShortReader(b"skipabcdefgh")
+        source.seek(4)
+        part = Part(source)
+        assert part.peek(1).startswith(b"a")
+        assert part.tell() == 0
+        assert part.read(5) == b"abcde"
+        assert part.tell() == 5
+        assert part.seek(0) == 0
+        assert part.read() == b"abcdefgh"
+        part.close()
+        assert not source.closed
+        assert max(source.requests) <= io.DEFAULT_BUFFER_SIZE
+
+    def test_text(self) -> None:
+        assert Part("caf\xe9").read() == b"caf\xc3\xa9"
+
+    def test_nonseekable(self) -> None:
+        class Nonseekable(io.BytesIO):
+            def tell(self) -> int:
+                raise io.UnsupportedOperation
+
+            def seekable(self) -> bool:
+                return False
+
+        part = Part(Nonseekable(b"value"))
+        assert not part.seekable()
+        assert part.read() == b"value"
+        with pytest.raises(io.UnsupportedOperation):
+            part.seek(0)
+        with pytest.raises(io.UnsupportedOperation):
+            part.raw.seek(0, 0)
+
+
+class TestMultipartEncoder:
+    @pytest.mark.parametrize("size", [1, 3, 17, 8192])
+    def test_exact_wire_and_rewind(self, size: int) -> None:
+        source = ShortReader(b"abc\x00def")
+        encoder = MultipartEncoder.from_fields(
+            [("field", "value"), ("file", ("file.bin", source))], boundary="test"
+        )
+        expected = (
+            b'--test\r\nContent-Disposition: form-data; name="field"\r\n\r\nvalue\r\n'
+            b'--test\r\nContent-Disposition: form-data; name="file"; filename="file.bin"\r\n'
+            b"Content-Type: application/octet-stream\r\n\r\nabc\x00def\r\n--test--\r\n"
+        )
+        assert encoder.read(0) == b""
+        assert encoder.tell() == 0
+        assert read_chunks(encoder, size) == expected
+        assert encoder.tell() == len(expected)
+        assert encoder.read(3) == b""
+        assert encoder.seek(0, 0) == 0
+        assert encoder.read() == expected
+        assert max(source.requests) <= io.DEFAULT_BUFFER_SIZE
+        encoder.close()
+        assert not source.closed
+
+    @pytest.mark.parametrize(
+        "error_type", [io.UnsupportedOperation, ValueError, RuntimeError]
+    )
+    def test_rewind_attempts_every_part_after_failure(
+        self, error_type: type[Exception]
+    ) -> None:
+        attempts = []
+
+        class RecordedPart(Part):
+            def __init__(self, name: str, fails: bool) -> None:
+                super().__init__(b"body")
+                self.label = name
+                self.fails = fails
+
+            def seek(self, offset: int, whence: int = io.SEEK_SET) -> int:
+                attempts.append(self.label)
+                if self.fails:
+                    raise error_type(self.label)
+                return super().seek(offset, whence)
+
+        parts = [
+            RecordedPart("first", True),
+            RecordedPart("second", True),
+            RecordedPart("last", False),
+        ]
+        encoder = MultipartEncoder(parts, "boundary")
+        encoder.read(10)
+        with pytest.raises(io.UnsupportedOperation):
+            encoder.seek(0)
+        assert attempts == ["first", "second", "last"]
+        with pytest.raises(OSError, match="invalid after a failed rewind"):
+            encoder.read(1)
+        for part in parts:
+            part.fails = False
+        assert encoder.seek(0) == 0
+        assert encoder.read().endswith(b"--boundary--\r\n")
+
+    def test_readinto_uses_bytes_not_element_count(self) -> None:
+        encoder = MultipartEncoder([], "b")
+        buffer = array("I", [0, 0])
+        count = encoder.readinto(buffer)
+        assert count == 7
+        assert memoryview(buffer).cast("B")[:count].tobytes() == b"--b--\r\n"
+
+    def test_legacy_helper_accepts_streams(self) -> None:
+        source = io.BytesIO(b"contents")
+        body, content_type = encode_multipart_formdata(
+            {"file": ("file.txt", source)}, boundary="b"
+        )
+        assert isinstance(body, bytes)
+        assert b"\r\n\r\ncontents\r\n" in body
+        assert content_type == "multipart/form-data; boundary=b"
+        assert not source.closed
+
+
+class TestMultipartDecoder:
+    @pytest.mark.parametrize("size", [1, 2, 3, 7, 8192])
+    def test_chunk_boundaries_and_lookalikes(self, size: int) -> None:
+        payload = b"binary\x00\xff\r\n--bX\r\n--b--X\r\n--b-\r\nend"
+        wire = (
+            b'--b\r\nContent-Disposition: form-data; name="x"\r\n\r\n'
+            + payload
+            + b"\r\n--b--\r\n"
+        )
+        source = ShortReader(wire, size)
+        decoder = MultipartDecoder(source, "b", buffer_size=size)
+        part = next(decoder)
+        assert part.headers["content-disposition"] == 'form-data; name="x"'
+        assert read_chunks(part, 3) == payload
+        with pytest.raises(StopIteration):
+            next(decoder)
+        assert max(source.requests) == size
+        part.close()
+        assert not source.closed
+
+    def test_skip_unread_part_and_keep_parts_separate(self) -> None:
+        wire = b"--b\r\n\r\nfirst\r\n--b\r\n\r\nsecond\r\n--b--\r\n"
+        decoder = MultipartDecoder(wire, "b", buffer_size=1)
+        first = next(decoder)
+        assert first.read(1) == b"f"
+        second = next(decoder)
+        assert second.read() == b"second"
+        assert b"second" not in first.read()
+        with pytest.raises(StopIteration):
+            next(decoder)
+
+    def test_empty_multipart(self) -> None:
+        assert list(MultipartDecoder(b"--b--\r\n", "b")) == []
+
+    def test_headers_and_empty_body(self) -> None:
+        wire = b"preamble\r\n--b \t\r\nX: first\r\nX: second\r\n continued\r\n\r\n\r\n--b--\t\r\nepilogue"
+        decoder = MultipartDecoder(wire, "b", buffer_size=3)
+        part = next(decoder)
+        assert part.headers.getlist("x") == ["first", "second continued"]
+        assert part.read() == b""
+        assert list(decoder) == []
+
+    @pytest.mark.parametrize(
+        "wire",
+        [b"", b"--b\r\nX: value", b"--b\r\n\r\nbody", b"--b\r\n\r\nbody\r\n--b-"],
+    )
+    def test_truncated_input(self, wire: bytes) -> None:
+        with pytest.raises(ValueError):
+            for part in MultipartDecoder(wire, "b", buffer_size=1):
+                part.read()
+
+    def test_header_limit(self) -> None:
+        with pytest.raises(ValueError, match="too long"):
+            next(
+                MultipartDecoder(
+                    b"--b\r\nX: " + b"x" * 100 + b"\r\n\r\n", "b", max_header_size=32
+                )
+            )
+
+    def test_round_trip(self) -> None:
+        encoder = MultipartEncoder(
+            [Part(b"one", {"X-Name": "first"}), Part(b"two")], "b"
+        )
+        decoder = MultipartDecoder(encoder, "b", buffer_size=2)
+        bodies = [(dict(part.headers), part.read()) for part in decoder]
+        assert bodies == [({"X-Name": "first"}, b"one"), ({}, b"two")]
+
+
+class TestMultipartCompatibility:
+    @pytest.mark.parametrize("body", [bytearray(b"data"), memoryview(b"data")])
+    def test_legacy_buffer_values(self, body: bytearray | memoryview) -> None:
+        encoded, _ = encode_multipart_formdata({"x": body}, boundary="b")
+        assert (
+            encoded
+            == b'--b\r\nContent-Disposition: form-data; name="x"\r\n\r\ndata\r\n--b--\r\n'
+        )
+
+    def test_legacy_boundary_encoding(self) -> None:
+        body, content_type = encode_multipart_formdata([], boundary="caf\xe9")
+        assert body == b"--caf\xe9--\r\n"
+        assert content_type == "multipart/form-data; boundary=caf\xe9"
+        assert list(MultipartDecoder(body, "caf\xe9")) == []
+
+    @pytest.mark.parametrize("decoded", [False, True])
+    def test_modified_part_headers_are_encoded(self, decoded: bool) -> None:
+        if decoded:
+            part = next(
+                MultipartDecoder(b"--b\r\nX: old\r\n\r\nbody\r\n--b--\r\n", "b")
+            )
+        else:
+            part = Part.from_field(RequestField("field", b"body", headers={"X": "old"}))
+        part.headers["X"] = "new"
+        wire = MultipartEncoder([part], "b").read()
+        assert b"X: new\r\n" in wire
+        assert b"X: old\r\n" not in wire
+
+    @pytest.mark.parametrize(
+        "wire",
+        [
+            b"--b\r\nbad-header\r\n\r\n",
+            b"--b\r\n continuation\r\n\r\n",
+            b"--b\r\n X: value\r\n\r\n",
+            b"--b\r\nX : value\r\n\r\n",
+        ],
+    )
+    def test_malformed_header(self, wire: bytes) -> None:
+        with pytest.raises(ValueError):
+            next(MultipartDecoder(wire, "b", buffer_size=1))
+
+    def test_closing_boundary_without_final_crlf(self) -> None:
+        decoder = MultipartDecoder(b"--b\r\n\r\nx\r\n--b--", "b", buffer_size=1)
+        assert next(decoder).read() == b"x"
+        assert list(decoder) == []
+
+    def test_encoder_rejects_fractional_read_size(self) -> None:
+        with pytest.raises(TypeError):
+            MultipartEncoder([], "b").read(1.5)  # type: ignore[arg-type]
+
+
+class RepeatedBody(io.RawIOBase):
+    """Generate a large body without allocating it before profiling starts."""
+
+    def __init__(self, size: int) -> None:
+        self.remaining = size
+
+    def readable(self) -> bool:
+        return True
+
+    def read(self, size: int = -1) -> bytes:
+        assert 0 <= size <= io.DEFAULT_BUFFER_SIZE
+        count = min(size, self.remaining)
+        self.remaining -= count
+        return b"x" * count
+
+
+@pytest.mark.limit_memory("1 MB")
+@pytest.mark.parametrize("size", [1024 * 1024, 16 * 1024 * 1024])
+@pytest.mark.parametrize("decode", [False, True])
+def test_bounded_streaming_memory(size: int, decode: bool) -> None:
+    source = RepeatedBody(size)
+    encoder = MultipartEncoder([Part(source)], "b")
+    reader: io.BufferedIOBase
+    if decode:
+        decoder = MultipartDecoder(encoder, "b")
+        reader = next(decoder)
+    else:
+        reader = encoder
+    count = 0
+    while chunk := reader.read(8192):
+        count += len(chunk)
+        if decode:
+            assert chunk == b"x" * len(chunk)
+    assert count == size if decode else count == size + len(b"--b\r\n\r\n\r\n--b--\r\n")
+    assert source.remaining == 0
+    if decode:
+        assert list(decoder) == []
+
+
+class TestMultipartInvalidInputs:
+    @pytest.mark.parametrize("boundary", ["", "bad\rboundary", "bad\nboundary"])
+    def test_boundary(self, boundary: str) -> None:
+        with pytest.raises(ValueError, match="boundary"):
+            MultipartEncoder([], boundary)
+        with pytest.raises(ValueError, match="boundary"):
+            MultipartDecoder(b"", boundary)
+
+    @pytest.mark.parametrize("name,value", [("Bad:Name", "ok"), ("X", "bad\r\nvalue")])
+    def test_encoder_headers(self, name: str, value: str) -> None:
+        with pytest.raises(ValueError, match="header"):
+            MultipartEncoder([Part(b"body", {name: value})], "b")
+
+    @pytest.mark.parametrize("limit", [0, -1])
+    def test_decoder_limits(self, limit: int) -> None:
+        with pytest.raises(ValueError, match="positive"):
+            MultipartDecoder(b"", "b", buffer_size=limit)
+        with pytest.raises(ValueError, match="positive"):
+            MultipartDecoder(b"", "b", max_header_size=limit)
+
+    @pytest.mark.parametrize("decode", [False, True])
+    @pytest.mark.parametrize("text", [False, True])
+    def test_invalid_stream_read(self, decode: bool, text: bool) -> None:
+        class InvalidReader(io.BytesIO):
+            def read(self, size: int | None = -1) -> bytes:
+                return "text" if text else b"x" * (size + 1)  # type: ignore[return-value,operator]
+
+        with pytest.raises(TypeError if text else ValueError):
+            if decode:
+                next(MultipartDecoder(InvalidReader(), "b"))
+            else:
+                Part(InvalidReader()).read(1)
+
+    @pytest.mark.parametrize(
+        "wire",
+        [
+            b"--b\r\nX: " + b"x" * 40,
+            b"--b\r\n" + b"X: x\r\n" * 8 + b"\r\n",
+            b"--b\r\n\r\nx\r\n--b--" + b" " * 40 + b"\r\n",
+        ],
+    )
+    def test_oversized_headers_or_padding(self, wire: bytes) -> None:
+        with pytest.raises(ValueError, match="too long"):
+            for part in MultipartDecoder(wire, "b", buffer_size=1, max_header_size=32):
+                part.read()
+
+    def test_encoder_io_contract(self) -> None:
+        # Legacy RequestField rendering accepts integer values at runtime.
+        field = RequestField("number", 42)  # type: ignore[arg-type]
+        encoder = MultipartEncoder([Part.from_field(field)], "b")
+        assert encoder.readable()
+        assert encoder.seekable()
+        assert b"\r\n\r\n42\r\n" in encoder.read(None)
+        with pytest.raises(io.UnsupportedOperation):
+            encoder.seek(1)
+        with pytest.raises(TypeError, match="writable"):
+            encoder.readinto(b"immutable")
+        encoder.close()
+        with pytest.raises(ValueError):
+            encoder.read()
+        with pytest.raises(ValueError):
+            encoder.seek(0)
+        with pytest.raises(ValueError):
+            encoder.tell()

--- a/test/with_dummyserver/test_connectionpool.py
+++ b/test/with_dummyserver/test_connectionpool.py
@@ -30,6 +30,7 @@ from urllib3.exceptions import (
     UnrewindableBodyError,
 )
 from urllib3.fields import _TYPE_FIELD_VALUE_TUPLE
+from urllib3.multipart import MultipartEncoder
 from urllib3.util import SKIP_HEADER, SKIPPABLE_HEADERS
 from urllib3.util.retry import RequestHistory, Retry
 from urllib3.util.timeout import _TYPE_TIMEOUT, Timeout
@@ -265,6 +266,29 @@ class TestConnectionPool(HypercornDummyServerTestCase):
         with HTTPConnectionPool(self.host, self.port) as pool:
             r = pool.request("POST", "/upload", fields=fields)
             assert r.status == 200, r.data
+
+    @pytest.mark.parametrize("redirect", [False, True])
+    def test_streaming_multipart_upload(self, redirect: bool) -> None:
+        source = io.BytesIO(b"skip" + b"data" * 16384)
+        source.seek(4)
+        encoder = MultipartEncoder.from_fields(
+            {
+                "upload_param": "filefield",
+                "upload_filename": "stream.bin",
+                "upload_size": str(65536),
+                "filefield": ("stream.bin", source),
+            }
+        )
+        url = "/redirect?target=/upload&status=307" if redirect else "/upload"
+        with HTTPConnectionPool(self.host, self.port, timeout=LONG_TIMEOUT) as pool:
+            response = pool.request(
+                "POST",
+                url,
+                body=encoder,
+                headers={"Content-Type": encoder.content_type},
+            )
+        assert response.status == 200, response.data
+        assert not source.closed
 
     def test_one_name_multiple_values(self) -> None:
         fields = [("foo", "a"), ("foo", "b")]


### PR DESCRIPTION
Multipart uploads can now use bounded reads instead of materializing the complete body. This adds `urllib3.multipart.Part`, `MultipartEncoder`, and `MultipartDecoder`; the legacy `encode_multipart_formdata()` helper uses the encoder internally while retaining its `(bytes, content_type)` return contract.

The encoder accepts field structures or explicit buffered parts, supports `read()`, `readinto()`, `tell()` and complete rewind with `seek(0, 0)`. Rewind attempts every part even when an earlier part raises; a failed rewind prevents further reading until a successful retry. Input streams remain caller-owned and rewinds return to their original offsets.

The decoder iterates forward-only parts, recognizes boundaries across source chunks, preserves boundary lookalikes in payloads, and rejects truncated framing and malformed or oversized headers. Advancing drains the previous part without allowing it to read into the next part. Positive bounded reads stream data; unbounded reads and the legacy bytes-returning helper still allocate the complete requested output. Documentation includes upload and decode examples and these ownership/rewind limits.

Validation:

- Existing legacy wire-output tests and real loopback HTTP upload tests, including same-origin 307 rewind.
- Actual Linux CPython 3.12 memray run: 1 MiB and 16 MiB generated inputs both peak at 40.1 KiB for the encoder and 64.2 KiB for encode/decode, below the 1 MB regression limit. Inputs are generated inside the measured test and never materialized as one large allocation.
- New module statement coverage: 100%. Linux-target mypy: 82 files. Changed-file Black, isort and flake8 checks pass.
- Full Linux CPython 3.12 suite with memray and socket isolation: **2,404 passed, 310 skipped, 4 xfailed**. IPv6 was unavailable locally; platform/integration skips are preserved.
- Sphinx HTML builds were compared against unchanged main: both `-W` builds report the same four existing unresolved-reference warnings (`connection._TYPE_SOCKET_OPTIONS` three times and `Retry.respect_retry_after_header` once). The new API introduces no remaining warnings. This is a baseline comparison, not a claim of a warning-free documentation build.
- All [31 CI jobs](https://github.com/stantheman0128/urllib3/actions/runs/34369679065) passed at `5f9d64f`, including the platform matrix, package checks, and aggregate 100% coverage gate.
- [Full repository lint](https://github.com/stantheman0128/urllib3/actions/runs/34369679092) and [Requests/botocore downstream suites](https://github.com/stantheman0128/urllib3/actions/runs/34369679039) passed at the same commit.

The implementation was prepared independently from merged urllib3 source. OpenAI Codex was used for implementation, tests, and documentation; no human review is claimed.

Closes #624.
