### PR TITLE
Classify TLS handshake timeouts as connect timeouts

### DIFF
--- a/changelog/2591.bugfix.rst
+++ b/changelog/2591.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed TLS handshake timeouts being incorrectly raised as ``ReadTimeoutError`` instead of ``ConnectTimeoutError``.

--- a/src/urllib3/connectionpool.py
+++ b/src/urllib3/connectionpool.py
@@ -26,6 +26,7 @@ from .connection import (
 from .connection import port_by_scheme as port_by_scheme
 from .exceptions import (
     ClosedPoolError,
+    ConnectTimeoutError,
     EmptyPoolError,
     FullPoolError,
     HostChangedError,
@@ -468,7 +469,13 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
             # Trigger any extra validation we need to do.
             try:
                 self._validate_conn(conn)
-            except (SocketTimeout, BaseSSLError) as e:
+            except SocketTimeout as e:
+                raise ConnectTimeoutError(
+                    conn,
+                    f"Connection to {self.host} timed out. "
+                    f"(connect timeout={conn.timeout})",
+                ) from e
+            except BaseSSLError as e:
                 self._raise_timeout(err=e, url=url, timeout_value=conn.timeout)
                 raise
 

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -46,6 +46,7 @@ from urllib3._collections import HTTPHeaderDict
 from urllib3.connection import HTTPConnection, _get_default_user_agent
 from urllib3.connectionpool import _url_from_pool
 from urllib3.exceptions import (
+    ConnectTimeoutError,
     InsecureRequestWarning,
     MaxRetryError,
     ProtocolError,
@@ -554,8 +555,8 @@ class TestSocketClosing(SocketDummyServerTestCase):
             finally:
                 timed_out.set()
 
-    def test_https_connection_read_timeout(self) -> None:
-        """Handshake timeouts should fail with a Timeout"""
+    def test_https_connection_timeout_classification(self) -> None:
+        """Handshake timeouts are connect timeouts; response timeouts are reads."""
         timed_out = Event()
 
         def socket_handler(listener: socket.socket) -> None:
@@ -566,19 +567,22 @@ class TestSocketClosing(SocketDummyServerTestCase):
             timed_out.wait()
             sock.close()
 
-        # first ReadTimeoutError due to SocketTimeout
         self._start_server(socket_handler)
+        timeout = Timeout(connect=SHORT_TIMEOUT, read=LONG_TIMEOUT)
         with HTTPSConnectionPool(
-            self.host, self.port, timeout=LONG_TIMEOUT, retries=False
+            self.host, self.port, timeout=timeout, retries=False
         ) as pool:
             try:
-                with pytest.raises(ReadTimeoutError):
+                with pytest.raises(
+                    ConnectTimeoutError,
+                    match=rf"connect timeout={SHORT_TIMEOUT}",
+                ):
                     pool.request("GET", "/")
             finally:
                 timed_out.set()
 
-        # second ReadTimeoutError due to errno
-        with HTTPSConnectionPool(host=self.host):
+        # A timeout detected while reading remains a ReadTimeoutError.
+        with HTTPSConnectionPool(host=self.host) as pool:
             err = OSError()
             err.errno = errno.EAGAIN
             with pytest.raises(ReadTimeoutError):


### PR DESCRIPTION
Closes #2591.
Closes #1366.

## Summary

TLS handshakes run while the socket is configured with the connection timeout. A socket timeout raised during HTTPS connection validation was incorrectly converted to `ReadTimeoutError`, making callers treat a connection-establishment failure like a response-read timeout.

This change:

- raises `ConnectTimeoutError` for `SocketTimeout` during connection validation and TLS handshake;
- preserves existing handling for other SSL errors and response-read timeouts;
- uses distinct connect and read timeout values in the regression test; and
- adds the required Towncrier news fragment.

## Validation

- Focused TLS regression: 1 passed
- Affected socket, connection-pool, retry, and exception suites: 330 passed, 8 skipped
- Full Python 3.13 nox suite: 2,357 passed, 288 skipped, 45 expected failures
- `nox -rs lint`: passed, including pyupgrade, Black, isort, Flake8, uv-lock, zizmor, Prettier, ESLint, and mypy
- Towncrier draft: passed
- Wheel and source distribution builds: passed