### PR TITLE
Test pickling of `InvalidChunkLength`

### DIFF
--- a/test/test_exceptions.py
+++ b/test/test_exceptions.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import io
 import pickle
 import socket
 from email.errors import MessageDefect
@@ -16,12 +17,14 @@ from urllib3.exceptions import (
     HeaderParsingError,
     HostChangedError,
     HTTPError,
+    InvalidChunkLength,
     LocationParseError,
     MaxRetryError,
     NameResolutionError,
     NewConnectionError,
     ReadTimeoutError,
 )
+from urllib3.response import HTTPResponse
 
 
 class TestPickle:
@@ -64,6 +67,24 @@ class TestPickle:
         if hasattr(exception, "_reason"):
             # reason is likely an exception so do string comparison instead
             assert str(exception._reason) == str(result._reason)  # type: ignore[attr-defined]
+
+    def test_invalid_chunk_length(self) -> None:
+        response = HTTPResponse(
+            body=io.BytesIO(b"abcdef"),
+            headers={"Content-Length": "10"},
+            preload_content=False,
+        )
+        response.read(3)
+        exception = InvalidChunkLength(response, b"zz")
+        assert exception.partial == 3
+        assert exception.expected == 7
+
+        result = pickle.loads(pickle.dumps(exception))
+        assert isinstance(result, InvalidChunkLength)
+        assert result.partial == exception.partial
+        assert result.expected == exception.expected
+        assert result.length == exception.length
+        assert repr(result) == repr(exception)
 
 
 class TestFormat:


### PR DESCRIPTION
`InvalidChunkLength` is not covered by the `TestPickle` matrix, and it is a natural candidate for it: the exception carries a whole `HTTPResponse` object in its `args`, which is exactly the kind of payload that can break pickling when an exception crosses a process boundary (e.g. multiprocessing or concurrent.futures workers).

The test builds a response that has been partially read, so that `partial`, `expected`, and `length` all hold non-default values, and asserts that each of them survives a pickle round trip.
